### PR TITLE
NODE: fix node build on osx for node 4 & 6

### DIFF
--- a/bindings/node/binding.gyp
+++ b/bindings/node/binding.gyp
@@ -21,6 +21,13 @@
       'sources': [
         'src/mongocrypt.cc'
       ],
+      'xcode_settings': {
+        'OTHER_CFLAGS': [
+          "-std=c++11",
+          "-stdlib=libc++",
+          "-mmacosx-version-min=10.12"
+        ],
+      },
       'conditions': [
         ['build_type=="dynamic"', {
           'link_settings': {


### PR DESCRIPTION
On OSX, node 4 and node 6 do not compile with C++11 by default.
Needed to add xcode_settings to force C++11 compilation to allow
for smart pointers