### PR TITLE
NODE: Add tools to generate documentation in README

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -1,0 +1,158 @@
+MongoDB Client Encryption
+=========================
+
+The node.js wrapper for the Client Side Encryption library
+
+### Requirements
+
+Follow the instructions for building `libmongocrypt` [here](../../README.md#building-libmongocrypt).
+
+### Installation
+
+Now you can install `mongodb-client-encryption` with the following:
+
+```bash
+npm install mongodb-client-encryption
+```
+
+### Testing
+
+Run the test suite using:
+
+```bash
+npm test
+```
+
+# Documentation
+
+## Classes
+
+<dl>
+<dt><a href="#AutoEncrypter">AutoEncrypter</a></dt>
+<dd><p>An internal class to be used by the driver for auto encryption
+<strong>NOTE</strong>: Not meant to be instantiated directly, this is for internal use only.</p>
+</dd>
+<dt><a href="#ClientEncryption">ClientEncryption</a></dt>
+<dd><p>The public interface for explicit client side encryption</p>
+</dd>
+</dl>
+
+<a name="AutoEncrypter"></a>
+
+## AutoEncrypter
+An internal class to be used by the driver for auto encryption
+**NOTE**: Not meant to be instantiated directly, this is for internal use only.
+
+
+* [AutoEncrypter](#AutoEncrypter)
+
+    * [new AutoEncrypter(options)](#new_AutoEncrypter_new)
+
+    * [.encrypt(ns, cmd, callback)](#AutoEncrypter+encrypt)
+
+    * [.decrypt(buffer, callback)](#AutoEncrypter+decrypt)
+
+
+<a name="new_AutoEncrypter_new"></a>
+
+### new AutoEncrypter(options)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>object</code> | Optional settings |
+| options.client | <code>MongoClient</code> | The parent client auto encryption is enabled on |
+| options.mongocryptdClient | <code>MongoClient</code> | The client used for communication with `mongocryptd` |
+| options.keyVaultNamespace | <code>string</code> | The namespace of the key vault, used to store encryption keys |
+| options.schemaMap | <code>object</code> |  |
+| options.kmsProviders | <code>object</code> |  |
+| options.logger | <code>function</code> |  |
+
+Create an AutoEncrypter
+
+<a name="AutoEncrypter+encrypt"></a>
+
+### *autoEncrypter*.encrypt(ns, cmd, callback)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ns | <code>string</code> | The namespace for this encryption context |
+| cmd | <code>object</code> | The command to encrypt |
+| callback | <code>function</code> |  |
+
+Encrypt a command for a given namespace
+
+<a name="AutoEncrypter+decrypt"></a>
+
+### *autoEncrypter*.decrypt(buffer, callback)
+
+| Param | Type |
+| --- | --- |
+| buffer | <code>\*</code> | 
+| callback | <code>\*</code> | 
+
+Decrypt a command response
+
+<a name="ClientEncryption"></a>
+
+## ClientEncryption
+The public interface for explicit client side encryption
+
+
+* [ClientEncryption](#ClientEncryption)
+
+    * [new ClientEncryption(client, options)](#new_ClientEncryption_new)
+
+    * [.createDataKey(provider, options, callback)](#ClientEncryption+createDataKey)
+
+    * [.encrypt(value, options, callback)](#ClientEncryption+encrypt)
+
+    * [.decrypt(value, callback)](#ClientEncryption+decrypt)
+
+
+<a name="new_ClientEncryption_new"></a>
+
+### new ClientEncryption(client, options)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| client | <code>MongoClient</code> | The client used for encryption |
+| options | <code>object</code> | Optional settings |
+| options.keyVaultNamespace | <code>string</code> | The namespace of the key vault, used to store encryption keys |
+
+Create a new encryption instance
+
+<a name="ClientEncryption+createDataKey"></a>
+
+### *clientEncryption*.createDataKey(provider, options, callback)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| provider | <code>string</code> | The KMS provider used for this data key |
+| options | <code>\*</code> |  |
+| callback | <code>function</code> |  |
+
+Creates a data key used for explicit encryption
+
+<a name="ClientEncryption+encrypt"></a>
+
+### *clientEncryption*.encrypt(value, options, callback)
+
+| Param | Type |
+| --- | --- |
+| value | <code>\*</code> | 
+| options | <code>\*</code> | 
+| callback | <code>\*</code> | 
+
+Explicitly encrypt a provided value
+
+<a name="ClientEncryption+decrypt"></a>
+
+### *clientEncryption*.decrypt(value, callback)
+
+| Param | Type |
+| --- | --- |
+| value | <code>\*</code> | 
+| callback | <code>\*</code> | 
+
+Explicitly decrypt a provided encrypted value
+

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -1,7 +1,7 @@
 MongoDB Client Encryption
 =========================
 
-The node.js wrapper for the Client Side Encryption library
+The node.js wrapper for [`libmongocrypt`](../../README.md)
 
 ### Requirements
 

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -1,7 +1,7 @@
 MongoDB Client Encryption
 =========================
 
-The node.js wrapper for [`libmongocrypt`](../../README.md)
+The Node.js wrapper for [`libmongocrypt`](../../README.md)
 
 ### Requirements
 

--- a/bindings/node/etc/README.hbs
+++ b/bindings/node/etc/README.hbs
@@ -1,7 +1,7 @@
 MongoDB Client Encryption
 =========================
 
-The node.js wrapper for the Client Side Encryption library
+The node.js wrapper for [`libmongocrypt`](../../README.md)
 
 ### Requirements
 

--- a/bindings/node/etc/README.hbs
+++ b/bindings/node/etc/README.hbs
@@ -1,7 +1,7 @@
 MongoDB Client Encryption
 =========================
 
-The node.js wrapper for [`libmongocrypt`](../../README.md)
+The Node.js wrapper for [`libmongocrypt`](../../README.md)
 
 ### Requirements
 

--- a/bindings/node/etc/README.hbs
+++ b/bindings/node/etc/README.hbs
@@ -1,0 +1,28 @@
+MongoDB Client Encryption
+=========================
+
+The node.js wrapper for the Client Side Encryption library
+
+### Requirements
+
+Follow the instructions for building `libmongocrypt` [here](../../README.md#building-libmongocrypt).
+
+### Installation
+
+Now you can install `mongodb-client-encryption` with the following:
+
+```bash
+npm install mongodb-client-encryption
+```
+
+### Testing
+
+Run the test suite using:
+
+```bash
+npm test
+```
+
+# Documentation
+
+{{>main}}

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -11,6 +11,7 @@
     "format-cxx": "git-clang-format",
     "format-js": "prettier --print-width 100 --tab-width 2 --single-quote --write index.js 'test/**/*.js' 'lib/**/*.js'",
     "lint": "eslint lib test",
+    "docs": "jsdoc2md --template etc/README.hbs --plugin dmd-clear --files lib/**/*.js > README.md",
     "test": "mocha test"
   },
   "author": "Matt Broadstone <mbroadst@mongodb.com>",
@@ -24,8 +25,10 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "chai-subset": "^1.6.0",
+    "dmd-clear": "^0.1.2",
     "eslint": "^4.5.0",
     "eslint-plugin-prettier": "^2.2.0",
+    "jsdoc-to-markdown": "^5.0.0",
     "mocha": "^6.1.4",
     "mongodb": "^3.2.7",
     "mongodb-extjson": "^3.0.3",


### PR DESCRIPTION
Ignore `README.md`, it is autogenerated from `etc/README.hbs`