### PR TITLE
NODE: Adding node tests to evergreen

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -67,6 +67,13 @@ functions:
         script: |-
           ${compile_env|} ./libmongocrypt/.evergreen/compile.sh
           cd ./libmongocrypt/bindings/python && ${test_env|} ./.evergreen/test.sh
+  
+  "build and test node":
+    - command: "shell.exec"
+      params:
+        script: |-
+          ${compile_env|} ./libmongocrypt/.evergreen/compile.sh
+          cd ./libmongocrypt/bindings/node && ${test_env|} PROJECT_DIRECTORY=${project_directory} ./.evergreen/test.sh
 
   "publish snapshot":
     - command: shell.exec
@@ -156,6 +163,12 @@ tasks:
   commands:
   - func: "fetch source"
   - func: "build csharp and test"
+
+- name: build-and-test-node
+  commands:
+    - func: "fetch source"
+    - func: "build and test node"
+
 - name: publish-snapshot
   depends_on:
     - variant: rhel-62-64-bit
@@ -391,6 +404,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-java
   - build-and-test-python
+  - build-and-test-node
 - name: rhel-67-s390x
   display_name: "RHEL 6.7 s390x"
   run_on: rhel67-zseries-test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -337,6 +337,7 @@ buildvariants:
   - build-and-test-asan
   - build-and-test-valgrind
   - build-and-test-java
+  - build-and-test-node
 - name: rhel76
   display_name: "RHEL 7.6"
   run_on: rhel76-test
@@ -346,6 +347,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-java
   - build-csharp-and-test
+  - build-and-test-node
 - name: macos
   display_name: "macOS 10.14"
   run_on: macos-1014
@@ -354,6 +356,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan-mac
   - build-and-test-java
+  - build-and-test-node
 - name: rhel72-zseries-test
   display_name: "RHEL 7.2 on zSeries"
   run_on: rhel72-zseries-test
@@ -377,6 +380,7 @@ buildvariants:
   - build-and-test-and-upload
   - build-and-test-shared-bson
   - build-and-test-java
+  - build-and-test-node
 - name: amazon2
   display_name: "Amazon Linux 2"
   run_on: amazon2-test
@@ -386,6 +390,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-java
+  - build-and-test-node
 - name: debian92
   display_name: "Debian 9.2"
   run_on: debian92-test
@@ -395,6 +400,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-java
+  - build-and-test-node
 - name: rhel-62-64-bit
   display_name: "RHEL 6.2 64-bit"
   run_on: rhel62-small
@@ -419,6 +425,7 @@ buildvariants:
   - build-and-test-and-upload
   - build-and-test-shared-bson
   - build-and-test-java
+  - build-and-test-node
 - name: rhel-71-ppc64el
   display_name: "RHEL 7.1 ppc64el"
   run_on: rhel71-power8-test
@@ -436,6 +443,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-java
+  - build-and-test-node
 - name: suse15-64
   display_name: "SLES 15 64-bit"
   run_on: suse15-test
@@ -445,6 +453,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-java
+  - build-and-test-node
 - name: suse12-s390x  
   display_name: "SLES 12 s390x"
   run_on: suse12-zseries-test
@@ -453,6 +462,7 @@ buildvariants:
   - build-and-test-and-upload
   - build-and-test-shared-bson
   - build-and-test-java
+  - build-and-test-node
 - name: ubuntu1604-arm64
   display_name: "Ubuntu 16.04 arm64"
   run_on: ubuntu1604-arm64-large
@@ -462,6 +472,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-java
+  - build-and-test-node
 - name: ubuntu1604-s390x
   display_name: "Ubuntu 16.04 s390x"
   run_on: ubuntu1604-zseries-small
@@ -470,6 +481,7 @@ buildvariants:
   - build-and-test-and-upload
   - build-and-test-shared-bson
   - build-and-test-java
+  - build-and-test-node
 - name: ubuntu1804-64
   display_name: "Ubuntu 18.04 64-bit"
   run_on: ubuntu1804-test
