### PR TITLE
Node use prebuild

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -72,8 +72,7 @@ functions:
     - command: "shell.exec"
       params:
         script: |-
-          ${compile_env|} ./libmongocrypt/.evergreen/compile.sh
-          cd ./libmongocrypt/bindings/node && ${test_env|} PROJECT_DIRECTORY=${project_directory} ./.evergreen/test.sh
+          cd ./libmongocrypt/bindings/node && ${test_env|} ./.evergreen/test.sh
 
   "publish snapshot":
     - command: shell.exec
@@ -168,6 +167,14 @@ tasks:
   commands:
     - func: "fetch source"
     - func: "build and test node"
+      vars:
+        test_env: PROJECT_DIRECTORY=${project_directory} NODE_GITHUB_TOKEN=${node_github_token}
+- name: build-and-test-node-force-publish
+  commands:
+    - func: "fetch source"
+    - func: "build and test node"
+      vars:
+        test_env: PROJECT_DIRECTORY=${project_directory} NODE_GITHUB_TOKEN=${node_github_token} NODE_FORCE_PUBLISH=1
 
 - name: publish-snapshot
   depends_on:
@@ -338,6 +345,7 @@ buildvariants:
   - build-and-test-valgrind
   - build-and-test-java
   - build-and-test-node
+  - build-and-test-node-force-publish
 - name: rhel76
   display_name: "RHEL 7.6"
   run_on: rhel76-test
@@ -348,6 +356,7 @@ buildvariants:
   - build-and-test-java
   - build-csharp-and-test
   - build-and-test-node
+  - build-and-test-node-force-publish
 - name: macos
   display_name: "macOS 10.14"
   run_on: macos-1014
@@ -357,6 +366,7 @@ buildvariants:
   - build-and-test-asan-mac
   - build-and-test-java
   - build-and-test-node
+  - build-and-test-node-force-publish
 - name: rhel72-zseries-test
   display_name: "RHEL 7.2 on zSeries"
   run_on: rhel72-zseries-test
@@ -381,6 +391,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-java
   - build-and-test-node
+  - build-and-test-node-force-publish
 - name: amazon2
   display_name: "Amazon Linux 2"
   run_on: amazon2-test
@@ -391,6 +402,7 @@ buildvariants:
   - build-and-test-asan
   - build-and-test-java
   - build-and-test-node
+  - build-and-test-node-force-publish
 - name: debian92
   display_name: "Debian 9.2"
   run_on: debian92-test
@@ -401,6 +413,7 @@ buildvariants:
   - build-and-test-asan
   - build-and-test-java
   - build-and-test-node
+  - build-and-test-node-force-publish
 - name: rhel-62-64-bit
   display_name: "RHEL 6.2 64-bit"
   run_on: rhel62-small
@@ -411,6 +424,7 @@ buildvariants:
   - build-and-test-java
   - build-and-test-python
   - build-and-test-node
+  - build-and-test-node-force-publish
 - name: rhel-67-s390x
   display_name: "RHEL 6.7 s390x"
   run_on: rhel67-zseries-test
@@ -426,6 +440,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-java
   - build-and-test-node
+  - build-and-test-node-force-publish
 - name: rhel-71-ppc64el
   display_name: "RHEL 7.1 ppc64el"
   run_on: rhel71-power8-test
@@ -444,6 +459,7 @@ buildvariants:
   - build-and-test-asan
   - build-and-test-java
   - build-and-test-node
+  - build-and-test-node-force-publish
 - name: suse15-64
   display_name: "SLES 15 64-bit"
   run_on: suse15-test
@@ -454,6 +470,7 @@ buildvariants:
   - build-and-test-asan
   - build-and-test-java
   - build-and-test-node
+  - build-and-test-node-force-publish
 - name: suse12-s390x  
   display_name: "SLES 12 s390x"
   run_on: suse12-zseries-test
@@ -463,6 +480,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-java
   - build-and-test-node
+  - build-and-test-node-force-publish
 - name: ubuntu1604-arm64
   display_name: "Ubuntu 16.04 arm64"
   run_on: ubuntu1604-arm64-large
