### PR TITLE
MONGOCRYPT-269 create data key support for Azure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ set (MONGOCRYPT_SOURCES
    src/mongocrypt-cache.c
    src/mongocrypt-cache-collinfo.c
    src/mongocrypt-cache-key.c
+   src/mongocrypt-cache-oauth.c
    src/mongocrypt-ciphertext.c
    src/mongocrypt-crypto.c
    src/mongocrypt-ctx-datakey.c

--- a/kms-message/src/kms_request_str.h
+++ b/kms-message/src/kms_request_str.h
@@ -67,6 +67,8 @@ kms_request_str_append_lowercase (kms_request_str_t *str,
 KMS_MSG_EXPORT (void)
 kms_request_str_appendf (kms_request_str_t *str, const char *format, ...);
 KMS_MSG_EXPORT (void)
+kms_request_strdupf (kms_request_str_t *str, const char *format, ...);
+KMS_MSG_EXPORT (void)
 kms_request_str_append_escaped (kms_request_str_t *str,
                                 kms_request_str_t *appended,
                                 bool escape_slash);

--- a/src/mongocrypt-cache-oauth-private.h
+++ b/src/mongocrypt-cache-oauth-private.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MONGOCRYPT_CACHE_OAUTH_PRIVATE_H
+#define MONGOCRYPT_CACHE_OAUTH_PRIVATE_H
+
+#include "mongocrypt-mutex-private.h"
+#include "mongocrypt-status-private.h"
+
+typedef struct {
+   bson_t *entry;
+   const char *access_token;
+   int64_t expiration_time_us;
+   mongocrypt_mutex_t mutex; /* global lock of cache. */
+} _mongocrypt_cache_oauth_t;
+
+_mongocrypt_cache_oauth_t *
+_mongocrypt_cache_oauth_new (void);
+
+void
+_mongocrypt_cache_oauth_destroy (_mongocrypt_cache_oauth_t *cache);
+
+bool
+_mongocrypt_cache_oauth_add (_mongocrypt_cache_oauth_t *cache,
+                             bson_t *oauth_response,
+                             mongocrypt_status_t *status);
+
+/* Returns a copy of the base64 encoded oauth token, or NULL if nothing is
+ * cached. */
+char *
+_mongocrypt_cache_oauth_get (_mongocrypt_cache_oauth_t *cache);
+
+#endif /* MONGOCRYPT_CACHE_OAUTH_PRIVATE_H */

--- a/src/mongocrypt-cache-oauth-private.h
+++ b/src/mongocrypt-cache-oauth-private.h
@@ -22,7 +22,7 @@
 
 typedef struct {
    bson_t *entry;
-   const char *access_token;
+   char *access_token;
    int64_t expiration_time_us;
    mongocrypt_mutex_t mutex; /* global lock of cache. */
 } _mongocrypt_cache_oauth_t;

--- a/src/mongocrypt-cache-oauth.c
+++ b/src/mongocrypt-cache-oauth.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mongocrypt-cache-oauth-private.h"
+
+#include "mongocrypt-private.h"
+
+/* How long before the reported "expires_in" time cache entries get evicted.
+ * This is intended to prevent use of an oauth token too close to the expiration
+ * time.
+ */
+#define MONGOCRYPT_OAUTH_CACHE_EVICTION_PERIOD_US 5000 * 5000
+
+_mongocrypt_cache_oauth_t *
+_mongocrypt_cache_oauth_new (void)
+{
+   _mongocrypt_cache_oauth_t *cache;
+
+   cache = bson_malloc0 (sizeof (_mongocrypt_cache_oauth_t));
+   _mongocrypt_mutex_init (&cache->mutex);
+   return cache;
+}
+
+void
+_mongocrypt_cache_oauth_destroy (_mongocrypt_cache_oauth_t *cache)
+{
+   _mongocrypt_mutex_cleanup (&cache->mutex);
+   bson_destroy (cache->entry);
+   bson_free (cache);
+}
+
+bool
+_mongocrypt_cache_oauth_add (_mongocrypt_cache_oauth_t *cache,
+                             bson_t *oauth_response,
+                             mongocrypt_status_t *status)
+{
+   bson_iter_t iter;
+   int64_t expiration_time_us;
+   int64_t cache_time_us;
+   const char *access_token;
+
+   if (!bson_iter_init_find (&iter, oauth_response, "expires_in") ||
+       !BSON_ITER_HOLDS_INT (&iter)) {
+      CLIENT_ERR ("OAuth response invalid, no 'expires_in' field.");
+      return false;
+   }
+   cache_time_us = bson_get_monotonic_time ();
+   expiration_time_us = (bson_iter_as_int64 (&iter) * 1000 * 1000) +
+                        cache_time_us -
+                        MONGOCRYPT_OAUTH_CACHE_EVICTION_PERIOD_US;
+
+   if (!bson_iter_init_find (&iter, oauth_response, "access_token") ||
+       !BSON_ITER_HOLDS_UTF8 (&iter)) {
+      CLIENT_ERR ("OAuth response invalid, no 'access_token' field.");
+      return false;
+   }
+   access_token = bson_iter_utf8 (&iter, NULL);
+
+   _mongocrypt_mutex_lock (&cache->mutex);
+   if (expiration_time_us > cache->expiration_time_us) {
+      cache->entry = bson_copy (oauth_response);
+      cache->expiration_time_us = expiration_time_us;
+      cache->access_token = bson_strdup (access_token);
+   }
+   _mongocrypt_mutex_unlock (&cache->mutex);
+   return true;
+}
+
+/* Returns a copy of the base64 encoded oauth token, or NULL if nothing is
+ * cached. */
+char *
+_mongocrypt_cache_oauth_get (_mongocrypt_cache_oauth_t *cache)
+{
+   char *access_token;
+
+   _mongocrypt_mutex_lock (&cache->mutex);
+   if (!cache->entry) {
+      _mongocrypt_mutex_unlock (&cache->mutex);
+      return NULL;
+   }
+
+   if (bson_get_monotonic_time () >= cache->expiration_time_us) {
+      bson_destroy (cache->entry);
+      cache->expiration_time_us = 0;
+      _mongocrypt_mutex_unlock (&cache->mutex);
+      return NULL;
+   }
+
+   access_token = bson_strdup (cache->access_token);
+   _mongocrypt_mutex_unlock (&cache->mutex);
+
+   return access_token;
+}

--- a/src/mongocrypt-ctx-datakey.c
+++ b/src/mongocrypt-ctx-datakey.c
@@ -54,6 +54,7 @@ _kms_start (mongocrypt_ctx_t *ctx)
 {
    bool ret = false;
    _mongocrypt_ctx_datakey_t *dkctx;
+   char *access_token = NULL;
 
    dkctx = (_mongocrypt_ctx_datakey_t *) ctx;
 
@@ -129,7 +130,6 @@ _kms_start (mongocrypt_ctx_t *ctx)
       ctx->state = MONGOCRYPT_CTX_NEED_KMS;
    } else if (ctx->opts.masterkey_kms_provider ==
               MONGOCRYPT_KMS_PROVIDER_AZURE) {
-      char *access_token;
 
       access_token =
          _mongocrypt_cache_oauth_get (ctx->crypt->cache_oauth_azure);
@@ -161,6 +161,7 @@ _kms_start (mongocrypt_ctx_t *ctx)
 
    ret = true;
 done:
+   bson_free (access_token);
    return ret;
 }
 

--- a/src/mongocrypt-ctx-datakey.c
+++ b/src/mongocrypt-ctx-datakey.c
@@ -28,6 +28,7 @@ _cleanup (mongocrypt_ctx_t *ctx)
    _mongocrypt_buffer_cleanup (&dkctx->key_doc);
    _mongocrypt_kms_ctx_cleanup (&dkctx->kms);
    _mongocrypt_buffer_cleanup (&dkctx->encrypted_key_material);
+   _mongocrypt_buffer_cleanup (&dkctx->plaintext_key_material);
 }
 
 
@@ -44,19 +45,153 @@ _next_kms_ctx (mongocrypt_ctx_t *ctx)
    return &dkctx->kms;
 }
 
