### PR TITLE
NODE: fix(crypyoHooks): make crypto hooks work in Node 4

### DIFF
--- a/bindings/node/lib/cryptoCallbacks.js
+++ b/bindings/node/lib/cryptoCallbacks.js
@@ -31,7 +31,24 @@ function aes256CbcDecryptHook(key, iv, input, output) {
 }
 
 function randomHook(buffer, count) {
-  crypto.randomFillSync(buffer, 0, count);
+  try {
+    crypto.randomFillSync(buffer, 0, count);
+  } catch (e) {
+    return e;
+  }
+  return count;
+}
+
+function randomHookNode4(buffer, count) {
+  let result;
+  try {
+    result = crypto.randomBytes(count);
+  } catch (e) {
+    return e;
+  }
+
+  result.copy(buffer);
+  return count;
 }
 
 function sha256Hook(input, output) {
@@ -69,7 +86,7 @@ function makeHmacHook(algorithm) {
 module.exports = {
   aes256CbcEncryptHook,
   aes256CbcDecryptHook,
-  randomHook,
+  randomHook: typeof crypto.randomFillSync === 'function' ? randomHook : randomHookNode4,
   hmacSha512Hook: makeHmacHook('sha512'),
   hmacSha256Hook: makeHmacHook('sha256'),
   sha256Hook

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -32,7 +32,7 @@
     "eslint": "^4.5.0",
     "eslint-plugin-prettier": "^2.2.0",
     "jsdoc-to-markdown": "^5.0.0",
-    "mocha": "^6.1.4",
+    "mocha": "^4.0.0",
     "mongodb": "^3.2.7",
     "mongodb-extjson": "^3.0.3",
     "node-gyp": "^5.0.3",

--- a/bindings/node/src/mongocrypt.cc
+++ b/bindings/node/src/mongocrypt.cc
@@ -289,7 +289,14 @@ bool MongoCrypt::setupCryptoHooks(mongocrypt_t* mongoCrypt, CryptoHooks* cryptoH
 
             v8::Local<v8::Object> outBuffer = BufferFromBinaryNoCopy(out);
             v8::Local<v8::Value> argv[] = {outBuffer, Nan::New(count)};
-            Nan::Call(*hook, Nan::GetCurrentContext()->Global(), 2, argv);
+            v8::Local<v8::Value> defaultValue = Nan::False();
+            v8::Local<v8::Value> result = Nan::Call(*hook, Nan::GetCurrentContext()->Global(), 2, argv).FromMaybe(defaultValue);
+
+            if (!result->IsNumber()) {
+                MaybeSetCryptoHookErrorStatus(result, status);
+                return false;
+            }
+
             return true;
         };
 


### PR DESCRIPTION
Node 4 does not support crypto.randomFill, so we fall back to
crypto.randomBytes.

Fixes NODE-2117

Currently working on a test to ensure that an error throw of `randomBytes` will be properly caught.