@@ -479,6 +491,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-java
+  - build-and-test-node
 - name: ubuntu1804-arm64
   display_name: "Ubuntu 18.04 arm64"
   run_on: ubuntu1804-arm64-build
@@ -488,6 +501,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-java
+  - build-and-test-node
 - name: ubuntu1804-ppc64el
   display_name: "Ubuntu 18.04 ppc64el"
   run_on: ubuntu1804-power8-test
@@ -496,6 +510,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-java
+  - build-and-test-node
 - name: ubuntu1804-s390x
   display_name: "Ubuntu 18.04 s390x"
   run_on: ubuntu1804-zseries-test
@@ -504,6 +519,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan-s390x
   - build-and-test-java
+  - build-and-test-node
 - name: publish-snapshot
   display_name: "Publish"
   run_on: ubuntu1804-test

--- a/bindings/node/.evergreen/find_cmake.sh
+++ b/bindings/node/.evergreen/find_cmake.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash -x
+
+# Copied from the mongo-c-driver
+find_cmake ()
+{
+  if [ ! -z "$CMAKE" ]; then
+    return 0
+  elif [ -f "/Applications/cmake-3.2.2-Darwin-x86_64/CMake.app/Contents/bin/cmake" ]; then
+    CMAKE="/Applications/cmake-3.2.2-Darwin-x86_64/CMake.app/Contents/bin/cmake"
+  elif [ -f "/Applications/Cmake.app/Contents/bin/cmake" ]; then
+    CMAKE="/Applications/Cmake.app/Contents/bin/cmake"
+  elif [ -f "/opt/cmake/bin/cmake" ]; then
+    CMAKE="/opt/cmake/bin/cmake"
+  elif command -v cmake 2>/dev/null; then
+     CMAKE=cmake
+  elif uname -a | grep -iq 'x86_64 GNU/Linux'; then
+     curl --retry 5 https://cmake.org/files/v3.11/cmake-3.11.0-Linux-x86_64.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz
+     mkdir cmake-3.11.0
+     tar xzf cmake.tar.gz -C cmake-3.11.0 --strip-components=1
+     CMAKE=$(pwd)/cmake-3.11.0/bin/cmake
+  fi
+  if [ -z "$CMAKE" -o -z "$( $CMAKE --version 2>/dev/null )" ]; then
+     # Some images have no cmake yet, or a broken cmake (see: BUILD-8570)
+     echo "-- MAKE CMAKE --"
+     CMAKE_INSTALL_DIR=$(readlink -f cmake-install)
+     curl --retry 5 https://cmake.org/files/v3.11/cmake-3.11.0.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz
+     tar xzf cmake.tar.gz
+     cd cmake-3.11.0
+     ./bootstrap --prefix="${CMAKE_INSTALL_DIR}"
+     make -j8
+     make install
+     cd ..
+     CMAKE="${CMAKE_INSTALL_DIR}/bin/cmake"
+     echo "-- DONE MAKING CMAKE --"
+  fi
+}
+
+find_cmake
+
+export CMAKE=$CMAKE