+/* For local, immediately encrypt.
+ * For AWS, create the KMS request to encrypt.
+ * For Azure, auth first if needed, otherwise encrypt.
+ */
+static bool
+_kms_start (mongocrypt_ctx_t *ctx)
+{
+   bool ret = false;
+   _mongocrypt_ctx_datakey_t *dkctx;
+
+   dkctx = (_mongocrypt_ctx_datakey_t *) ctx;
+
+   /* Clear out any pre-existing initialized KMS context, and zero it (so it is
+    * safe to call cleanup again). */
+   _mongocrypt_kms_ctx_cleanup (&dkctx->kms);
+   memset (&dkctx->kms, 0, sizeof (dkctx->kms));
+   dkctx->kms_returned = false;
+   if (ctx->opts.masterkey_kms_provider == MONGOCRYPT_KMS_PROVIDER_LOCAL) {
+      bool crypt_ret;
+      uint32_t bytes_written;
+      _mongocrypt_buffer_t iv;
+
+      if (ctx->opts.masterkey_aws_endpoint) {
+         _mongocrypt_ctx_fail_w_msg (
+            ctx, "endpoint not supported for local masterkey");
+         goto done;
+      }
+
+      /* For a local KMS provider, the customer master key is supplied by the
+       * user in mongocrypt_setopt_kms_provider_local. We use it to
+       * encrypt/decrypt data keys directly. */
+      dkctx->encrypted_key_material.len = _mongocrypt_calculate_ciphertext_len (
+         dkctx->plaintext_key_material.len);
+      dkctx->encrypted_key_material.data =
+         bson_malloc (dkctx->encrypted_key_material.len);
+      dkctx->encrypted_key_material.owned = true;
+      BSON_ASSERT (dkctx->encrypted_key_material.data);
+
+      /* use a random IV. */
+      _mongocrypt_buffer_init (&iv);
+      iv.data = bson_malloc0 (MONGOCRYPT_IV_LEN);
+      BSON_ASSERT (iv.data);
+
+      iv.len = MONGOCRYPT_IV_LEN;
+      iv.owned = true;
+      if (!_mongocrypt_random (
+             ctx->crypt->crypto, &iv, MONGOCRYPT_IV_LEN, ctx->status)) {
+         _mongocrypt_buffer_cleanup (&iv);
+         _mongocrypt_ctx_fail (ctx);
+         goto done;
+      }
+
+      crypt_ret = _mongocrypt_do_encryption (ctx->crypt->crypto,
+                                             &iv,
+                                             NULL /* associated data. */,
+                                             &ctx->crypt->opts.kms_local_key,
+                                             &dkctx->plaintext_key_material,
+                                             &dkctx->encrypted_key_material,
+                                             &bytes_written,
+                                             ctx->status);
+      _mongocrypt_buffer_cleanup (&iv);
+      if (!crypt_ret) {
+         _mongocrypt_ctx_fail (ctx);
+         goto done;
+      }
+      ctx->state = MONGOCRYPT_CTX_READY;
+   } else if (ctx->opts.masterkey_kms_provider == MONGOCRYPT_KMS_PROVIDER_AWS) {
+      /* For AWS provider, AWS credentials are supplied in
+       * mongocrypt_setopt_kms_provider_aws. Data keys are encrypted with an
+       * "encrypt" HTTP message to KMS. */
+      if (!_mongocrypt_kms_ctx_init_aws_encrypt (&dkctx->kms,
+                                                 &ctx->crypt->opts,
+                                                 &ctx->opts,
+                                                 &dkctx->plaintext_key_material,
+                                                 &ctx->crypt->log,
+                                                 ctx->crypt->crypto)) {
+         mongocrypt_kms_ctx_status (&dkctx->kms, ctx->status);
+         _mongocrypt_ctx_fail (ctx);
+         goto done;
+      }
+
+      ctx->state = MONGOCRYPT_CTX_NEED_KMS;
+   } else if (ctx->opts.masterkey_kms_provider ==
+              MONGOCRYPT_KMS_PROVIDER_AZURE) {
+      char *access_token;
+
+      access_token =
+         _mongocrypt_cache_oauth_get (ctx->crypt->cache_oauth_azure);
+      if (access_token) {
+         if (!_mongocrypt_kms_ctx_init_azure_wrapkey (
+                &dkctx->kms,
+                &ctx->crypt->log,
+                &ctx->crypt->opts,
+                &ctx->opts,
+                access_token,
+                &dkctx->plaintext_key_material)) {
+            mongocrypt_kms_ctx_status (&dkctx->kms, ctx->status);
+            _mongocrypt_ctx_fail (ctx);
+            goto done;
+         }
+      } else {
+         if (!_mongocrypt_kms_ctx_init_azure_auth (
+                &dkctx->kms,
+                &ctx->crypt->log,
+                &ctx->crypt->opts,
+                ctx->opts.azure_kek.key_vault_endpoint)) {
+            mongocrypt_kms_ctx_status (&dkctx->kms, ctx->status);
+            _mongocrypt_ctx_fail (ctx);
+            goto done;
+         }
+      }
+      ctx->state = MONGOCRYPT_CTX_NEED_KMS;
+   }
+
+   ret = true;
+done:
+   return ret;
+}
 
 static bool
 _kms_done (mongocrypt_ctx_t *ctx)
 {
    _mongocrypt_ctx_datakey_t *dkctx;
+   mongocrypt_status_t *status;
 
    dkctx = (_mongocrypt_ctx_datakey_t *) ctx;
+   status = ctx->status;
    if (!mongocrypt_kms_ctx_status (&dkctx->kms, ctx->status)) {
       return _mongocrypt_ctx_fail (ctx);
    }
 
    if (mongocrypt_kms_ctx_bytes_needed (&dkctx->kms) != 0) {
       return _mongocrypt_ctx_fail_w_msg (ctx, "KMS response unfinished");
+   }
+
+   /* If this was an oauth request, store the response and proceed to encrypt.
+    */
+   if (dkctx->kms.req_type == MONGOCRYPT_KMS_AZURE_OAUTH) {
+      bson_t oauth_response;
+
+      BSON_ASSERT (
+         _mongocrypt_buffer_to_bson (&dkctx->kms.result, &oauth_response));
+      if (!_mongocrypt_cache_oauth_add (
+             ctx->crypt->cache_oauth_azure, &oauth_response, status)) {
+         return _mongocrypt_ctx_fail (ctx);
+      }
+      return _kms_start (ctx);
    }
 
    /* Store the result. */
@@ -184,6 +319,27 @@ _finalize (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
                                     MONGOCRYPT_STR_AND_LEN ("provider"),
                                     MONGOCRYPT_STR_AND_LEN ("local")));
    }
