### PR TITLE
update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,23 @@ Win32/*
 cmake_install.cmake
 x64/*
 Testing/
+CPackConfig.cmake
+CPackSourceConfig.cmake
+dist_manifest.txt
+*.sdf
+.vs
+install_manifest.txt
+
+# Build artifacts.
+*.a
+*.dylib
+*.gcda
+*.gcno
+*.gz
+*.o
+*.pc
+*.so
+*.so.*
 
 # Generated header
 src/mongocrypt-export.h

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ install_manifest.txt
 *.gcda
 *.gcno
 *.gz
+*.lo
 *.o
 *.pc
 *.so


### PR DESCRIPTION
Sync up with mongo-c-driver's .gitignore. This should prevent build artifacts from getting tracked in git in case of an in-source build.