### PR TITLE
NODE: fix node evergreen config

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -169,6 +169,7 @@ tasks:
     - func: "build and test node"
       vars:
         test_env: PROJECT_DIRECTORY=${project_directory} NODE_GITHUB_TOKEN=${node_github_token}
+# Note: keep this disabled unless you want master to force-push
 - name: build-and-test-node-force-publish
   commands:
     - func: "fetch source"
@@ -345,7 +346,6 @@ buildvariants:
   - build-and-test-valgrind
   - build-and-test-java
   - build-and-test-node
-  - build-and-test-node-force-publish
 - name: rhel76
   display_name: "RHEL 7.6"
   run_on: rhel76-test
@@ -356,7 +356,6 @@ buildvariants:
   - build-and-test-java
   - build-csharp-and-test
   - build-and-test-node
-  - build-and-test-node-force-publish
 - name: macos
   display_name: "macOS 10.14"
   run_on: macos-1014
@@ -366,7 +365,6 @@ buildvariants:
   - build-and-test-asan-mac
   - build-and-test-java
   - build-and-test-node
-  - build-and-test-node-force-publish
 - name: rhel72-zseries-test
   display_name: "RHEL 7.2 on zSeries"
   run_on: rhel72-zseries-test
@@ -391,7 +389,6 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-java
   - build-and-test-node
-  - build-and-test-node-force-publish
 - name: amazon2
   display_name: "Amazon Linux 2"
   run_on: amazon2-test
@@ -402,7 +399,6 @@ buildvariants:
   - build-and-test-asan
   - build-and-test-java
   - build-and-test-node
-  - build-and-test-node-force-publish
 - name: debian92
   display_name: "Debian 9.2"
   run_on: debian92-test
@@ -413,7 +409,6 @@ buildvariants:
   - build-and-test-asan
   - build-and-test-java
   - build-and-test-node
-  - build-and-test-node-force-publish
 - name: rhel-62-64-bit
   display_name: "RHEL 6.2 64-bit"
   run_on: rhel62-small
@@ -424,7 +419,6 @@ buildvariants:
   - build-and-test-java
   - build-and-test-python
   - build-and-test-node
-  - build-and-test-node-force-publish
 - name: rhel-67-s390x
   display_name: "RHEL 6.7 s390x"
   run_on: rhel67-zseries-test
@@ -440,7 +434,6 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-java
   - build-and-test-node
-  - build-and-test-node-force-publish
 - name: rhel-71-ppc64el
   display_name: "RHEL 7.1 ppc64el"
   run_on: rhel71-power8-test
@@ -459,7 +452,6 @@ buildvariants:
   - build-and-test-asan
   - build-and-test-java
   - build-and-test-node
-  - build-and-test-node-force-publish
 - name: suse15-64
   display_name: "SLES 15 64-bit"
   run_on: suse15-test
@@ -470,7 +462,6 @@ buildvariants:
   - build-and-test-asan
   - build-and-test-java
   - build-and-test-node
-  - build-and-test-node-force-publish
 - name: suse12-s390x  
   display_name: "SLES 12 s390x"
   run_on: suse12-zseries-test
@@ -480,7 +471,6 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-java
   - build-and-test-node
-  - build-and-test-node-force-publish
 - name: ubuntu1604-arm64
   display_name: "Ubuntu 16.04 arm64"
   run_on: ubuntu1604-arm64-large
@@ -491,7 +481,6 @@ buildvariants:
   - build-and-test-asan
   - build-and-test-java
   - build-and-test-node
-  - build-and-test-node-force-publish
 - name: ubuntu1604-s390x
   display_name: "Ubuntu 16.04 s390x"
   run_on: ubuntu1604-zseries-small
@@ -501,7 +490,6 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-java
   - build-and-test-node
-  - build-and-test-node-force-publish
 - name: ubuntu1804-64
   display_name: "Ubuntu 18.04 64-bit"
   run_on: ubuntu1804-test
@@ -512,7 +500,6 @@ buildvariants:
   - build-and-test-asan
   - build-and-test-java
   - build-and-test-node
-  - build-and-test-node-force-publish
 - name: ubuntu1804-arm64
   display_name: "Ubuntu 18.04 arm64"
   run_on: ubuntu1804-arm64-build
@@ -523,7 +510,6 @@ buildvariants:
   - build-and-test-asan
   - build-and-test-java
   - build-and-test-node
-  - build-and-test-node-force-publish
 - name: ubuntu1804-ppc64el
   display_name: "Ubuntu 18.04 ppc64el"
   run_on: ubuntu1804-power8-test
@@ -545,7 +531,6 @@ buildvariants:
   - build-and-test-asan-s390x
   - build-and-test-java
   - build-and-test-node
-  - build-and-test-node-force-publish
 - name: publish-snapshot
   display_name: "Publish"
   run_on: ubuntu1804-test

--- a/bindings/node/.evergreen/prebuild.sh
+++ b/bindings/node/.evergreen/prebuild.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -o error
+set -o errexit
 
 get_version_at_git_rev () {
   local REV=$1


### PR DESCRIPTION
Fixing node evergreen:

- fixing a typo in the prebuild script
- disabling the force-publish task