### PR TITLE
Strong reference to callback

### DIFF
--- a/bindings/java/mongocrypt/build.gradle.kts
+++ b/bindings/java/mongocrypt/build.gradle.kts
@@ -42,7 +42,7 @@ repositories {
 }
 
 group = "org.mongodb"
-version = "1.0.0-beta3"
+version = "1.0.0-SNAPSHOT"
 description = "MongoDB client-side crypto support"
 
 java {

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
@@ -366,7 +366,7 @@ public class CAPI {
     /**
      * Set the keyAltName to use for explicit encryption.
      * keyAltName should be a binary encoding a bson document
-     * with the following format: <code>{ "keyAltName" : <BSON UTF8 value> }</code>
+     * with the following format: <code>{ "keyAltName" : &gt;BSON UTF8 value&lt; }</code>
      *
      * <p>It is an error to set both this and the key id.</p>
      *

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoCryptImpl.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoCryptImpl.java
@@ -65,6 +65,11 @@ class MongoCryptImpl implements MongoCrypt {
     private static final Logger LOGGER = Loggers.getLogger();
 
     private final mongocrypt_t wrapped;
+
+    // Keep a strong reference to the callback so that it doesn't get garbage collected
+    @SuppressWarnings("FieldCanBeLocal")
+    private final LogCallback logCallback;
+
     private volatile boolean closed;
 
     MongoCryptImpl(final MongoCryptOptions options) {
@@ -75,7 +80,9 @@ class MongoCryptImpl implements MongoCrypt {
 
         boolean success;
 
-        success = mongocrypt_setopt_log_handler(wrapped, new LogCallback(), null);
+        logCallback = new LogCallback();
+
+        success = mongocrypt_setopt_log_handler(wrapped, logCallback, null);
         if (!success) {
             throwExceptionFromStatus();
         }


### PR DESCRIPTION
@markbenvenuto reported an error while running YCSB tests using the Java bindings:

`
JNA: callback object has been garbage collected. 
`

I suspected it had to do with the LogCallback instance not having a strong reference to it, and it turned out to be the case.  Running YCSB with this fix shows that the error messages are gone.

Also fixed a few other issues I found while testing the fix.