### PR TITLE
Fix missing ssize_t

### DIFF
--- a/kms-message/src/kms_request_str.h
+++ b/kms-message/src/kms_request_str.h
@@ -24,6 +24,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
+#include <sys/types.h>
 
 #if defined(_WIN32)
 #include <basetsd.h>


### PR DESCRIPTION
I'm trying to package PHP mongo 1.7.0 for Alpinelinux but getting error on build

```
 In file included from /builds/andypost/aports/testing/php7-pecl-mongodb/src/mongodb-1.7.0/src/libmongocrypt/kms-message/src/kms_kv_list.h:21,
                  from /builds/andypost/aports/testing/php7-pecl-mongodb/src/mongodb-1.7.0/src/libmongocrypt/kms-message/src/kms_kv_list.c:18:
 /builds/andypost/aports/testing/php7-pecl-mongodb/src/mongodb-1.7.0/src/libmongocrypt/kms-message/src/kms_request_str.h:42:52: error: unknown type name 'ssize_t'; did you mean 'size_t'?
    42 | kms_request_str_new_from_chars (const char *chars, ssize_t len);
       |                                                    ^~~~~~~
       |                                                    size_t
 /builds/andypost/aports/testing/php7-pecl-mongodb/src/mongodb-1.7.0/src/libmongocrypt/kms-message/src/kms_request_str.h:44:36: error: unknown type name 'ssize_t'; did you mean 'size_t'?
    44 | kms_request_str_wrap (char *chars, ssize_t len);
       |                                    ^~~~~~~
       |                                    size_t
 /builds/andypost/aports/testing/php7-pecl-mongodb/src/mongodb-1.7.0/src/libmongocrypt/kms-message/src/kms_request_str.h:56:28: error: unknown type name 'ssize_t'; did you mean 'size_t'?
    56 |                            ssize_t len);
       |                            ^~~~~~~
       |                            size_t
 /builds/andypost/aports/testing/php7-pecl-mongodb/src/mongodb-1.7.0/src/libmongocrypt/kms-message/src/kms_request_str.h:66:31: error: unknown type name 'ssize_t'; did you mean 'size_t'?
    66 |                               ssize_t len);
       |                               ^~~~~~~
       |                               size_t
 /bin/sh /builds/andypost/aports/testing/php7-pecl-mongo
```