### PR TITLE
PYTHON-2012 Support custom endpoint with AWS masterkey provider

### DIFF
--- a/bindings/python/pymongocrypt/explicit_encrypter.py
+++ b/bindings/python/pymongocrypt/explicit_encrypter.py
@@ -38,15 +38,20 @@ class DataKeyOpts(object):
 
         :Parameters:
           - `master_key`: Identifies a KMS-specific key used to encrypt the
-            new data key. If the kmsProvider is "aws" it is required and must
-            have the following fields:
+            new data key. If the kmsProvider is "local" the `master_key` is
+            not applicable and may be omitted. If the kmsProvider is "aws" it
+            is required and has the following fields:
             {
-               region: String,
-               key: String // The Amazon Resource Name (ARN) to the AWS
-                           // customer master key (CMK).
+               # Required, eg "us-east-1".
+               "region": "string",
+               # Required. The Amazon Resource Name (ARN) to the AWS customer
+               # master key (CMK).
+               "key": "string",
+               # Optional. An alternate host to send KMS requests to. May
+               # include port number, eg "kms.us-east-1.amazonaws.com:443"
+               "endpoint": "string"
             }
-            If the kmsProvider is "local" the masterKey is not applicable.
-          - `key_alt_name`: An optional list of bytes suitable to be passed to
+          - `key_alt_names`: An optional list of bytes suitable to be passed to
             mongocrypt_ctx_setopt_key_alt_name. Each element must be BSON
             encoded document in the form: { "keyAltName" : (BSON UTF8 value) }
         """
@@ -77,16 +82,20 @@ class ExplicitEncrypter(object):
         :Parameters:
           - `kms_provider`: The KMS provider to use. Supported values are
             "aws" and "local".
-          - `master_key`: The `master_key` identifies a KMS-specific key used
-            to encrypt the new data key. If the kmsProvider is "local" the
-            `master_key` is not applicable and may be omitted.
-            If the `kms_provider` is "aws", `master_key` is required and must
-            have the following fields:
-
-              - `region` (string): The AWS region as a string.
-              - `key` (string): The Amazon Resource Name (ARN) to the AWS
-                customer master key (CMK).
-
+          - `master_key`: Identifies a KMS-specific key used to encrypt the
+            new data key. If the kmsProvider is "local" the `master_key` is
+            not applicable and may be omitted. If the kmsProvider is "aws" it
+            is required and has the following fields:
+            {
+               # Required, eg "us-east-1".
+               "region": "string",
+               # Required. The Amazon Resource Name (ARN) to the AWS customer
+               # master key (CMK).
+               "key": "string",
+               # Optional. An alternate host to send KMS requests to. May
+               # include port number, eg "kms.us-east-1.amazonaws.com:443"
+               "endpoint": "string"
+            }
           - `key_alt_names` (optional): An optional list of string alternate
             names used to reference a key. If a key is created with alternate
             names, then encryption may refer to the key by the unique

--- a/bindings/python/pymongocrypt/explicit_encrypter.py
+++ b/bindings/python/pymongocrypt/explicit_encrypter.py
@@ -39,18 +39,16 @@ class DataKeyOpts(object):
         :Parameters:
           - `master_key`: Identifies a KMS-specific key used to encrypt the
             new data key. If the kmsProvider is "local" the `master_key` is
-            not applicable and may be omitted. If the kmsProvider is "aws" it
-            is required and has the following fields:
-            {
-               # Required, eg "us-east-1".
-               "region": "string",
-               # Required. The Amazon Resource Name (ARN) to the AWS customer
-               # master key (CMK).
-               "key": "string",
-               # Optional. An alternate host to send KMS requests to. May
-               # include port number, eg "kms.us-east-1.amazonaws.com:443"
-               "endpoint": "string"
-            }
+            not applicable and may be omitted. If the `kms_provider` is "aws"
+            it is required and has the following fields::
+
+              - `region` (string): Required. The AWS region, e.g. "us-east-1".
+              - `key` (string): Required. The Amazon Resource Name (ARN) to
+                 the AWS customer.
+              - `endpoint` (string): Optional. An alternate host to send KMS
+                requests to. May include port number, e.g.
+                "kms.us-east-1.amazonaws.com:443".
+
           - `key_alt_names`: An optional list of bytes suitable to be passed to
             mongocrypt_ctx_setopt_key_alt_name. Each element must be BSON
             encoded document in the form: { "keyAltName" : (BSON UTF8 value) }
@@ -84,18 +82,16 @@ class ExplicitEncrypter(object):
             "aws" and "local".
           - `master_key`: Identifies a KMS-specific key used to encrypt the
             new data key. If the kmsProvider is "local" the `master_key` is
-            not applicable and may be omitted. If the kmsProvider is "aws" it
-            is required and has the following fields:
-            {
-               # Required, eg "us-east-1".
-               "region": "string",
-               # Required. The Amazon Resource Name (ARN) to the AWS customer
-               # master key (CMK).
-               "key": "string",
-               # Optional. An alternate host to send KMS requests to. May
-               # include port number, eg "kms.us-east-1.amazonaws.com:443"
-               "endpoint": "string"
-            }
+            not applicable and may be omitted. If the `kms_provider` is "aws"
+            it is required and has the following fields::
+
+              - `region` (string): Required. The AWS region, e.g. "us-east-1".
+              - `key` (string): Required. The Amazon Resource Name (ARN) to
+                 the AWS customer.
+              - `endpoint` (string): Optional. An alternate host to send KMS
+                requests to. May include port number, e.g.
+                "kms.us-east-1.amazonaws.com:443".
+
           - `key_alt_names` (optional): An optional list of string alternate
             names used to reference a key. If a key is created with alternate
             names, then encryption may refer to the key by the unique

--- a/bindings/python/pymongocrypt/mongocrypt.py
+++ b/bindings/python/pymongocrypt/mongocrypt.py
@@ -450,6 +450,11 @@ class DataKeyContext(MongoCryptContext):
                 if not lib.mongocrypt_ctx_setopt_masterkey_aws(
                         ctx, region, len(region), key, len(key)):
                     self._raise_from_status()
+                if 'endpoint' in opts.master_key:
+                    endpoint = str_to_bytes(opts.master_key['endpoint'])
+                    if not lib.mongocrypt_ctx_setopt_masterkey_aws_endpoint(
+                            ctx, endpoint, len(endpoint)):
+                        self._raise_from_status()
             elif kms_provider == 'local':
                 if not lib.mongocrypt_ctx_setopt_masterkey_local(ctx):
                     self._raise_from_status()

--- a/bindings/python/strip_header.py
+++ b/bindings/python/strip_header.py
@@ -14,7 +14,7 @@
 
 """Generate a CFFI.cdef() string from a C header file
 
