### PR TITLE
MONGOCRYPT-282 support chunked transfer encoding

### DIFF
--- a/etc/rewrite.py
+++ b/etc/rewrite.py
@@ -1,0 +1,16 @@
+help = """
+Script to rewrite \n to \r\n
+Usage: python3 rewrite.py file-in.txt file-out.txt
+file-in.txt will be rewritten to have \n replaced with \r\n.
+"""
+import sys
+if len(sys.argv) != 3:
+    print (help)
+    sys.exit(1)
+
+src = open (sys.argv[1], "r")
+dst = open (sys.argv[2], "w")
+for line in src:
+    print (line)
+    dst.write(line.strip() + "\r\n")
+dst.close()

--- a/kms-message/src/hexlify.c
+++ b/kms-message/src/hexlify.c
@@ -20,6 +20,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _MSC_VER
+#define SSCANF sscanf_s
+#else
+#define SSCANF sscanf
+#endif
+
 char *
 hexlify (const uint8_t *buf, size_t len)
 {
@@ -36,4 +42,32 @@ hexlify (const uint8_t *buf, size_t len)
    *p = '\0';
 
    return hex_chars;
+}
+
+/* Returns -1 on error. */
+int
+unhexlify (const char *in, size_t len)
+{
+   int i;
+   int byte;
+   int total = 0;
+   int multiplier = 1;
+
+   for (i = (int) len - 1; i >= 0; i--) {
+      char c = *(in + i);
+
+      if (c >= '0' && c <= '9') {
+         byte = c - 48;
+      } else if (c >= 'a' && c <= 'f') {
+         byte = c - 97 + 10;
+      } else if (c >= 'A' && c <= 'F') {
+         byte = c - 65 + 10;
+      } else {
+         return -1;
+      }
+
+      total += byte * multiplier;
+      multiplier *= 16;
+   }
+   return total;
 }

--- a/kms-message/src/hexlify.c
+++ b/kms-message/src/hexlify.c
@@ -20,12 +20,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef _MSC_VER
-#define SSCANF sscanf_s
-#else
-#define SSCANF sscanf
-#endif
-
 char *
 hexlify (const uint8_t *buf, size_t len)
 {

--- a/kms-message/src/hexlify.h
+++ b/kms-message/src/hexlify.h
@@ -19,3 +19,6 @@
 
 char *
 hexlify (const uint8_t *buf, size_t len);
+
+int
+unhexlify (const char *in, size_t len);

--- a/kms-message/src/kms_message_private.h
+++ b/kms-message/src/kms_message_private.h
@@ -58,6 +58,8 @@ typedef enum {
    PARSING_STATUS_LINE,
    PARSING_HEADER,
    PARSING_BODY,
+   PARSING_CHUNK_LENGTH,
+   PARSING_CHUNK,
    PARSING_DONE
 } kms_response_parser_state_t;
 
@@ -68,6 +70,14 @@ struct _kms_response_parser_t {
    kms_request_str_t *raw_response;
    int content_length;
    int start; /* start of the current thing getting parsed. */
+
+   /* Support two types of HTTP 1.1 responses.
+    * - "Content-Length: x" header is present, indicating the body length.
+    * - "Transfer-Encoding: chunked" header is present, indicating a stream of
+    * chunks.
+    */
+   bool transfer_encoding_chunked;
+   int chunk_size;
    kms_response_parser_state_t state;
 };
 

--- a/kms-message/src/kms_response_parser.c
+++ b/kms-message/src/kms_response_parser.c
@@ -57,6 +57,7 @@ kms_response_parser_wants_bytes (kms_response_parser_t *parser, int32_t max)
    case PARSING_CHUNK_LENGTH:
       return max;
    case PARSING_CHUNK:
+      /* add 2 for trailing \r\n */
       return (parser->chunk_size + 2) -
              ((int) parser->raw_response->len - parser->start);
    case PARSING_BODY:

--- a/kms-message/src/kms_response_parser.c
+++ b/kms-message/src/kms_response_parser.c
@@ -6,6 +6,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "hexlify.h"
+
 /* destroys the members of parser, but not the parser itself. */
 static void
 _parser_destroy (kms_response_parser_t *parser)
@@ -50,6 +52,11 @@ kms_response_parser_wants_bytes (kms_response_parser_t *parser, int32_t max)
    case PARSING_STATUS_LINE:
    case PARSING_HEADER:
       return max;
+   case PARSING_CHUNK_LENGTH:
+      return max;
+   case PARSING_CHUNK:
+      return (parser->chunk_size + 2) -
+             ((int) parser->raw_response->len - parser->start);
    case PARSING_BODY:
       KMS_ASSERT (parser->content_length != -1);
       return parser->content_length -
@@ -99,6 +106,16 @@ _parse_int_from_view (const char *str, int start, int end, int *result)
    ret = _parse_int (num_str, result);
    free (num_str);
    return ret;
+}
+
+static bool
+_parse_hex_from_view (const char *str, int start, int end, int *result)
+{
+   *result = unhexlify (str, end - start);
+   if (*result < 0) {
+      return false;
+   }
+   return true;
 }
 
 /* returns true if char is "linear white space". This *ignores* the folding case
@@ -154,6 +171,9 @@ _parse_line (kms_response_parser_t *parser, int end)
 
       if (i == end) {
          /* empty line, this signals the start of the body. */