--- a/bindings/node/.evergreen/setup_environment.sh
+++ b/bindings/node/.evergreen/setup_environment.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# set -o xtrace   # Write all commands first to stderr
+set -o errexit  # Exit the script with error if any of the commands fail
+
+echo "PROJECT_DIRECTORY=${PROJECT_DIRECTORY}"
+NODE_LTS_NAME=${NODE_LTS_NAME:-dubnium}
+echo "NODE_LTS_NAME=${NODE_LTS_NAME}"
+NODE_BINDINGS_PATH="${PROJECT_DIRECTORY}/bindings/node"
+NODE_ARTIFACTS_PATH="${NODE_BINDINGS_PATH}/node-artifacts"
+NPM_CACHE_DIR="${NODE_ARTIFACTS_PATH}/npm"
+NPM_TMP_DIR="${NODE_ARTIFACTS_PATH}/tmp"
+BUILD_STATIC_SCRIPT="${NODE_BINDINGS_PATH}/etc/build_static.sh"
+
+# create node artifacts path if needed
+mkdir -p ${NODE_ARTIFACTS_PATH}
+mkdir -p ${NPM_CACHE_DIR}
+mkdir -p "${NPM_TMP_DIR}"
+
+# this needs to be explicitly exported for the nvm install below
+export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
+mkdir -p ${NVM_DIR}
+
+# install Node.js
+echo "Installing NVM"
+curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
+[ -s "${NVM_DIR}/nvm.sh" ] && \. "${NVM_DIR}/nvm.sh"
+echo "Installing Node ${NODE_LTS_NAME}"
+nvm install --lts=${NODE_LTS_NAME}
+
+# setup npm cache in a local directory
+cat <<EOT > .npmrc
+devdir=${NPM_CACHE_DIR}/.node-gyp
+init-module=${NPM_CACHE_DIR}/.npm-init.js
+cache=${NPM_CACHE_DIR}
+tmp=${NPM_TMP_DIR}
+EOT
+
+# Add mongodb toolchain to path
+export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
+
+# if no mongocryptd installed, install mongocryptd and add it to path
+if ! [ -x "$(command -v mongocryptd)" ]
+then
+  echo "Installing mongocryptd"
+  wget -O mongocryptd.tgz https://s3.amazonaws.com/mciuploads/mongodb-mongo-v4.2/enterprise-ubuntu1604-64/f92115cad9d2a4c2ddcf3c2c65092dda2fd7147a/binaries/mongo-cryptd-mongodb_mongo_v4.2_enterprise_ubuntu1604_64_f92115cad9d2a4c2ddcf3c2c65092dda2fd7147a_19_06_13_17_31_40.tgz
+  mkdir -p mongocryptd && tar xzf mongocryptd.tgz -C mongocryptd --strip-components 1
+  export PATH="$PATH:$(pwd)/mongocryptd/bin"
+fi

--- a/bindings/node/.evergreen/setup_environment.sh
+++ b/bindings/node/.evergreen/setup_environment.sh
@@ -1,15 +1,18 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 # set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
-echo "PROJECT_DIRECTORY=${PROJECT_DIRECTORY}"
 NODE_LTS_NAME=${NODE_LTS_NAME:-dubnium}
-echo "NODE_LTS_NAME=${NODE_LTS_NAME}"
 NODE_BINDINGS_PATH="${PROJECT_DIRECTORY}/bindings/node"
 NODE_ARTIFACTS_PATH="${NODE_BINDINGS_PATH}/node-artifacts"
 NPM_CACHE_DIR="${NODE_ARTIFACTS_PATH}/npm"
 NPM_TMP_DIR="${NODE_ARTIFACTS_PATH}/tmp"
 BUILD_STATIC_SCRIPT="${NODE_BINDINGS_PATH}/etc/build_static.sh"
+
+
+# Add mongodb toolchain to path
+export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
 
 # create node artifacts path if needed
 mkdir -p ${NODE_ARTIFACTS_PATH}
@@ -35,14 +38,11 @@ cache=${NPM_CACHE_DIR}
 tmp=${NPM_TMP_DIR}
 EOT
 
-# Add mongodb toolchain to path
-export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
-
 # if no mongocryptd installed, install mongocryptd and add it to path
 if ! [ -x "$(command -v mongocryptd)" ]
 then
   echo "Installing mongocryptd"
-  wget -O mongocryptd.tgz https://s3.amazonaws.com/mciuploads/mongodb-mongo-v4.2/enterprise-ubuntu1604-64/f92115cad9d2a4c2ddcf3c2c65092dda2fd7147a/binaries/mongo-cryptd-mongodb_mongo_v4.2_enterprise_ubuntu1604_64_f92115cad9d2a4c2ddcf3c2c65092dda2fd7147a_19_06_13_17_31_40.tgz
+  curl -o mongocryptd.tgz https://s3.amazonaws.com/mciuploads/mongodb-mongo-v4.2/enterprise-ubuntu1604-64/f92115cad9d2a4c2ddcf3c2c65092dda2fd7147a/binaries/mongo-cryptd-mongodb_mongo_v4.2_enterprise_ubuntu1604_64_f92115cad9d2a4c2ddcf3c2c65092dda2fd7147a_19_06_13_17_31_40.tgz
   mkdir -p mongocryptd && tar xzf mongocryptd.tgz -C mongocryptd --strip-components 1
   export PATH="$PATH:$(pwd)/mongocryptd/bin"
 fi

