### PR TITLE
NODE: rely on request.bytesNeeded for ending kms requests

### DIFF
--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -147,12 +147,10 @@ class StateMachine {
         reject(err);
       });
 
-      let bytesReceived = 0;
       socket.on('data', buffer => {
-        bytesReceived += buffer.length;
         request.addResponse(buffer);
 
-        if (bytesReceived >= request.bytesNeeded) {
+        if (request.bytesNeeded <= 0) {
           socket.end(resolve);
         }
       });


### PR DESCRIPTION
We were incorrectly calculating how many bytes we needed
to read, resulting in cryptic TLS errors. Now we
will rely solely on request.bytesNeeded.

TODO: Write tests