### PR TITLE
MONGOCRYPT-196 Allow compile.sh to run on Windows dev machines

### DIFF
--- a/cmake/GetVersion.cmake
+++ b/cmake/GetVersion.cmake
@@ -39,7 +39,7 @@ function (GetVersion OUTVAR)
 
     # Otherwise, append our custom suffix -<date>-git<short hash>
     execute_process (
-        COMMAND git rev-parse --revs-only --short=10 'HEAD^{commit}'
+        COMMAND git rev-parse --revs-only --short=10 HEAD
         OUTPUT_VARIABLE SUFFIX_SHA
         RESULT_VARIABLE GIT_STATUS
         ERROR_VARIABLE GIT_ERROR

--- a/cmake/GetVersion.cmake
+++ b/cmake/GetVersion.cmake
@@ -39,7 +39,7 @@ function (GetVersion OUTVAR)
 
     # Otherwise, append our custom suffix -<date>-git<short hash>
     execute_process (
-        COMMAND git rev-parse --revs-only --short=10 HEAD^{commit}
+        COMMAND git rev-parse --revs-only --short=10 'HEAD^{commit}'
         OUTPUT_VARIABLE SUFFIX_SHA
         RESULT_VARIABLE GIT_STATUS
         ERROR_VARIABLE GIT_ERROR


### PR DESCRIPTION
https://jira.mongodb.org/browse/MONGOCRYPT-196
~~https://evergreen.mongodb.com/version/5db2176dc9ec445c66adb3de~~
https://evergreen.mongodb.com/version/5db222b82a60ed51bcee3e9b