### PR TITLE
Ensure that JNA-managed memory is not GC'd before we're done with it

### DIFF
--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/BinaryHolder.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/BinaryHolder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.crypt.capi;
+
+import com.mongodb.crypt.capi.CAPI.mongocrypt_binary_t;
+
+import static com.mongodb.crypt.capi.CAPI.mongocrypt_binary_destroy;
+
+// Wrap JNA memory and a mongocrypt_binary_t that references that memory, in order to ensure that the JNA Memory is not GC'd before the
+// mongocrypt_binary_t is destroyed
+class BinaryHolder implements AutoCloseable {
+
+    private final DisposableMemory memory;
+    private final mongocrypt_binary_t binary;
+
+    BinaryHolder(final DisposableMemory memory, final mongocrypt_binary_t binary) {
+        this.memory = memory;
+        this.binary = binary;
+    }
+
+    mongocrypt_binary_t getBinary() {
+        return binary;
+    }
+
+    @Override
+    public void close() {
+        mongocrypt_binary_destroy(binary);
+        memory.dispose();
+    }
+}

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/DisposableMemory.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/DisposableMemory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.crypt.capi;
+
+import com.sun.jna.Memory;
+
+// Subclass of JNA's Memory class so that we can call its protected dispose method
+class DisposableMemory extends Memory {
+    DisposableMemory(final int size) {
+        super(size);
+    }
+
+    public void dispose() {
+        super.dispose();
+    }
+}

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoCryptContextImpl.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoCryptContextImpl.java
@@ -77,17 +77,12 @@ class MongoCryptContextImpl implements MongoCryptContext {
     public void addMongoOperationResult(final BsonDocument document) {
         isTrue("open", !closed);
 
-        mongocrypt_binary_t binary = toBinary(document);
-
-        try {
-            boolean success = mongocrypt_ctx_mongo_feed(wrapped, binary);
+        try (BinaryHolder binaryHolder = toBinary(document)) {
+            boolean success = mongocrypt_ctx_mongo_feed(wrapped, binaryHolder.getBinary());
             if (!success) {
                 throwExceptionFromStatus();
             }
-        } finally {
-            mongocrypt_binary_destroy(binary);
         }
-
     }
 
     @Override

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoKeyDecryptorImpl.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoKeyDecryptorImpl.java
@@ -80,14 +80,11 @@ class MongoKeyDecryptorImpl implements MongoKeyDecryptor {
 
     @Override
     public void feed(final ByteBuffer bytes) {
-        mongocrypt_binary_t binary = toBinary(bytes);
-        try {
-            boolean success = mongocrypt_kms_ctx_feed(wrapped, binary);
+        try (BinaryHolder binaryHolder = toBinary(bytes)) {
+            boolean success = mongocrypt_kms_ctx_feed(wrapped, binaryHolder.getBinary());
             if (!success) {
                 throwExceptionFromStatus();
             }
-        } finally {
-            mongocrypt_binary_destroy(binary);
         }
     }
 


### PR DESCRIPTION
Since mongocrypt_binary_t is non-owning, the binding must ensure that
the data it creates one with is not freed before the mongocrypt_binary_t
is destroyed.  We accomplish this by creating a BinaryHolder class to
wrap the JNA memory and the mongocrypt_binary_t and make it
AutoCloseable.

CDRIVER-3233