### PR TITLE
PYTHON-1888 Add evergreen testing for Python binding

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -61,6 +61,13 @@ functions:
           ${compile_env|} ./libmongocrypt/.evergreen/compile.sh
           cd ./libmongocrypt/bindings/java/mongocrypt && ${test_env|} ./.evergreen/test.sh
 
+  "build and test python":
+    - command: "shell.exec"
+      params:
+        script: |-
+          ${compile_env|} ./libmongocrypt/.evergreen/compile.sh
+          cd ./libmongocrypt/bindings/python && ${test_env|} ./.evergreen/test.sh
+
   "publish snapshot":
     - command: shell.exec
       params:
@@ -131,6 +138,11 @@ tasks:
   commands:
     - func: "fetch source"
     - func: "build and test java"
+
+- name: build-and-test-python
+  commands:
+    - func: "fetch source"
+    - func: "build and test python"
 
 - name: publish-snapshot
   depends_on:
@@ -360,6 +372,7 @@ buildvariants:
   - build-and-test-and-upload
   - build-and-test-shared-bson
   - build-and-test-java
+  - build-and-test-python
 - name: rhel-67-s390x
   display_name: "RHEL 6.7 s390x"
   run_on: rhel67-zseries-test

--- a/bindings/python/.evergreen/test.sh
+++ b/bindings/python/.evergreen/test.sh
@@ -9,6 +9,9 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #   PYTHON_BINARY           The Python version to use.
 PYTHON_BINARY=${PYTHON_BINARY:-"/opt/python/3.6/bin/python3"}
 
+evergreen_root="$(pwd)"/../../..
+INSTALL_PREFIX=${evergreen_root}/install/libmongocrypt/lib64
+
 $PYTHON_BINARY -c 'import sys; print(sys.version)'
 
-$PYTHON_BINARY setup.py test
+LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$INSTALL_PREFIX $PYTHON_BINARY setup.py test

--- a/bindings/python/.evergreen/test.sh
+++ b/bindings/python/.evergreen/test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Test the Python bindings for libmongocrypt
+
+set -o xtrace   # Write all commands first to stderr
+set -o errexit  # Exit the script with error if any of the commands fail
+
+# Supported/used environment variables:
+#   PYTHON_BINARY           The Python version to use. Defaults to "/opt/python/2.7/bin/python"
+PYTHON_BINARY=${PYTHON_BINARY:-"/opt/python/2.7/bin/python"}
+
+$PYTHON_BINARY -c 'import sys; print(sys.version)'
+
+$PYTHON_BINARY setup.py test

--- a/bindings/python/.evergreen/test.sh
+++ b/bindings/python/.evergreen/test.sh
@@ -13,7 +13,7 @@ PYTHONS=("/opt/python/2.7/bin/python" \
          "/opt/python/3.4/bin/python3" \
          "/opt/python/3.5/bin/python3" \
          "/opt/python/3.6/bin/python3" \
-         "/opt/python/pypy/bin/pypy" \
+#         "/opt/python/pypy/bin/pypy" \  # TODO: PyPy segfaults on RHEL 6.2
          "/opt/python/pypy3.6/bin/pypy3")
 
 for PYTHON_BINARY in "${PYTHONS[@]}"; do

--- a/bindings/python/.evergreen/test.sh
+++ b/bindings/python/.evergreen/test.sh
@@ -6,8 +6,8 @@ set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 # Supported/used environment variables:
-#   PYTHON_BINARY           The Python version to use. Defaults to "/opt/python/2.7/bin/python"
-PYTHON_BINARY=${PYTHON_BINARY:-"/opt/python/2.7/bin/python"}
+#   PYTHON_BINARY           The Python version to use.
+PYTHON_BINARY=${PYTHON_BINARY:-"/opt/python/3.6/bin/python3"}
 
 $PYTHON_BINARY -c 'import sys; print(sys.version)'
 

