### PR TITLE
PYTHON-2169 Migrate Python tests to windows-64-vsMulti-small

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -147,11 +147,11 @@ functions:
           ${compile_env|} ./libmongocrypt/.evergreen/build_all.sh
           cd ./libmongocrypt/bindings/java/mongocrypt && ${test_env|} ./.evergreen/test.sh
 
-  "build and test python":
+  "test python":
     - command: "shell.exec"
       params:
         script: |-
-          ${compile_env|} ./libmongocrypt/.evergreen/build_all.sh
+          export MONGOCRYPT_DIR="$(pwd)/all/${variant_name}"
           cd ./libmongocrypt/bindings/python && ${test_env|} ./.evergreen/test.sh
 
   "build and test node":
@@ -340,13 +340,31 @@ tasks:
     - func: "fetch source"
     - func: "build and test java"
 
-- name: build-and-test-python
+- name: test-python
   depends_on:
   - variant: ubuntu1804-64
     name: prep-c-driver-source
+  - build-and-test-and-upload
   commands:
     - func: "fetch source"
-    - func: "build and test python"
+    - func: "download tarball"
+      vars: { variant_name: "${build_variant}" }
+    - func: "test python"
+      vars: { variant_name: "${build_variant}" }
+
+- name: test-python-windows
+  depends_on:
+  - variant: ubuntu1804-64
+    name: prep-c-driver-source
+  # Depends on the windows-64-vs2017-test upload.
+  - variant: windows-test
+    name: build-and-test-and-upload
+  commands:
+    - func: "fetch source"
+    - func: "download tarball"
+      vars: { variant_name: windows-test }
+    - func: "test python"
+      vars: { variant_name: windows-test }
 
 - name: build-csharp-and-test
   depends_on:
@@ -667,7 +685,7 @@ buildvariants:
   - build-and-test-asan-mac
   - build-and-test-java
   - build-and-test-node
-  - build-and-test-python
+  - test-python
 - name: rhel72-zseries-test
   display_name: "RHEL 7.2 on zSeries"
   run_on: rhel72-zseries-test
@@ -689,9 +707,13 @@ buildvariants:
   - build-and-test-and-upload
   - build-and-test-shared-bson
   - build-csharp-and-test
-  - build-and-test-python
   - build-and-test-node
   - windows-upload-check
+- name: windows-test-python
+  display_name: "Windows Python"
+  run_on: windows-64-vsMulti-small
+  tasks:
+  - test-python-windows
 - name: linux-64-amazon-ami
   display_name: "Amazon Linux"
   run_on: amazon1-2018-test
@@ -766,7 +788,7 @@ buildvariants:
   - build-and-test-and-upload
   - build-and-test-shared-bson
   - build-and-test-java
-  - build-and-test-python
+  - test-python
   - build-and-test-node
   - name: publish-packages
     distros:


### PR DESCRIPTION
This change does three things:

1. Migrates Python tests to windows-64-vsMulti-small. This distro has the modern python toolchain which solves the current build failures.
1. Changes our evergreen to download the libmongocrypt build from "build-and-test-and-upload". This removes the need to compile libmongocrypt from source. I had to do this because libmongocrypt does not compile on windows-64-vsMulti-small.
1. Changes our test script to always use virtualenv on Windows.

Patch: https://evergreen.mongodb.com/version/5e729af11e2d17595815ecdc