@@ -473,6 +491,7 @@ buildvariants:
   - build-and-test-asan
   - build-and-test-java
   - build-and-test-node
+  - build-and-test-node-force-publish
 - name: ubuntu1604-s390x
   display_name: "Ubuntu 16.04 s390x"
   run_on: ubuntu1604-zseries-small
@@ -482,6 +501,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-java
   - build-and-test-node
+  - build-and-test-node-force-publish
 - name: ubuntu1804-64
   display_name: "Ubuntu 18.04 64-bit"
   run_on: ubuntu1804-test
@@ -492,6 +512,7 @@ buildvariants:
   - build-and-test-asan
   - build-and-test-java
   - build-and-test-node
+  - build-and-test-node-force-publish
 - name: ubuntu1804-arm64
   display_name: "Ubuntu 18.04 arm64"
   run_on: ubuntu1804-arm64-build
@@ -502,6 +523,7 @@ buildvariants:
   - build-and-test-asan
   - build-and-test-java
   - build-and-test-node
+  - build-and-test-node-force-publish
 - name: ubuntu1804-ppc64el
   display_name: "Ubuntu 18.04 ppc64el"
   run_on: ubuntu1804-power8-test
@@ -510,7 +532,10 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-java
-  - build-and-test-node
+  # commenting out node b/c there seems to be scheduling
+  # problems with this variant
+  # - build-and-test-node
+  # - build-and-test-node-force-publish
 - name: ubuntu1804-s390x
   display_name: "Ubuntu 18.04 s390x"
   run_on: ubuntu1804-zseries-test
@@ -520,6 +545,7 @@ buildvariants:
   - build-and-test-asan-s390x
   - build-and-test-java
   - build-and-test-node
+  - build-and-test-node-force-publish
 - name: publish-snapshot
   display_name: "Publish"
   run_on: ubuntu1804-test

--- a/bindings/node/.evergreen/prebuild.sh
+++ b/bindings/node/.evergreen/prebuild.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -o error
+
+get_version_at_git_rev () {
+  local REV=$1
+  local GIT_OUTPUT=$(git show $REV:./package.json)
+  local VERSION=$(echo $GIT_OUTPUT | node -r fs -e 'console.log(JSON.parse(fs.readFileSync("/dev/stdin", "utf-8")).version);')
+  echo $VERSION
+}
+
+run_prebuild() {
+  if [[ -z $NODE_GITHUB_TOKEN ]];then
+    echo "No github token set. Cannot run prebuild."
+    exit 1
+  else
+    echo "Github token detected. Running prebuild."
+    npm run prebuild -- -u $NODE_GITHUB_TOKEN
+  fi
+}
+
+VERSION_AT_HEAD=$(get_version_at_git_rev "HEAD")
+VERSION_AT_HEAD_1=$(get_version_at_git_rev "HEAD~1")
+
+if [[ ! -z $NODE_FORCE_PUBLISH ]]; then
+  echo '$NODE_FORCE_PUBLISH detected'
+  echo "Beginning prebuild"
+  run_prebuild
+elif [[ $VERSION_AT_HEAD != $VERSION_AT_HEAD_1 ]]; then
+  echo "Difference is package version ($VERSION_AT_HEAD_1 -> $VERSION_AT_HEAD)"
+  echo "Beginning prebuild"
+  run_prebuild
+else
+  echo "No difference is package version ($VERSION_AT_HEAD_1 -> $VERSION_AT_HEAD)"
+  echo "No prebuild required"
+fi

--- a/bindings/node/.evergreen/test.sh
+++ b/bindings/node/.evergreen/test.sh
@@ -2,6 +2,7 @@
 # set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
+echo "Setting up environment"
 . ./.evergreen/setup_environment.sh
 
 # install node dependencies
@@ -12,3 +13,7 @@ echo "Installing package dependencies (includes a static build)"
 # Run tests
 echo "Running tests"
 MONGODB_NODE_SKIP_LIVE_TESTS=true npm test