--- a/bindings/python/.evergreen/test.sh
+++ b/bindings/python/.evergreen/test.sh
@@ -5,14 +5,19 @@
 set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
-# Supported/used environment variables:
-#   PYTHON_BINARY           The Python version to use.
-PYTHON_BINARY=${PYTHON_BINARY:-"/opt/python/3.6/bin/python3"}
-
 # This library is built by libmongocrypt/.evergreen/compile.sh
 evergreen_root="$(cd ../../../; pwd)"
 export MONGOCRYPT_LIB=${evergreen_root}/install/libmongocrypt/lib64/libmongocrypt.so
 
-$PYTHON_BINARY -c 'import sys; print(sys.version)'
+PYTHONS=("/opt/python/2.7/bin/python" \
+         "/opt/python/3.4/bin/python3" \
+         "/opt/python/3.5/bin/python3" \
+         "/opt/python/3.6/bin/python3" \
+         "/opt/python/pypy/bin/pypy" \
+         "/opt/python/pypy3.6/bin/pypy3")
 
-$PYTHON_BINARY setup.py test
+for PYTHON_BINARY in "${PYTHONS[@]}"; do
+    $PYTHON_BINARY -c 'import sys; print(sys.version)'
+
+    $PYTHON_BINARY setup.py test
+done

--- a/bindings/python/.evergreen/test.sh
+++ b/bindings/python/.evergreen/test.sh
@@ -9,9 +9,10 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #   PYTHON_BINARY           The Python version to use.
 PYTHON_BINARY=${PYTHON_BINARY:-"/opt/python/3.6/bin/python3"}
 
-evergreen_root="$(pwd)"/../../..
-INSTALL_PREFIX=${evergreen_root}/install/libmongocrypt/lib64
+# This library is built by libmongocrypt/.evergreen/compile.sh
+evergreen_root="$(cd ../../../; pwd)"
+export MONGOCRYPT_LIB=${evergreen_root}/install/libmongocrypt/lib64/libmongocrypt.so
 
 $PYTHON_BINARY -c 'import sys; print(sys.version)'
 
-LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$INSTALL_PREFIX $PYTHON_BINARY setup.py test
+$PYTHON_BINARY setup.py test

--- a/bindings/python/README.rst
+++ b/bindings/python/README.rst
@@ -63,7 +63,7 @@ Please include all of the following information when opening an issue:
 Security Vulnerabilities
 ------------------------
 
-If you’ve identified a security vulnerability in a driver or any other
+If you've identified a security vulnerability in a driver or any other
 MongoDB project, please report it according to the `instructions here
 <http://docs.mongodb.org/manual/tutorial/create-a-vulnerability-report>`_.
 

--- a/bindings/python/pymongocrypt/mongocrypt.py
+++ b/bindings/python/pymongocrypt/mongocrypt.py
@@ -23,6 +23,9 @@ class _MongoCryptBinary(object):
     def __init__(self, binary):
         """Wraps a mongocrypt_binary_t."""
         self.bin = binary
+        if binary == ffi.NULL:
+            raise MongoCryptError(
+                "unable to create new mongocrypt_binary object")
 
     def _close(self):
         """Cleanup resources."""

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -3,8 +3,8 @@ import os
 from setuptools import setup, find_packages
 
 
