### PR TITLE
NODE-2071: implement crypto hooks for the node bindings

### DIFF
--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -7,6 +7,7 @@ module.exports = function(modules) {
   const StateMachine = modules.stateMachine.StateMachine;
   const MongocryptdManager = require('./mongocryptdManager').MongocryptdManager;
   const MongoClient = modules.mongodb.MongoClient;
+  const cryptoCallbacks = require('./cryptoCallbacks');
 
   /**
    * An internal class to be used by the driver for auto encryption
@@ -49,6 +50,7 @@ module.exports = function(modules) {
         mongoCryptOptions.logger = options.logger;
       }
 
+      Object.assign(mongoCryptOptions, { cryptoCallbacks });
       this._mongocrypt = new mc.MongoCrypt(mongoCryptOptions);
       this._contextCounter = 0;
     }

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -7,6 +7,7 @@ module.exports = function(modules) {
   const collectionNamespace = common.collectionNamespace;
   const promiseOrCallback = common.promiseOrCallback;
   const StateMachine = modules.stateMachine.StateMachine;
+  const cryptoCallbacks = require('./cryptoCallbacks');
 
   /**
    * The public interface for explicit client side encryption
@@ -27,6 +28,7 @@ module.exports = function(modules) {
         throw new TypeError('Missing required option `keyVaultNamespace`');
       }
 
+      Object.assign(options, { cryptoCallbacks });
       this._keyVaultNamespace = options.keyVaultNamespace;
       this._mongoCrypt = new mc.MongoCrypt(options);
     }

--- a/bindings/node/lib/cryptoCallbacks.js
+++ b/bindings/node/lib/cryptoCallbacks.js
@@ -1,0 +1,74 @@
+'use strict';
+const crypto = require('crypto');
+
+function aes256CbcEncryptHook(key, iv, input, output) {
+  let result;
+
+  try {
+    let cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
+    cipher.setAutoPadding(false);
+    result = cipher.update(input);
+  } catch (e) {
+    console.dir({ e });
+  }
+
+  result.copy(output);
+  return result.length;
+}
+
+function aes256CbcDecryptHook(key, iv, input, output) {
+  let result;
+  try {
+    let cipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
+    cipher.setAutoPadding(false);
+    result = cipher.update(input);
+  } catch (e) {
+    console.dir({ e });
+  }
+
+  result.copy(output);
+  return result.length;
+}
+
+function randomHook(buffer, count) {
+  crypto.randomFillSync(buffer, count);
+}
+
+function sha256Hook(input, output) {
+  let result;
+  try {
+    result = crypto
+      .createHash('sha256')
+      .update(input)
+      .digest();
+  } catch (e) {
+    console.dir({ e });
+  }
+
+  result.copy(output);
+}
+
+function makeHmacHook(algorithm) {
+  return (key, input, output) => {
+    let result;
+    try {
+      result = crypto
+        .createHmac(algorithm, key)
+        .update(input)
+        .digest();
+    } catch (e) {
+      console.dir({ e });
+    }
+
+    result.copy(output);
+  };
+}
+
+module.exports = {
+  aes256CbcEncryptHook,
+  aes256CbcDecryptHook,
+  randomHook,
+  hmacSha512Hook: makeHmacHook('sha512'),
+  hmacSha256Hook: makeHmacHook('sha256'),
+  sha256Hook
+};

--- a/bindings/node/src/mongocrypt.h
+++ b/bindings/node/src/mongocrypt.h
@@ -43,8 +43,19 @@ class MongoCrypt : public Nan::ObjectWrap {
     static NAN_GETTER(Status);
 
    private:
+    struct CryptoHooks {
+        std::unique_ptr<Nan::Callback> aes256CbcEncryptHook;
+        std::unique_ptr<Nan::Callback> aes256CbcDecryptHook;
+        std::unique_ptr<Nan::Callback> randomHook;
+        std::unique_ptr<Nan::Callback> hmacSha512Hook;
+        std::unique_ptr<Nan::Callback> hmacSha256Hook;
+        std::unique_ptr<Nan::Callback> sha256Hook;
+    };
+
     friend class MongoCryptContext;
-    explicit MongoCrypt(mongocrypt_t* mongo_crypt, Nan::Callback* logger);
+    explicit MongoCrypt(mongocrypt_t* mongo_crypt, Nan::Callback* logger, CryptoHooks* hooks);
+    static bool setupCryptoHooks(mongocrypt_t* mongoCrypt, CryptoHooks* cryptoHooks);
+
     static void logHandler(mongocrypt_log_level_t level,
                            const char* message,
                            uint32_t message_len,
@@ -52,6 +63,7 @@ class MongoCrypt : public Nan::ObjectWrap {
 
     std::unique_ptr<mongocrypt_t, MongoCryptDeleter> _mongo_crypt;
     std::unique_ptr<Nan::Callback> _logger;
+    std::unique_ptr<CryptoHooks> _cryptoHooks;
 };
 
 class MongoCryptContext : public Nan::ObjectWrap {

--- a/bindings/node/test/clientEncryption.test.js
+++ b/bindings/node/test/clientEncryption.test.js
@@ -33,7 +33,12 @@ describe('ClientEncryption', function() {
 
   beforeEach(() => {
     client = new MongoClient('mongodb://localhost:27017/test', { useNewUrlParser: true });
-    return client.connect();
+    return client.connect().then(() =>
+      client
+        .db('client')
+        .collection('encryption')
+        .drop()
+    );
   });
 
   afterEach(() => {


### PR DESCRIPTION
This implements crypto callbacks so that the node bindings can be implemented without having to link to OpenSSL. The required methods are passed in via options passed into `MongoCrypt`. Ideally, this will be refactored to set the crypto hooks one time on the top-level module, but that can be follow-on work.