### PR TITLE
MONGOCRYPT-281 fail task on script err

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -60,6 +60,8 @@ functions:
     - command: "shell.exec"
       params:
         script: |-
+          set -o errexit
+          set -o xtrace
           ${compile_env|} ./libmongocrypt/.evergreen/build_all.sh
           ${test_env|} ./libmongocrypt/.evergreen/test.sh
           cd libmongocrypt

--- a/kms-message/src/kms_crypto_libcrypto.c
+++ b/kms-message/src/kms_crypto_libcrypto.c
@@ -102,7 +102,7 @@ kms_sign_rsaes_pkcs1_v1_5 (void *unused_ctx,
    EVP_MD_CTX *ctx;
    EVP_PKEY *pkey = NULL;
    bool ret = false;
-   size_t signature_out_len;
+   size_t signature_out_len = 256;
 
    ctx = EVP_MD_CTX_new ();
    pkey = d2i_PrivateKey (EVP_PKEY_RSA,


### PR DESCRIPTION
I noticed that a failure of test_kms_request was not failing the build-and–test-and-upload task. After fixing that, that surfaced a bug in the OpenSSL signature code.