-with open('README.rst') as f:
-    LONG_DESCRIPTION = f.read()
+with open('README.rst', 'rb') as f:
+    LONG_DESCRIPTION = f.read().decode('utf8')
 
 # Single source the version.
 version_file = os.path.realpath(os.path.join(

--- a/bindings/python/test/__init__.py
+++ b/bindings/python/test/__init__.py
@@ -18,17 +18,17 @@ import unittest
 
 sys.path[0:0] = [""]
 
-from pymongocrypt.compat import PY3
-
 from pymongocrypt.binding import init
 
 
-if PY3:
+try:
     # Enable the fault handler to dump the traceback of each running thread
     # after a segfault.
     import faulthandler
-
     faulthandler.enable()
+except ImportError:
+    pass
+
 
 # Load the mongocrypt library.
 init(os.environ.get('MONGOCRYPT_LIB', 'mongocrypt'))

--- a/bindings/python/test/__init__.py
+++ b/bindings/python/test/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 import unittest
 
@@ -19,17 +20,18 @@ sys.path[0:0] = [""]
 
 from pymongocrypt.compat import PY3
 
+from pymongocrypt.binding import init
+
 
 if PY3:
     # Enable the fault handler to dump the traceback of each running thread
     # after a segfault.
     import faulthandler
 
-    def enable_faulthandler():
-        faulthandler.enable()
-else:
-    def enable_faulthandler():
-        pass
+    faulthandler.enable()
+
+# Load the mongocrypt library.
+init(os.environ.get('MONGOCRYPT_LIB', 'mongocrypt'))
 
 # Use assertRaisesRegex if available, otherwise use Python 2.7's
 # deprecated assertRaisesRegexp, with a 'p'.

--- a/bindings/python/test/test_binding.py
+++ b/bindings/python/test/test_binding.py
@@ -19,13 +19,9 @@ import sys
 sys.path[0:0] = [""]
 
 import pymongocrypt
+from pymongocrypt.binding import ffi, lib
 
-from pymongocrypt.binding import lib, ffi
-
-from test import enable_faulthandler, unittest
-
-
-enable_faulthandler()
+from test import unittest
 
 
 class TestBinding(unittest.TestCase):

--- a/bindings/python/test/test_mongocrypt.py
+++ b/bindings/python/test/test_mongocrypt.py
@@ -30,11 +30,7 @@ from pymongocrypt.mongocrypt import (MongoCrypt,
                                      MongoCryptBinaryOut,
                                      MongoCryptOptions)
 
-from test import enable_faulthandler, unittest
-
-
-enable_faulthandler()
-
+from test import unittest
 
 # Data for testing libbmongocrypt binding.
 DATA_DIR = os.path.realpath(os.path.join(os.path.dirname(__file__), 'data'))

--- a/bindings/python/test/test_mongocrypt.py
+++ b/bindings/python/test/test_mongocrypt.py
@@ -20,6 +20,8 @@ import sys
 from bson import json_util, BSON
 from bson.binary import STANDARD
 from bson.codec_options import CodecOptions
+from bson.json_util import JSONOptions
+from bson.son import SON
 
 sys.path[0:0] = [""]
 
@@ -200,9 +202,12 @@ def read(filename, **kwargs):
 
 OPTS = CodecOptions(uuid_representation=STANDARD)
 
+# Use SON to preserve the order of fields while parsing json.
+JSON_OPTS = JSONOptions(document_class=SON, uuid_representation=STANDARD)
+
 
 def json_data(filename):
-    return json_util.loads(read(filename))
+    return json_util.loads(read(filename), json_options=JSON_OPTS)
 
 
 def bson_data(filename):


### PR DESCRIPTION
Patch: https://evergreen.mongodb.com/version/5d3b778457e85a2fe4c2d023

This change adds evergreen tests for the python binding. Right now it only tests on RHEL 6.2 with the following interpreters:
```
PYTHONS=("/opt/python/2.7/bin/python" \
         "/opt/python/3.4/bin/python3" \
         "/opt/python/3.5/bin/python3" \
         "/opt/python/3.6/bin/python3" \
         "/opt/python/pypy/bin/pypy" \
         "/opt/python/pypy3.6/bin/pypy3")
```

This change required me to introduce a `init()` method to allow overriding the libmongocrypt library path. Without an `init()` method we would need to use `LD_LIBRARY_PATH` or other platform specific environment variables. Also note that we can remove `init()` once we bind and distribute the nocrypto build.