+
+   if (ctx->opts.masterkey_kms_provider == MONGOCRYPT_KMS_PROVIDER_AZURE) {
+      BSON_CHECK (bson_append_utf8 (&child,
+                                    MONGOCRYPT_STR_AND_LEN ("provider"),
+                                    MONGOCRYPT_STR_AND_LEN ("azure")));
+      BSON_CHECK (bson_append_utf8 (
+         &child,
+         MONGOCRYPT_STR_AND_LEN ("keyVaultEndpoint"),
+         ctx->opts.azure_kek.key_vault_endpoint->host_and_port,
+         -1));
+      BSON_CHECK (bson_append_utf8 (&child,
+                                    MONGOCRYPT_STR_AND_LEN ("keyName"),
+                                    ctx->opts.azure_kek.key_name,
+                                    -1));
+      if (ctx->opts.azure_kek.key_version) {
+         BSON_CHECK (bson_append_utf8 (&child,
+                                       MONGOCRYPT_STR_AND_LEN ("keyVersion"),
+                                       ctx->opts.azure_kek.key_version,
+                                       -1));
+      }
+   }
    BSON_CHECK (bson_append_document_end (&key_doc, &child));
    _mongocrypt_buffer_steal_from_bson (&dkctx->key_doc, &key_doc);
    _mongocrypt_buffer_to_binary (&dkctx->key_doc, out);