--- a/bindings/node/.evergreen/setup_environment.sh
+++ b/bindings/node/.evergreen/setup_environment.sh
@@ -8,16 +8,20 @@ NODE_BINDINGS_PATH="${PROJECT_DIRECTORY}/bindings/node"
 NODE_ARTIFACTS_PATH="${NODE_BINDINGS_PATH}/node-artifacts"
 NPM_CACHE_DIR="${NODE_ARTIFACTS_PATH}/npm"
 NPM_TMP_DIR="${NODE_ARTIFACTS_PATH}/tmp"
-BUILD_STATIC_SCRIPT="${NODE_BINDINGS_PATH}/etc/build_static.sh"
-
-
-# Add mongodb toolchain to path
-export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
+BIN_DIR="$(pwd)/bin"
+MONGOCRYPTD_PATH="https://s3.amazonaws.com/mciuploads/mongodb-mongo-v4.2/enterprise-ubuntu1604-64/f92115cad9d2a4c2ddcf3c2c65092dda2fd7147a/binaries/mongo-cryptd-mongodb_mongo_v4.2_enterprise_ubuntu1604_64_f92115cad9d2a4c2ddcf3c2c65092dda2fd7147a_19_06_13_17_31_40.tgz"
 
 # create node artifacts path if needed
 mkdir -p ${NODE_ARTIFACTS_PATH}
 mkdir -p ${NPM_CACHE_DIR}
 mkdir -p "${NPM_TMP_DIR}"
+mkdir -p ${BIN_DIR}
+
+# Add mongodb toolchain to path
+export PATH="$BIN_DIR:/opt/mongodbtoolchain/v2/bin:$PATH"
+
+# locate cmake
+. ./.evergreen/find_cmake.sh
 
 # this needs to be explicitly exported for the nvm install below
 export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
@@ -42,7 +46,7 @@ EOT
 if ! [ -x "$(command -v mongocryptd)" ]
 then
   echo "Installing mongocryptd"
-  curl -o mongocryptd.tgz https://s3.amazonaws.com/mciuploads/mongodb-mongo-v4.2/enterprise-ubuntu1604-64/f92115cad9d2a4c2ddcf3c2c65092dda2fd7147a/binaries/mongo-cryptd-mongodb_mongo_v4.2_enterprise_ubuntu1604_64_f92115cad9d2a4c2ddcf3c2c65092dda2fd7147a_19_06_13_17_31_40.tgz
+  curl -o mongocryptd.tgz $MONGOCRYPTD_PATH
   mkdir -p mongocryptd && tar xzf mongocryptd.tgz -C mongocryptd --strip-components 1
-  export PATH="$PATH:$(pwd)/mongocryptd/bin"
+  mv mongocryptd/bin/mongocryptd "$BIN_DIR/mongocryptd"
 fi

--- a/bindings/node/.evergreen/test.sh
+++ b/bindings/node/.evergreen/test.sh
@@ -1,12 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
-source ./.evergreen/setup_environment.sh
+. ./.evergreen/setup_environment.sh
 
 # install node dependencies
 echo "Installing package dependencies (includes a static build)"
-source ./etc/build-static.sh
+. ./etc/build-static.sh
 # npm install
 
 # Run tests

--- a/bindings/node/.evergreen/test.sh
+++ b/bindings/node/.evergreen/test.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# set -o xtrace   # Write all commands first to stderr
+set -o errexit  # Exit the script with error if any of the commands fail
+
+source ./.evergreen/setup_environment.sh
+
+# install node dependencies
+echo "Installing package dependencies (includes a static build)"
+source ./etc/build-static.sh
+# npm install
+
+# Run tests
+echo "Running tests"
+NODE_SKIP_LIVE_TESTS=true npm test

