### PR TITLE
MONGOCRYPT-261 Build tests on musl

### DIFF
--- a/test/test-mongocrypt-log.c
+++ b/test/test-mongocrypt-log.c
@@ -96,7 +96,7 @@ _test_trace_log (_mongocrypt_tester_t *tester)
    mongocrypt_destroy (crypt);
 }
 
-#ifndef _WIN32
+#if defined(__GLIBC__) || defined(__APPLE__)
 static void
 _test_no_log (_mongocrypt_tester_t *tester)
 {
@@ -131,7 +131,7 @@ _mongocrypt_tester_install_log (_mongocrypt_tester_t *tester)
 {
    INSTALL_TEST (_test_log);
    INSTALL_TEST (_test_trace_log);
-#ifndef _WIN32
+#if defined(__GLIBC__) || defined(__APPLE__)
    INSTALL_TEST (_test_no_log);
 #endif
 }


### PR DESCRIPTION
stdout is a readonly with musl libc which is used by Alpine Linux.

There is no define check for MUSL (i.e. there is no equivalent to __GLIBC__). As a result, I defined this test as only running on APPLE and GLIBC. This will miss Freebsd, etc but we will still get coverage on our core platforms.