### PR TITLE
NODE-2109: Follow spec for auto-spawning mongocryptd

### DIFF
--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -94,7 +94,8 @@ module.exports = function(modules) {
       this._mongocryptdManager = new MongocryptdManager(options.extraOptions);
       this._mongocryptdClient = new MongoClient(this._mongocryptdManager.uri, {
         useNewUrlParser: true,
-        useUnifiedTopology: true
+        useUnifiedTopology: true,
+        serverSelectionTimeoutMS: 1000
       });
       this._keyVaultNamespace = options.keyVaultNamespace || 'admin.datakeys';
       this._keyVaultClient = options.keyVaultClient || client;

--- a/bindings/node/lib/mongocryptdManager.js
+++ b/bindings/node/lib/mongocryptdManager.js
@@ -1,60 +1,6 @@
 'use strict';
 
 const spawn = require('child_process').spawn;
-const readFile = require('fs').readFile;
-
-const mongocryptdPidFileName = 'mongocryptd.pid';
-const checkIntervalMS = 50;
-
-/**
- * @ignore
- * A heuristic check to see if a mongocryptd is running. Checks for a mongocryptd.pid
- * file that contains valid JSON. If the pid file exists, the mongocryptd is likely
- * running.
- * @param {} callback Invoked with true if a valid pid file is found, false otherwise
- */
-function checkIsUp(callback) {
-  readFile(mongocryptdPidFileName, 'utf8', (err, data) => {
-    if (err) {
-      return callback(undefined, false);
-    }
-
-    if (!data || !data.length) {
-      return callback(undefined, false);
-    }
-
-    try {
-      JSON.parse(data);
-    } catch (e) {
-      return callback(e, false);
-    }
-
-    callback(undefined, true);
-  });
-}
-
-/**
- * @ignore
- * Attempts to wait for a mongocryptd to be up. Will check with checkIsUp
- * in 50ms intervals up to tries times.
- * @param {number} tries The number of times to check for a mongocryptd
- * @param {Function} callback Is called when either the number of tries have been
- * attempted, or when we think a mongocryptd is up
- */
-function waitForUp(tries, callback) {
-  if (tries <= 0) {
-    return callback();
-  }
-
-  checkIsUp((err, isUp) => {
-    if (isUp) {
-      return callback();
-    }
-
-    tries -= 1;
-    setTimeout(() => waitForUp(tries, callback), checkIntervalMS);
-  });
-}
 
 /**
  * @ignore
@@ -98,28 +44,21 @@ class MongocryptdManager {
    * @param {Function} callback Invoked when we think a mongocryptd is up
    */
   spawn(callback) {
-    checkIsUp((err, isUp) => {
-      if (!err && isUp) {
-        process.nextTick(callback);
-        return;
-      }
+    const cmdName = this.spawnPath || 'mongocryptd';
 
-      const cmdName = this.spawnPath || 'mongocryptd';
-
-      // Spawned with stdio: ignore and detatched:true
-      // to ensure child can outlive parent.
-      this._child = spawn(cmdName, this.spawnArgs, {
-        stdio: 'ignore',
-        detached: true
-      });
-
-      this._child.on('error', () => {});
-
-      // unref child to remove handle from event loop
-      this._child.unref();
-
-      waitForUp(20, callback);
+    // Spawned with stdio: ignore and detatched:true
+    // to ensure child can outlive parent.
+    this._child = spawn(cmdName, this.spawnArgs, {
+      stdio: 'ignore',
+      detached: true
     });
+
+    this._child.on('error', () => {});
+
+    // unref child to remove handle from event loop
+    this._child.unref();
+
+    process.nextTick(callback);
   }
 }
 

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-prettier": "^2.2.0",
     "jsdoc-to-markdown": "^5.0.0",
     "mocha": "^4.0.0",
-    "mongodb": "^3.2.7",
+    "mongodb": "^3.3.4-rc0",
     "mongodb-extjson": "^3.0.3",
     "node-gyp": "^5.0.3",
     "prebuild": "^9.0.1",


### PR DESCRIPTION
Now that we have server selection in 3.3.4-rc0 working, we
can remove the heuristic logic from the MongocryptdManager
and instead rely on server selection to do it for us.

Fixes NODE-2109