### PR TITLE
MONGOCRYPT-273 support Azure auto/explicit

### DIFF
--- a/kms-message/src/kms_azure_request.c
+++ b/kms-message/src/kms_azure_request.c
@@ -204,8 +204,8 @@ kms_azure_request_unwrapkey_new (const char *host,
                                  const char *access_token,
                                  const char *key_name,
                                  const char *key_version,
-                                 const uint8_t *plaintext,
-                                 size_t plaintext_len,
+                                 const uint8_t *ciphertext,
+                                 size_t ciphertext_len,
                                  const kms_request_opt_t *opt)
 {
    return _wrap_unwrap_common ("unwrapkey",
@@ -213,7 +213,7 @@ kms_azure_request_unwrapkey_new (const char *host,
                                access_token,
                                key_name,
                                key_version,
-                               plaintext,
-                               plaintext_len,
+                               ciphertext,
+                               ciphertext_len,
                                opt);
 }

--- a/src/mongocrypt-buffer.c
+++ b/src/mongocrypt-buffer.c
@@ -325,8 +325,8 @@ _mongocrypt_buffer_to_bson_value (_mongocrypt_buffer_t *plaintext,
    bson_value_copy (bson_iter_value (&iter), out);
 
    /* Due to an open libbson bug (CDRIVER-3340), give an empty
-      * binary payload a real address. TODO: remove this after
-      * CDRIVER-3340 is fixed. */
+    * binary payload a real address. TODO: remove this after
+    * CDRIVER-3340 is fixed. */
    if (out->value_type == BSON_TYPE_BINARY &&
        0 == out->value.v_binary.data_len) {
       out->value.v_binary.data =

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -321,8 +321,7 @@ _kms_done (mongocrypt_ctx_t *ctx)
       BSON_ASSERT (!_mongocrypt_key_broker_status (&ctx->kb, ctx->status));
       return _mongocrypt_ctx_fail (ctx);
    }
-   ctx->state = MONGOCRYPT_CTX_READY;
-   return true;
+   return _mongocrypt_ctx_state_from_key_broker (ctx);
 }
 
 
@@ -767,6 +766,7 @@ _mongocrypt_ctx_state_from_key_broker (mongocrypt_ctx_t *ctx)
       new_state = MONGOCRYPT_CTX_NEED_MONGO_KEYS;
       ret = true;
       break;
+   case KB_AUTHENTICATING:
    case KB_DECRYPTING_KEY_MATERIAL:
       /* Encrypted keys need KMS. */
       new_state = MONGOCRYPT_CTX_NEED_KMS;

--- a/src/mongocrypt-endpoint-private.h
+++ b/src/mongocrypt-endpoint-private.h
@@ -33,6 +33,9 @@ typedef struct {
    char *host_and_port; /* e.g. kevin.keyvault.azure.net:443 */
 } _mongocrypt_endpoint_t;
 
+_mongocrypt_endpoint_t *
+_mongocrypt_endpoint_copy (_mongocrypt_endpoint_t *src);
+
 void
 _mongocrypt_endpoint_destroy (_mongocrypt_endpoint_t *endpoint);
 

--- a/src/mongocrypt-endpoint.c
+++ b/src/mongocrypt-endpoint.c
@@ -159,3 +159,23 @@ fail:
    }
    return endpoint;
 }
+
+_mongocrypt_endpoint_t *
+_mongocrypt_endpoint_copy (_mongocrypt_endpoint_t *src) {
+   _mongocrypt_endpoint_t *endpoint;
+
+   if (!src) {
+      return NULL;
+   }
+   endpoint = bson_malloc0 (sizeof (_mongocrypt_endpoint_t));
+   endpoint->original = bson_strdup (src->original);
+   endpoint->protocol = bson_strdup (src->protocol);
+   endpoint->host = bson_strdup (src->host);
+   endpoint->port = bson_strdup (src->port);
+   endpoint->domain = bson_strdup (src->domain);
+   endpoint->subdomain = bson_strdup (src->subdomain);
+   endpoint->path = bson_strdup (src->path);
+   endpoint->query = bson_strdup (src->query);
+   endpoint->host_and_port = bson_strdup (src->host_and_port);
+   return endpoint;
+}

