### PR TITLE
CSHARP-3142: mongocrypt.dll not present when using mongocsharpdriver in an 'SDK' project

### DIFF
--- a/bindings/cs/MongoDB.Libmongocrypt/LibraryLoader.cs
+++ b/bindings/cs/MongoDB.Libmongocrypt/LibraryLoader.cs
@@ -87,7 +87,8 @@ namespace MongoDB.Libmongocrypt
                     {
                         string[] suffixPaths = new[]
                         {
-                            @"..\..\x64\native\windows\",
+                            @"..\..\runtimes\win\native\",
+                            @".\runtimes\win\native\",
                             string.Empty
                         };
                         string path = FindLibrary(candidatePaths, suffixPaths, "mongocrypt.dll");

--- a/bindings/cs/MongoDB.Libmongocrypt/MongoDB.Libmongocrypt.csproj
+++ b/bindings/cs/MongoDB.Libmongocrypt/MongoDB.Libmongocrypt.csproj
@@ -62,7 +62,7 @@
   <ItemGroup>
     <Content Include="$(LibMongoCryptBinaries)/mongocrypt.dll">
       <Pack>true</Pack>
-      <PackagePath>x64/native/windows</PackagePath>
+      <PackagePath>runtimes/win/native</PackagePath>
     </Content>
   </ItemGroup>
 

--- a/bindings/cs/MongoDB.Libmongocrypt/MongoDB.Libmongocrypt.targets
+++ b/bindings/cs/MongoDB.Libmongocrypt/MongoDB.Libmongocrypt.targets
@@ -1,10 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-    <ItemGroup Condition="$([MSBuild]::IsOsPlatform('Windows'))">
-        <Content Include="$(MSBuildThisFileDirectory)../x64/native/windows/mongocrypt.dll">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Link>mongocrypt.dll</Link>
-        </Content>
-    </ItemGroup>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Condition="Exists('packages.config') OR Exists('$(MSBuildProjectName).packages.config') OR Exists('packages.$(MSBuildProjectName).config')">
+    <Content Include="$(MSBuildThisFileDirectory)\..\runtimes\win\native\mongocrypt.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+      <Link>mongocrypt.dll</Link>
+    </Content>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
https://jira.mongodb.org/browse/CSHARP-3142

Note: changes in .sln file were made because solution wasn't opening in visual studio 2019 and were made automatically.