@@ -196,7 +352,6 @@ bool
 mongocrypt_ctx_datakey_init (mongocrypt_ctx_t *ctx)
 {
    _mongocrypt_ctx_datakey_t *dkctx;
-   _mongocrypt_buffer_t plaintext_key_material;
    _mongocrypt_ctx_opts_spec_t opts_spec;
    bool ret;
 
@@ -223,90 +378,25 @@ mongocrypt_ctx_datakey_init (mongocrypt_ctx_t *ctx)
    ctx->vtable.finalize = _finalize;
    ctx->vtable.cleanup = _cleanup;
 
-   _mongocrypt_buffer_init (&plaintext_key_material);
-   plaintext_key_material.data = bson_malloc (MONGOCRYPT_KEY_LEN);
-   BSON_ASSERT (plaintext_key_material.data);
+   _mongocrypt_buffer_init (&dkctx->plaintext_key_material);
+   dkctx->plaintext_key_material.data = bson_malloc (MONGOCRYPT_KEY_LEN);
+   BSON_ASSERT (dkctx->plaintext_key_material.data);
 
-   plaintext_key_material.len = MONGOCRYPT_KEY_LEN;
-   plaintext_key_material.owned = true;
+   dkctx->plaintext_key_material.len = MONGOCRYPT_KEY_LEN;
+   dkctx->plaintext_key_material.owned = true;
    if (!_mongocrypt_random (ctx->crypt->crypto,
-                            &plaintext_key_material,
+                            &dkctx->plaintext_key_material,
                             MONGOCRYPT_KEY_LEN,
                             ctx->status)) {
       _mongocrypt_ctx_fail (ctx);
       goto done;
    }
 
-   if (ctx->opts.masterkey_kms_provider == MONGOCRYPT_KMS_PROVIDER_LOCAL) {
-      bool crypt_ret;
-      uint32_t bytes_written;
-      _mongocrypt_buffer_t iv;
-
-      if (ctx->opts.masterkey_aws_endpoint) {
-         _mongocrypt_ctx_fail_w_msg (
-            ctx, "endpoint not supported for local masterkey");
-         goto done;
-      }
-
-      /* For a local KMS provider, the customer master key is supplied by the
-       * user in mongocrypt_setopt_kms_provider_local. We use it to
-       * encrypt/decrypt data keys directly. */
-      dkctx->encrypted_key_material.len =
-         _mongocrypt_calculate_ciphertext_len (plaintext_key_material.len);
-      dkctx->encrypted_key_material.data =
-         bson_malloc (dkctx->encrypted_key_material.len);
-      dkctx->encrypted_key_material.owned = true;
-      BSON_ASSERT (dkctx->encrypted_key_material.data);
-
-      /* use a random IV. */
-      _mongocrypt_buffer_init (&iv);
-      iv.data = bson_malloc0 (MONGOCRYPT_IV_LEN);
-      BSON_ASSERT (iv.data);
-
-      iv.len = MONGOCRYPT_IV_LEN;
-      iv.owned = true;
-      if (!_mongocrypt_random (
-             ctx->crypt->crypto, &iv, MONGOCRYPT_IV_LEN, ctx->status)) {
-         _mongocrypt_ctx_fail (ctx);
-         goto done;
-      }
-
-      crypt_ret = _mongocrypt_do_encryption (ctx->crypt->crypto,
-                                             &iv,
-                                             NULL /* associated data. */,
-                                             &ctx->crypt->opts.kms_local_key,
-                                             &plaintext_key_material,
-                                             &dkctx->encrypted_key_material,
-                                             &bytes_written,
-                                             ctx->status);
-      _mongocrypt_buffer_cleanup (&iv);
-      if (!crypt_ret) {
-         _mongocrypt_ctx_fail (ctx);
-         goto done;
-      }
-      ctx->state = MONGOCRYPT_CTX_READY;
-   }
-
-   if (ctx->opts.masterkey_kms_provider == MONGOCRYPT_KMS_PROVIDER_AWS) {
-      /* For AWS provider, AWS credentials are supplied in
-       * mongocrypt_setopt_kms_provider_aws. Data keys are encrypted with an
-       * "encrypt" HTTP message to KMS. */
-      if (!_mongocrypt_kms_ctx_init_aws_encrypt (&dkctx->kms,
-                                                 &ctx->crypt->opts,
-                                                 &ctx->opts,
-                                                 &plaintext_key_material,
-                                                 &ctx->crypt->log,
-                                                 ctx->crypt->crypto)) {
-         mongocrypt_kms_ctx_status (&dkctx->kms, ctx->status);
-         _mongocrypt_ctx_fail (ctx);
-         goto done;
-      }
-
-      ctx->state = MONGOCRYPT_CTX_NEED_KMS;
+   if (!_kms_start (ctx)) {
+      goto done;
    }
 
    ret = true;
 done:
-   _mongocrypt_buffer_cleanup (&plaintext_key_material);
    return ret;
 }

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -149,6 +149,7 @@ typedef struct {
    mongocrypt_kms_ctx_t kms;
    bool kms_returned;
    _mongocrypt_buffer_t key_doc;
+   _mongocrypt_buffer_t plaintext_key_material;
    _mongocrypt_buffer_t encrypted_key_material;
 } _mongocrypt_ctx_datakey_t;
 

--- a/src/mongocrypt-kms-ctx-private.h
+++ b/src/mongocrypt-kms-ctx-private.h
@@ -21,6 +21,7 @@
 #include "mongocrypt-compat.h"
 #include "mongocrypt-buffer-private.h"
 #include "mongocrypt-cache-key-private.h"
+#include "mongocrypt-endpoint-private.h"
 #include "mongocrypt-opts-private.h"
 #include "kms_message/kms_message.h"
 #include "mongocrypt-crypto-private.h"
@@ -28,8 +29,10 @@
 struct __mongocrypt_ctx_opts_t;
 
 typedef enum {
-   MONGOCRYPT_KMS_ENCRYPT,
-   MONGOCRYPT_KMS_DECRYPT
+   MONGOCRYPT_KMS_AWS_ENCRYPT,
+   MONGOCRYPT_KMS_AWS_DECRYPT,
+   MONGOCRYPT_KMS_AZURE_OAUTH,
+   MONGOCRYPT_KMS_AZURE_WRAPKEY
 } _kms_request_type_t;
 
 struct _mongocrypt_kms_ctx_t {
@@ -62,7 +65,6 @@ _mongocrypt_kms_ctx_init_aws_encrypt (
    _mongocrypt_log_t *log,
    _mongocrypt_crypto_t *crypto) MONGOCRYPT_WARN_UNUSED_RESULT;
 
-
 bool
 _mongocrypt_kms_ctx_result (mongocrypt_kms_ctx_t *kms,
                             _mongocrypt_buffer_t *out)
@@ -70,5 +72,21 @@ _mongocrypt_kms_ctx_result (mongocrypt_kms_ctx_t *kms,
 
 void
 _mongocrypt_kms_ctx_cleanup (mongocrypt_kms_ctx_t *kms);
+
+bool
+_mongocrypt_kms_ctx_init_azure_auth (mongocrypt_kms_ctx_t *kms,
+                                     _mongocrypt_log_t *log,
+                                     _mongocrypt_opts_t *crypt_opts,
+                                     _mongocrypt_endpoint_t *key_vault_endpoint)
+   MONGOCRYPT_WARN_UNUSED_RESULT;
+
+bool
+_mongocrypt_kms_ctx_init_azure_wrapkey (
+   mongocrypt_kms_ctx_t *kms,
+   _mongocrypt_log_t *log,
+   _mongocrypt_opts_t *crypt_opts,
+   struct __mongocrypt_ctx_opts_t *ctx_opts,
+   const char *access_token,
+   _mongocrypt_buffer_t *plaintext_key_material) MONGOCRYPT_WARN_UNUSED_RESULT;
 
 #endif /* MONGOCRYPT_KMX_CTX_PRIVATE_H */

--- a/src/mongocrypt-kms-ctx.c
+++ b/src/mongocrypt-kms-ctx.c
@@ -468,7 +468,7 @@ _ctx_done_azure_oauth (mongocrypt_kms_ctx_t *kms)
    bson_body =
       bson_new_from_json ((const uint8_t *) body, body_len, &bson_error);
    if (!bson_body) {
-      CLIENT_ERR ("Invalid JSON in KMS response. HTTP status=%d", http_status);
+      CLIENT_ERR ("Invalid JSON in KMS response. HTTP status=%d. Error: %s", http_status, bson_error.message);
       goto fail;
    }
 
@@ -586,7 +586,6 @@ _ctx_done_azure_wrapkey_unwrapkey (mongocrypt_kms_ctx_t *kms)
    kms->result.data = bson_malloc0 (b64_len);
    kms->result.len = kms_message_b64_pton (b64_data, kms->result.data, b64_len);
    kms->result.owned = true;
-   bson_body = NULL;
 
    ret = true;
 fail:

--- a/src/mongocrypt-private.h
+++ b/src/mongocrypt-private.h
@@ -28,6 +28,7 @@
 #include "mongocrypt-mutex-private.h"
 #include "mongocrypt-opts-private.h"
 #include "mongocrypt-crypto-private.h"
+#include "mongocrypt-cache-oauth-private.h"
 
 
 #define MONGOCRYPT_GENERIC_ERROR_CODE 1
@@ -81,6 +82,7 @@ struct _mongocrypt_t {
    _mongocrypt_crypto_t *crypto;
    /* A counter, protected by mutex, for generating unique context ids */
    uint32_t ctx_counter;
+   _mongocrypt_cache_oauth_t *cache_oauth_azure;
 };
 
 typedef enum {

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -123,6 +123,7 @@ mongocrypt_new (void)
    _mongocrypt_opts_init (&crypt->opts);
    _mongocrypt_log_init (&crypt->log);
    crypt->ctx_counter = 1;
+   crypt->cache_oauth_azure = _mongocrypt_cache_oauth_new ();
    return crypt;
 }
 
@@ -424,6 +425,7 @@ mongocrypt_destroy (mongocrypt_t *crypt)
    _mongocrypt_log_cleanup (&crypt->log);
    mongocrypt_status_destroy (crypt->status);
    bson_free (crypt->crypto);
+   _mongocrypt_cache_oauth_destroy (crypt->cache_oauth_azure);
    bson_free (crypt);
 }
 


### PR DESCRIPTION
Adds support for the create data key function using the Azure KMS provider.
Adds a simple oauth cache, which obtains a new token if the token is expiring within a buffer period of 5s.