### PR TITLE
fix(bson): respect user bson options when using autoEncryption

### DIFF
--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -139,7 +139,7 @@ module.exports = function(modules) {
      * @param {object} cmd The command to encrypt
      * @param {Function} callback
      */
-    encrypt(ns, cmd, callback) {
+    encrypt(ns, cmd, options, callback) {
       if (typeof ns !== 'string') {
         throw new TypeError('Parameter `ns` must be a string');
       }
@@ -148,8 +148,13 @@ module.exports = function(modules) {
         throw new TypeError('Parameter `cmd` must be an object');
       }
 
+      if (typeof options === 'function' && callback == null) {
+        callback = options;
+        options = {};
+      }
+
       const bson = this._bson;
-      const commandBuffer = Buffer.isBuffer(cmd) ? cmd : bson.serialize(cmd);
+      const commandBuffer = Buffer.isBuffer(cmd) ? cmd : bson.serialize(cmd, options);
 
       let context;
       try {
@@ -164,7 +169,7 @@ module.exports = function(modules) {
       context.ns = ns;
       context.document = cmd;
 
-      const stateMachine = new StateMachine();
+      const stateMachine = new StateMachine({ userBsonOptions: options });
       stateMachine.execute(this, context, callback);
     }
 
@@ -175,9 +180,14 @@ module.exports = function(modules) {
      * @param {Buffer} buffer
      * @param {Function} callback
      */
-    decrypt(response, callback) {
+    decrypt(response, options, callback) {
+      if (typeof options === 'function' && callback == null) {
+        callback = options;
+        options = {};
+      }
+
       const bson = this._bson;
-      const buffer = Buffer.isBuffer(response) ? response : bson.serialize(response);
+      const buffer = Buffer.isBuffer(response) ? response : bson.serialize(response, options);
 
       let context;
       try {
@@ -190,7 +200,7 @@ module.exports = function(modules) {
       // TODO: should this be an accessor from the addon?
       context.id = this._contextCounter++;
 
-      const stateMachine = new StateMachine();
+      const stateMachine = new StateMachine({ userBsonOptions: options });
       stateMachine.execute(this, context, callback);
     }
   }

--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -169,7 +169,7 @@ module.exports = function(modules) {
       context.ns = ns;
       context.document = cmd;
 
-      const stateMachine = new StateMachine({ userBsonOptions: options });
+      const stateMachine = new StateMachine(options);
       stateMachine.execute(this, context, callback);
     }
 
@@ -200,7 +200,7 @@ module.exports = function(modules) {
       // TODO: should this be an accessor from the addon?
       context.id = this._contextCounter++;
 
-      const stateMachine = new StateMachine({ userBsonOptions: options });
+      const stateMachine = new StateMachine(options);
       stateMachine.execute(this, context, callback);
     }
   }

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -69,8 +69,7 @@ module.exports = function(modules) {
    */
   class StateMachine {
     constructor(options) {
-      options = options || {};
-      this.userBsonOptions = options.userBsonOptions || undefined;
+      this.options = options || {};
     }
 
     /**
@@ -188,7 +187,7 @@ module.exports = function(modules) {
             callback(new MongoCryptError(message));
             return;
           }
-          callback(null, bson.deserialize(finalizedContext, this.userBsonOptions));
+          callback(null, bson.deserialize(finalizedContext, this.options));
           return;
         }
         case MONGOCRYPT_CTX_ERROR: {
@@ -294,7 +293,7 @@ module.exports = function(modules) {
           return;
         }
 
-        callback(err, bson.serialize(response, this.userBsonOptions));
+        callback(err, bson.serialize(response, this.options));
       });
     }
 

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -68,6 +68,11 @@ module.exports = function(modules) {
    * @class StateMachine
    */
   class StateMachine {
+    constructor(options) {
+      options = options || {};
+      this.userBsonOptions = options.userBsonOptions || undefined;
+    }
+
     /**
      * @ignore
      * Executes the state machine according to the specification
@@ -183,7 +188,7 @@ module.exports = function(modules) {
             callback(new MongoCryptError(message));
             return;
           }
-          callback(null, bson.deserialize(finalizedContext));
+          callback(null, bson.deserialize(finalizedContext, this.userBsonOptions));
           return;
         }
         case MONGOCRYPT_CTX_ERROR: {
@@ -281,7 +286,7 @@ module.exports = function(modules) {
     markCommand(client, ns, command, callback) {
       const bson = client.topology.bson;
       const dbName = databaseNamespace(ns);
-      const rawCommand = bson.deserialize(command);
+      const rawCommand = bson.deserialize(command, { promoteLongs: false, promoteValues: false });
 
       client.db(dbName).command(rawCommand, (err, response) => {
         if (err) {
@@ -289,7 +294,7 @@ module.exports = function(modules) {
           return;
         }
 
-        callback(err, bson.serialize(response));
+        callback(err, bson.serialize(response, this.userBsonOptions));
       });
     }
 


### PR DESCRIPTION
Adds a field where we can pass in user BSON serialization
options like promoteValues. We need to respect these options
when it comes to user data.

Fixes NODE-2278

~TODO: Find a way to test this.~ Tests in https://github.com/mongodb/node-mongodb-native/pull/2194