### PR TITLE
Remove clunky init method from python binding

### DIFF
--- a/bindings/python/.evergreen/test.sh
+++ b/bindings/python/.evergreen/test.sh
@@ -7,7 +7,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 
 # This library is built by libmongocrypt/.evergreen/compile.sh
 evergreen_root="$(cd ../../../; pwd)"
-export MONGOCRYPT_LIB=${evergreen_root}/install/libmongocrypt/lib64/libmongocrypt.so
+export PYMONGOCRYPT_LIB=${evergreen_root}/install/libmongocrypt/lib64/libmongocrypt.so
 
 PYTHONS=("/opt/python/2.7/bin/python" \
          "/opt/python/3.4/bin/python3" \

--- a/bindings/python/README.rst
+++ b/bindings/python/README.rst
@@ -95,10 +95,10 @@ like this:
   >>> import pymongocrypt
   Traceback (most recent call last):
     File "<stdin>", line 1, in <module>
-    File "/Users/shane/git/libmongocrypt/bindings/python/pymongocrypt/__init__.py", line 15, in <module>
-      from pymongocrypt.binding import mongocrypt_version, lib
-    File "/Users/shane/git/libmongocrypt/bindings/python/pymongocrypt/binding.py", line 741, in <module>
-      lib = ffi.dlopen("mongocrypt")
+    File "pymongocrypt/__init__.py", line 15, in <module>
+      from pymongocrypt.binding import libmongocrypt_version, lib
+    File "pymongocrypt/binding.py", line 803, in <module>
+      lib = ffi.dlopen(os.environ.get('PYMONGOCRYPT_LIB', 'mongocrypt'))
     File "/Users/shane/venv/libmongocrypt/py3.7/lib/python3.7/site-packages/cffi/api.py", line 146, in dlopen
       lib, function_cache = _make_ffi_library(self, name, flags)
     File "/Users/shane/venv/libmongocrypt/py3.7/lib/python3.7/site-packages/cffi/api.py", line 828, in _make_ffi_library
@@ -106,6 +106,15 @@ like this:
     File "/Users/shane/venv/libmongocrypt/py3.7/lib/python3.7/site-packages/cffi/api.py", line 823, in _load_backend_lib
       raise OSError(msg)
   OSError: ctypes.util.find_library() did not manage to locate a library called 'mongocrypt'
+
+
+Use the ``PYMONGOCRYPT_LIB`` environment variable to load a locally installed
+libmongocrypt build without relying on platform specific library path environment
+variables, like ``LD_LIBRARY_PATH``. For example::
+
+  $ export PYMONGOCRYPT_LIB='/path/to/libmongocrypt.so'
+  $ python -c "import pymongocrypt; print(pymongocrypt.libmongocrypt_version())"
+
 
 Documentation
 =============

--- a/bindings/python/README.rst
+++ b/bindings/python/README.rst
@@ -99,11 +99,11 @@ like this:
       from pymongocrypt.binding import libmongocrypt_version, lib
     File "pymongocrypt/binding.py", line 803, in <module>
       lib = ffi.dlopen(os.environ.get('PYMONGOCRYPT_LIB', 'mongocrypt'))
-    File "/Users/shane/venv/libmongocrypt/py3.7/lib/python3.7/site-packages/cffi/api.py", line 146, in dlopen
+    File "/.../lib/python3.7/site-packages/cffi/api.py", line 146, in dlopen
       lib, function_cache = _make_ffi_library(self, name, flags)
-    File "/Users/shane/venv/libmongocrypt/py3.7/lib/python3.7/site-packages/cffi/api.py", line 828, in _make_ffi_library
+    File "/.../lib/python3.7/site-packages/cffi/api.py", line 828, in _make_ffi_library
       backendlib = _load_backend_lib(backend, libname, flags)
-    File "/Users/shane/venv/libmongocrypt/py3.7/lib/python3.7/site-packages/cffi/api.py", line 823, in _load_backend_lib
+    File "/.../lib/python3.7/site-packages/cffi/api.py", line 823, in _load_backend_lib
       raise OSError(msg)
   OSError: ctypes.util.find_library() did not manage to locate a library called 'mongocrypt'
 

--- a/bindings/python/pymongocrypt/binding.py
+++ b/bindings/python/pymongocrypt/binding.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import cffi
 
 from pymongocrypt.compat import PY3
@@ -794,30 +796,11 @@ void
 mongocrypt_ctx_destroy (mongocrypt_ctx_t *ctx);
 """)
 
-lib = None
-_mongocrypt_lib = None
-
-
-def init(mongocrypt_lib='mongocrypt'):
-    """Initialize the mongocrypt library.
-
-    Use this function to load a custom libmongocrypt build without relying on
-    platform specific library path environment variables, like
-    LD_LIBRARY_PATH::
-
-      >>> init('/path/to/libmongocrypt.so')
-
-    :Parameters:
-      - `mongocrypt_lib`: The name of or path to the mongocrypt library.
-        Defaults to 'mongocrypt'.
-    """
-    global lib, _mongocrypt_lib
-    if lib is None:
-        _mongocrypt_lib = mongocrypt_lib
-        lib = ffi.dlopen(mongocrypt_lib)
-    elif _mongocrypt_lib != mongocrypt_lib:
-        raise Exception("init already called with %r, cannot call again "
-                        "with: %r" % (_mongocrypt_lib, mongocrypt_lib))
+# Use the PYMONGOCRYPT_LIB environment variable to load a custom libmongocrypt
+# build without relying on platform specific library path environment
+# variables, like LD_LIBRARY_PATH. For example:
+# export PYMONGOCRYPT_LIB='/path/to/libmongocrypt.so'
+lib = ffi.dlopen(os.environ.get('PYMONGOCRYPT_LIB', 'mongocrypt'))
 
 
 if PY3:
@@ -832,6 +815,4 @@ else:
 
 def libmongocrypt_version():
     """Returns the version of libmongocrypt."""
-    if lib is None:
-        init()
     return _to_string(lib.mongocrypt_version(ffi.NULL))

--- a/bindings/python/test/__init__.py
+++ b/bindings/python/test/__init__.py
@@ -12,14 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
 import unittest
 
 sys.path[0:0] = [""]
-
-from pymongocrypt.binding import init
-
 
 try:
     # Enable the fault handler to dump the traceback of each running thread
@@ -28,10 +24,6 @@ try:
     faulthandler.enable()
 except ImportError:
     pass
-
-
-# Load the mongocrypt library.
-init(os.environ.get('MONGOCRYPT_LIB', 'mongocrypt'))
 
 # Use assertRaisesRegex if available, otherwise use Python 2.7's
 # deprecated assertRaisesRegexp, with a 'p'.


### PR DESCRIPTION
Patch: https://evergreen.mongodb.com/version/5d4c7d9c7742ae7cdbbcc850

This change makes pymongocrypt load the library at import time and removes the clunky `init` method. I've also renamed MONGOCRYPT_LIB to PYMONGOCRYPT_LIB.