+         if (parser->transfer_encoding_chunked) {
+            return PARSING_CHUNK_LENGTH;
+         }
          return PARSING_BODY;
       }
 
@@ -201,9 +221,29 @@ _parse_line (kms_response_parser_t *parser, int end)
             return PARSING_DONE;
          }
       }
+
+      if (0 == strcmp (key->str, "Transfer-Encoding")) {
+         if (0 == strcmp (val->str, "chunked")) {
+            parser->transfer_encoding_chunked = true;
+         } else {
+            KMS_ERROR (parser, "Unsupported Transfer-Encoding: %s", val->str);
+            kms_request_str_destroy (key);
+            kms_request_str_destroy (val);
+            return PARSING_DONE;
+         }
+      }
       kms_request_str_destroy (key);
       kms_request_str_destroy (val);
       return PARSING_HEADER;
+   } else if (parser->state == PARSING_CHUNK_LENGTH) {
+      int result = 0;
+
+      if (!_parse_hex_from_view (raw + i, i, end, &result)) {
+         KMS_ERROR (parser, "Failed to parse hex chunk length.");
+         return PARSING_DONE;
+      }
+      parser->chunk_size = result;
+      return PARSING_CHUNK;
    }
    return PARSING_DONE;
 }
@@ -214,7 +254,7 @@ kms_response_parser_feed (kms_response_parser_t *parser,
                           uint32_t len)
 {
    kms_request_str_t *raw = parser->raw_response;
-   int curr, body_read;
+   int curr, body_read, chunk_read;
 
    curr = (int) raw->len;
    kms_request_str_append_chars (raw, (char *) buf, len);
@@ -223,6 +263,7 @@ kms_response_parser_feed (kms_response_parser_t *parser,
       switch (parser->state) {
       case PARSING_STATUS_LINE:
       case PARSING_HEADER:
+      case PARSING_CHUNK_LENGTH:
          /* find the next \r\n. */
          if (curr && strncmp (raw->str + (curr - 1), "\r\n", 2) == 0) {
             parser->state = _parse_line (parser, curr - 1);
@@ -253,6 +294,29 @@ kms_response_parser_feed (kms_response_parser_t *parser,
          }
 
          curr = (int) raw->len;
+         break;
+      case PARSING_CHUNK:
+         chunk_read = (int) raw->len - parser->start;
+         /* check if we've read the full chunk and the trailing \r\n */
+         if (chunk_read >= parser->chunk_size + 2) {
+            if (!parser->response->body) {
+               parser->response->body = kms_request_str_new ();
+            }
+            kms_request_str_append_chars (parser->response->body,
+                                          raw->str + parser->start,
+                                          parser->chunk_size);
+            curr = parser->start + parser->chunk_size + 2;
+            parser->start = curr;
+            if (parser->chunk_size == 0) {
+               printf ("done\n");
+               /* last chunk. */
+               parser->state = PARSING_DONE;
+            } else {
+               parser->state = PARSING_CHUNK_LENGTH;
+            }
+         } else {
+            curr = (int) raw->len;
+         }
          break;
       case PARSING_DONE:
          KMS_ERROR (parser, "Unexpected extra HTTP content");

--- a/kms-message/src/kms_response_parser.c
+++ b/kms-message/src/kms_response_parser.c
@@ -31,6 +31,8 @@ _parser_init (kms_response_parser_t *parser)
    parser->state = PARSING_STATUS_LINE;
    parser->start = 0;
    parser->failed = false;
+   parser->chunk_size = 0;
+   parser->transfer_encoding_chunked = false;
 }
 
 kms_response_parser_t *

--- a/kms-message/src/kms_response_parser.c
+++ b/kms-message/src/kms_response_parser.c
@@ -112,9 +112,9 @@ _parse_int_from_view (const char *str, int start, int end, int *result)
 }
 
 static bool
-_parse_hex_from_view (const char *str, int start, int end, int *result)
+_parse_hex_from_view (const char *str, int len, int *result)
 {
-   *result = unhexlify (str, end - start);
+   *result = unhexlify (str, len);
    if (*result < 0) {
       return false;
    }
@@ -241,7 +241,7 @@ _parse_line (kms_response_parser_t *parser, int end)
    } else if (parser->state == PARSING_CHUNK_LENGTH) {
       int result = 0;
 
-      if (!_parse_hex_from_view (raw + i, i, end, &result)) {
+      if (!_parse_hex_from_view (raw + i, end - i, &result)) {
          KMS_ERROR (parser, "Failed to parse hex chunk length.");
          return PARSING_DONE;
       }
@@ -311,7 +311,6 @@ kms_response_parser_feed (kms_response_parser_t *parser,
             curr = parser->start + parser->chunk_size + 2;
             parser->start = curr;
             if (parser->chunk_size == 0) {
-               printf ("done\n");
                /* last chunk. */
                parser->state = PARSING_DONE;
             } else {

--- a/kms-message/test/example-chunked-response.bin
+++ b/kms-message/test/example-chunked-response.bin
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=UTF-8
+Vary: X-Origin
+Vary: Referer
+Date: Thu, 24 Sep 2020 14:21:44 GMT
+Server: scaffolding on HTTPServer2
+Cache-Control: private
+X-XSS-Protection: 0
+X-Frame-Options: SAMEORIGIN
+X-Content-Type-Options: nosniff
+Alt-Svc: h3-Q050=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-27=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-T050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+Accept-Ranges: none
+Vary: Origin,Accept-Encoding
+Connection: close
+Transfer-Encoding: chunked
+
+105
+{"access_token":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","expires_in":3599,"token_type":"Bearer"}
+0
+

--- a/kms-message/test/example-multi-chunked-response.bin
+++ b/kms-message/test/example-multi-chunked-response.bin
@@ -1,0 +1,22 @@
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=UTF-8
+Vary: X-Origin
+Vary: Referer
+Date: Thu, 24 Sep 2020 14:21:44 GMT
+Server: scaffolding on HTTPServer2
+Cache-Control: private
+X-XSS-Protection: 0
+X-Frame-Options: SAMEORIGIN
+X-Content-Type-Options: nosniff
+Alt-Svc: h3-Q050=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-27=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-T050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+Accept-Ranges: none
+Vary: Origin,Accept-Encoding
+Connection: close
+Transfer-Encoding: chunked
+
+DD
+{"access_token":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+28
+"expires_in":3599,"token_type":"Bearer"}
+0
+

--- a/kms-message/test/test_kms_request.c
+++ b/kms-message/test/test_kms_request.c
@@ -953,13 +953,12 @@ parser_testcase_run (parser_testcase_t *testcase)
    kms_response_t *response;
    uint8_t buf[512] = {0};
    int bytes_to_read;
-   int i;
 
    response_file = fopen (testcase->filepath, "rb");
    ASSERT (response_file);
 
    parser = kms_response_parser_new ();
-   i = 0;
+
    while ((bytes_to_read = kms_response_parser_wants_bytes (
               parser, testcase->max_to_read)) > 0) {
       if (bytes_to_read > testcase->max_to_read) {
@@ -967,14 +966,10 @@ parser_testcase_run (parser_testcase_t *testcase)
       }
       size_t ret = fread (buf, 1, (size_t) bytes_to_read, response_file);
 
-      // printf ("bytes_to_read=%d\n", bytes_to_read);
       if (!kms_response_parser_feed (parser, buf, (int) ret)) {
          printf ("feed error: %s\n", parser->error);
          ASSERT (false);
       }
-      i++;
-      if (i > 1000)
-         break;
    }
 
    fclose (response_file);

--- a/kms-message/test/test_kms_request.c
+++ b/kms-message/test/test_kms_request.c
@@ -809,35 +809,8 @@ b64_b64url_test (void)
 void
 kms_response_parser_test (void)
 {
-   FILE *response_file;
    kms_response_parser_t *parser = kms_response_parser_new ();
-   uint8_t buf[512] = {0};
-   int bytes_to_read = 0;
    kms_response_t *response;
-
-   response_file = fopen ("./test/example-response.bin", "rb");
-   ASSERT (response_file);
-
-   while ((bytes_to_read = kms_response_parser_wants_bytes (parser, 512)) > 0) {
-      size_t ret = fread (buf, 1, (size_t) bytes_to_read, response_file);
-
-      ASSERT (kms_response_parser_feed (parser, buf, (int) ret));
-   }
-
-   fclose (response_file);
-
-   response = kms_response_parser_get_response (parser);
-
-   ASSERT (response->status == 200);
-   ASSERT_CMPSTR (response->body->str,
-                  "{\"CiphertextBlob\":\"AQICAHifzrL6n/"
-                  "3uqZyz+z1bJj80DhqPcSAibAaIoYc+HOVP6QEplwbM0wpvU5zsQG/"
-                  "1SBKvAAAAZDBiBgkqhkiG9w0BBwagVTBTAgEAME4GCSqGSIb3DQEHATAeBgl"
-                  "ghkgBZQMEAS4wEQQM5syMJE7RodxDaqYqAgEQgCHMFCnFso4Lih0CNbLT1ki"
-                  "ET0hQyzjgoa9733353GQkGlM=\",\"KeyId\":\"arn:aws:kms:us-east-"
-                  "1:524754917239:key/bd05530b-0a7f-4fbd-8362-ab3667370db0\"}");
-
-   kms_response_destroy (response);
 
    /* the parser resets after returning a response. */
    ASSERT (
@@ -962,6 +935,88 @@ kms_response_parser_test (void)
    ASSERT (strstr (kms_response_parser_error (parser),
                    "Unexpected: exceeded content length"));
    kms_response_parser_destroy (parser);
+}
+
+typedef struct {
+   const char *filepath;
+   const char *expected_body;
+   int max_to_read;
+   int expected_status;
+} parser_testcase_t;
+
+/* File should have \r\n line endings (use /etc/rewrite.py) */
+static void
+parser_testcase_run (parser_testcase_t *testcase)
+{
+   FILE *response_file;
+   kms_response_parser_t *parser;
+   kms_response_t *response;
+   uint8_t buf[512] = {0};
+   int bytes_to_read;
+   int i;
+
+   response_file = fopen (testcase->filepath, "rb");
+   ASSERT (response_file);
+
+   parser = kms_response_parser_new ();
+   i = 0;
+   while ((bytes_to_read = kms_response_parser_wants_bytes (
+              parser, testcase->max_to_read)) > 0) {
+      if (bytes_to_read > testcase->max_to_read) {
+         bytes_to_read = testcase->max_to_read;
+      }
+      size_t ret = fread (buf, 1, (size_t) bytes_to_read, response_file);
+
+      // printf ("bytes_to_read=%d\n", bytes_to_read);
+      if (!kms_response_parser_feed (parser, buf, (int) ret)) {
+         printf ("feed error: %s\n", parser->error);
+         ASSERT (false);
+      }
+      i++;
+      if (i > 1000)
+         break;
+   }
+
+   fclose (response_file);
+
+   ASSERT (0 == kms_response_parser_wants_bytes (parser, 123));
+   response = kms_response_parser_get_response (parser);
+   ASSERT_CMPSTR (testcase->expected_body, response->body->str);
+   ASSERT (response->status == testcase->expected_status);
+
+   kms_response_parser_destroy (parser);
+   kms_response_destroy (response);
+}
+
+static void
+kms_response_parser_files (void)
+{
+   const char *body = "{\"CiphertextBlob\":\"AQICAHifzrL6n/"
+                      "3uqZyz+z1bJj80DhqPcSAibAaIoYc+HOVP6QEplwbM0wpvU5zsQG/"
+                      "1SBKvAAAAZDBiBgkqhkiG9w0BBwagVTBTAgEAME4GCSqGSIb3DQEHATA"
+                      "eBglghkgBZQMEAS4wEQQM5syMJE7RodxDaqYqAgEQgCHMFCnFso4Lih0"
+                      "CNbLT1kiET0hQyzjgoa9733353GQkGlM=\",\"KeyId\":\"arn:aws:"
+                      "kms:us-east-1:524754917239:key/"
+                      "bd05530b-0a7f-4fbd-8362-ab3667370db0\"}";
+   const char *chunked_body =
+      "{\"access_token\":"
+      "\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\","
+      "\"expires_in\":3599,\"token_type\":\"Bearer\"}";
+   parser_testcase_t tests[] = {
+      {"./test/example-response.bin", body, 512, 200},
+      {"./test/example-response.bin", body, 1, 200},
+      {"./test/example-chunked-response.bin", chunked_body, 512, 200},
+      {"./test/example-chunked-response.bin", chunked_body, 1, 200},
+      {"./test/example-multi-chunked-response.bin", chunked_body, 512, 200},
+      {"./test/example-multi-chunked-response.bin", chunked_body, 1, 200}};
+   size_t i;
+
+   for (i = 0; i < sizeof (tests) / sizeof (tests[0]); i++) {
+      printf (" parser testcase: %d\n", (int) i);
+      parser_testcase_run (tests + i);
+   }
 }
 
 #define CLEAR(_field)                   \
@@ -1165,6 +1220,7 @@ main (int argc, char *argv[])
    ran_tests |= all_aws_sig_v4_tests (aws_test_suite_dir, selector);
 
    RUN_TEST (kms_response_parser_test);
+   RUN_TEST (kms_response_parser_files);
    RUN_TEST (kms_request_validate_test);
 
    RUN_TEST (kms_signature_test);


### PR DESCRIPTION
GCP HTTP responses used `Transfer-Encoding: chunked`. This adds support in the tiny kms-message HTTP parser.