### PR TITLE
NODE-2339: change APIn to remove mandatory injection

### DIFF
--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -1,102 +1,8 @@
 'use strict';
 
-/**
- * @module mongodbClientEncryption
- * @description An extension that can be installed to enable MongoDB Client-Side Encryption.
- * @example
- * // Using AutoEncryption
- * 
- * const mongodb = require('mongodb');
- * 
- * // Simply create a MongoClient with the option `autoEncryption`. If
- * // mongodb-client-encryption is installed, it will be automatically
- * // loaded. Your encrypted client will automatically encrypt and decrypt
- * // according to the schema provided by the server.
- * const encryptedClient = new mongodb.MongoClient('mongodb://localhost:27017', {
- *   useNewUrlParser: true,
- *   useUnifiedTopology: true,
- *   autoEncryption: {
- *     kmsProviders: {
- *       aws: {
- *         accessKeyId: AWS_ACCESS_KEY,
- *         secretAccessKey: AWS_SECRET_KEY
- *       }
- *     }
- *   }
- * });
- * 
- * main();
- * 
- * async function main() {
- *   try {
- *     await client.connect();
- *     await client.db('db').collection('coll').insertOne({
- *       name: 'Darmok',
- *       // If encryption is defined as an encrypted value in the collection schema,
- *       // it will be automatically encrypted.
- *       ssn: '123-456-7890'
- *     });
- *     // Additionally, when you query documents with encrypted values, they will automatically
- *     // decrypt when they are retrieved. Here, result.ssn will be a decrypted value.
- *     const result = await client.db('db').collection('coll').findOne({ name: 'Darmok' });
- *   } finally {
- *     await client.close();
- *   }
- * }
- * 
- * @example
- * // Using manual ClientEncryption
- * 
- * const mongodb = require('mongodb');
- * 
- * // Unlike autoEncryption, manual Client Encryption requires you to import 
- * // mongodb-client-encrypion, which returns a function. To access the members of the
- * // extension, you must invoke the function while passing in your mongodb instance.
- * // This returns an object with all members of the extension bound to your mongodb
- * // library.
- * const mongodbClientEncryption = require('mongodb-client-encryption')(mongodb);
- * 
- * // Create a new MongoClient connected to your cluster. This is used by your 
- * const client = new mongodb.MongoClient('mongodb://localhost:27017/', {
- *   useNewUrlParser: true,
- *   useUnifiedTopology: true
- * });
- * 
- * main();
- * 
- * async function main() {
- *   try {
- *     await client.connect();
- *     // Create a new ClientEncryption object, passing in your client
- *     const encryption = new ClientEncryption(client, {
- *       keyVaultNamespace: 'client.encryption',
- *       kmsProviders: {
- *         local: {
- *           key: masterKey // The master key used for encryption/decryption. A 96-byte long Buffer
- *         }
- *       }
- *     });
- *     // create a data key for encryption
- *     const keyId = await encryption.createDataKey('local');
- *     const algorithm = 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic';
- *     // Manually encrypt a SSN
- *     const ssn = await encryption.encrypt('123-456-7890', { keyId, algorithm });
- *     // Insert document w/ encrypted value
- *     await client.db('db').coll('coll').insertOne({
- *       name: 'Darmok',
- *       ssn
- *     });
- *     // Retrieve value from collection. result.ssn is still encrypted
- *     const result = await client.db('db').collection('coll').findOne({ name: 'Darmok' });
- *     // Manually decrypt the SSN
- *     const decryptedSsn = await encryption.decrypt(result.ssn);
- *   } finally {
- *     await client.close();
- *   }
- * }
- */
+const MongoCryptError = require('./lib/common').MongoCryptError;
 
-module.exports = function(mongodb) {
+function extension(mongodb) {
   const modules = { mongodb };
 
   modules.stateMachine = require('./lib/stateMachine')(modules);
@@ -106,6 +12,30 @@ module.exports = function(mongodb) {
   return {
     AutoEncrypter: modules.autoEncrypter.AutoEncrypter,
     ClientEncryption: modules.clientEncryption.ClientEncryption,
-    MongoCryptError: require('./lib/common').MongoCryptError
+    MongoCryptError
   };
-};
+}
+let _module;
+function loadModule() {
+  if (!_module) {
+    _module = extension(require('mongodb'));
+  }
+
+  return _module;
+}
+
+function memo(fn) {
+  let value;
+  return () => value || (value = fn());
+}
+
+exports.extension = extension;
+exports.MongoCryptError = MongoCryptError;
+Object.defineProperty(exports, 'AutoEncrypter', {
+  enumerable: true,
+  get: memo(() => loadModule().AutoEncrypter)
+});
+Object.defineProperty(exports, 'ClientEncryption', {
+  enumerable: true,
+  get: memo(() => loadModule().ClientEncryption)
+});

--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -1,7 +1,15 @@
 'use strict';
 
-const MongoCryptError = require('./lib/common').MongoCryptError;
+let defaultModule;
+function loadDefaultModule() {
+  if (!defaultModule) {
+    defaultModule = extension(require('mongodb'));
+  }
 
+  return defaultModule;
+}
+
+const MongoCryptError = require('./lib/common').MongoCryptError;
 function extension(mongodb) {
   const modules = { mongodb };
 
@@ -15,27 +23,20 @@ function extension(mongodb) {
     MongoCryptError
   };
 }
-let _module;
-function loadModule() {
-  if (!_module) {
-    _module = extension(require('mongodb'));
+
+module.exports = {
+  extension,
+  MongoCryptError,
+  get AutoEncrypter() {
+    const m = loadDefaultModule();
+    delete module.exports.AutoEncrypter;
+    module.exports.AutoEncrypter = m.AutoEncrypter;
+    return m.AutoEncrypter;
+  },
+  get ClientEncryption() {
+    const m = loadDefaultModule();
+    delete module.exports.ClientEncryption;
+    module.exports.ClientEncryption = m.ClientEncryption;
+    return m.ClientEncryption;
   }
-
-  return _module;
-}
-
-function memo(fn) {
-  let value;
-  return () => value || (value = fn());
-}
-
-exports.extension = extension;
-exports.MongoCryptError = MongoCryptError;
-Object.defineProperty(exports, 'AutoEncrypter', {
-  enumerable: true,
-  get: memo(() => loadModule().AutoEncrypter)
-});
-Object.defineProperty(exports, 'ClientEncryption', {
-  enumerable: true,
-  get: memo(() => loadModule().ClientEncryption)
-});
+};

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -42,6 +42,9 @@
     "sinon": "^4.3.0",
     "sinon-chai": "^3.3.0"
   },
+  "peerDependencies": {
+    "mongodb": "~3.4.0"
+  },
   "repository": {
     "url": "https://github.com/mongodb/libmongocrypt"
   }


### PR DESCRIPTION
Rather than require users inject mongodb into
mongodb-client-encryption we assume that require('mongodb')
resolves to the user mongodb package. If users need to ensure
their mongodb version is used, they can use the extension function
to achieve the old injection effect.

Note: Uses getters to avoid a circular load call.