### PR TITLE
PYTHON-1924 Enable testing with PyPy 2

### DIFF
--- a/bindings/python/.evergreen/test.sh
+++ b/bindings/python/.evergreen/test.sh
@@ -13,7 +13,7 @@ PYTHONS=("/opt/python/2.7/bin/python" \
          "/opt/python/3.4/bin/python3" \
          "/opt/python/3.5/bin/python3" \
          "/opt/python/3.6/bin/python3" \
-#         "/opt/python/pypy/bin/pypy" \  # TODO: PyPy segfaults on RHEL 6.2
+         "/opt/python/pypy/bin/pypy" \
          "/opt/python/pypy3.6/bin/pypy3")
 
 for PYTHON_BINARY in "${PYTHONS[@]}"; do


### PR DESCRIPTION
Passing patch: https://evergreen.mongodb.com/version/5d4ef3480305b95ae4b3a568

The PyPy 2 segfault was resolved by  [PYTHON-1925](https://jira.mongodb.org/browse/PYTHON-1925).  