+
+# Run prebuild and deploy
+echo "Running prebuild and deploy"
+. ./.evergreen/prebuild.sh

--- a/bindings/node/binding.gyp
+++ b/bindings/node/binding.gyp
@@ -22,10 +22,10 @@
         'src/mongocrypt.cc'
       ],
       'xcode_settings': {
+        'MACOSX_DEPLOYMENT_TARGET': '10.7',
         'OTHER_CFLAGS': [
           "-std=c++11",
-          "-stdlib=libc++",
-          "-mmacosx-version-min=10.12"
+          "-stdlib=libc++"
         ],
       },
       'conditions': [

--- a/bindings/node/etc/build-static.sh
+++ b/bindings/node/etc/build-static.sh
@@ -25,6 +25,9 @@ tar xzf mongo-c-driver-1.14.0.tar.gz
 # NOTE: we are setting -DCMAKE_INSTALL_LIBDIR=lib to ensure that the built 
 # files are always installed to lib instead of alternate directories like
 # lib64.
+# NOTE: On OSX, -DCMAKE_OSX_DEPLOYMENT_TARGET can be set to an OSX version
+# to suppress build warnings. However, doing that tends to break some
+# of the versions that can be built
 
 pushd bson-build #./deps/tmp/bson-build
 $CMAKE -DENABLE_MONGOC=OFF -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_INSTALL_PREFIX=$DEPS_PREFIX -DCMAKE_INSTALL_LIBDIR=lib ../mongo-c-driver-1.14.0
@@ -38,8 +41,9 @@ $CMAKE -DDISABLE_NATIVE_CRYPTO=1 -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_PREFIX_PATH=$DE
 popd #./deps/tmp
 
 popd #./deps
+popd #./
 
 # build the `mongodb-client-encryption` addon
 # note the --unsafe-perm parameter to make the build work
 # when running as root. See https://github.com/npm/npm/issues/3497
-BUILD_TYPE=static npm install --unsafe-perm
+BUILD_TYPE=static npm install --unsafe-perm --build-from-source

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -7,12 +7,14 @@
     "lib": "lib"
   },
   "scripts": {
-    "install": "node-gyp rebuild",
+    "install": "prebuild-install || node-gyp rebuild",
     "format-cxx": "git-clang-format",
     "format-js": "prettier --print-width 100 --tab-width 2 --single-quote --write index.js 'test/**/*.js' 'lib/**/*.js'",
     "lint": "eslint lib test",
     "docs": "jsdoc2md --template etc/README.hbs --plugin dmd-clear --files lib/**/*.js > README.md",
-    "test": "mocha test"
+    "test": "mocha test",
+    "rebuild": "prebuild --compile",
+    "prebuild": "prebuild  --strip --verbose --tag-prefix node-v -t 10.16.0 -t 8.16.0 -t 6.17.1 -t 4.9.1"
   },
   "author": "Matt Broadstone <mbroadst@mongodb.com>",
   "license": "Apache-2.0",
@@ -20,7 +22,8 @@
   "dependencies": {
     "bindings": "^1.5.0",
     "bson": "^1.0.5",
-    "nan": "^2.14.0"
+    "nan": "^2.14.0",
+    "prebuild-install": "^5.3.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",
@@ -33,9 +36,13 @@
     "mongodb": "^3.2.7",
     "mongodb-extjson": "^3.0.3",
     "node-gyp": "^5.0.3",
+    "prebuild": "^9.0.1",
     "prettier": "~1.18.2",
     "segfault-handler": "^1.2.0",
     "sinon": "^4.3.0",
     "sinon-chai": "^3.3.0"
+  },
+  "repository": {
+    "url": "https://github.com/mongodb/libmongocrypt"
   }
 }


### PR DESCRIPTION
this is an extension of #39, and will be rebased once #39 is merged.

This adds support for using `prebuild` to publish prebuilt node bindings that can be auto-downloaded. This allows users to avoid having to install `libbson` or `libmongocrypt` locally.