### PR TITLE
fix installation layout, e.g. honors GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,7 +351,7 @@ configure_file (cmake/mongocrypt-config.cmake
 install (EXPORT mongocrypt_targets
    NAMESPACE mongo::
    FILE mongocrypt_targets.cmake
-   DESTINATION lib/cmake/mongocrypt
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mongocrypt
 )
 
 install (
@@ -359,7 +359,7 @@ install (
       cmake/mongocrypt-config.cmake
       "${CMAKE_CURRENT_BINARY_DIR}/mongocrypt/mongocrypt-config-version.cmake"
    DESTINATION
-      lib/cmake/mongocrypt
+      ${CMAKE_INSTALL_LIBDIR}/cmake/mongocrypt
    COMPONENT
       Devel
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 set (CMAKE_C_STANDARD 99)
 
 option (ENABLE_SHARED_BSON "Dynamically link libbson (default is static)" OFF)
+option (ENABLE_STATIC "Install static libraries" ON)
 
 set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 
@@ -262,7 +263,13 @@ if (NOT MONGOCRYPT_CRYPTO STREQUAL none)
    target_include_directories (example-state-machine-static PRIVATE ./src)
 endif ()
 
-install (TARGETS mongocrypt mongocrypt_static
+if (ENABLE_STATIC)
+   set (TARGETS_TO_INSTALL mongocrypt mongocrypt_static)
+else ()
+   set (TARGETS_TO_INSTALL mongocrypt)
+endif ()
+install (
+   TARGETS ${TARGETS_TO_INSTALL}
    EXPORT mongocrypt_targets
    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -324,10 +331,12 @@ install (
    FILES "${CMAKE_BINARY_DIR}/libmongocrypt.pc"
    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )
-install (
-   FILES "${CMAKE_BINARY_DIR}/libmongocrypt-static.pc"
-   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-)
+if (ENABLE_STATIC)
+   install (
+      FILES "${CMAKE_BINARY_DIR}/libmongocrypt-static.pc"
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+   )
+endif ()
 
 include (CMakePackageConfigHelpers)
 set (INCLUDE_INSTALL_DIRS "${CMAKE_INSTALL_INCLUDEDIR}/mongocrypt")

--- a/kms-message/CMakeLists.txt
+++ b/kms-message/CMakeLists.txt
@@ -124,10 +124,10 @@ set_property (TARGET kms_message_static APPEND PROPERTY
 include (CMakePackageConfigHelpers)
 install (TARGETS kms_message kms_message_static
    EXPORT kms_message_targets
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-   RUNTIME DESTINATION bin
-   INCLUDES DESTINATION include
+   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 install (
@@ -141,7 +141,7 @@ install (
    src/kms_message/kms_request_opt.h
    src/kms_message/kms_response.h
    src/kms_message/kms_response_parser.h
-   DESTINATION include/kms_message
+   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/kms_message
    COMPONENT Devel
 )
 
@@ -162,7 +162,7 @@ configure_file (cmake/kms_message-config.cmake
    COPYONLY
 )
 
-set (ConfigPackageLocation lib/cmake/kms_message)
+set (ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/kms_message)
 install (EXPORT kms_message_targets
    NAMESPACE mongo::
    FILE kms_message_targets.cmake
@@ -178,8 +178,8 @@ install (
 )
 
 # pkg-config.
-set (PKG_CONFIG_LIBDIR "\${prefix}/lib")
-set (PKG_CONFIG_INCLUDEDIR "\${prefix}/include")
+set (PKG_CONFIG_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+set (PKG_CONFIG_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
 set (PKG_CONFIG_LIBS "-L\${libdir} -lkms_message")
 set (PKG_CONFIG_CFLAGS "-I\${includedir}")
 configure_file (
@@ -189,7 +189,7 @@ configure_file (
 
 install (
    FILES "${CMAKE_CURRENT_BINARY_DIR}/libkms_message.pc"
-   DESTINATION lib/pkgconfig
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )
 
 # cannot run tests without crypto

--- a/kms-message/CMakeLists.txt
+++ b/kms-message/CMakeLists.txt
@@ -122,7 +122,13 @@ set_property (TARGET kms_message_static APPEND PROPERTY
    )
 
 include (CMakePackageConfigHelpers)
-install (TARGETS kms_message kms_message_static
+if (ENABLE_STATIC)
+   set (TARGETS_TO_INSTALL kms_message kms_message_static)
+else ()
+   set (TARGETS_TO_INSTALL kms_message)
+endif ()
+install (
+   TARGETS ${TARGETS_TO_INSTALL}
    EXPORT kms_message_targets
    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
On RPM distribution, some files are installed in /usr/lib instead of /usr/lib64
