### PR TITLE
MONGOCRYPT-270 add Azure KMS message requests

### DIFF
--- a/kms-message/CMakeLists.txt
+++ b/kms-message/CMakeLists.txt
@@ -15,6 +15,7 @@ set (KMS_MESSAGE_SOURCES
    src/kms_message/kms_b64.h
    src/hexlify.c
    src/hexlify.h
+   src/kms_azure_request.c
    src/kms_crypto.h
    src/kms_crypto_none.c
    src/kms_crypto_windows.c
@@ -27,6 +28,7 @@ set (KMS_MESSAGE_SOURCES
    src/kms_kv_list.h
    src/kms_message.c
    src/kms_port.c
+   src/kms_message/kms_azure_request.h
    src/kms_message/kms_caller_identity_request.h
    src/kms_message/kms_decrypt_request.h
    src/kms_message/kms_encrypt_request.h
@@ -144,6 +146,7 @@ install (
 
 install (
    FILES
+   src/kms_message/kms_azure_request.h
    src/kms_message/kms_b64.h
    src/kms_message/kms_caller_identity_request.h
    src/kms_message/kms_decrypt_request.h

--- a/kms-message/src/kms_azure_request.c
+++ b/kms-message/src/kms_azure_request.c
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2020-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kms_message/kms_azure_request.h"
+
+#include "kms_message/kms_b64.h"
+#include "kms_message_private.h"
+#include "kms_request_opt_private.h"
+#include "kms_request_str.h"
+
+/*
+ * Request has the following form:
+ * 
+ * POST /{tenant ID}/oauth2/v2.0/token HTTP/1.1
+ * Host: {host of identify platform URL}
+ * Content-Type: application/x-www-form-urlencoded
+ * 
+ * client_id={client ID}
+ * &scope=https%3A%2F%2Fvault.azure.net%2F.default
+ * &client_secret={client secret}
+ * &grant_type=client_credentials
+*/
+kms_request_t *
+kms_azure_request_oauth_new (const char *host,
+                             const char *scope,
+                             const char *tenant_id,
+                             const char *client_id,
+                             const char *client_secret,
+                             const kms_request_opt_t *opt)
+{
+   char *path_and_query = NULL;
+   char *payload = NULL;
+   kms_request_t *req;
+   kms_request_str_t *str;
+
+   str = kms_request_str_new ();
+   kms_request_str_appendf (str, "/%s/oauth2/v2.0/token", tenant_id);
+   path_and_query = kms_request_str_detach (str);
+   str = kms_request_str_new ();
+   kms_request_str_appendf (
+      str,
+      "client_id=%s&scope=%s&client_secret=%s&grant_type=client_credentials",
+      client_id,
+      scope,
+      client_secret);
+   payload = kms_request_str_detach (str);
+
+   req = kms_request_new ("POST", path_and_query, opt);
+
+   if (opt->provider != KMS_REQUEST_PROVIDER_AZURE) {
+      KMS_ERROR (req, "Expected KMS request with provider type: Azure");
+      goto done;
+   }
+
+   if (kms_request_get_error (req)) {
+      goto done;
+   }
+
+   if (!kms_request_add_header_field (
+          req, "Content-Type", "application/x-www-form-urlencoded")) {
+      goto done;
+   }
+   if (!kms_request_add_header_field (req, "Host", host)) {
+      goto done;
+   }
+   if (!kms_request_add_header_field (req, "Accept", "application/json")) {
+      goto done;
+   }
+
+   if (!kms_request_append_payload (req, payload, strlen (payload))) {
+      goto done;
+   }
+
+done:
+   kms_request_free_string (path_and_query);
+   kms_request_free_string (payload);
+   return req;
+}
+
+static kms_request_t *
+_wrap_unwrap_common (const char *wrap_unwrap,
+                     const char *host,
+                     const char *access_token,
+                     const char *key_name,
+                     const char *key_version,
+                     const uint8_t *value,
+                     size_t value_len,
+                     const kms_request_opt_t *opt)
+{
+   char *path_and_query = NULL;
+   char *payload = NULL;
+   char *bearer_token_value = NULL;
+   char *value_base64url = NULL;
+   kms_request_t *req;
+   kms_request_str_t *str;
+
+   str = kms_request_str_new ();
+   /* {vaultBaseUrl}/keys/{key-name}/{key-version}/wrapkey?api-version=7.1 */
+   kms_request_str_appendf (str,
+                            "/keys/%s/%s/%s?api-version=7.1",
+                            key_name,
+                            key_version ? key_version : "",
+                            wrap_unwrap);
+   path_and_query = kms_request_str_detach (str);
+
+   req = kms_request_new ("POST", path_and_query, opt);
+
+   if (opt->provider != KMS_REQUEST_PROVIDER_AZURE) {
+      KMS_ERROR (req, "Expected KMS request with provider type: Azure");
+      goto done;
+   }
+
+   if (kms_request_get_error (req)) {
+      goto done;
+   }
+
+   value_base64url = kms_message_raw_to_b64url (value, value_len);
+   if (!value_base64url) {
+      KMS_ERROR (req, "Could not bases64url-encode plaintext");
+      goto done;
+   }
+
+   str = kms_request_str_new ();
+   kms_request_str_appendf (
+      str, "{\"alg\": \"RSA-OAEP-256\", \"value\": \"%s\"}", value_base64url);
+   payload = kms_request_str_detach (str);
+   str = kms_request_str_new ();
+   kms_request_str_appendf (str, "Bearer %s", access_token);
+   bearer_token_value = kms_request_str_detach (str);
+   if (!kms_request_add_header_field (
+          req, "Authorization", bearer_token_value)) {
+      goto done;
+   }
+   if (!kms_request_add_header_field (
+          req, "Content-Type", "application/json")) {
+      goto done;
+   }
+   if (!kms_request_add_header_field (req, "Host", host)) {
+      goto done;
+   }
+   if (!kms_request_add_header_field (req, "Accept", "application/json")) {
+      goto done;
+   }
+
+   if (!kms_request_append_payload (req, payload, strlen (payload))) {
+      goto done;
+   }
+
+done:
+   kms_request_free_string (path_and_query);
+   kms_request_free_string (payload);
+   kms_request_free_string (bearer_token_value);
+   kms_request_free_string (value_base64url);
+   return req;
+}
+
+/* 
+ * Request has the following form:
+ * 
+ * POST /keys/{key-name}/{key-version}/wrapkey?api-version=7.1
+ * Host: {host of key vault endpoint}
+ * Authentication: Bearer {token}
+ * Content-Type: application/json
+ * 
+ * {
+ *     "alg": "RSA-OAEP-256"
+ *     "value": "base64url encoded data"
+ * }
+ */
+kms_request_t *
+kms_azure_request_wrapkey_new (const char *host,
+                               const char *access_token,
+                               const char *key_name,
+                               const char *key_version,
+                               const uint8_t *plaintext,
+                               size_t plaintext_len,
+                               const kms_request_opt_t *opt)
+{
+   return _wrap_unwrap_common ("wrapkey",
+                               host,
+                               access_token,
+                               key_name,
+                               key_version,
+                               plaintext,
+                               plaintext_len,
+                               opt);
+}
+
+kms_request_t *
+kms_azure_request_unwrapkey_new (const char *host,
+                                 const char *access_token,
+                                 const char *key_name,
+                                 const char *key_version,
+                                 const uint8_t *plaintext,
+                                 size_t plaintext_len,
+                                 const kms_request_opt_t *opt)
+{
+   return _wrap_unwrap_common ("unwrapkey",
+                               host,
+                               access_token,
+                               key_name,
+                               key_version,
+                               plaintext,
+                               plaintext_len,
+                               opt);
+}

--- a/kms-message/src/kms_b64.c
+++ b/kms-message/src/kms_b64.c
@@ -41,11 +41,12 @@
  */
 
 #include <ctype.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "kms_message/kms_message.h"
+
 #include "kms_message/kms_b64.h"
-#include <stdio.h>
+#include "kms_message/kms_message.h"
 
 #define Assert(Cond) \
    if (!(Cond))      \
@@ -606,10 +607,12 @@ kms_message_b64_to_raw (const char *b64, size_t *out)
 {
    uint8_t *raw;
    int ret;
+   size_t b64len;
 
-   raw = (uint8_t *) malloc (strlen (b64) + 1);
-   memset (raw, 0, strlen(b64) + 1);
-   ret = kms_message_b64_pton (b64, raw, strlen (b64));
+   b64len = strlen (b64);
+   raw = (uint8_t *) malloc (b64len + 1);
+   memset (raw, 0, b64len + 1);
+   ret = kms_message_b64_pton (b64, raw, b64len);
    if (ret > 0) {
       *out = (size_t) ret;
       return raw;
@@ -622,13 +625,15 @@ char *
 kms_message_raw_to_b64url (const uint8_t *raw, size_t raw_len)
 {
    char *b64;
+   size_t b64len;
 
    b64 = kms_message_raw_to_b64 (raw, raw_len);
    if (!b64) {
       return NULL;
    }
 
-   if (-1 == kms_message_b64_to_b64url (b64, strlen (b64), b64, strlen (b64))) {
+   b64len = strlen (b64);
+   if (-1 == kms_message_b64_to_b64url (b64, b64len, b64, b64len)) {
       free (b64);
       return NULL;
    }
@@ -642,13 +647,15 @@ kms_message_b64url_to_raw (const char *b64url, size_t *out)
    char *b64;
    size_t capacity;
    uint8_t *raw;
+   size_t b64urllen;
 
+   b64urllen = strlen(b64url);
    /* Add four for padding '=' characters. */
-   capacity = strlen (b64url) + 4;
+   capacity = b64urllen + 4;
    b64 = malloc (capacity);
    memset (b64, 0, capacity);
    if (-1 ==
-       kms_message_b64url_to_b64 (b64url, strlen (b64url), b64, capacity)) {
+       kms_message_b64url_to_b64 (b64url, b64urllen, b64, capacity)) {
       free (b64);
       return NULL;
    }

--- a/kms-message/src/kms_message/kms_azure_request.h
+++ b/kms-message/src/kms_message/kms_azure_request.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KMS_AZURE_REQUEST_H
+#define KMS_AZURE_REQUEST_H
+
+#include "kms_message_defines.h"
+#include "kms_request.h"
+#include "kms_request_opt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Constructs an oauth client credentials grant request for Azure.
+ * See
+ * https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow#get-a-token.
+ *
+ * Parameters:
+ * All parameters must be NULL terminated strings.
+ * - host: The value of the Host header. This should be a custom host or
+ * "login.microsoftonline.com".
+ * - scope: The oauth scope. This should be a custom scope or
+ * "https%3A%2F%2Fvault.azure.net%2F.default". Must be URL encoded.
+ * - tenant_id: The Azure tenant ID.
+ * - client_id: The client ID to authenticate.
+ * - client_secret: The client secret to authenticate.
+ * - opt: Additional options. This must have the Azure provider set via
+ * kms_request_opt_set_provider.
+ *
+ * Returns: A new kms_request_t.
+ * Always returns a new kms_request_t, even on error.
+ * Caller must check if an error occurred by calling kms_request_get_error.
+ */
+KMS_MSG_EXPORT (kms_request_t *)
+kms_azure_request_oauth_new (const char *host,
+                             const char *scope,
+                             const char *tenant_id,
+                             const char *client_id,
+                             const char *client_secret,
+                             const kms_request_opt_t *opt);
+
+/* Constructs a wrapkey request for Azure.
+ * See https://docs.microsoft.com/en-us/rest/api/keyvault/wrapkey/wrapkey
+ *
+ * Parameters:
+ * All parameters must be NULL terminated strings.
+ * - host: The value of the Host header, like "mykeyvault.vault.azure.net".
+ * - access_token: The access_token obtained from an oauth response as a
+ * base64url encoded string.
+ * - key_name: The azure key name.
+ * - key_version: An optional key version. May be NULL or empty string.
+ * - plaintext: The plaintext key to encrypt.
+ * - plaintext_len: The number of bytes of plaintext.
+ * - opt: Additional options. This must have the Azure provider set via
+ * kms_request_opt_set_provider.
+ */
+
+KMS_MSG_EXPORT (kms_request_t *)
+kms_azure_request_wrapkey_new (const char *host,
+                               const char *access_token,
+                               const char *key_name,
+                               const char *key_version,
+                               const uint8_t *plaintext,
+                               size_t plaintext_len,
+                               const kms_request_opt_t *opt);
+
+/* Constructs an unwrapkey request for Azure.
+ * See https://docs.microsoft.com/en-us/rest/api/keyvault/unwrapkey/unwrapkey
+ *
+ * Parameters:
+ * All parameters must be NULL terminated strings.
+ * - host: The value of the Host header, like "mykeyvault.vault.azure.net".
+ * - access_token: The access_token obtained from an oauth response as a
+ * base64url encoded string.
+ * - key_name: The azure key name.
+ * - key_version: An optional key version. May be NULL or empty string.
+ * - ciphertext: The ciphertext key to decrypt.
+ * - ciphertext_len: The number of bytes of ciphertext.
+ * - opt: Additional options. This must have the Azure provider set via
+ * kms_request_opt_set_provider.
+ */
+
+KMS_MSG_EXPORT (kms_request_t *)
+kms_azure_request_unwrapkey_new (const char *host,
+                                 const char *access_token,
+                                 const char *key_name,
+                                 const char *key_version,
+                                 const uint8_t *ciphertext,
+                                 size_t ciphertext_len,
+                                 const kms_request_opt_t *opt);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* KMS_AZURE_REQUEST_H */

--- a/kms-message/src/kms_message/kms_b64.h
+++ b/kms-message/src/kms_message/kms_b64.h
@@ -50,6 +50,19 @@ kms_message_b64url_to_b64 (const char *src,
                            char *target,
                            size_t targsize);
 
+/* Convenience conversions which return copies. */
+char *
+kms_message_raw_to_b64 (const uint8_t *raw, size_t raw_len);
+
+uint8_t *
+kms_message_b64_to_raw (const char *b64, size_t *out);
+
+char *
+kms_message_raw_to_b64url (const uint8_t *raw, size_t raw_len);
+
+uint8_t *
+kms_message_b64url_to_raw (const char *b64url, size_t *out);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/kms-message/test/test_kms_azure_online.c
+++ b/kms-message/test/test_kms_azure_online.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <kms_message/kms_azure_request.h>
 #include <kms_message/kms_b64.h>
 #include <kms_message/kms_request.h>
 #include <kms_message/kms_response.h>
@@ -44,6 +45,8 @@ typedef struct {
    char *key_vault_url;
    char *key_path;
    char *key_host;
+   char *key_name;
+   char *key_version;
 } test_env_t;
 
 static char *
@@ -67,6 +70,8 @@ test_env_init (test_env_t *test_env)
    test_env->client_id = test_getenv ("AZURE_CLIENT_ID");
    test_env->client_secret = test_getenv ("AZURE_CLIENT_SECRET");
    test_env->key_url = test_getenv ("AZURE_KEY_URL");
+   test_env->key_name = test_getenv ("AZURE_KEY_NAME");
+   test_env->key_version = test_getenv ("AZURE_KEY_VERSION");
 
    loc = strstr (test_env->key_url, azure_domain);
    TEST_ASSERT (loc);
@@ -194,8 +199,6 @@ azure_authenticate (void)
 {
    kms_request_t *req;
    kms_request_opt_t *opt;
-   char *path;
-   char *payload;
    char *req_str;
    const char *res_str;
    bson_t *res_bson;
@@ -210,21 +213,12 @@ azure_authenticate (void)
    kms_request_opt_set_connection_close (opt, true);
    kms_request_opt_set_provider (opt, KMS_REQUEST_PROVIDER_AZURE);
 
-   path = bson_strdup_printf ("/%s/oauth2/v2.0/token", test_env.tenant_id);
-   payload = bson_strdup_printf (
-      "client_id=%s&scope=%s&client_secret=%s&grant_type=client_credentials",
-      test_env.client_id,
-      SCOPE,
-      test_env.client_secret);
-
-   req = kms_request_new ("POST", path, opt);
-   TEST_ASSERT (kms_request_add_header_field (
-      req, "Content-Type", "application/x-www-form-urlencoded"));
-   TEST_ASSERT (
-      kms_request_add_header_field (req, "Host", "login.microsoftonline.com"));
-   TEST_ASSERT (
-      kms_request_add_header_field (req, "Accept", "application/json"));
-   TEST_ASSERT (kms_request_append_payload (req, payload, strlen (payload)));
+   req = kms_azure_request_oauth_new ("login.microsoftonline.com",
+                                      SCOPE,
+                                      test_env.tenant_id,
+                                      test_env.client_id,
+                                      test_env.client_secret,
+                                      opt);
    req_str = kms_request_to_string (req);
    TEST_TRACE ("--> HTTP request:\n%s\n", req_str);
 
@@ -245,8 +239,6 @@ azure_authenticate (void)
    kms_request_free_string (req_str);
    kms_response_destroy (res);
    kms_request_destroy (req);
-   bson_free (path);
-   bson_free (payload);
    bson_destroy (res_bson);
    test_env_cleanup (&test_env);
    kms_request_opt_destroy (opt);
@@ -264,39 +256,37 @@ test_azure_wrapkey (void)
    char *req_str;
    char *bearer_token;
    kms_response_t *res;
-   char *path_and_query;
-   char *bearer_token_value;
-   char *payload;
    const char *res_str;
-   char *encrypted;
+   uint8_t *encrypted_raw;
+   size_t encrypted_raw_len;
    char *decrypted;
    bson_t *res_bson;
    bson_iter_t iter;
+   uint8_t *key_data;
+   char *key_data_b64url;
+   int i;
 
-/* value is 96 bytes, generated with openssl rand -base64 96. Then converted
- * to the base64url encoding, which Azure uses (slightly different from base64).
- */
-#define KEY_DATA_BASE64URL                                      \
-   "IyyjC2eyMNcYOgZaIXl1H0qTYZhdVbyyn-0kiSK0n9O-"               \
-   "5OPNLi9xdDnCO3VBSsI9cUWMtVfTwvL7HY8S1VCCUQDnTyx8ZPVNTSRZk_" \
-   "liS7BDsQjPEfC4LZv8Un3bSHs"
+#define KEYLEN 96
+
+   key_data = bson_malloc0 (KEYLEN);
+   for (i = 0; i < KEYLEN; i++) {
+      key_data[i] = i;
+   }
+   key_data_b64url = kms_message_raw_to_b64url (key_data, KEYLEN);
 
    test_env_init (&test_env);
-   path_and_query =
-      bson_strdup_printf ("%s/wrapkey?api-version=7.0", test_env.key_path);
    bearer_token = azure_authenticate ();
-   bearer_token_value = bson_strdup_printf ("Bearer %s", bearer_token);
-   payload = bson_strdup_printf (
-      "{\"alg\": \"RSA-OAEP-256\", \"value\": \"%s\"}", KEY_DATA_BASE64URL);
 
    opt = kms_request_opt_new ();
    kms_request_opt_set_connection_close (opt, true);
    kms_request_opt_set_provider (opt, KMS_REQUEST_PROVIDER_AZURE);
-   req = kms_request_new ("POST", path_and_query, opt);
-   kms_request_add_header_field (req, "Authorization", bearer_token_value);
-   kms_request_add_header_field (req, "Host", test_env.key_host);
-   kms_request_add_header_field (req, "Content-Type", "application/json");
-   kms_request_append_payload (req, payload, strlen (payload));
+   req = kms_azure_request_wrapkey_new (test_env.key_host,
+                                        bearer_token,
+                                        test_env.key_name,
+                                        test_env.key_version,
+                                        key_data,
+                                        KEYLEN,
+                                        opt);
    req_str = kms_request_to_string (req);
    TEST_TRACE ("--> HTTP request:\n%s\n", req_str);
    res = send_kms_request (req, test_env.key_host);
@@ -307,25 +297,22 @@ test_azure_wrapkey (void)
       bson_new_from_json ((const uint8_t *) res_str, strlen (res_str), NULL);
    TEST_ASSERT (res_bson);
    TEST_ASSERT (bson_iter_init_find (&iter, res_bson, "value"));
-   encrypted = bson_strdup (bson_iter_utf8 (&iter, NULL));
+   encrypted_raw = kms_message_b64url_to_raw (bson_iter_utf8 (&iter, NULL), &encrypted_raw_len);
+   TEST_ASSERT (encrypted_raw);
 
    bson_destroy (res_bson);
-   bson_free (payload);
    bson_free (req_str);
    kms_request_destroy (req);
    kms_response_destroy (res);
-   bson_free (path_and_query);
 
    /* Send a request to unwrap the encrypted key. */
-   path_and_query =
-      bson_strdup_printf ("%s/unwrapkey?api-version=7.0", test_env.key_path);
-   payload = bson_strdup_printf (
-      "{\"alg\": \"RSA-OAEP-256\", \"value\": \"%s\"}", encrypted);
-   req = kms_request_new ("POST", path_and_query, opt);
-   kms_request_add_header_field (req, "Authorization", bearer_token_value);
-   kms_request_add_header_field (req, "Host", test_env.key_host);
-   kms_request_add_header_field (req, "Content-Type", "application/json");
-   kms_request_append_payload (req, payload, strlen (payload));
+   req = kms_azure_request_unwrapkey_new (test_env.key_host,
+                                          bearer_token,
+                                          test_env.key_name,
+                                          test_env.key_version,
+                                          encrypted_raw,
+                                          encrypted_raw_len,
+                                          opt);
    req_str = kms_request_to_string (req);
    TEST_TRACE ("--> HTTP request:\n%s\n", req_str);
    res = send_kms_request (req, test_env.key_host);
@@ -336,18 +323,17 @@ test_azure_wrapkey (void)
    TEST_ASSERT (res_bson);
    TEST_ASSERT (bson_iter_init_find (&iter, res_bson, "value"));
    decrypted = bson_strdup (bson_iter_utf8 (&iter, NULL));
-   TEST_ASSERT_STREQUAL (decrypted, KEY_DATA_BASE64URL);
+   TEST_ASSERT_STREQUAL (decrypted, key_data_b64url);
 
    bson_destroy (res_bson);
    kms_response_destroy (res);
    bson_free (req_str);
-   bson_free (payload);
-   bson_free (path_and_query);
    bson_free (bearer_token);
-   bson_free (bearer_token_value);
    test_env_cleanup (&test_env);
    kms_request_destroy (req);
-   bson_free (encrypted);
+   bson_free (encrypted_raw);
+   bson_free (key_data_b64url);
+   bson_free (key_data);
    bson_free (decrypted);
    kms_request_opt_destroy (opt);
 }
@@ -355,6 +341,7 @@ test_azure_wrapkey (void)
 int
 main (int argc, char **argv)
 {
+   kms_message_init ();
    RUN_TEST (test_azure_wrapkey);
    return 0;
 }


### PR DESCRIPTION
Convenience helpers for constructing Azure requests in KMS message. The test-python task failure is unrelated, and tracked in MONGOCRYPT-276.