### PR TITLE
MONGOCRYPT-212 add null check for `kms_request_get_canonical`

### DIFF
--- a/kms-message/src/kms_request.c
+++ b/kms-message/src/kms_request.c
@@ -523,6 +523,10 @@ kms_request_get_string_to_sign (kms_request_t *request)
    kms_request_str_append_chars (sts, "/aws4_request\n", -1);
 
    creq = kms_request_str_wrap (kms_request_get_canonical (request), -1);
+   if (!creq) {
+      goto done;
+   }
+
    if (!kms_request_str_append_hashed (&request->crypto, sts, creq)) {
       goto done;
    }

--- a/test/test-mongocrypt-crypto-hooks.c
+++ b/test/test-mongocrypt-crypto-hooks.c
@@ -583,6 +583,31 @@ _test_crypto_hooks_explicit_err (_mongocrypt_tester_t *tester)
    bson_string_free (call_history, true);
 }
 
+/* validate that sha256 errors are handled correctly */
+static void
+_test_crypto_hooks_explicit_sha256_err (_mongocrypt_tester_t *tester)
+{
+   mongocrypt_t *crypt;
+   mongocrypt_status_t *status;
+   mongocrypt_ctx_t *ctx;
+
+   status = mongocrypt_status_new ();
+   crypt = _create_mongocrypt ("error_on:sha256");
+   ctx = mongocrypt_ctx_new (crypt);
+
+   call_history = bson_string_new (NULL);
+
+   ASSERT_OK (
+      mongocrypt_ctx_setopt_masterkey_aws (ctx, "us-east-1", -1, "cmk", -1),
+      ctx);
+   ASSERT_FAILS (mongocrypt_ctx_datakey_init (ctx), ctx, "failed to create KMS message");
+
+   mongocrypt_ctx_destroy (ctx);
+   mongocrypt_status_destroy (status);
+   mongocrypt_destroy (crypt);
+   bson_string_free (call_history, true);
+}
+
 
 void
 _mongocrypt_tester_install_crypto_hooks (_mongocrypt_tester_t *tester)
@@ -594,4 +619,5 @@ _mongocrypt_tester_install_crypto_hooks (_mongocrypt_tester_t *tester)
    INSTALL_TEST_CRYPTO (_test_kms_request, CRYPTO_OPTIONAL);
    INSTALL_TEST_CRYPTO (_test_crypto_hooks_unset, CRYPTO_PROHIBITED);
    INSTALL_TEST_CRYPTO (_test_crypto_hooks_explicit_err, CRYPTO_OPTIONAL);
+   INSTALL_TEST_CRYPTO (_test_crypto_hooks_explicit_sha256_err, CRYPTO_OPTIONAL);
 }


### PR DESCRIPTION
This method can return `NULL`, so a null check is required in order to prevent segfaults.

**NOTE:** sorry for the kind of cheesy test case. I think the unit test belongs in `kms_message` but there didn't seem to be existing tests there outside of the AWS test suite, and this was much easier for me to add.