### PR TITLE
fix typo in node bindings

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -244,7 +244,7 @@ Creates a data key used for explicit encryption and inserts it into the key vaul
 **Example**  
 ```js
 // Using callbacks to create a local key
-clientEncrypion.createDataKey('local', (err, dataKey) => {
+clientEncryption.createDataKey('local', (err, dataKey) => {
   if (err) {
     // This means creating the key failed.
   } else {

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -131,7 +131,7 @@ module.exports = function(modules) {
      * @returns {Promise|void} If no callback is provided, returns a Promise that either resolves with {@link ClientEncryption~dataKeyId the id of the created data key}, or rejects with an error. If a callback is provided, returns nothing.
      * @example
      * // Using callbacks to create a local key
-     * clientEncrypion.createDataKey('local', (err, dataKey) => {
+     * clientEncryption.createDataKey('local', (err, dataKey) => {
      *   if (err) {
      *     // This means creating the key failed.
      *   } else {


### PR DESCRIPTION
Was pointed out in the crypto audit of libmongocrypt.