### PR TITLE
MONGOCRYPT-271 add KMS message API for GCP

### DIFF
--- a/kms-message/CMakeLists.txt
+++ b/kms-message/CMakeLists.txt
@@ -24,6 +24,7 @@ set (KMS_MESSAGE_SOURCES
    src/kms_caller_identity_request.c
    src/kms_decrypt_request.c
    src/kms_encrypt_request.c
+   src/kms_gcp_request.c
    src/kms_kv_list.c
    src/kms_kv_list.h
    src/kms_message.c
@@ -32,6 +33,7 @@ set (KMS_MESSAGE_SOURCES
    src/kms_message/kms_caller_identity_request.h
    src/kms_message/kms_decrypt_request.h
    src/kms_message/kms_encrypt_request.h
+   src/kms_message/kms_gcp_request.h
    src/kms_message/kms_message.h
    src/kms_message/kms_request.h
    src/kms_message/kms_request_opt.h
@@ -152,6 +154,7 @@ install (
    src/kms_message/kms_caller_identity_request.h
    src/kms_message/kms_decrypt_request.h
    src/kms_message/kms_encrypt_request.h
+   src/kms_message/kms_gcp_request.h
    src/kms_message/kms_message.h
    src/kms_message/kms_message_defines.h
    src/kms_message/kms_request.h
@@ -237,10 +240,17 @@ if(NOT mongoc-1.0_FOUND)
 elseif(DISABLE_NATIVE_CRYPTO)
    message ("test_kms_azure_online target disabled: Not building with native crypto.")
 elseif(ENABLE_ONLINE_TESTS)
-   add_executable(test_kms_azure_online test/test_kms_azure_online.c test/test_kms.c)
+   add_executable(test_kms_azure_online test/test_kms_azure_online.c test/test_kms.c test/test_kms_online_util.c)
    target_include_directories(test_kms_azure_online PRIVATE ${PROJECT_SOURCE_DIR}/src)
    target_include_directories(test_kms_azure_online PRIVATE ${PROJECT_SOURCE_DIR}/src/kms_message)
    target_compile_definitions(test_kms_azure_online PRIVATE ${KMS_MESSAGE_DEFINITIONS})
    target_link_libraries(test_kms_azure_online mongo::mongoc_shared)
    target_link_libraries(test_kms_azure_online kms_message_static)
+
+   add_executable(test_kms_gcp_online test/test_kms_gcp_online.c test/test_kms.c test/test_kms_online_util.c)
+   target_include_directories(test_kms_gcp_online PRIVATE ${PROJECT_SOURCE_DIR}/src)
+   target_include_directories(test_kms_gcp_online PRIVATE ${PROJECT_SOURCE_DIR}/src/kms_message)
+   target_compile_definitions(test_kms_gcp_online PRIVATE ${KMS_MESSAGE_DEFINITIONS})
+   target_link_libraries(test_kms_gcp_online mongo::mongoc_shared)
+   target_link_libraries(test_kms_gcp_online kms_message_static)
 endif ()

--- a/kms-message/src/kms_crypto.h
+++ b/kms-message/src/kms_crypto.h
@@ -31,6 +31,12 @@ typedef struct {
                         const char *input,
                         size_t len,
                         unsigned char *hash_out);
+   bool (*sign_rsaes_pkcs1_v1_5) (void *ctx,
+                                  const char *private_key,
+                                  size_t private_key_len,
+                                  const char *input,
+                                  size_t input_len,
+                                  unsigned char *signature_out);
    void *ctx;
 } _kms_crypto_t;
 

--- a/kms-message/src/kms_gcp_request.c
+++ b/kms-message/src/kms_gcp_request.c
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2020-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kms_message/kms_gcp_request.h"
+
+#include "kms_message/kms_b64.h"
+#include "kms_message_private.h"
+#include "kms_request_opt_private.h"
+
+/* Set a default expiration of 5 minutes for JSON Web Tokens (GCP allows up to
+ * one hour) */
+#define JWT_EXPIRATION_SECS 5 * 60
+#define SIGNATURE_LEN 256
+
+kms_request_t *
+kms_gcp_request_oauth_new (const char *host,
+                           const char *email,
+                           const char *audience,
+                           const char *scope,
+                           const char *private_key_data,
+                           size_t private_key_len,
+                           const kms_request_opt_t *opt)
+{
+   kms_request_t *req = NULL;
+   kms_request_str_t *str = NULL;
+   time_t issued_at;
+   /* base64 encoding of {"alg":"RS256","typ":"JWT"} */
+   const char *jwt_header_b64url = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9";
+   char *jwt_claims_b64url = NULL;
+   char *jwt_header_and_claims_b64url = NULL;
+   uint8_t *jwt_signature = NULL;
+   char *jwt_signature_b64url = NULL;
+   char *jwt_assertion_b64url = NULL;
+   char *payload = NULL;
+
+   req = kms_request_new ("POST", "/token", opt);
+   if (opt->provider != KMS_REQUEST_PROVIDER_GCP) {
+      KMS_ERROR (req, "Expected KMS request with provider type: GCP");
+      goto done;
+   }
+
+   if (kms_request_get_error (req)) {
+      goto done;
+   }
+
+   /* Produce the signed JWT <base64url header>.<base64url claims>.<base64url
+    * signature> */
+   issued_at = time (NULL);
+   str = kms_request_str_new ();
+   kms_request_str_appendf (str,
+                            "{\"iss\": \"%s\", \"aud\": \"%s\", \"scope\": "
+                            "\"%s\", \"iat\": %lu, \"exp\": %lu}",
+                            email,
+                            audience,
+                            scope,
+                            (unsigned long) issued_at,
+                            (unsigned long) issued_at + JWT_EXPIRATION_SECS);
+   jwt_claims_b64url =
+      kms_message_raw_to_b64url ((const uint8_t *) str->str, str->len);
+   kms_request_str_destroy (str);
+   if (!jwt_claims_b64url) {
+      KMS_ERROR (req, "Failed to base64url encode JWT claims");
+      goto done;
+   }
+
+   str = kms_request_str_new ();
+   kms_request_str_appendf (str, "%s.%s", jwt_header_b64url, jwt_claims_b64url);
+   jwt_header_and_claims_b64url = kms_request_str_detach (str);
+
+   /* Produce the signature of <base64url header>.<base64url claims> */
+   req->crypto.sign_rsaes_pkcs1_v1_5 = kms_sign_rsaes_pkcs1_v1_5;
+   if (opt->crypto.sign_rsaes_pkcs1_v1_5) {
+      req->crypto.sign_rsaes_pkcs1_v1_5 = opt->crypto.sign_rsaes_pkcs1_v1_5;
+   }
+
+   jwt_signature = malloc (SIGNATURE_LEN);
+   if (!req->crypto.sign_rsaes_pkcs1_v1_5 (
+          req->crypto.ctx,
+          private_key_data,
+          private_key_len,
+          jwt_header_and_claims_b64url,
+          strlen (jwt_header_and_claims_b64url),
+          jwt_signature)) {
+      KMS_ERROR (req, "Failed to create GCP oauth request signature");
+      goto done;
+   }
+
+   jwt_signature_b64url =
+      kms_message_raw_to_b64url (jwt_signature, SIGNATURE_LEN);
+   if (!jwt_signature_b64url) {
+      KMS_ERROR (req, "Failed to base64url encode JWT signature");
+      goto done;
+   }
+   str = kms_request_str_new ();
+   kms_request_str_appendf (str,
+                            "%s.%s.%s",
+                            jwt_header_b64url,
+                            jwt_claims_b64url,
+                            jwt_signature_b64url);
+   jwt_assertion_b64url = kms_request_str_detach (str);
+
+   str =
+      kms_request_str_new_from_chars ("grant_type=urn%3Aietf%3Aparams%3Aoauth%"
+                                      "3Agrant-type%3Ajwt-bearer&assertion=",
+                                      -1);
+   kms_request_str_append_chars (str, jwt_assertion_b64url, -1);
+   payload = kms_request_str_detach (str);
+
+   if (!kms_request_add_header_field (
+          req, "Content-Type", "application/x-www-form-urlencoded")) {
+      goto done;
+   }
+   if (!kms_request_add_header_field (req, "Host", host)) {
+      goto done;
+   }
+   if (!kms_request_add_header_field (req, "Accept", "application/json")) {
+      goto done;
+   }
+
+   if (!kms_request_append_payload (req, payload, strlen (payload))) {
+      goto done;
+   }
+
+done:
+   free (jwt_signature);
+   free (jwt_signature_b64url);
+   free (jwt_claims_b64url);
+   free (jwt_header_and_claims_b64url);
+   free (jwt_assertion_b64url);
+   free (payload);
+   return req;
+}
+
+static kms_request_t *
+_encrypt_decrypt_common (const char *encrypt_decrypt,
+                         const char *host,
+                         const char *access_token,
+                         const char *project_id,
+                         const char *location,
+                         const char *key_ring_name,
+                         const char *key_name,
+                         const char *key_version,
+                         const uint8_t *value,
+                         size_t value_len,
+                         const kms_request_opt_t *opt)
+{
+   char *path_and_query = NULL;
+   char *payload = NULL;
+   char *bearer_token_value = NULL;
+   char *value_base64 = NULL;
+   kms_request_t *req;
+   kms_request_str_t *str;
+
+   str = kms_request_str_new ();
+   /* /v1/projects/{project-id}/locations/{location}/keyRings/{key-ring-name}/cryptoKeys/{key-name}
+    */
+   kms_request_str_appendf (
+      str,
+      "/v1/projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s",
+      project_id,
+      location,
+      key_ring_name,
+      key_name);
+   if (key_version && strlen (key_version) > 0) {
+      kms_request_str_appendf (str, "/cryptoKeyVersions/%s", key_version);
+   }
+   kms_request_str_appendf (str, ":%s", encrypt_decrypt);
+   path_and_query = kms_request_str_detach (str);
+
+   req = kms_request_new ("POST", path_and_query, opt);
+
+   if (opt->provider != KMS_REQUEST_PROVIDER_GCP) {
+      KMS_ERROR (req, "Expected KMS request with provider type: GCP");
+      goto done;
+   }
+
+   if (kms_request_get_error (req)) {
+      goto done;
+   }
+
+   value_base64 = kms_message_raw_to_b64 (value, value_len);
+   if (!value_base64) {
+      KMS_ERROR (req, "Could not bases64-encode plaintext");
+      goto done;
+   }
+
+   str = kms_request_str_new ();
+   if (0 == strcmp ("encrypt", encrypt_decrypt)) {
+      kms_request_str_appendf (str, "{\"plaintext\": \"%s\"}", value_base64);
+   } else {
+      kms_request_str_appendf (str, "{\"ciphertext\": \"%s\"}", value_base64);
+   }
+
+   payload = kms_request_str_detach (str);
+   str = kms_request_str_new ();
+   kms_request_str_appendf (str, "Bearer %s", access_token);
+   bearer_token_value = kms_request_str_detach (str);
+   if (!kms_request_add_header_field (
+          req, "Authorization", bearer_token_value)) {
+      goto done;
+   }
+   if (!kms_request_add_header_field (
+          req, "Content-Type", "application/json")) {
+      goto done;
+   }
+   if (!kms_request_add_header_field (req, "Host", host)) {
+      goto done;
+   }
+   if (!kms_request_add_header_field (req, "Accept", "application/json")) {
+      goto done;
+   }
+
+   if (!kms_request_append_payload (req, payload, strlen (payload))) {
+      goto done;
+   }
+
+done:
+   kms_request_free_string (path_and_query);
+   kms_request_free_string (payload);
+   kms_request_free_string (bearer_token_value);
+   kms_request_free_string (value_base64);
+   return req;
+}
+
+kms_request_t *
+kms_gcp_request_encrypt_new (const char *host,
+                             const char *access_token,
+                             const char *project_id,
+                             const char *location,
+                             const char *key_ring_name,
+                             const char *key_name,
+                             const char *key_version,
+                             const uint8_t *plaintext,
+                             size_t plaintext_len,
+                             const kms_request_opt_t *opt)
+{
+   return _encrypt_decrypt_common ("encrypt",
+                                   host,
+                                   access_token,
+                                   project_id,
+                                   location,
+                                   key_ring_name,
+                                   key_name,
+                                   key_version,
+                                   plaintext,
+                                   plaintext_len,
+                                   opt);
+}
+
+kms_request_t *
+kms_gcp_request_decrypt_new (const char *host,
+                             const char *access_token,
+                             const char *project_id,
+                             const char *location,
+                             const char *key_ring_name,
+                             const char *key_name,
+                             const uint8_t *ciphertext,
+                             size_t ciphertext_len,
+                             const kms_request_opt_t *opt)
+{
+   return _encrypt_decrypt_common ("decrypt",
+                                   host,
+                                   access_token,
+                                   project_id,
+                                   location,
+                                   key_ring_name,
+                                   key_name,
+                                   NULL /* key_version */,
+                                   ciphertext,
+                                   ciphertext_len,
+                                   opt);
+}

--- a/kms-message/src/kms_message/kms_gcp_request.h
+++ b/kms-message/src/kms_message/kms_gcp_request.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KMS_GCP_REQUEST_H
+#define KMS_GCP_REQUEST_H
+
+#include "kms_message_defines.h"
+#include "kms_request.h"
+#include "kms_request_opt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Constructs an oauth client credentials request for GCP.
+ * See https://developers.google.com/identity/protocols/oauth2/service-account
+ *
+ * Parameters:
+ * - host: The host header, like "oauth2.googleapis.com".
+ * - email: The email for the service account to authenticate.
+ * - audience: The "aud" field in the JSON Web Token (JWT). Should be a URL
+ *   like "https://oauth2.googleapis.com/token"
+ * - scope: The "scope" field in the JSON Web Token (JWT). Should be a URL
+ *   like "https://www.googleapis.com/auth/cloudkms".
+ * - private_key_data: Bytes pointing to a PKCS#8 private key.
+ * - private_key_len: The length of private_key_data.
+ * - opt: Request options. The provider must be set to KMS_REQUEST_PROVIDER_GCP
+ *   with kms_request_opt_set_provider. Callers that want to use a custom crypto
+ *   callback to sign the request should set the callback on opt with
+ *   kms_request_opt_set_crypto_hook_rsaes_pkcs1_v1_5.
+ *
+ * Returns: A new kms_request_t.
+ * Always returns a new kms_request_t, even on error.
+ * Caller must check if an error occurred by calling kms_request_get_error.
+ */
+KMS_MSG_EXPORT (kms_request_t *)
+kms_gcp_request_oauth_new (const char *host,
+                           const char *email,
+                           const char *audience,
+                           const char *scope,
+                           const char *private_key_data,
+                           size_t private_key_len,
+                           const kms_request_opt_t *opt);
+
+/* Constructs the encrypt request for GCP.
+ * See
+ * https://cloud.google.com/kms/docs/encrypt-decrypt#kms-encrypt-symmetric-api
+ *
+ * Parameters:
+ * - host: The value of the Host header, like "cloudkms.googleapis.com".
+ * - project_id: The project id.
+ * - location: The location id, like "global".
+ * - key_ring_name: The key ring name.
+ * - key_name: The key name.
+ * - key_version: The optional key version. May be NULL.
+ * - plaintext: The plaintext key to encrypt.
+ * - plaintext_len: The number of bytes of plaintext.
+ * - opt: Request options. The provider must be set to KMS_REQUEST_PROVIDER_GCP
+ *   with kms_request_opt_set_provider.
+ *
+ * Returns: A new kms_request_t.
+ * Always returns a new kms_request_t, even on error.
+ * Caller must check if an error occurred by calling kms_request_get_error.
+ */
+KMS_MSG_EXPORT (kms_request_t *)
+kms_gcp_request_encrypt_new (const char *host,
+                             const char *access_token,
+                             const char *project_id,
+                             const char *location,
+                             const char *key_ring_name,
+                             const char *key_name,
+                             const char *key_version,
+                             const uint8_t *plaintext,
+                             size_t plaintext_len,
+                             const kms_request_opt_t *opt);
+
+/* Constructs the decrypt request for GCP.
+ * See
+ * https://cloud.google.com/kms/docs/encrypt-decrypt#kms-decrypt-symmetric-api
+ *
+ * Parameters:
+ * - host: The value of the Host header, like "cloudkms.googleapis.com".
+ * - project_id: The project id.
+ * - location: The location id, like "global".
+ * - key_ring_name: The key ring name.
+ * - key_name: The key name.
+ * - ciphertext: The ciphertext key to encrypt.
+ * - ciphertext_len: The number of bytes of ciphertext.
+ * - opt: Request options. The provider must be set to KMS_REQUEST_PROVIDER_GCP
+ *   with kms_request_opt_set_provider.
+ *
+ * Returns: A new kms_request_t.
+ * Always returns a new kms_request_t, even on error.
+ * Caller must check if an error occurred by calling kms_request_get_error.
+ */
+KMS_MSG_EXPORT (kms_request_t *)
+kms_gcp_request_decrypt_new (const char *host,
+                             const char *access_token,
+                             const char *project_id,
+                             const char *location,
+                             const char *key_ring_name,
+                             const char *key_name,
+                             const uint8_t *ciphertext,
+                             size_t ciphertext_len,
+                             const kms_request_opt_t *opt);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* KMS_GCP_REQUEST_H */

--- a/kms-message/src/kms_message/kms_request_opt.h
+++ b/kms-message/src/kms_message/kms_request_opt.h
@@ -32,6 +32,7 @@ typedef size_t kms_request_provider_t;
 
 #define KMS_REQUEST_PROVIDER_AWS 0
 #define KMS_REQUEST_PROVIDER_AZURE 1
+#define KMS_REQUEST_PROVIDER_GCP 2
 
 KMS_MSG_EXPORT (kms_request_opt_t *)
 kms_request_opt_new (void);
@@ -46,6 +47,7 @@ kms_request_opt_destroy (kms_request_opt_t *request);
 KMS_MSG_EXPORT (void)
 kms_request_opt_set_connection_close (kms_request_opt_t *opt,
                                       bool connection_close);
+
 KMS_MSG_EXPORT (void)
 kms_request_opt_set_crypto_hooks (kms_request_opt_t *opt,
                                   bool (*sha256) (void *ctx,
@@ -60,6 +62,16 @@ kms_request_opt_set_crypto_hooks (kms_request_opt_t *opt,
                                                        unsigned char *hash_out),
                                   void *ctx);
 
+KMS_MSG_EXPORT (void)
+kms_request_opt_set_crypto_hook_sign_rsaes_pkcs1_v1_5 (
+   kms_request_opt_t *opt,
+   bool (*sign_rsaes_pkcs1_v1_5) (void *ctx,
+                                  const char *private_key,
+                                  size_t private_key_len,
+                                  const char *input,
+                                  size_t input_len,
+                                  unsigned char *signature_out),
+   void *ctx);
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/kms-message/src/kms_request_opt.c
+++ b/kms-message/src/kms_request_opt.c
@@ -63,9 +63,25 @@ kms_request_opt_set_provider (kms_request_opt_t *opt,
                               kms_request_provider_t provider)
 {
    if (provider != KMS_REQUEST_PROVIDER_AWS &&
-       provider != KMS_REQUEST_PROVIDER_AZURE) {
+       provider != KMS_REQUEST_PROVIDER_AZURE &&
+       provider != KMS_REQUEST_PROVIDER_GCP) {
       return false;
    }
    opt->provider = provider;
    return true;
+}
+
+void
+kms_request_opt_set_crypto_hook_sign_rsaes_pkcs1_v1_5 (
+   kms_request_opt_t *opt,
+   bool (*sign_rsaes_pkcs1_v1_5) (void *ctx,
+                                  const char *private_key,
+                                  size_t private_key_len,
+                                  const char *input,
+                                  size_t input_len,
+                                  unsigned char *signature_out),
+   void *ctx)
+{
+   opt->crypto.sign_rsaes_pkcs1_v1_5 = sign_rsaes_pkcs1_v1_5;
+   opt->crypto.ctx = ctx;
 }

--- a/kms-message/test/test_kms_online_util.c
+++ b/kms-message/test/test_kms_online_util.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test_kms_online_util.h"
+
+#include "test_kms.h"
+
+#include <kms_message/kms_response_parser.h>
+
+
+/* Create a TLS stream to a host. */
+mongoc_stream_t *
+connect_with_tls (const char *host)
+{
+   mongoc_stream_t *stream;
+   mongoc_socket_t *sock = NULL;
+   struct addrinfo hints;
+   struct addrinfo *result, *rp;
+   int64_t expire_at;
+   int s;
+   const int connecttimeoutms = 5000;
+
+   memset (&hints, 0, sizeof hints);
+   hints.ai_family = AF_INET;
+   hints.ai_socktype = SOCK_STREAM;
+   hints.ai_flags = 0;
+   hints.ai_protocol = 0;
+
+   s = getaddrinfo (host, "443", &hints, &result);
+   TEST_ASSERT (s == 0);
+
+   for (rp = result; rp; rp = rp->ai_next) {
+      if (!(sock = mongoc_socket_new (
+               rp->ai_family, rp->ai_socktype, rp->ai_protocol))) {
+         continue;
+      }
+
+      expire_at = bson_get_monotonic_time () + (connecttimeoutms * 1000L);
+      if (0 !=
+          mongoc_socket_connect (
+             sock, rp->ai_addr, (mongoc_socklen_t) rp->ai_addrlen, expire_at)) {
+         mongoc_socket_destroy (sock);
+         sock = NULL;
+         continue;
+      }
+
+      break;
+   }
+
+   if (!sock) {
+      TEST_ERROR ("Failed to connect: %s", host);
+   }
+
+   freeaddrinfo (result);
+
+   stream = mongoc_stream_socket_new (sock);
+   TEST_ASSERT (stream);
+   return mongoc_stream_tls_new_with_hostname (
+      stream, host, (mongoc_ssl_opt_t *) mongoc_ssl_opt_get_default (), 1);
+}
+
+/* Helper to send an HTTP request and receive a response. */
+kms_response_t *
+send_kms_request (kms_request_t *req, const char *host)
+{
+   mongoc_stream_t *tls_stream;
+   char *req_str;
+   int32_t socket_timeout_ms = 5000;
+   ssize_t write_ret;
+   kms_response_parser_t *response_parser;
+   int bytes_to_read;
+   int bytes_read;
+   uint8_t buf[1024];
+   kms_response_t *response;
+
+   tls_stream = connect_with_tls (host);
+   req_str = kms_request_to_string (req);
+
+   write_ret = mongoc_stream_write (
+      tls_stream, req_str, strlen (req_str), socket_timeout_ms);
+   TEST_ASSERT (write_ret == (ssize_t) strlen (req_str));
+
+   response_parser = kms_response_parser_new ();
+   while ((bytes_to_read =
+              kms_response_parser_wants_bytes (response_parser, 1024)) > 0) {
+      bytes_read =
+         (int) mongoc_stream_read (tls_stream, buf, 1024, 0, socket_timeout_ms);
+      printf ("read bytes: %.*s", bytes_read, (char*) buf);
+      if (!kms_response_parser_feed (response_parser, buf, bytes_read)) {
+         TEST_ERROR ("read failed: %s",
+                     kms_response_parser_error (response_parser));
+      }
+   }
+
+   response = kms_response_parser_get_response (response_parser);
+   TEST_ASSERT (response);
+
+   kms_request_free_string (req_str);
+   kms_response_parser_destroy (response_parser);
+   mongoc_stream_destroy (tls_stream);
+   return response;
+}

--- a/kms-message/test/test_kms_online_util.h
+++ b/kms-message/test/test_kms_online_util.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TEST_KMS_ONLINE_UTIL_H
+#define TEST_KMS_ONLINE_UTIL_H
+
+#include <mongoc/mongoc.h>
+#include <kms_message/kms_request.h>
+#include <kms_message/kms_response.h>
+
+mongoc_stream_t *
+connect_with_tls (const char *host);
+
+kms_response_t *
+send_kms_request (kms_request_t *req, const char *host);
+
+#endif /* TEST_KMS_ONLINE_UTIL_H */


### PR DESCRIPTION
This adds the API to KMS message for the three new GCP requests (oauth, encrypt, and decrypt) as well as the API for configuring a callback for producing the JWT signature.