### PR TITLE
PYTHON-1928 Add state machine/callback/auto encryption API

### DIFF
--- a/bindings/python/pymongocrypt/auto_encrypter.py
+++ b/bindings/python/pymongocrypt/auto_encrypter.py
@@ -1,0 +1,61 @@
+# Copyright 2019-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pymongocrypt.mongocrypt import MongoCrypt
+from pymongocrypt.state_machine import run_state_machine
+
+
+class AutoEncrypter(object):
+    def __init__(self, callback, mongo_crypt_opts):
+        """Encrypts and decrypts MongoDB commands.
+
+        This class is used by a driver to support automatic encryption and
+        decryption of MongoDB commands.
+
+        :Parameters:
+          - `callback`: A :class:`MongoCryptCallback`.
+          - `mongo_crypt_opts`: A :class:`MongoCryptOptions`.
+        """
+        self.callback = callback
+        self.mongocrypt = MongoCrypt(mongo_crypt_opts)
+
+    def encrypt(self, database, cmd):
+        """Encrypt a MongoDB command.
+
+        :Parameters:
+          - `database`: The database for this command.
+          - `cmd`: A MongoDB command as BSON.
+
+        :Returns:
+          The encrypted command.
+        """
+        with self.mongocrypt.encryption_context(database, cmd) as ctx:
+            return run_state_machine(ctx, self.callback)
+
+    def decrypt(self, response):
+        """Decrypt a MongoDB command response.
+
+        :Parameters:
+          - `response`: A MongoDB command response as BSON.
+
+        :Returns:
+          The decrypted command response.
+        """
+        with self.mongocrypt.decryption_context(response) as ctx:
+            return run_state_machine(ctx, self.callback)
+
+    def close(self):
+        """Cleanup resources."""
+        self.mongocrypt.close()
+        self.callback.close()

--- a/bindings/python/pymongocrypt/compat.py
+++ b/bindings/python/pymongocrypt/compat.py
@@ -17,3 +17,9 @@
 import sys
 
 PY3 = sys.version_info[0] == 3
+
+if PY3:
+    from abc import ABC
+else:
+    from abc import ABCMeta as _ABCMeta
+    ABC = _ABCMeta('ABC', (object,), {})

--- a/bindings/python/pymongocrypt/state_machine.py
+++ b/bindings/python/pymongocrypt/state_machine.py
@@ -1,0 +1,139 @@
+# Copyright 2019-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import abstractmethod
+
+from pymongocrypt.binding import lib
+from pymongocrypt.compat import ABC
+from pymongocrypt.errors import MongoCryptError
+
+
+class MongoCryptCallback(ABC):
+    """Callback ABC to perform I/O on behalf of libbmongocrypt."""
+
+    @abstractmethod
+    def kms_request(self, kms_context):
+        """Complete a KMS request.
+
+        :Parameters:
+          - `kms_context`: A :class:`MongoCryptKmsContext`.
+
+        :Returns:
+          None
+        """
+        pass
+
+    @abstractmethod
+    def collection_info(self, database, filter):
+        """Get the collection info for a namespace.
+
+        The returned collection info is passed to libmongocrypt which reads
+        the JSON schema.
+
+        :Parameters:
+          - `database`: The database on which to run listCollections.
+          - `filter`: The filter to pass to listCollections.
+
+        :Returns:
+          The first document from the listCollections command response as BSON.
+        """
+        pass
+
+    @abstractmethod
+    def mark_command(self, database, cmd):
+        """Mark a command for encryption.
+
+        :Parameters:
+          - `database`: The database on which to run this command.
+          - `cmd`: The BSON command to run.
+
+        :Returns:
+          The marked command response from mongocryptd.
+        """
+        pass
+
+    @abstractmethod
+    def fetch_keys(self, filter):
+        """Yields one or more keys from the key vault.
+
+        :Parameters:
+          - `filter`: The filter to pass to find.
+
+        :Returns:
+          A generator which yields the requested keys from the key vault.
+        """
+        pass
+
+    @abstractmethod
+    def insert_data_key(self, data_key):
+        """Insert a data key into the key vault.
+
+        :Parameters:
+          - `data_key`: The data key document to insert.
+
+        :Returns:
+          The _id of the inserted data key document.
+        """
+        pass
+
+    @abstractmethod
+    def close(self):
+        """Release resources."""
+        pass
+
+
+def run_state_machine(ctx, callback):
+    """Run the libmongocrypt state machine until completion.
+
+    :Parameters:
+      - `ctx`: A :class:`MongoCryptContext`.
+      - `callback`: A :class:`MongoCryptCallback`.
+
+    :Returns:
+      The completed libmongocrypt operation.
+    """
+    while True:
+        state = ctx.state
+        # Check for terminal states first.
+        if state == lib.MONGOCRYPT_CTX_ERROR:
+            ctx._raise_from_status()
+        elif state == lib.MONGOCRYPT_CTX_READY:
+            return ctx.finish()
+        elif state == lib.MONGOCRYPT_CTX_DONE:
+            return None
+
+        if state == lib.MONGOCRYPT_CTX_NEED_MONGO_COLLINFO:
+            list_colls_filter = ctx.mongo_operation()
+            coll_info = callback.collection_info(
+                ctx.database, list_colls_filter)
+            if coll_info:
+                ctx.add_mongo_operation_result(coll_info)
+            ctx.complete_mongo_operation()
+        elif state == lib.MONGOCRYPT_CTX_NEED_MONGO_MARKINGS:
+            mongocryptd_cmd = ctx.mongo_operation()
+            result = callback.mark_command(ctx.database, mongocryptd_cmd)
+            ctx.add_mongo_operation_result(result)
+            ctx.complete_mongo_operation()
+        elif state == lib.MONGOCRYPT_CTX_NEED_MONGO_KEYS:
+            key_filter = ctx.mongo_operation()
+            for key in callback.fetch_keys(key_filter):
+                ctx.add_mongo_operation_result(key)
+            ctx.complete_mongo_operation()
+        elif state == lib.MONGOCRYPT_CTX_NEED_KMS:
+            for kms_ctx in ctx.kms_contexts():
+                with kms_ctx:
+                    callback.kms_request(kms_ctx)
+            ctx.complete_kms()
+        else:
+            raise MongoCryptError('unknown state: %r' % (state,))


### PR DESCRIPTION
Patch: https://evergreen.mongodb.com/version/5d436d763066150e7cbd0e28

This is the branch that https://jira.mongodb.org/browse/PYTHON-1884 is using.