### PR TITLE
NODE: feat(cryptoCallbacks): pass crypto errors to libmongocrypt

### DIFF
--- a/bindings/node/lib/cryptoCallbacks.js
+++ b/bindings/node/lib/cryptoCallbacks.js
@@ -10,6 +10,7 @@ function aes256CbcEncryptHook(key, iv, input, output) {
     result = cipher.update(input);
   } catch (e) {
     console.dir({ e });
+    return e;
   }
 
   result.copy(output);
@@ -24,6 +25,7 @@ function aes256CbcDecryptHook(key, iv, input, output) {
     result = cipher.update(input);
   } catch (e) {
     console.dir({ e });
+    return e;
   }
 
   result.copy(output);
@@ -43,9 +45,11 @@ function sha256Hook(input, output) {
       .digest();
   } catch (e) {
     console.dir({ e });
+    return e;
   }
 
   result.copy(output);
+  return result.length;
 }
 
 function makeHmacHook(algorithm) {
@@ -58,9 +62,11 @@ function makeHmacHook(algorithm) {
         .digest();
     } catch (e) {
       console.dir({ e });
+      return e;
     }
 
     result.copy(output);
+    return result.length;
   };
 }
 

--- a/bindings/node/lib/cryptoCallbacks.js
+++ b/bindings/node/lib/cryptoCallbacks.js
@@ -9,7 +9,6 @@ function aes256CbcEncryptHook(key, iv, input, output) {
     cipher.setAutoPadding(false);
     result = cipher.update(input);
   } catch (e) {
-    console.dir({ e });
     return e;
   }
 
@@ -24,7 +23,6 @@ function aes256CbcDecryptHook(key, iv, input, output) {
     cipher.setAutoPadding(false);
     result = cipher.update(input);
   } catch (e) {
-    console.dir({ e });
     return e;
   }
 
@@ -44,7 +42,6 @@ function sha256Hook(input, output) {
       .update(input)
       .digest();
   } catch (e) {
-    console.dir({ e });
     return e;
   }
 
@@ -61,7 +58,6 @@ function makeHmacHook(algorithm) {
         .update(input)
         .digest();
     } catch (e) {
-      console.dir({ e });
       return e;
     }
 

