### PR TITLE
Node 2069/support key alt names

### DIFF
--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -9,6 +9,43 @@ module.exports = function(modules) {
   const StateMachine = modules.stateMachine.StateMachine;
   const cryptoCallbacks = require('./cryptoCallbacks');
 
+  function sanitizeDataKeyOptions(bson, options) {
+    options = Object.assign({}, options);
+
+    // To avoid using libbson inside the bindings, we pre-serialize
+    // any keyAltNames here.
+    if (options.keyAltNames) {
+      if (!Array.isArray(options.keyAltNames)) {
+        throw new TypeError(
+          `Option "keyAltNames" must be an array of string, but was of type ${typeof options.keyAltNames}.`
+        );
+      }
+      const serializedKeyAltNames = [];
+      for (let i = 0; i < options.keyAltNames.length; i += 1) {
+        const item = options.keyAltNames[i];
+        const itemType = typeof item;
+        if (itemType !== 'string') {
+          throw new TypeError(
+            `Option "keyAltNames" must be an array of string, but item at index ${i} was of type ${itemType} `
+          );
+        }
+
+        serializedKeyAltNames.push(bson.serialize({ keyAltName: item }));
+      }
+
+      options.keyAltNames = serializedKeyAltNames;
+    } else if (options.keyAltNAmes == null) {
+      // If keyAltNames is null or undefined, we can assume the intent of
+      // the user is to not pass in the value. B/c Nan::Has will still
+      // register a value of null or undefined as present as long
+      // as the key is present, we delete it off of the options
+      // object here.
+      delete options.keyAltNames;
+    }
+
+    return options;
+  }
+
   /**
    * The public interface for explicit client side encryption
    */
@@ -42,34 +79,7 @@ module.exports = function(modules) {
      */
     createDataKey(provider, options, callback) {
       if (typeof options === 'function') (callback = options), (options = {});
-      options = Object.assign({}, options);
-
-      // To avoid using libbson inside the bindings, we pre-serialize
-      // any keyAltNames here.
-      if (options.keyAltNames) {
-        if (!Array.isArray(options.keyAltNames)) {
-          throw new TypeError(
-            `Option "keyAltNames" must be an array of string, but was of type ${typeof options.keyAltNames}.`
-          );
-        }
-        const bson = this._bson;
-        const serializedKeyAltNames = [];
-        for (let i = 0; i < options.keyAltNames.length; i += 1) {
-          const item = options.keyAltNames[i];
-          const itemType = typeof item;
-          if (itemType !== 'string') {
-            throw new TypeError(
-              `Option "keyAltNames" must be an array of string, but item at index ${i} was of type ${itemType} `
-            );
-          }
-
-          serializedKeyAltNames.push(bson.serialize({ keyAltName: item }));
-        }
-
-        options.keyAltNames = serializedKeyAltNames;
-      } else {
-        delete options.keyAltNames;
-      }
+      options = sanitizeDataKeyOptions(this._bson, options);
 
       const context = this._mongoCrypt.makeDataKeyContext(provider, options);
       const stateMachine = new StateMachine();

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -42,7 +42,34 @@ module.exports = function(modules) {
      */
     createDataKey(provider, options, callback) {
       if (typeof options === 'function') (callback = options), (options = {});
-      options = options || {};
+      options = Object.assign({}, options);
+
+      // To avoid using libbson inside the bindings, we pre-serialize
+      // any keyAltNames here.
+      if (options.keyAltNames) {
+        if (!Array.isArray(options.keyAltNames)) {
+          throw new TypeError(
+            `Option "keyAltNames" must be an array of string, but was of type ${typeof options.keyAltNames}.`
+          );
+        }
+        const bson = this._bson;
+        const serializedKeyAltNames = [];
+        for (let i = 0; i < options.keyAltNames.length; i += 1) {
+          const item = options.keyAltNames[i];
+          const itemType = typeof item;
+          if (itemType !== 'string') {
+            throw new TypeError(
+              `Option "keyAltNames" must be an array of string, but item at index ${i} was of type ${itemType} `
+            );
+          }
+
+          serializedKeyAltNames.push(bson.serialize({ keyAltName: item }));
+        }
+
+        options.keyAltNames = serializedKeyAltNames;
+      } else {
+        delete options.keyAltNames;
+      }
 
       const context = this._mongoCrypt.makeDataKeyContext(provider, options);
       const stateMachine = new StateMachine();
@@ -85,6 +112,20 @@ module.exports = function(modules) {
       const contextOptions = Object.assign({}, options);
       if (options.keyId) {
         contextOptions.keyId = options.keyId.buffer;
+      }
+      if (options.keyAltName) {
+        const keyAltName = options.keyAltName;
+        if (options.keyId) {
+          throw new TypeError(`"options" cannot contain both "keyId" and "keyAltName"`);
+        }
+        const keyAltNameType = typeof keyAltName;
+        if (keyAltNameType !== 'string') {
+          throw new TypeError(
+            `"options.keyAltName" must be of type string, but was of type ${keyAltNameType}`
+          );
+        }
+
+        contextOptions.keyAltName = bson.serialize({ keyAltName });
       }
 
       const stateMachine = new StateMachine();

--- a/bindings/node/src/mongocrypt.cc
+++ b/bindings/node/src/mongocrypt.cc
@@ -559,7 +559,9 @@ NAN_METHOD(MongoCrypt::MakeExplicitEncryptionContext) {
                 Nan::ThrowTypeError(errorStringFromStatus(context.get()));
                 return;
             }
-        } else if (Nan::Has(options, KEY_ALT_NAME_KEY).FromMaybe(false)) {
+        }
+
+        if (Nan::Has(options, KEY_ALT_NAME_KEY).FromMaybe(false)) {
             v8::Local<v8::Value> keyAltName = Nan::Get(options, KEY_ALT_NAME_KEY).ToLocalChecked();
             if (!keyAltName->IsObject()) {
                 Nan::ThrowTypeError("`keyAltName` must be a Buffer");

--- a/bindings/node/src/mongocrypt.cc
+++ b/bindings/node/src/mongocrypt.cc
@@ -512,8 +512,10 @@ NAN_METHOD(MongoCrypt::MakeEncryptionContext) {
         return;
     }
 
+
+    std::unique_ptr<mongocrypt_binary_t, MongoCryptBinaryDeleter> binaryCommand(BufferToBinary(commandBuffer));
     if (!mongocrypt_ctx_encrypt_init(
-            context.get(), ns.c_str(), ns.size(), BufferToBinary(commandBuffer))) {
+            context.get(), ns.c_str(), ns.size(), binaryCommand.get())) {
         Nan::ThrowTypeError(errorStringFromStatus(context.get()));
         return;
     }
@@ -592,7 +594,8 @@ NAN_METHOD(MongoCrypt::MakeExplicitEncryptionContext) {
         }
     }
 
-    if (!mongocrypt_ctx_explicit_encrypt_init(context.get(), BufferToBinary(valueBuffer))) {
+    std::unique_ptr<mongocrypt_binary_t, MongoCryptBinaryDeleter> binaryValue(BufferToBinary(valueBuffer));
+    if (!mongocrypt_ctx_explicit_encrypt_init(context.get(), binaryValue.get())) {
         Nan::ThrowTypeError(errorStringFromStatus(context.get()));
         return;
     }

--- a/bindings/node/src/mongocrypt.cc
+++ b/bindings/node/src/mongocrypt.cc
@@ -152,8 +152,8 @@ std::pair<bool, std::string> setKmsProviderOptions(mongocrypt_t* crypt,
                 return std::make_pair(false, "Local key must be a Buffer");
             }
 
-            mongocrypt_binary_t* binary = BufferToBinary(key);
-            if (!mongocrypt_setopt_kms_provider_local(crypt, binary)) {
+            std::unique_ptr<mongocrypt_binary_t, MongoCryptBinaryDeleter> binary(BufferToBinary(key));
+            if (!mongocrypt_setopt_kms_provider_local(crypt, binary.get())) {
                 return std::make_pair(false, errorStringFromStatus(crypt));
             }
         }
@@ -554,8 +554,8 @@ NAN_METHOD(MongoCrypt::MakeExplicitEncryptionContext) {
                 return;
             }
 
-            mongocrypt_binary_t* binary = BufferToBinary(keyId);
-            if (!mongocrypt_ctx_setopt_key_id(context.get(), binary)) {
+            std::unique_ptr<mongocrypt_binary_t, MongoCryptBinaryDeleter> binary(BufferToBinary(keyId));
+            if (!mongocrypt_ctx_setopt_key_id(context.get(), binary.get())) {
                 Nan::ThrowTypeError(errorStringFromStatus(context.get()));
                 return;
             }

--- a/bindings/node/test/clientEncryption.test.js
+++ b/bindings/node/test/clientEncryption.test.js
@@ -22,17 +22,6 @@ const requirements = require('./requirements.helper');
 
 describe('ClientEncryption', function() {
   let client;
-  let sandbox = sinon.createSandbox();
-
-  after(() => sandbox.restore());
-  before(() => {
-    // stubbed out for AWS unit testing below
-    const MOCK_KMS_ENCRYPT_REPLY = readHttpResponse(`${__dirname}/data/kms-encrypt-reply.txt`);
-    sandbox.stub(StateMachine.prototype, 'kmsRequest').callsFake(request => {
-      request.addResponse(MOCK_KMS_ENCRYPT_REPLY);
-      return Promise.resolve();
-    });
-  });
 
   beforeEach(function() {
     if (requirements.SKIP_LIVE_TESTS) {
@@ -62,270 +51,272 @@ describe('ClientEncryption', function() {
     return client.close();
   });
 
-  [
-    {
-      name: 'local',
-      kmsProviders: { local: { key: Buffer.alloc(96) } }
-    },
-    {
-      name: 'aws',
-      kmsProviders: { aws: { accessKeyId: 'example', secretAccessKey: 'example' } },
-      options: { masterKey: { region: 'region', key: 'cmk' } }
-    }
-  ].forEach(providerTest => {
-    it(`should create a data key with the "${providerTest.name}" KMS provider`, function(done) {
-      const providerName = providerTest.name;
-      const encryption = new ClientEncryption(client, {
-        keyVaultNamespace: 'client.encryption',
-        kmsProviders: providerTest.kmsProviders
-      });
+  describe('stubbed stateMachine', function() {
+    let sandbox = sinon.createSandbox();
 
-      const dataKeyOptions = providerTest.options || {};
-      encryption.createDataKey(providerName, dataKeyOptions, (err, dataKey) => {
-        expect(err).to.not.exist;
-        expect(dataKey._bsontype).to.equal('Binary');
-
-        client
-          .db('client')
-          .collection('encryption')
-          .findOne({ _id: dataKey }, (err, doc) => {
-            expect(err).to.not.exist;
-            expect(doc).to.have.property('masterKey');
-            expect(doc.masterKey).to.have.property('provider');
-            expect(doc.masterKey.provider).to.eql(providerName);
-            done();
-          });
+    after(() => sandbox.restore());
+    before(() => {
+      // stubbed out for AWS unit testing below
+      const MOCK_KMS_ENCRYPT_REPLY = readHttpResponse(`${__dirname}/data/kms-encrypt-reply.txt`);
+      sandbox.stub(StateMachine.prototype, 'kmsRequest').callsFake(request => {
+        request.addResponse(MOCK_KMS_ENCRYPT_REPLY);
+        return Promise.resolve();
       });
     });
-  });
 
-  it('should explicitly encrypt and decrypt with the "local" KMS provider', function(done) {
-    const encryption = new ClientEncryption(client, {
-      keyVaultNamespace: 'client.encryption',
-      kmsProviders: { local: { key: Buffer.alloc(96) } }
-    });
+    [
+      {
+        name: 'local',
+        kmsProviders: { local: { key: Buffer.alloc(96) } }
+      },
+      {
+        name: 'aws',
+        kmsProviders: { aws: { accessKeyId: 'example', secretAccessKey: 'example' } },
+        options: { masterKey: { region: 'region', key: 'cmk' } }
+      }
+    ].forEach(providerTest => {
+      it(`should create a data key with the "${providerTest.name}" KMS provider`, function(done) {
+        const providerName = providerTest.name;
+        const encryption = new ClientEncryption(client, {
+          keyVaultNamespace: 'client.encryption',
+          kmsProviders: providerTest.kmsProviders
+        });
 
-    encryption.createDataKey('local', (err, dataKey) => {
-      expect(err).to.not.exist;
-
-      const encryptOptions = {
-        keyId: dataKey,
-        algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
-      };
-
-      encryption.encrypt('hello', encryptOptions, (err, encrypted) => {
-        expect(err).to.not.exist;
-        expect(encrypted._bsontype).to.equal('Binary');
-        expect(encrypted.sub_type).to.equal(6);
-
-        encryption.decrypt(encrypted, (err, decrypted) => {
+        const dataKeyOptions = providerTest.options || {};
+        encryption.createDataKey(providerName, dataKeyOptions, (err, dataKey) => {
           expect(err).to.not.exist;
-          expect(decrypted).to.equal('hello');
-          done();
+          expect(dataKey._bsontype).to.equal('Binary');
+
+          client
+            .db('client')
+            .collection('encryption')
+            .findOne({ _id: dataKey }, (err, doc) => {
+              expect(err).to.not.exist;
+              expect(doc).to.have.property('masterKey');
+              expect(doc.masterKey).to.have.property('provider');
+              expect(doc.masterKey.provider).to.eql(providerName);
+              done();
+            });
         });
       });
     });
-  });
 
-  it('should explicitly encrypt and decrypt with the "local" KMS provider (promise)', function() {
-    const encryption = new ClientEncryption(client, {
-      keyVaultNamespace: 'client.encryption',
-      kmsProviders: { local: { key: Buffer.alloc(96) } }
-    });
+    it('should explicitly encrypt and decrypt with the "local" KMS provider', function(done) {
+      const encryption = new ClientEncryption(client, {
+        keyVaultNamespace: 'client.encryption',
+        kmsProviders: { local: { key: Buffer.alloc(96) } }
+      });
 
-    return encryption
-      .createDataKey('local')
-      .then(dataKey => {
+      encryption.createDataKey('local', (err, dataKey) => {
+        expect(err).to.not.exist;
+
         const encryptOptions = {
           keyId: dataKey,
           algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
         };
 
-        return encryption.encrypt('hello', encryptOptions);
-      })
-      .then(encrypted => {
-        expect(encrypted._bsontype).to.equal('Binary');
-        expect(encrypted.sub_type).to.equal(6);
+        encryption.encrypt('hello', encryptOptions, (err, encrypted) => {
+          expect(err).to.not.exist;
+          expect(encrypted._bsontype).to.equal('Binary');
+          expect(encrypted.sub_type).to.equal(6);
 
-        return encryption.decrypt(encrypted);
-      })
-      .then(decrypted => {
-        expect(decrypted).to.equal('hello');
+          encryption.decrypt(encrypted, (err, decrypted) => {
+            expect(err).to.not.exist;
+            expect(decrypted).to.equal('hello');
+            done();
+          });
+        });
       });
-  });
-
-  it.skip('should explicitly encrypt and decrypt with the "aws" KMS provider', function(done) {
-    const encryption = new ClientEncryption(client, {
-      keyVaultNamespace: 'client.encryption',
-      kmsProviders: { aws: { accessKeyId: 'example', secretAccessKey: 'example' } }
     });
 
-    const dataKeyOptions = {
-      masterKey: { region: 'region', key: 'cmk' }
-    };
+    it('should explicitly encrypt and decrypt with the "local" KMS provider (promise)', function() {
+      const encryption = new ClientEncryption(client, {
+        keyVaultNamespace: 'client.encryption',
+        kmsProviders: { local: { key: Buffer.alloc(96) } }
+      });
 
-    encryption.createDataKey('aws', dataKeyOptions, (err, dataKey) => {
-      expect(err).to.not.exist;
+      return encryption
+        .createDataKey('local')
+        .then(dataKey => {
+          const encryptOptions = {
+            keyId: dataKey,
+            algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
+          };
 
-      const encryptOptions = {
-        keyId: dataKey,
-        algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
+          return encryption.encrypt('hello', encryptOptions);
+        })
+        .then(encrypted => {
+          expect(encrypted._bsontype).to.equal('Binary');
+          expect(encrypted.sub_type).to.equal(6);
+
+          return encryption.decrypt(encrypted);
+        })
+        .then(decrypted => {
+          expect(decrypted).to.equal('hello');
+        });
+    });
+
+    it.skip('should explicitly encrypt and decrypt with the "aws" KMS provider', function(done) {
+      const encryption = new ClientEncryption(client, {
+        keyVaultNamespace: 'client.encryption',
+        kmsProviders: { aws: { accessKeyId: 'example', secretAccessKey: 'example' } }
+      });
+
+      const dataKeyOptions = {
+        masterKey: { region: 'region', key: 'cmk' }
       };
 
-      encryption.encrypt('hello', encryptOptions, (err, encrypted) => {
+      encryption.createDataKey('aws', dataKeyOptions, (err, dataKey) => {
         expect(err).to.not.exist;
-        expect(encrypted).to.have.property('v');
-        expect(encrypted.v._bsontype).to.equal('Binary');
-        expect(encrypted.v.sub_type).to.equal(6);
 
-        encryption.decrypt(encrypted, (err, decrypted) => {
+        const encryptOptions = {
+          keyId: dataKey,
+          algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
+        };
+
+        encryption.encrypt('hello', encryptOptions, (err, encrypted) => {
           expect(err).to.not.exist;
-          expect(decrypted).to.equal('hello');
-          done();
+          expect(encrypted).to.have.property('v');
+          expect(encrypted.v._bsontype).to.equal('Binary');
+          expect(encrypted.v.sub_type).to.equal(6);
+
+          encryption.decrypt(encrypted, (err, decrypted) => {
+            expect(err).to.not.exist;
+            expect(decrypted).to.equal('hello');
+            done();
+          });
         });
       });
     });
+
+    it('should be able to auto decrypt explicit encryption');
   });
 
-  it('should be able to auto decrypt explicit encryption');
-});
-
-describe('ClientEncryptionKeyAltNames', function() {
-  const kmsProviders = requirements.awsKmsProviders;
-  const dataKeyOptions = requirements.awsDataKeyOptions;
-  beforeEach(function() {
-    if (requirements.SKIP_AWS_TESTS) {
-      this.skip();
-      return;
-    }
-    this.client = new MongoClient('mongodb://localhost:27017/test', { useNewUrlParser: true });
-    return this.client.connect().then(() => {
-      this.collection = this.client.db('test').collection('encryption');
-      return this.collection
-        .drop()
-        .catch(err => {
-          if (err.message.match(/ns not found/)) {
-            return;
-          }
-
-          throw err;
-        })
-        .then(() => {
-          this.encryption = new ClientEncryption(this.client, {
-            keyVaultNamespace: 'test.encryption',
-            kmsProviders
-          });
-        });
+  describe('ClientEncryptionKeyAltNames', function() {
+    const kmsProviders = requirements.awsKmsProviders;
+    const dataKeyOptions = requirements.awsDataKeyOptions;
+    beforeEach(function() {
+      if (requirements.SKIP_AWS_TESTS) {
+        this.skip();
+        return;
+      }
+      this.client = client;
+      this.collection = client.db('client').collection('encryption');
+      this.encryption = new ClientEncryption(this.client, {
+        keyVaultNamespace: 'client.encryption',
+        kmsProviders
+      });
     });
-  });
 
-  afterEach(function() {
-    this.encryption = undefined;
-    this.collection = undefined;
-    if (!requirements.SKIP_AWS_TESTS && this.client) {
-      const client = this.client;
+    afterEach(function() {
+      this.encryption = undefined;
+      this.collection = undefined;
       this.client = undefined;
-      return client.close();
+    });
+
+    function makeOptions(keyAltNames) {
+      return Object.assign({}, dataKeyOptions, { keyAltNames });
     }
-  });
 
-  function makeOptions(keyAltNames) {
-    return Object.assign({}, dataKeyOptions, { keyAltNames });
-  }
-
-  describe('errors', function() {
-    [42, 'hello', { keyAltNames: 'foobar' }, /foobar/].forEach(val => {
-      it(`should fail if typeof keyAltNames = ${typeof val}`, function(done) {
-        try {
-          this.encryption.createDataKey('aws', makeOptions(val), () => {
-            done(new Error('expected test to fail'));
-          });
-        } catch (e) {
+    describe('errors', function() {
+      [42, 'hello', { keyAltNames: 'foobar' }, /foobar/].forEach(val => {
+        it(`should fail if typeof keyAltNames = ${typeof val}`, function(done) {
           try {
-            expect(e).to.be.an.instanceof(TypeError);
-            done();
-          } catch (_e) {
-            done(_e);
+            this.encryption.createDataKey('aws', makeOptions(val), () => {
+              done(new Error('expected test to fail'));
+            });
+          } catch (e) {
+            try {
+              expect(e).to.be.an.instanceof(TypeError);
+              done();
+            } catch (_e) {
+              done(_e);
+            }
           }
-        }
+        });
+      });
+
+      [undefined, null, 42, { keyAltNames: 'foobar' }, ['foobar'], /foobar/].forEach(val => {
+        it(`should fail if typeof keyAltNames[x] = ${typeof val}`, function(done) {
+          try {
+            this.encryption.createDataKey('aws', makeOptions([val]), () => {
+              done(new Error('expected test to fail'));
+            });
+          } catch (e) {
+            try {
+              expect(e).to.be.an.instanceof(TypeError);
+              done();
+            } catch (_e) {
+              done(_e);
+            }
+          }
+        });
       });
     });
 
-    [undefined, null, 42, { keyAltNames: 'foobar' }, ['foobar'], /foobar/].forEach(val => {
-      it(`should fail if typeof keyAltNames[x] = ${typeof val}`, function(done) {
-        try {
-          this.encryption.createDataKey('aws', makeOptions([val]), () => {
-            done(new Error('expected test to fail'));
-          });
-        } catch (e) {
-          try {
-            expect(e).to.be.an.instanceof(TypeError);
-            done();
-          } catch (_e) {
-            done(_e);
-          }
-        }
-      });
+    it('should create a key with keyAltNames', function() {
+      let dataKey;
+      return this.encryption
+        .createDataKey('aws', makeOptions(['foobar']))
+        .then(_dataKey => (dataKey = _dataKey))
+        .then(() => this.collection.findOne({ keyAltNames: 'foobar' }))
+        .then(document => {
+          expect(document)
+            .to.have.property('keyAltNames')
+            .that.includes.members(['foobar']);
+          expect(document)
+            .to.have.property('_id')
+            .that.deep.equals(dataKey);
+        });
     });
-  });
 
-  it('should create a key with keyAltNames', function() {
-    let dataKey;
-    return this.encryption
-      .createDataKey('aws', makeOptions(['foobar']))
-      .then(_dataKey => (dataKey = _dataKey))
-      .then(() => this.collection.findOne({ keyAltNames: 'foobar' }))
-      .then(document => {
-        expect(document)
-          .to.have.property('keyAltNames')
-          .that.includes.members(['foobar']);
-        expect(document).to.have.nested.property('_id.buffer');
-        expect(Buffer.compare(document._id.buffer, dataKey.buffer)).to.equal(0);
-      });
-  });
+    it('should create a key with multiple keyAltNames', function() {
+      let dataKey;
+      return this.encryption
+        .createDataKey('aws', makeOptions(['foobar', 'fizzbuzz']))
+        .then(_dataKey => (dataKey = _dataKey))
+        .then(() =>
+          Promise.all([
+            this.collection.findOne({ keyAltNames: 'foobar' }),
+            this.collection.findOne({ keyAltNames: 'fizzbuzz' })
+          ])
+        )
+        .then(docs => {
+          const doc1 = docs[0];
+          const doc2 = docs[1];
+          expect(doc1)
+            .to.have.property('keyAltNames')
+            .that.includes.members(['foobar', 'fizzbuzz']);
+          expect(doc1)
+            .to.have.property('_id')
+            .that.deep.equals(dataKey);
+          expect(doc2)
+            .to.have.property('keyAltNames')
+            .that.includes.members(['foobar', 'fizzbuzz']);
+          expect(doc2)
+            .to.have.property('_id')
+            .that.deep.equals(dataKey);
+        });
+    });
 
-  it('should create a key with multiple keyAltNames', function() {
-    let dataKey;
-    let doc1;
-    let doc2;
-    return this.encryption
-      .createDataKey('aws', makeOptions(['foobar', 'fizzbuzz']))
-      .then(_dataKey => (dataKey = _dataKey))
-      .then(() => this.collection.findOne({ keyAltNames: 'foobar' }))
-      .then(document => (doc1 = document))
-      .then(() => this.collection.findOne({ keyAltNames: 'fizzbuzz' }))
-      .then(document => (doc2 = document))
-      .then(() => {
-        expect(doc1)
-          .to.have.property('keyAltNames')
-          .that.includes.members(['foobar', 'fizzbuzz']);
-        expect(doc1).to.have.nested.property('_id.buffer');
-        expect(Buffer.compare(doc1._id.buffer, dataKey.buffer)).to.equal(0);
-        expect(doc2)
-          .to.have.property('keyAltNames')
-          .that.includes.members(['foobar', 'fizzbuzz']);
-        expect(doc2).to.have.nested.property('_id.buffer');
-        expect(Buffer.compare(doc2._id.buffer, dataKey.buffer)).to.equal(0);
-      });
-  });
+    it('should be able to reference a key with `keyAltName` during encryption', function() {
+      let keyId;
+      const keyAltName = 'mySpecialKey';
+      const algorithm = 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic';
 
-  it('should be able to reference a key with `keyAltName` during encryption', function() {
-    let keyId;
-    const keyAltName = 'mySpecialKey';
-    const algorithm = 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic';
+      const valueToEncrypt = 'foobar';
 
-    const valueToEncrypt = 'foobar';
-
-    return this.encryption
-      .createDataKey('aws', makeOptions([keyAltName]))
-      .then(_dataKey => (keyId = _dataKey))
-      .then(() => this.encryption.encrypt(valueToEncrypt, { keyId, algorithm }))
-      .then(encryptedValue => {
-        return this.encryption
-          .encrypt(valueToEncrypt, { keyAltName, algorithm })
-          .then(encryptedValue2 => {
-            expect(encryptedValue).to.deep.equal(encryptedValue2);
-          });
-      });
+      return this.encryption
+        .createDataKey('aws', makeOptions([keyAltName]))
+        .then(_dataKey => (keyId = _dataKey))
+        .then(() => this.encryption.encrypt(valueToEncrypt, { keyId, algorithm }))
+        .then(encryptedValue => {
+          return this.encryption
+            .encrypt(valueToEncrypt, { keyAltName, algorithm })
+            .then(encryptedValue2 => {
+              expect(encryptedValue).to.deep.equal(encryptedValue2);
+            });
+        });
+    });
   });
 });

--- a/bindings/node/test/cryptoCallbacks.test.js
+++ b/bindings/node/test/cryptoCallbacks.test.js
@@ -13,22 +13,15 @@ const ClientEncryption = require('../lib/clientEncryption')({ mongodb, stateMach
 const SegfaultHandler = require('segfault-handler');
 SegfaultHandler.registerHandler();
 
-// Data Key Stuff
-const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID;
-const AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY;
-const AWS_REGION = process.env.AWS_REGION;
-const AWS_CMK_ID = process.env.AWS_CMK_ID;
-const kmsProviders = {
-  aws: { accessKeyId: AWS_ACCESS_KEY_ID, secretAccessKey: AWS_SECRET_ACCESS_KEY }
-};
-const dataKeyOptions = { masterKey: { key: AWS_CMK_ID, region: AWS_REGION } };
+const requirements = require('./requirements.helper');
 
-const willRunTheseTests =
-  AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY && AWS_CMK_ID && !process.env.NODE_SKIP_LIVE_TESTS;
+// Data Key Stuff
+const kmsProviders = Object.assign({}, requirements.awsKmsProviders);
+const dataKeyOptions = Object.assign({}, requirements.awsDataKeyOptions);
 
 describe('cryptoCallbacks', function() {
   before(function() {
-    if (!willRunTheseTests) {
+    if (requirements.SKIP_AWS_TESTS) {
       console.log('Skipping crypto callback tests');
       return;
     }
@@ -36,7 +29,7 @@ describe('cryptoCallbacks', function() {
   });
 
   beforeEach(function() {
-    if (!willRunTheseTests) {
+    if (requirements.SKIP_AWS_TESTS) {
       this.test.skip();
       return;
     }
@@ -50,7 +43,7 @@ describe('cryptoCallbacks', function() {
   });
 
   afterEach(function() {
-    if (!willRunTheseTests) {
+    if (requirements.SKIP_AWS_TESTS) {
       return;
     }
     this.sinon.restore();

--- a/bindings/node/test/requirements.helper.js
+++ b/bindings/node/test/requirements.helper.js
@@ -1,0 +1,29 @@
+'use strict';
+
+// Data Key Stuff
+const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID;
+const AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY;
+const AWS_REGION = process.env.AWS_REGION;
+const AWS_CMK_ID = process.env.AWS_CMK_ID;
+
+const awsKmsProviders = {
+  aws: { accessKeyId: AWS_ACCESS_KEY_ID, secretAccessKey: AWS_SECRET_ACCESS_KEY }
+};
+const awsDataKeyOptions = { masterKey: { key: AWS_CMK_ID, region: AWS_REGION } };
+
+const SKIP_LIVE_TESTS = !!process.env.MONGODB_NODE_SKIP_LIVE_TESTS;
+const SKIP_AWS_TESTS =
+  SKIP_LIVE_TESTS || !AWS_ACCESS_KEY_ID || !AWS_SECRET_ACCESS_KEY || !AWS_REGION || !AWS_CMK_ID;
+
+module.exports = {
+  SKIP_LIVE_TESTS,
+  SKIP_AWS_TESTS,
+  KEYS: {
+    AWS_ACCESS_KEY_ID,
+    AWS_SECRET_ACCESS_KEY,
+    AWS_REGION,
+    AWS_CMK_ID
+  },
+  awsKmsProviders,
+  awsDataKeyOptions
+};


### PR DESCRIPTION
Adds support for keyAltNames when defining data keys and during explicit encryption.