### PR TITLE
NODE-2072: provide infrastructure for statically linking the addon

### DIFF
--- a/bindings/node/.gitignore
+++ b/bindings/node/.gitignore
@@ -17,4 +17,5 @@ build
 npm-debug.log
 package-lock.json
 .vscode
+deps
 

--- a/bindings/node/binding.gyp
+++ b/bindings/node/binding.gyp
@@ -5,16 +5,43 @@
       'include_dirs': [
           '<!(node -e "require(\'nan\')")'
       ],
+      'variables': {
+          'variables': {
+              'build_type%': "dynamic",
+          },
+          'conditions': [
+            ['OS=="win"', {
+              'build_type' : "<!(echo %BUILD_TYPE%)"
+            }],
+            ['OS!="win"', {
+              'build_type' : "<!(echo $BUILD_TYPE)",
+            }]
+          ]
+      },
       'sources': [
         'src/mongocrypt.cc'
       ],
-      'link_settings': {
-        'libraries': [
-          '-lmongocrypt'
-          # '<(module_root_dir)/deps/libmongocrypt/lib/libmongocrypt-static.a',
-          # '/usr/local/lib/libbson-static-1.0.a'
-        ]
-      }
+      'conditions': [
+        ['build_type=="dynamic"', {
+          'link_settings': {
+            'libraries': [
+              '-lmongocrypt'
+            ]
+          }
+        }],
+        ['build_type!="dynamic"', {
+          'include_dirs': [
+            '<(module_root_dir)/deps/include'
+          ],
+          'link_settings': {
+            'libraries': [
+              '<(module_root_dir)/deps/lib/libmongocrypt-static.a',
+              '<(module_root_dir)/deps/lib/libkms_message-static.a',
+              '<(module_root_dir)/deps/lib/libbson-static-1.0.a'
+            ]
+          }
+        }],
+      ],
     }
   ]
 }

--- a/bindings/node/etc/build-static.sh
+++ b/bindings/node/etc/build-static.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -x
+
+DEPS_PREFIX="$(pwd)/deps"
+MONGOC_URL="https://github.com/mongodb/mongo-c-driver/releases/download/1.14.0/mongo-c-driver-1.14.0.tar.gz"
+BUILD_DIR=$DEPS_PREFIX/tmp
+LIBMONGOCRYPT_DIR="$(pwd)/../../"
+
+# create relevant folders
+mkdir -p $DEPS_PREFIX
+mkdir -p $BUILD_DIR
+mkdir -p $BUILD_DIR/bson-build
+mkdir -p $BUILD_DIR/libmongocrypt-build
+
+pushd $BUILD_DIR
+
+# build and install bson
+wget $MONGOC_URL
+tar xzf mongo-c-driver-1.14.0.tar.gz
+
+pushd bson-build
+cmake -DENABLE_MONGOC=OFF -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_INSTALL_PREFIX=$DEPS_PREFIX ../mongo-c-driver-1.14.0
+make -j8 install
+popd
+
+# build and install libmongocrypt
+pushd libmongocrypt-build
+cmake -DDISABLE_NATIVE_CRYPTO=1 -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_PREFIX_PATH=$DEPS_PREFIX -DCMAKE_INSTALL_PREFIX=$DEPS_PREFIX $LIBMONGOCRYPT_DIR
+make -j8 install
+popd
+
+# build the `mongodb-client-encryption` addon
+BUILD_TYPE=static npm install

--- a/bindings/node/lib/mongocryptdManager.js
+++ b/bindings/node/lib/mongocryptdManager.js
@@ -92,6 +92,8 @@ class MongocryptdManager {
         detached: true
       });
 
+      this._child.on('error', () => {});
+
       // unref child to remove handle from event loop
       this._child.unref();
 

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -32,6 +32,7 @@
     "mocha": "^6.1.4",
     "mongodb": "^3.2.7",
     "mongodb-extjson": "^3.0.3",
+    "node-gyp": "^5.0.3",
     "prettier": "~1.18.2",
     "segfault-handler": "^1.2.0",
     "sinon": "^4.3.0",

--- a/bindings/node/test/clientEncryption.test.js
+++ b/bindings/node/test/clientEncryption.test.js
@@ -38,6 +38,13 @@ describe('ClientEncryption', function() {
         .db('client')
         .collection('encryption')
         .drop()
+        .catch(err => {
+          if (err.message.match(/ns not found/)) {
+            return;
+          }
+
+          throw err;
+        })
     );
   });
 


### PR DESCRIPTION
This change set includes all the pieces required to build the addon statically on a given host:
 - `binding.gyp` has been updated to accept a build variant: `dynamic` or `static`
 - A script, `etc/build-static.sh` automates the process of downloading and building libbson, and libmongocrypt (currently from source for libbson, and from the current working tree for libmongocrypt)