--- a/bindings/node/lib/cryptoCallbacks.js
+++ b/bindings/node/lib/cryptoCallbacks.js
@@ -33,7 +33,7 @@ function aes256CbcDecryptHook(key, iv, input, output) {
 }
 
 function randomHook(buffer, count) {
-  crypto.randomFillSync(buffer, count);
+  crypto.randomFillSync(buffer, 0, count);
 }
 
 function sha256Hook(input, output) {

--- a/bindings/node/src/mongocrypt.cc
+++ b/bindings/node/src/mongocrypt.cc
@@ -238,8 +238,32 @@ void MongoCrypt::logHandler(mongocrypt_log_level_t level,
     Nan::Call(*mongoCrypt->_logger.get(), Nan::GetCurrentContext()->Global(), 2, argv);
 }
 
+
+void MaybeSetCryptoHookErrorStatus(v8::Local<v8::Value> result, mongocrypt_status_t *status) {
+    if (!result->IsObject()) {
+        return;
+    }
+    auto kErrorMessageKey = Nan::New("message").ToLocalChecked();
+    auto hookError = result->ToObject();
+    if (!Nan::Has(hookError, kErrorMessageKey).FromMaybe(false)) {
+        return;
+    }
+    v8::Local<v8::Value> emptyString = Nan::New("").ToLocalChecked();
+    auto errorMessageValue = Nan::Get(hookError, kErrorMessageKey).FromMaybe(emptyString);
+    // auto errmsg = *Nan::Utf8String(errorMessageValue->ToString());
+    std::string errorMessage(*Nan::Utf8String(errorMessageValue->ToString()));
+    mongocrypt_status_set(
+        status,
+        MONGOCRYPT_STATUS_ERROR_CLIENT,
+        1,
+        errorMessage.c_str(),
+        errorMessage.length() + 1
+    );
+}
+
 MongoCrypt::MongoCrypt(mongocrypt_t* mongo_crypt, Nan::Callback* logger, CryptoHooks* hooks)
     : _mongo_crypt(mongo_crypt), _logger(logger), _cryptoHooks(hooks) {}
+
 
 bool MongoCrypt::setupCryptoHooks(mongocrypt_t* mongoCrypt, CryptoHooks* cryptoHooks) {
     auto aes_256_cbc_encrypt =
@@ -259,7 +283,7 @@ bool MongoCrypt::setupCryptoHooks(mongocrypt_t* mongoCrypt, CryptoHooks* cryptoH
                 Nan::Call(*hook, Nan::GetCurrentContext()->Global(), 4, argv).FromMaybe(defaultValue);
 
             if (!result->IsNumber()) {
-                // TODO: error checking, use status
+                MaybeSetCryptoHookErrorStatus(result, status);
                 return false;
             }
 
@@ -284,7 +308,7 @@ bool MongoCrypt::setupCryptoHooks(mongocrypt_t* mongoCrypt, CryptoHooks* cryptoH
                 Nan::Call(*hook, Nan::GetCurrentContext()->Global(), 4, argv).FromMaybe(defaultValue);
 
             if (!result->IsNumber()) {
-                // TODO: error checking, use status
+                MaybeSetCryptoHookErrorStatus(result, status);
                 return false;
             }
 
@@ -314,9 +338,13 @@ bool MongoCrypt::setupCryptoHooks(mongocrypt_t* mongoCrypt, CryptoHooks* cryptoH
             v8::Local<v8::Object> inputBuffer = BufferFromBinary(in);
             v8::Local<v8::Object> outputBuffer = BufferFromBinaryNoCopy(out);
 
-            // TODO: error checking, use status if passed back value is not undefined
             v8::Local<v8::Value> argv[] = {keyBuffer, inputBuffer, outputBuffer};
-            Nan::Call(*hook, Nan::GetCurrentContext()->Global(), 3, argv);
+            v8::Local<v8::Value> defaultValue = Nan::False();
+            v8::Local<v8::Value> result = Nan::Call(*hook, Nan::GetCurrentContext()->Global(), 3, argv).FromMaybe(defaultValue);
+            if (!result->IsNumber()) {
+                MaybeSetCryptoHookErrorStatus(result, status);
+                return false;
+            }
             return true;
         };
 
@@ -330,9 +358,13 @@ bool MongoCrypt::setupCryptoHooks(mongocrypt_t* mongoCrypt, CryptoHooks* cryptoH
             v8::Local<v8::Object> inputBuffer = BufferFromBinary(in);
             v8::Local<v8::Object> outputBuffer = BufferFromBinaryNoCopy(out);
 
-            // TODO: error checking, use status if passed back value is not undefined
             v8::Local<v8::Value> argv[] = {keyBuffer, inputBuffer, outputBuffer};
-            Nan::Call(*hook, Nan::GetCurrentContext()->Global(), 3, argv);
+            v8::Local<v8::Value> defaultValue = Nan::False();
+            v8::Local<v8::Value> result = Nan::Call(*hook, Nan::GetCurrentContext()->Global(), 3, argv).FromMaybe(defaultValue);
+            if (!result->IsNumber()) {
+                MaybeSetCryptoHookErrorStatus(result, status);
+                return false;
+            }
             return true;
         };
 
@@ -346,8 +378,13 @@ bool MongoCrypt::setupCryptoHooks(mongocrypt_t* mongoCrypt, CryptoHooks* cryptoH
             v8::Local<v8::Object> outputBuffer = BufferFromBinaryNoCopy(out);
             v8::Local<v8::Value> argv[] = {inputBuffer, outputBuffer};
 
-            // TODO: error checking, use status if passed back value is not undefined
-            Nan::Call(*hook, Nan::GetCurrentContext()->Global(), 2, argv);
+            v8::Local<v8::Value> defaultValue = Nan::False();
+            v8::Local<v8::Value> result = Nan::Call(*hook, Nan::GetCurrentContext()->Global(), 2, argv).FromMaybe(defaultValue);
+
+            if (!result->IsNumber()) {
+                MaybeSetCryptoHookErrorStatus(result, status);
+                return false;
+            }
             return true;
         };
 

--- a/bindings/node/src/mongocrypt.cc
+++ b/bindings/node/src/mongocrypt.cc
@@ -250,7 +250,6 @@ void MaybeSetCryptoHookErrorStatus(v8::Local<v8::Value> result, mongocrypt_statu
     }
     v8::Local<v8::Value> emptyString = Nan::New("").ToLocalChecked();
     auto errorMessageValue = Nan::Get(hookError, kErrorMessageKey).FromMaybe(emptyString);
-    // auto errmsg = *Nan::Utf8String(errorMessageValue->ToString());
     std::string errorMessage(*Nan::Utf8String(errorMessageValue->ToString()));
     mongocrypt_status_set(
         status,

--- a/bindings/node/test/cryptoCallbacks.test.js
+++ b/bindings/node/test/cryptoCallbacks.test.js
@@ -1,0 +1,211 @@
+'use strict';
+
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(require('sinon-chai'));
+const mongodb = require('mongodb');
+const MongoClient = mongodb.MongoClient;
+const stateMachine = require('../lib/stateMachine')({ mongodb });
+const cryptoCallbacks = require('../lib/cryptoCallbacks');
+const ClientEncryption = require('../lib/clientEncryption')({ mongodb, stateMachine })
+  .ClientEncryption;
+const SegfaultHandler = require('segfault-handler');
+SegfaultHandler.registerHandler();
+
+// Data Key Stuff
+const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID;
+const AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY;
+const AWS_REGION = process.env.AWS_REGION;
+const AWS_CMK_ID = process.env.AWS_CMK_ID;
+const kmsProviders = {
+  aws: { accessKeyId: AWS_ACCESS_KEY_ID, secretAccessKey: AWS_SECRET_ACCESS_KEY }
+};
+const dataKeyOptions = { masterKey: { key: AWS_CMK_ID, region: AWS_REGION } };
+
+const willRunTheseTests =
+  AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY && AWS_CMK_ID && !process.env.NODE_SKIP_LIVE_TESTS;
+
+describe('cryptoCallbacks', function() {
+  before(function() {
+    if (!willRunTheseTests) {
+      console.log('Skipping crypto callback tests');
+      return;
+    }
+    this.sinon = sinon.createSandbox();
+  });
+
+  beforeEach(function() {
+    if (!willRunTheseTests) {
+      this.test.skip();
+      return;
+    }
+    this.sinon.restore();
+    this.client = new MongoClient('mongodb://localhost:27017/', {
+      useUnifiedTopology: true,
+      useNewUrlParser: true
+    });
+
+    return this.client.connect();
+  });
+
+  afterEach(function() {
+    if (!willRunTheseTests) {
+      return;
+    }
+    this.sinon.restore();
+    let p = Promise.resolve();
+    if (this.client) {
+      p = p.then(() => this.client.close()).then(() => (this.client = undefined));
+    }
+
+    return p;
+  });
+
+  after(function() {
+    this.sinon = undefined;
+  });
+
+  const hookNames = new Set([
+    'aes256CbcEncryptHook',
+    'aes256CbcDecryptHook',
+    'randomHook',
+    'hmacSha512Hook',
+    'hmacSha256Hook',
+    'sha256Hook'
+  ]);
+
+  it('should invoke crypto callbacks when doing encryption', function(done) {
+    for (const name of hookNames) {
+      this.sinon.spy(cryptoCallbacks, name);
+    }
+
+    function assertCertainHooksCalled(expectedSet) {
+      expectedSet = expectedSet || new Set([]);
+      for (const name of hookNames) {
+        const hook = cryptoCallbacks[name];
+        if (expectedSet.has(name)) {
+          expect(hook).to.have.been.called;
+        } else {
+          expect(hook).to.not.have.been.called;
+        }
+
+        hook.resetHistory();
+      }
+    }
+
+    const encryption = new ClientEncryption(this.client, {
+      keyVaultNamespace: 'test.encryption',
+      kmsProviders
+    });
+
+    try {
+      assertCertainHooksCalled();
+    } catch (e) {
+      return done(e);
+    }
+
+    encryption.createDataKey('aws', dataKeyOptions, (err, dataKey) => {
+      try {
+        expect(err).to.not.exist;
+        assertCertainHooksCalled(new Set(['hmacSha256Hook', 'sha256Hook', 'randomHook']));
+      } catch (e) {
+        return done(e);
+      }
+
+      const encryptOptions = {
+        keyId: dataKey,
+        algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
+      };
+
+      encryption.encrypt('hello', encryptOptions, (err, encryptedValue) => {
+        try {
+          expect(err).to.not.exist;
+          assertCertainHooksCalled(
+            new Set(['aes256CbcEncryptHook', 'hmacSha512Hook', 'hmacSha256Hook', 'sha256Hook'])
+          );
+        } catch (e) {
+          return done(e);
+        }
+        encryption.decrypt(encryptedValue, err => {
+          try {
+            expect(err).to.not.exist;
+            assertCertainHooksCalled(new Set(['aes256CbcDecryptHook', 'hmacSha512Hook']));
+          } catch (e) {
+            return done(e);
+          }
+          done();
+        });
+      });
+    });
+  });
+
+  describe('error testing', function() {
+    ['aes256CbcEncryptHook', 'aes256CbcDecryptHook', 'hmacSha512Hook'].forEach(hookName => {
+      it(`should properly propagate an error when ${hookName} fails`, function(done) {
+        const error = new Error('some random error text');
+        this.sinon.stub(cryptoCallbacks, hookName).returns(error);
+
+        const encryption = new ClientEncryption(this.client, {
+          keyVaultNamespace: 'test.encryption',
+          kmsProviders
+        });
+
+        function finish(err) {
+          try {
+            expect(err, 'Expected an error to exist').to.exist;
+            expect(err).to.have.property('message', error.message);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        }
+
+        try {
+          encryption.createDataKey('aws', dataKeyOptions, (err, dataKey) => {
+            if (err) return finish(err);
+
+            const encryptOptions = {
+              keyId: dataKey,
+              algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
+            };
+
+            encryption.encrypt('hello', encryptOptions, (err, encryptedValue) => {
+              if (err) return finish(err);
+              encryption.decrypt(encryptedValue, err => finish(err));
+            });
+          });
+        } catch (e) {
+          done(new Error('We should not be here'));
+        }
+      });
+    });
+
+    // These ones will fail with an error, but that error will get overridden
+    // with "failed to create KMS message" in mongocrypt-kms-ctx.c
+    ['hmacSha256Hook', 'sha256Hook'].forEach(hookName => {
+      it(`should error with a specific kms erro when ${hookName} fails`, function(done) {
+        const error = new Error('some random error text');
+        this.sinon.stub(cryptoCallbacks, hookName).returns(error);
+
+        const encryption = new ClientEncryption(this.client, {
+          keyVaultNamespace: 'test.encryption',
+          kmsProviders
+        });
+
+        try {
+          encryption.createDataKey('aws', dataKeyOptions, () => {
+            done(new Error('We should not be here'));
+          });
+        } catch (err) {
+          try {
+            expect(err).to.have.property('message', 'failed to create KMS message');
+            done();
+          } catch (e) {
+            done(e);
+          }
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
Passes crypto errors that occur on the js side back to
libmongocrypt. Requires every cryptoCallback to return a number
on success, or an error on failure.

Also required an update to the state machine logic to account for
an error occurring during mongocrypt_ctx_finalize.

~Note: errors in cryptoCallbacks sha256 and hmacSha256 will
cause a segfault until CDRIVER-3282 is fixed~ This is fixed

Fixes NODE-2082