### PR TITLE
Rely on nocrypto builds of libmongocrypt

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -124,8 +124,6 @@ tasks:
   depends_on:
     - variant: ubuntu1604
       name: build-and-test-java
-    - variant: rhel-70-64-bit
-      name: build-and-test-java
     - variant: macos
       name: build-and-test-java
     - variant: windows-test


### PR DESCRIPTION
* Remove classifier jars, since we only need a single .so per arch
* Include the nocrypt builds of libmongocrypt both locally and from the
  tar.gz file

CDRIVER-3231

Patch build: https://evergreen.mongodb.com/version/5d3080c4e3c3310941d76c8a