-Usage (on macOS):: python strip_header.py ../../src/mongocrypt.h | pbcopy
+Usage (on macOS):: python strip_header.py ../../src/mongocrypt.h.in | pbcopy
 """
 
 import re

--- a/bindings/python/test/test_mongocrypt.py
+++ b/bindings/python/test/test_mongocrypt.py
@@ -325,6 +325,9 @@ class TestExplicitEncryption(unittest.TestCase):
             ('aws', {'region': 'region', 'key': 'cmk'}, ['third', 'forth']),
             # Unicode region and key
             ('aws', {'region': u'region-unicode', 'key': u'cmk-unicode'}, []),
+            # Endpoint
+            ('aws', {'region': 'region', 'key': 'cmk',
+                     'endpoint': 'kms.us-east-1.amazonaws.com:443'}, []),
         ]
         for kms_provider, master_key, key_alt_names in valid_args:
             key_id = encrypter.create_data_key(

--- a/bindings/python/test/test_mongocrypt.py
+++ b/bindings/python/test/test_mongocrypt.py
@@ -341,7 +341,7 @@ class TestExplicitEncryption(unittest.TestCase):
             for name in key_alt_names:
                 self.assertIn(name, data_key['keyAltNames'])
 
-        # Assert that q custom endpoint is passed to libmongocrypt correctly.
+        # Assert that the custom endpoint is passed to libmongocrypt.
         master_key = {
             "region": "region",
             "key": "key",


### PR DESCRIPTION
Implements the pymongocrypt side of https://jira.mongodb.org/browse/PYTHON-2012.

Patch: https://evergreen.mongodb.com/version/5dba26d232f4172b4e9ac3bb