### PR TITLE
PYTHON-1963 Make pymongocrypt compatible with manylinux2010 releases

### DIFF
--- a/bindings/python/build-manylinux-wheel.sh
+++ b/bindings/python/build-manylinux-wheel.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -ex
+cd /python
+
+# Compile wheel
+# https://github.com/pypa/manylinux/issues/49
+rm -rf build
+/opt/python/cp37-cp37m/bin/python setup.py bdist_wheel --universal
+
+# Audit wheels and write manylinux2010 tag
+for whl in dist/*.whl; do
+    # Skip already built manylinux2010 wheels.
+    if [[ "$whl" != *"manylinux2"* ]]; then
+        auditwheel repair $whl -w dist
+        rm $whl
+    fi
+done

--- a/bindings/python/pymongocrypt/binding.py
+++ b/bindings/python/pymongocrypt/binding.py
@@ -918,14 +918,16 @@ mongocrypt_setopt_crypto_hooks (mongocrypt_t *crypt,
 # build without relying on platform specific library path environment
 # variables, like LD_LIBRARY_PATH. For example:
 # export PYMONGOCRYPT_LIB='/path/to/libmongocrypt.so'
+# If the PYMONGOCRYPT_LIB is not set then load the embedded library and
+# fallback to the relying on a system installed library.
+_base = os.path.dirname(os.path.realpath(__file__))
 if sys.platform == 'win32':
-    # On windows the dll is named mongocrypt.dll
-    _path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), 'mongocrypt')
+    _path = os.path.join(_base, 'mongocrypt.dll')
+elif sys.platform == 'darwin':
+    _path = os.path.join(_base, 'libmongocrypt.dylib')
 else:
-    # On *nix the so is named libmongocrypt.so or libmongocrypt.dylib
-    _path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), 'libmongocrypt')
+    _path = os.path.join(_base, 'libmongocrypt.so')
+
 _PYMONGOCRYPT_LIB = os.environ.get('PYMONGOCRYPT_LIB')
 try:
     if _PYMONGOCRYPT_LIB:

--- a/bindings/python/release.sh
+++ b/bindings/python/release.sh
@@ -18,7 +18,6 @@ REVISION=latest
 # Build the manylinux2010 wheel
 rm -rf ./libmongocrypt
 curl -O https://s3.amazonaws.com/mciuploads/libmongocrypt/rhel-62-64-bit/master/${REVISION}/libmongocrypt.tar.gz
-curl -O https://s3.amazonaws.com/mciuploads/libmongocrypt/rhel-62-64-bit/master/latest/libmongocrypt.tar.gz
 mkdir libmongocrypt
 tar xzf libmongocrypt.tar.gz -C ./libmongocrypt
 NOCRYPTO_SO=libmongocrypt/nocrypto/lib64/libmongocrypt.so

--- a/bindings/python/release.sh
+++ b/bindings/python/release.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -ex
+
+# This script should be run on macOS to create the following distributions:
+# pymongocrypt-<version>.tar.gz
+# pymongocrypt-<version>-py2.py3-none-manylinux2010_x86_64.whl
+# pymongocrypt-<version>-py2.py3-none-macosx_10_9_x86_64.whl
+
+set -o xtrace   # Write all commands first to stderr
+set -o errexit  # Exit the script with error if any of the commands fail
+
+# Build the source dist first
+rm -rf build
+python3.7 setup.py sdist
+
+# The libmongocrypt git revision release to embed in our wheels.
+REVISION=latest
+
+# Build the manylinux2010 wheel
+rm -rf ./libmongocrypt
+curl -O https://s3.amazonaws.com/mciuploads/libmongocrypt/rhel-62-64-bit/master/${REVISION}/libmongocrypt.tar.gz
+curl -O https://s3.amazonaws.com/mciuploads/libmongocrypt/rhel-62-64-bit/master/latest/libmongocrypt.tar.gz
+mkdir libmongocrypt
+tar xzf libmongocrypt.tar.gz -C ./libmongocrypt
+NOCRYPTO_SO=libmongocrypt/nocrypto/lib64/libmongocrypt.so
+chmod +x ${NOCRYPTO_SO}
+cp ${NOCRYPTO_SO} pymongocrypt/
+rm -rf ./libmongocrypt libmongocrypt.tar.gz
+
+docker run --rm -v `pwd`:/python quay.io/pypa/manylinux2010_x86_64 /python/build-manylinux-wheel.sh
+
+rm -rf pymongocrypt/libmongocrypt.so
+
+
+# Build the mac wheel
+rm -rf ./libmongocrypt
+curl -O https://s3.amazonaws.com/mciuploads/libmongocrypt/macos/master/${REVISION}/libmongocrypt.tar.gz
+mkdir libmongocrypt
+tar xzf libmongocrypt.tar.gz -C ./libmongocrypt
+NOCRYPTO_SO=libmongocrypt/nocrypto/lib/libmongocrypt.dylib
+chmod +x ${NOCRYPTO_SO}
+cp ${NOCRYPTO_SO} pymongocrypt/
+rm -rf ./libmongocrypt libmongocrypt.tar.gz
+
+rm -rf build
+python3.7 setup.py bdist_wheel
+
+rm -rf pymongocrypt/libmongocrypt.dylib
+
+ls dist

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -10,10 +10,10 @@ from setuptools import setup, find_packages
 # library/libraries in purelib folder:
 # 	libmongocrypt.so
 # The wheel has to be platlib compliant in order to be repaired by auditwheel.
-try:
-    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-
-    if sys.platform in ('win32', 'darwin'):
+cmdclass = {}
+if sys.platform in ('win32', 'darwin'):
+    try:
+        from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
         class bdist_wheel(_bdist_wheel):
 
             def finalize_options(self):
@@ -25,10 +25,11 @@ try:
                 # Our python source is py2/3 compatible.
                 python, abi = 'py2.py3', 'none'
                 return python, abi, plat
-    else:
-        bdist_wheel = _bdist_wheel
-except ImportError:
-    bdist_wheel = None
+
+        cmdclass['bdist_wheel'] = bdist_wheel
+    except ImportError:
+        # Version of wheel is too old, use None to fail a bdist_wheel attempt.
+        cmdclass['bdist_wheel'] = None
 
 with open('README.rst', 'rb') as f:
     LONG_DESCRIPTION = f.read().decode('utf8')
@@ -75,5 +76,5 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Database"],
-    cmdclass={'bdist_wheel': bdist_wheel},
+    cmdclass=cmdclass,
 )


### PR DESCRIPTION
I've manually tested that the manylinux2010 wheel can be installed and used on RHEL 6.2, ubuntu 14.04, and amazon linux. 