--- a/bindings/node/.evergreen/test.sh
+++ b/bindings/node/.evergreen/test.sh
@@ -11,4 +11,4 @@ echo "Installing package dependencies (includes a static build)"
 
 # Run tests
 echo "Running tests"
-NODE_SKIP_LIVE_TESTS=true npm test
+MONGODB_NODE_SKIP_LIVE_TESTS=true npm test

--- a/bindings/node/etc/build-static.sh
+++ b/bindings/node/etc/build-static.sh
@@ -56,13 +56,13 @@ curl -L -o mongo-c-driver-1.14.0.tar.gz $MONGOC_URL
 tar xzf mongo-c-driver-1.14.0.tar.gz
 
 pushd bson-build #./deps/tmp/bson-build
-$CMAKE -DENABLE_MONGOC=OFF -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_INSTALL_PREFIX=$DEPS_PREFIX ../mongo-c-driver-1.14.0
+$CMAKE -DENABLE_MONGOC=OFF -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_INSTALL_PREFIX=$DEPS_PREFIX -DCMAKE_INSTALL_LIBDIR=lib ../mongo-c-driver-1.14.0
 make -j8 install
 popd #./deps/tmp
 
 # build and install libmongocrypt
 pushd libmongocrypt-build #./deps/tmp/libmongocrypt-build
-$CMAKE -DDISABLE_NATIVE_CRYPTO=1 -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_PREFIX_PATH=$DEPS_PREFIX -DCMAKE_INSTALL_PREFIX=$DEPS_PREFIX $LIBMONGOCRYPT_DIR
+$CMAKE -DDISABLE_NATIVE_CRYPTO=1 -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_PREFIX_PATH=$DEPS_PREFIX -DCMAKE_INSTALL_PREFIX=$DEPS_PREFIX  -DCMAKE_INSTALL_LIBDIR=lib $LIBMONGOCRYPT_DIR
   make -j8 install
 popd #./deps/tmp
 
@@ -71,10 +71,10 @@ popd #./deps
 # We need all built files to exist in lib.
 # Sometimes on linux systems they get installed to lib64 instead,
 # so we need to copy them over