--- a/src/mongocrypt-key-broker-private.h
+++ b/src/mongocrypt-key-broker-private.h
@@ -55,6 +55,8 @@ typedef enum {
    KB_REQUESTING,
    /* Accept key documents fetched from the key vault collection. */
    KB_ADDING_DOCS,
+   /* Getting oauth token(s) from KMS providers. */
+   KB_AUTHENTICATING,
    /* Accept KMS replies to decrypt key material in each key document. */
    KB_DECRYPTING_KEY_MATERIAL,
    KB_DONE,
@@ -79,8 +81,16 @@ typedef struct _key_returned_t {
    mongocrypt_kms_ctx_t kms;
    bool decrypted;
 
+   bool needs_auth;
+
    struct _key_returned_t *next;
 } key_returned_t;
+
+typedef struct _auth_request_t {
+   mongocrypt_kms_ctx_t kms;
+   bool returned;
+   bool initialized;
+} auth_request_t;
 
 typedef struct {
    key_broker_state_t state;
@@ -98,6 +108,8 @@ typedef struct {
    mongocrypt_t *crypt;
 
    key_returned_t *decryptor_iter;
+   /* TODO: for GCP, make this a list or array of two. */
+   auth_request_t auth_request;
 } _mongocrypt_key_broker_t;
 
 void

--- a/src/mongocrypt-key-private.h
+++ b/src/mongocrypt-key-private.h
@@ -27,6 +27,12 @@ typedef struct __mongocrypt_key_alt_name_t {
 } _mongocrypt_key_alt_name_t;
 
 typedef struct {
+   _mongocrypt_endpoint_t *key_vault_endpoint;
+   char *key_name;
+   char *key_version;
+} _mongocrypt_azure_kek_t;
+
+typedef struct {
    bson_t bson; /* original BSON for this key. */
    _mongocrypt_buffer_t id;
    _mongocrypt_key_alt_name_t *key_alt_names;
@@ -37,6 +43,7 @@ typedef struct {
    char *endpoint;
    uint64_t creation_date;
    uint64_t update_date;
+   _mongocrypt_azure_kek_t azure_kek;
 } _mongocrypt_key_doc_t;
 
 _mongocrypt_key_alt_name_t *

--- a/src/mongocrypt-kms-ctx-private.h
+++ b/src/mongocrypt-kms-ctx-private.h
@@ -32,7 +32,8 @@ typedef enum {
    MONGOCRYPT_KMS_AWS_ENCRYPT,
    MONGOCRYPT_KMS_AWS_DECRYPT,
    MONGOCRYPT_KMS_AZURE_OAUTH,
-   MONGOCRYPT_KMS_AZURE_WRAPKEY
+   MONGOCRYPT_KMS_AZURE_WRAPKEY,
+   MONGOCRYPT_KMS_AZURE_UNWRAPKEY
 } _kms_request_type_t;
 
 struct _mongocrypt_kms_ctx_t {
@@ -88,5 +89,13 @@ _mongocrypt_kms_ctx_init_azure_wrapkey (
    struct __mongocrypt_ctx_opts_t *ctx_opts,
    const char *access_token,
    _mongocrypt_buffer_t *plaintext_key_material) MONGOCRYPT_WARN_UNUSED_RESULT;
+
+bool
+_mongocrypt_kms_ctx_init_azure_unwrapkey (mongocrypt_kms_ctx_t *kms,
+                                          _mongocrypt_opts_t *crypt_opts,
+                                          const char *access_token,
+                                          _mongocrypt_key_doc_t *key,
+                                          _mongocrypt_log_t *log)
+   MONGOCRYPT_WARN_UNUSED_RESULT;
 
 #endif /* MONGOCRYPT_KMX_CTX_PRIVATE_H */

--- a/test/test-mongocrypt-key.c
+++ b/test/test-mongocrypt-key.c
@@ -149,7 +149,8 @@ test_mongocrypt_key_parsing (_mongocrypt_tester_t *tester)
    bson_concat (&key_bson, TMP_BSON ("{'masterKey': { 'provider': 'bad' }}"));
    _parse_fails (&key_bson,
                  status,
-                 "invalid 'masterKey.provider', expected 'aws' or 'local'");
+                 "invalid 'masterKey.provider', expected 'aws' or 'local' or "
+                 "'azure' or 'gcp'");
    /* masterKey: provider=aws, missing key */
    _recreate_and_reset (tester, &key_bson, status, "masterKey", NULL);
    bson_concat (
@@ -195,6 +196,15 @@ test_mongocrypt_key_parsing (_mongocrypt_tester_t *tester)
    /* status: missing */
    _recreate_and_reset (tester, &key_bson, status, "status", NULL);
    _parse_fails (&key_bson, status, "invalid key, no 'status'");
+
+   /* masterKey: unrecognized field */
+   _recreate_and_reset (tester, &key_bson, status, "masterKey", NULL);
+   bson_concat (
+      &key_bson,
+      TMP_BSON (
+         "{'masterKey': { 'provider': 'azure', 'keyVaultEndpoint': "
+         "'abc.example.com', 'keyName': 'test', 'keyVersion': 'abc' }}"));
+   _parse_ok (&key_bson, status);
 
    mongocrypt_status_destroy (status);
    bson_destroy (&key_bson);


### PR DESCRIPTION
Summary:
- Support Azure for automatic/explicit encryption/decryption.
- Adds a new state to mongocrypt_key_broker_t, KB_AUTHENTICATING.
- Parses the Azure key encryption key from a key document.

I did the following to test:
- Ran all existing CSFLE C driver tests (which only tests AWS/local).
- Used the new csfle runner in this repo to test auto/explicit encryption/decryption like so:


Create a datakey:
```
./cmake-build/csfle create_datakey --kms_provider azure --azure_kek_keyname test-key --azure_kek_keyvaultendpoint https://key-vault-kevinalbs.vault.azure.net/

{ "_id" : { "$binary" : { "base64": "Gp4a+RjPT4q3s+nHVlCuUQ==", "subType" : "04" } }, "keyMaterial" : { "$binary" : { "base64": "Aw3skVxuBo+Ta52qMboDEdxfvMJC3BULtLUEKSpHproZKonZ7KA/1Pj0KsRGyDQ4wZnjuxkwa3ummJxlS2+cM14vLQYYMOtLXM+knaX8BtFqVqsUGf9JfpI3/JVrR+9czWJzHizG8ZQkEvkRQHXBho3IRabK1x6zj+Ymh0Hj9JyhFM0M+qluOUuy5UxSXmLB5PXp9HZU10NyrEmpRRJXwpDevcTufuJtBoQAQfaVa3m/XHUdEf49SOEPffPQRZRHrTyl593xEQ9rBKEBq1uC07MP5DgAodjEAjkrngEub+tizOrIhDrswp8CXyBlSmGo9u6Jmw6oGSc258K/d3XTXA==", "subType" : "00" } }, "creationDate" : { "$date" : { "$numberLong" : "1600352502300" } }, "updateDate" : { "$date" : { "$numberLong" : "1600352502300" } }, "status" : { "$numberInt" : "0" }, "masterKey" : { "provider" : "azure", "keyVaultEndpoint" : "key-vault-kevinalbs.vault.azure.net", "keyName" : "test-key" } }
```

Test roundtrip with explicit encryption/decryption:

```
./cmake-build/csfle explicit_encrypt --key_id 'Gp4a+RjPT4q3s+nHVlCuUQ==' --value '{"v": "test"}' --algorithm 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'

{ "v" : { "$binary" : { "base64": "ARqeGvkYz0+Kt7Ppx1ZQrlECaGZ4PVLnln7+Mk3bGk10GkX6QE5QUqbSrvSHWul2azf+4GxbXGEeBnsAX8neYy80lTR58xBvIrZ7wJiaWXT8cw==", "subType" : "06" } } }

./cmake-build/csfle explicit_decrypt --value '{ "v" : { "$binary" : { "base64": "ARqeGvkYz0+Kt7Ppx1ZQrlECaGZ4PVLnln7+Mk3bGk10GkX6QE5QUqbSrvSHWul2azf+4GxbXGEeBnsAX8neYy80lTR58xBvIrZ7wJiaWXT8cw==", "subType" : "06" } } }'

{ "v" : "test" }
```

Test roundtrip with auto encryption/decryption:
```
./cmake-build/csfle auto_encrypt --schema_map_file ./.csfle/example-schemamap.json --command '{"insert": "coll", "documents": [{"ssn": "test"}]}' --db db

{ "insert" : "coll", "documents" : [ { "ssn" : { "$binary" : { "base64": "ARqeGvkYz0+Kt7Ppx1ZQrlECaGZ4PVLnln7+Mk3bGk10GkX6QE5QUqbSrvSHWul2azf+4GxbXGEeBnsAX8neYy80lTR58xBvIrZ7wJiaWXT8cw==", "subType" : "06" } } } ] }

./cmake-build/csfle auto_decrypt --document '{ "insert" : "coll", "documents" : [ { "ssn" : { "$binary" : { "base64": "ARqeGvkYz0+Kt7Ppx1ZQrlECaGZ4PVLnln7+Mk3bGk10GkX6QE5QUqbSrvSHWul2azf+4GxbXGEeBnsAX8neYy80lTR58xBvIrZ7wJiaWXT8cw==", "subType" : "06" } } } ] }'

{ "insert" : "coll", "documents" : [ { "ssn" : "test" } ] }
```