### PR TITLE
Node 2255/fle ga changes

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -217,6 +217,7 @@ new ClientEncryption(mongoClient, {
 | [options.masterKey] | <code>object</code> | Idenfities a new KMS-specific key used to encrypt the new data key. If the kmsProvider is "aws" it is required. |
 | [options.masterKey.region] | <code>string</code> | The AWS region of the KMS |
 | [options.masterKey.key] | <code>string</code> | The Amazon Resource Name (ARN) to the AWS customer master key (CMK) |
+| [options.masterKey.endpoint] | <code>string</code> | An alternate host to send KMS requests to. May include port number. |
 | [options.keyAltNames] | <code>Array.&lt;string&gt;</code> | An optional list of string alternate names used to reference a key. If a key is created with alternate names, then encryption may refer to the key by the unique alternate name instead of by _id. |
 | [callback] | [<code>createDataKeyCallback</code>](#ClientEncryption..createDataKeyCallback) | Optional callback to invoke when key is created |
 

--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -56,6 +56,7 @@ module.exports = function(modules) {
      *
      * @param {MongoClient} client The client autoEncryption is enabled on
      * @param {object} [options] Optional settings
+     * @param {MongoClient} [options.keyVaultClient] A `MongoClient` used to fetch keys from a key vault. Defaults to `client`
      * @param {string} [options.keyVaultNamespace='admin.dataKeys'] The namespace of the key vault, used to store encryption keys
      * @param {object} [options.schemaMap] A local specification of a JSON schema used for encryption
      * @param {KMSProviders} [options.kmsProviders] options for specific KMS providers to use
@@ -88,6 +89,7 @@ module.exports = function(modules) {
         useUnifiedTopology: true
       });
       this._keyVaultNamespace = options.keyVaultNamespace || 'admin.datakeys';
+      this._keyVaultClient = options.keyVaultClient || client;
 
       const mongoCryptOptions = {};
       if (options.schemaMap) {

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -121,6 +121,7 @@ module.exports = function(modules) {
      * @param {object} [options.masterKey] Idenfities a new KMS-specific key used to encrypt the new data key. If the kmsProvider is "aws" it is required.
      * @param {string} [options.masterKey.region] The AWS region of the KMS
      * @param {string} [options.masterKey.key] The Amazon Resource Name (ARN) to the AWS customer master key (CMK)
+     * @param {string} [options.masterKey.endpoint] An alternate host to send KMS requests to. May include port number.
      * @param {string[]} [options.keyAltNames] An optional list of string alternate names used to reference a key. If a key is created with alternate names, then encryption may refer to the key by the unique alternate name instead of by _id.
      * @param {ClientEncryption~createDataKeyCallback} [callback] Optional callback to invoke when key is created
      * @returns {Promise|void} If no callback is provided, returns a Promise that either resolves with the created data key, or rejects with an error. If a callback is provided, returns nothing.

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -66,6 +66,7 @@ module.exports = function(modules) {
      * @param {MongoClient} client The client used for encryption
      * @param {object} options Optional settings
      * @param {string} options.keyVaultNamespace The namespace of the key vault, used to store encryption keys
+     * @param {MongoClient} [options.keyVaultClient] A `MongoClient` used to fetch keys from a key vault. Defaults to `client`
      * @param {KMSProviders} [options.kmsProviders] options for specific KMS providers to use
      *
      * @example
@@ -99,6 +100,7 @@ module.exports = function(modules) {
 
       Object.assign(options, { cryptoCallbacks });
       this._keyVaultNamespace = options.keyVaultNamespace;
+      this._keyVaultClient = options.keyVaultClient || client;
       this._mongoCrypt = new mc.MongoCrypt(options);
     }
 
@@ -175,7 +177,7 @@ module.exports = function(modules) {
           const dbName = databaseNamespace(this._keyVaultNamespace);
           const collectionName = collectionNamespace(this._keyVaultNamespace);
 
-          this._client
+          this._keyVaultClient
             .db(dbName)
             .collection(collectionName)
             .insertOne(dataKey, { w: 'majority' }, (err, result) => {

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -177,7 +177,7 @@ module.exports = function(modules) {
           this._client
             .db(dbName)
             .collection(collectionName)
-            .insertOne(dataKey, (err, result) => {
+            .insertOne(dataKey, { w: 'majority' }, (err, result) => {
               if (err) {
                 cb(err, null);
                 return;

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -315,7 +315,7 @@ module.exports = function(modules) {
 
       client
         .db(dbName)
-        .collection(collectionName)
+        .collection(collectionName, { readConcern: { level: 'majority' } })
         .find(filter)
         .toArray((err, keys) => {
           if (err) {

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -84,6 +84,7 @@ module.exports = function(modules) {
       const bson = autoEncrypter._bson;
       const client = autoEncrypter._client;
       const keyVaultNamespace = autoEncrypter._keyVaultNamespace;
+      const keyVaultClient = autoEncrypter._keyVaultClient;
       const mongocryptdClient = autoEncrypter._mongocryptdClient;
       const mongocryptdManager = autoEncrypter._mongocryptdManager;
 
@@ -143,7 +144,7 @@ module.exports = function(modules) {
 
         case MONGOCRYPT_CTX_NEED_MONGO_KEYS: {
           const filter = context.nextMongoOperation();
-          this.fetchKeys(client, keyVaultNamespace, filter, (err, keys) => {
+          this.fetchKeys(keyVaultClient, keyVaultNamespace, filter, (err, keys) => {
             if (err) return callback(err, null);
             keys.forEach(key => {
               context.addMongoOperationResponse(bson.serialize(key));

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -212,7 +212,9 @@ module.exports = function(modules) {
      * @returns {Promise<void>} A promise that resolves when the KMS reply has be fully parsed
      */
     kmsRequest(request) {
-      const options = { host: request.endpoint, port: HTTPS_PORT };
+      const parsedUrl = request.endpoint.split(':');
+      const port = parsedUrl[1] != null ? Number.parseInt(parsedUrl[1], 10) : HTTPS_PORT;
+      const options = { host: parsedUrl[0], port };
       const message = request.message;
 
       return new Promise((resolve, reject) => {
@@ -229,7 +231,9 @@ module.exports = function(modules) {
         socket.once('error', err => {
           socket.removeAllListeners();
           socket.destroy();
-          reject(err);
+          const mcError = new MongoCryptError('KMS request failed');
+          mcError.originalError = err;
+          reject(mcError);
         });
 
         socket.on('data', buffer => {

--- a/bindings/node/src/mongocrypt.cc
+++ b/bindings/node/src/mongocrypt.cc
@@ -682,6 +682,16 @@ NAN_METHOD(MongoCrypt::MakeDataKeyContext) {
             Nan::ThrowTypeError(errorStringFromStatus(context.get()));
             return;
         }
+
+        v8::Local<v8::String> ENDPOINT_KEY = Nan::New("endpoint").ToLocalChecked();
+        if (Nan::Has(masterKey, ENDPOINT_KEY).FromMaybe(false)) {
+            std::string endpoint = StringOptionValue(masterKey, "endpoint");
+            if (!mongocrypt_ctx_setopt_masterkey_aws_endpoint(context.get(), endpoint.c_str(), endpoint.size())) {
+                Nan::ThrowTypeError(errorStringFromStatus(context.get()));
+                return;
+            }
+        }
+
     } else if (kmsProvider == "local") {
         mongocrypt_ctx_setopt_masterkey_local(context.get());
     } else {

--- a/bindings/node/test/stateMachine.test.js
+++ b/bindings/node/test/stateMachine.test.js
@@ -13,7 +13,7 @@ describe('StateMachine', function() {
       constructor(message, bytesNeeded) {
         this._bytesNeeded = typeof bytesNeeded === 'number' ? bytesNeeded : 1024;
         this._message = message;
-        this.endPoint = 'some.fake.host.com';
+        this.endpoint = 'some.fake.host.com';
       }
       get message() {
         return this._message;


### PR DESCRIPTION
Status:

- [x] Add API for specifying a custom endpoint with AWS masterkey provider
    - Update bindings to libmongocrypt to call mongocrypt_ctx_setopt_masterkey_aws_endpoint with the value of "endpoint" is passed DataKeyOpts.masterKey
    - Update libmongocrypt to latest version.
    - Implement prose test under the section Custom Endpoint Test.
- [x] createDataKey returns UUID
    - Update the return type (if necessary) of createDataKey to be a BSON binary
- [x] silence mongocryptd by default
    - Spawned mongocryptd should redirect stdout and stderr to /dev/null
- [x] test that fetching keys uses readConcern=majority
    - Resync the FLE JSON spec tests
- [x] test that created data keys insert with majority writeConcern
    - Update the prose test of Data key and double encryption to check command started events
- [x] SPEC-1397 limit 2MiB limit to bulk writes
    - Check that bulk write batch splitting logic matches the section "Size limits for Write Commands"
    - Update the prose test under the section BSON size limits and batch splitting.


Is validated by https://github.com/mongodb/node-mongodb-native/pull/2198