-if [ -d lib64 ]
-then
-  cp -R lib64/* lib/
-fi
+# if [ -d lib64 ]
+# then
+#   cp -R lib64/* lib/
+# fi
 
 # build the `mongodb-client-encryption` addon
 # note the --unsafe-perm parameter to make the build work

--- a/bindings/node/etc/build-static.sh
+++ b/bindings/node/etc/build-static.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/usr/bin/env bash -x
 
 DEPS_PREFIX="$(pwd)/deps"
 MONGOC_URL="https://github.com/mongodb/mongo-c-driver/releases/download/1.14.0/mongo-c-driver-1.14.0.tar.gz"
@@ -55,6 +55,10 @@ pushd $BUILD_DIR #./deps/tmp
 curl -L -o mongo-c-driver-1.14.0.tar.gz $MONGOC_URL
 tar xzf mongo-c-driver-1.14.0.tar.gz
 
+# NOTE: we are setting -DCMAKE_INSTALL_LIBDIR=lib to ensure that the built 
+# files are always installed to lib instead of alternate directories like
+# lib64.
+
 pushd bson-build #./deps/tmp/bson-build
 $CMAKE -DENABLE_MONGOC=OFF -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_INSTALL_PREFIX=$DEPS_PREFIX -DCMAKE_INSTALL_LIBDIR=lib ../mongo-c-driver-1.14.0
 make -j8 install
@@ -67,14 +71,6 @@ $CMAKE -DDISABLE_NATIVE_CRYPTO=1 -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_PREFIX_PATH=$DE
 popd #./deps/tmp
 
 popd #./deps
-
-# We need all built files to exist in lib.
-# Sometimes on linux systems they get installed to lib64 instead,
-# so we need to copy them over
-# if [ -d lib64 ]
-# then
-#   cp -R lib64/* lib/
-# fi
 
 # build the `mongodb-client-encryption` addon
 # note the --unsafe-perm parameter to make the build work

--- a/bindings/node/etc/build-static.sh
+++ b/bindings/node/etc/build-static.sh
@@ -11,22 +11,72 @@ mkdir -p $BUILD_DIR
 mkdir -p $BUILD_DIR/bson-build
 mkdir -p $BUILD_DIR/libmongocrypt-build
 
-pushd $BUILD_DIR
+# Copied from the mongo-c-driver
+find_cmake ()
+{
+  if [ ! -z "$CMAKE" ]; then
+    return 0
+  elif [ -f "/Applications/cmake-3.2.2-Darwin-x86_64/CMake.app/Contents/bin/cmake" ]; then
+    CMAKE="/Applications/cmake-3.2.2-Darwin-x86_64/CMake.app/Contents/bin/cmake"
+  elif [ -f "/Applications/Cmake.app/Contents/bin/cmake" ]; then
+    CMAKE="/Applications/Cmake.app/Contents/bin/cmake"
+  elif [ -f "/opt/cmake/bin/cmake" ]; then
+    CMAKE="/opt/cmake/bin/cmake"
+  elif command -v cmake 2>/dev/null; then
+     CMAKE=cmake
+  elif uname -a | grep -iq 'x86_64 GNU/Linux'; then
+     curl --retry 5 https://cmake.org/files/v3.11/cmake-3.11.0-Linux-x86_64.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz
+     mkdir cmake-3.11.0
+     tar xzf cmake.tar.gz -C cmake-3.11.0 --strip-components=1
+     CMAKE=$(pwd)/cmake-3.11.0/bin/cmake
+  fi
+  if [ -z "$CMAKE" -o -z "$( $CMAKE --version 2>/dev/null )" ]; then
+     # Some images have no cmake yet, or a broken cmake (see: BUILD-8570)
+     echo "-- MAKE CMAKE --"
+     CMAKE_INSTALL_DIR=$(readlink -f cmake-install)
+     curl --retry 5 https://cmake.org/files/v3.11/cmake-3.11.0.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz
+     tar xzf cmake.tar.gz
+     cd cmake-3.11.0
+     ./bootstrap --prefix="${CMAKE_INSTALL_DIR}"
+     make -j8
+     make install
+     cd ..
+     CMAKE="${CMAKE_INSTALL_DIR}/bin/cmake"
+     echo "-- DONE MAKING CMAKE --"
+  fi
+}
+
+find_cmake
+
+pushd $DEPS_PREFIX #./deps
+pushd $BUILD_DIR #./deps/tmp
 
 # build and install bson
-wget $MONGOC_URL
+curl -L -o mongo-c-driver-1.14.0.tar.gz $MONGOC_URL
 tar xzf mongo-c-driver-1.14.0.tar.gz
 
-pushd bson-build
-cmake -DENABLE_MONGOC=OFF -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_INSTALL_PREFIX=$DEPS_PREFIX ../mongo-c-driver-1.14.0
+pushd bson-build #./deps/tmp/bson-build
+$CMAKE -DENABLE_MONGOC=OFF -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_INSTALL_PREFIX=$DEPS_PREFIX ../mongo-c-driver-1.14.0
 make -j8 install
-popd
+popd #./deps/tmp
 
 # build and install libmongocrypt
-pushd libmongocrypt-build
-cmake -DDISABLE_NATIVE_CRYPTO=1 -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_PREFIX_PATH=$DEPS_PREFIX -DCMAKE_INSTALL_PREFIX=$DEPS_PREFIX $LIBMONGOCRYPT_DIR
-make -j8 install
-popd
+pushd libmongocrypt-build #./deps/tmp/libmongocrypt-build
+$CMAKE -DDISABLE_NATIVE_CRYPTO=1 -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_PREFIX_PATH=$DEPS_PREFIX -DCMAKE_INSTALL_PREFIX=$DEPS_PREFIX $LIBMONGOCRYPT_DIR
+  make -j8 install
+popd #./deps/tmp
+
+popd #./deps
+
+# We need all built files to exist in lib.
+# Sometimes on linux systems they get installed to lib64 instead,
+# so we need to copy them over
+if [ -d lib64 ]
+then
+  cp -R lib64/* lib/
+fi
 
 # build the `mongodb-client-encryption` addon
-BUILD_TYPE=static npm install
+# note the --unsafe-perm parameter to make the build work
+# when running as root. See https://github.com/npm/npm/issues/3497
+BUILD_TYPE=static npm install --unsafe-perm

--- a/bindings/node/etc/build-static.sh
+++ b/bindings/node/etc/build-static.sh
@@ -5,48 +5,15 @@ MONGOC_URL="https://github.com/mongodb/mongo-c-driver/releases/download/1.14.0/m
 BUILD_DIR=$DEPS_PREFIX/tmp
 LIBMONGOCRYPT_DIR="$(pwd)/../../"
 
+if [[ -z $CMAKE ]]; then
+  CMAKE=`which cmake`
+fi
+
 # create relevant folders
 mkdir -p $DEPS_PREFIX
 mkdir -p $BUILD_DIR
 mkdir -p $BUILD_DIR/bson-build
 mkdir -p $BUILD_DIR/libmongocrypt-build
-
-# Copied from the mongo-c-driver
-find_cmake ()
-{
-  if [ ! -z "$CMAKE" ]; then
-    return 0
-  elif [ -f "/Applications/cmake-3.2.2-Darwin-x86_64/CMake.app/Contents/bin/cmake" ]; then
-    CMAKE="/Applications/cmake-3.2.2-Darwin-x86_64/CMake.app/Contents/bin/cmake"
-  elif [ -f "/Applications/Cmake.app/Contents/bin/cmake" ]; then
-    CMAKE="/Applications/Cmake.app/Contents/bin/cmake"
-  elif [ -f "/opt/cmake/bin/cmake" ]; then
-    CMAKE="/opt/cmake/bin/cmake"
-  elif command -v cmake 2>/dev/null; then
-     CMAKE=cmake
-  elif uname -a | grep -iq 'x86_64 GNU/Linux'; then
-     curl --retry 5 https://cmake.org/files/v3.11/cmake-3.11.0-Linux-x86_64.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz
-     mkdir cmake-3.11.0
-     tar xzf cmake.tar.gz -C cmake-3.11.0 --strip-components=1
-     CMAKE=$(pwd)/cmake-3.11.0/bin/cmake
-  fi
-  if [ -z "$CMAKE" -o -z "$( $CMAKE --version 2>/dev/null )" ]; then
-     # Some images have no cmake yet, or a broken cmake (see: BUILD-8570)
-     echo "-- MAKE CMAKE --"
-     CMAKE_INSTALL_DIR=$(readlink -f cmake-install)
-     curl --retry 5 https://cmake.org/files/v3.11/cmake-3.11.0.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz
-     tar xzf cmake.tar.gz
-     cd cmake-3.11.0
-     ./bootstrap --prefix="${CMAKE_INSTALL_DIR}"
-     make -j8
-     make install
-     cd ..
-     CMAKE="${CMAKE_INSTALL_DIR}/bin/cmake"
-     echo "-- DONE MAKING CMAKE --"
-  fi
-}
-
-find_cmake
 
 pushd $DEPS_PREFIX #./deps
 pushd $BUILD_DIR #./deps/tmp

--- a/bindings/node/test/autoEncrypter.test.js
+++ b/bindings/node/test/autoEncrypter.test.js
@@ -53,6 +53,7 @@ describe('AutoEncrypter', function() {
   let ENABLE_LOG_TEST = false;
   let sandbox = sinon.createSandbox();
   beforeEach(() => {
+    sandbox.restore();
     sandbox.stub(StateMachine.prototype, 'kmsRequest').callsFake(request => {
       request.addResponse(MOCK_KMS_DECRYPT_REPLY);
       return Promise.resolve();
@@ -183,6 +184,13 @@ describe('AutoEncrypter', function() {
   });
 
   describe('autoSpawn', function() {
+    beforeEach(function() {
+      if (process.env.NODE_SKIP_LIVE_TESTS) {
+        this.test.skip();
+        sandbox.restore();
+        return;
+      }
+    });
     afterEach(function(done) {
       if (this.mc) {
         this.mc.teardown(false, err => {
@@ -326,6 +334,11 @@ describe('AutoEncrypter', function() {
 
   describe('noAutoSpawn', function() {
     beforeEach(function(done) {
+      if (process.env.NODE_SKIP_LIVE_TESTS) {
+        this.test.skip();
+        sandbox.restore();
+        return;
+      }
       this.mcdm = new MongocryptdManager({});
 
       this.mcdm.spawn(done);

--- a/bindings/node/test/autoEncrypter.test.js
+++ b/bindings/node/test/autoEncrypter.test.js
@@ -185,9 +185,8 @@ describe('AutoEncrypter', function() {
 
   describe('autoSpawn', function() {
     beforeEach(function() {
-      if (process.env.NODE_SKIP_LIVE_TESTS) {
+      if (process.env.MONGODB_NODE_SKIP_LIVE_TESTS) {
         this.test.skip();
-        sandbox.restore();
         return;
       }
     });
@@ -334,9 +333,8 @@ describe('AutoEncrypter', function() {
 
   describe('noAutoSpawn', function() {
     beforeEach(function(done) {
-      if (process.env.NODE_SKIP_LIVE_TESTS) {
+      if (process.env.MONGODB_NODE_SKIP_LIVE_TESTS) {
         this.test.skip();
-        sandbox.restore();
         return;
       }
       this.mcdm = new MongocryptdManager({});

--- a/bindings/node/test/clientEncryption.test.js
+++ b/bindings/node/test/clientEncryption.test.js
@@ -31,7 +31,11 @@ describe('ClientEncryption', function() {
     });
   });
 
-  beforeEach(() => {
+  beforeEach(function() {
+    if (process.env.NODE_SKIP_LIVE_TESTS) {
+      this.test.skip();
+      return;
+    }
     client = new MongoClient('mongodb://localhost:27017/test', { useNewUrlParser: true });
     return client.connect().then(() =>
       client
@@ -49,6 +53,9 @@ describe('ClientEncryption', function() {
   });
 
   afterEach(() => {
+    if (process.env.NODE_SKIP_LIVE_TESTS) {
+      return;
+    }
     return client.close();
   });
 

--- a/bindings/node/test/clientEncryption.test.js
+++ b/bindings/node/test/clientEncryption.test.js
@@ -32,7 +32,7 @@ describe('ClientEncryption', function() {
   });
 
   beforeEach(function() {
-    if (process.env.NODE_SKIP_LIVE_TESTS) {
+    if (process.env.MONGODB_NODE_SKIP_LIVE_TESTS) {
       this.test.skip();
       return;
     }
@@ -53,7 +53,7 @@ describe('ClientEncryption', function() {
   });
 
   afterEach(() => {
-    if (process.env.NODE_SKIP_LIVE_TESTS) {
+    if (process.env.MONGODB_NODE_SKIP_LIVE_TESTS) {
       return;
     }
     return client.close();


### PR DESCRIPTION
Have done the following:

1. Updated the unit tests so that all tests that require a `mongod` or `mongocryptd` can be skipped with the environment variable `NODE_SKIP_LIVE_TESTS`
1. Refactored `etc/build-static.sh` to properly keep track of directories and to copy over files installed in the "wrong" folder (`lib64` instead of `lib`).
1. Added a test task to libmongocrypt to build and test node.
    - Most tests are disabled in CI b/c they depend on a running `mongod` and/or `mongocryptd`. However, this at least gets a test that the library can be built and loaded