### PR TITLE
MONGOCRYPT-283 consolidate KEK and KMS provider API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 ## [Unreleased]
+### Deprecated
+- mongocrypt_setopt_kms_provider_aws and mongocrypt_setopt_kms_provider_local are deprecated in favor of the more flexible mongocrypt_setopt_kms_providers, which supports configuration of all KMS providers.
+- mongocrypt_ctx_setopt_masterkey_aws and mongocrypt_ctx_setopt_masterkey_aws_endpoint are deprecated in favor of the more flexible mongocrypt_ctx_setopt_key_encryption_key, which supports configuration for all KMS providers.
 ### Added
 - Introduces a new crypto hook for signing the JSON Web Token (JWT) for Google Cloud Platform (GCP) requests:
     - mongocrypt_setopt_crypto_hook_sign_rsaes_pkcs1_v1_5
@@ -9,3 +12,4 @@
         To set the KMS providers.
     - mongocrypt_ctx_setopt_key_encryption_key
         To set the key encryption key.
+- Adds support for Azure and GCP KMS providers.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ set (MONGOCRYPT_SOURCES
    src/mongocrypt-ctx-encrypt.c
    src/mongocrypt-ctx.c
    src/mongocrypt-endpoint.c
+   src/mongocrypt-kek.c
    src/mongocrypt-key.c
    src/mongocrypt-key-broker.c
    src/mongocrypt-kms-ctx.c
@@ -232,6 +233,7 @@ set (TEST_MONGOCRYPT_SOURCES
    test/test-mongocrypt-ctx-setopt.c
    test/test-mongocrypt-datakey.c
    test/test-mongocrypt-endpoint.c
+   test/test-mongocrypt-kek.c
    test/test-mongocrypt-key.c
    test/test-mongocrypt-key-broker.c
    test/test-mongocrypt-key-cache.c

--- a/etc/generate-kek-tests.py
+++ b/etc/generate-kek-tests.py
@@ -1,0 +1,69 @@
+import json
+keks = {
+    "aws": {
+        "template": {
+            "provider": "aws",
+            "key": "example arn",
+            "region": "example region",
+            "endpoint": "example.com"
+        },
+        "optional": [ "endpoint" ],
+        "endpoints": [ "endpoint" ]
+    },
+    "local": {
+        "template": {
+            "provider": "local"
+        }
+    },
+    "azure": {
+        "template": {
+            "provider": "azure",
+            "keyVaultEndpoint": "keyvault.example.com",
+            "keyName": "example keyName",
+            "keyVersion": "example keyVersion"
+        },
+        "optional": [ "keyVersion" ],
+        "endpoints": [ "keyVaultEndpoint" ]
+    },
+    "gcp": {
+        "template": {
+            "provider": "gcp",
+            "projectId": "example projectId",
+            "location": "example location",
+            "keyRing": "example keyRing",
+            "keyName": "example keyName",
+            "keyVersion": "example keyVersion",
+            "endpoint": "example.com"
+        },
+        "optional": [ "endpoint", "keyVersion" ],
+        "endpoints": [ "endpoint" ]
+    }
+}
+
+testcases = []
+def add_testcase (input, expect):
+    testcases.append ({
+        "input": input,
+        "expect": expect
+    })
+
+for name, kek in keks.items():
+    # Add successful case.
+    add_testcase (kek["template"], "ok")
+
+    # Test that endpoints are validated.
+    if "endpoints" in kek:
+        testcase = kek["template"].copy()
+        for endpoint in kek["endpoints"]:
+            testcase[endpoint] = "invalid endpoint"
+            add_testcase (testcase, "invalid endpoint")
+
+    # Test with all optional fields removed.
+    if "optional" in kek:
+        testcase = {}
+        for k,v in kek["template"].items():
+            if k not in kek["optional"]:
+                testcase[k] = v
+        add_testcase (testcase, "ok")
+
+print (json.dumps(testcases, indent=4))

--- a/src/mongocrypt-ctx-datakey.c
+++ b/src/mongocrypt-ctx-datakey.c
@@ -122,8 +122,7 @@ _kms_start (mongocrypt_ctx_t *ctx)
       }
 
       ctx->state = MONGOCRYPT_CTX_NEED_KMS;
-   } else if (ctx->opts.kek.kms_provider ==
-              MONGOCRYPT_KMS_PROVIDER_AZURE) {
+   } else if (ctx->opts.kek.kms_provider == MONGOCRYPT_KMS_PROVIDER_AZURE) {
       access_token =
          _mongocrypt_cache_oauth_get (ctx->crypt->cache_oauth_azure);
       if (access_token) {
@@ -165,10 +164,11 @@ _kms_start (mongocrypt_ctx_t *ctx)
             goto done;
          }
       } else {
-         if (!_mongocrypt_kms_ctx_init_gcp_auth (&dkctx->kms,
-                                                 &ctx->crypt->log,
-                                                 &ctx->crypt->opts,
-                                                 ctx->opts.kek.provider.gcp.endpoint)) {
+         if (!_mongocrypt_kms_ctx_init_gcp_auth (
+                &dkctx->kms,
+                &ctx->crypt->log,
+                &ctx->crypt->opts,
+                ctx->opts.kek.provider.gcp.endpoint)) {
             mongocrypt_kms_ctx_status (&dkctx->kms, ctx->status);
             _mongocrypt_ctx_fail (ctx);
             goto done;
@@ -349,9 +349,8 @@ mongocrypt_ctx_datakey_init (mongocrypt_ctx_t *ctx)
    }
    ret = false;
    memset (&opts_spec, 0, sizeof (opts_spec));
-   opts_spec.masterkey = OPT_REQUIRED;
+   opts_spec.kek = OPT_REQUIRED;
    opts_spec.key_alt_names = OPT_OPTIONAL;
-   opts_spec.endpoint = OPT_OPTIONAL;
 
    if (!_mongocrypt_ctx_init (ctx, &opts_spec)) {
       return false;

--- a/src/mongocrypt-ctx-datakey.c
+++ b/src/mongocrypt-ctx-datakey.c
@@ -95,7 +95,7 @@ _kms_start (mongocrypt_ctx_t *ctx)
       crypt_ret = _mongocrypt_do_encryption (ctx->crypt->crypto,
                                              &iv,
                                              NULL /* associated data. */,
-                                             &ctx->crypt->opts.kms_local_key,
+                                             &ctx->crypt->opts.kms_provider_local.key,
                                              &dkctx->plaintext_key_material,
                                              &dkctx->encrypted_key_material,
                                              &bytes_written,

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -848,7 +848,7 @@ mongocrypt_ctx_encrypt_init (mongocrypt_ctx_t *ctx,
 
    ectx->ns = bson_strdup_printf ("%s.%s", ectx->db_name, ectx->coll_name);
 
-   if (ctx->opts.masterkey_aws_region || ctx->opts.masterkey_aws_cmk) {
+   if (ctx->opts.kek.provider.aws.region || ctx->opts.kek.provider.aws.cmk) {
       return _mongocrypt_ctx_fail_w_msg (
          ctx, "aws masterkey options must not be set");
    }

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -147,12 +147,11 @@ typedef enum {
    OPT_OPTIONAL
 } _mongocrypt_ctx_opt_spec_t;
 typedef struct {
-   _mongocrypt_ctx_opt_spec_t masterkey;
+   _mongocrypt_ctx_opt_spec_t kek;
    _mongocrypt_ctx_opt_spec_t schema;
    _mongocrypt_ctx_opt_spec_t key_descriptor; /* a key_id or key_alt_name */
    _mongocrypt_ctx_opt_spec_t key_alt_names;
    _mongocrypt_ctx_opt_spec_t algorithm;
-   _mongocrypt_ctx_opt_spec_t endpoint;
 } _mongocrypt_ctx_opts_spec_t;
 
 /* Common initialization. */

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -31,43 +31,15 @@ typedef enum {
    _MONGOCRYPT_TYPE_CREATE_DATA_KEY,
 } _mongocrypt_ctx_type_t;
 
-/* Key encryption key (aka masterkey) options for Azure. */
-typedef struct {
-   _mongocrypt_endpoint_t *key_vault_endpoint;
-   char *key_name;
-   char *key_version;
-} _mongocrypt_ctx_opts_azure_kek_t;
-
-typedef struct {
-   _mongocrypt_endpoint_t *endpoint;
-   char *project_id;
-   char *location;
-   char *key_ring;
-   char *key_name;
-   char *key_version;
-} _mongocrypt_ctx_opts_gcp_kek_t;
-
 /* Option values are validated when set.
  * Different contexts accept/require different options,
  * validated when a context is initialized.
  */
 typedef struct __mongocrypt_ctx_opts_t {
-   _mongocrypt_kms_provider_t masterkey_kms_provider;
-   char *masterkey_aws_cmk;
-   uint32_t masterkey_aws_cmk_len;
-   char *masterkey_aws_region;
-   uint32_t masterkey_aws_region_len;
-   char *masterkey_aws_endpoint;
-   uint32_t masterkey_aws_endpoint_len;
    _mongocrypt_buffer_t key_id;
    _mongocrypt_key_alt_name_t *key_alt_names;
    mongocrypt_encryption_algorithm_t algorithm;
-
-   /* Determined by the masterkey_kms_provider. */
-   union {
-      _mongocrypt_ctx_opts_azure_kek_t azure;
-      _mongocrypt_ctx_opts_gcp_kek_t gcp;
-   } kek;
+   _mongocrypt_kek_t kek;
 } _mongocrypt_ctx_opts_t;
 
 

--- a/src/mongocrypt-kek-private.h
+++ b/src/mongocrypt-kek-private.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MONGOCRYPT_KEK_PRIVATE_H
+#define MONGOCRYPT_KEK_PRIVATE_H
+
+#include <bson/bson.h>
+
+#include "mongocrypt.h"
+#include "mongocrypt-endpoint-private.h"
+
+/* Defines structs for Key Encryption Keys (KEKs)
+ * The KEK is used as part of envelope encryption. It encrypts a Data Encryption
+ * Key (DEK). A KEK is specified when creating a new data encryption key, or
+ * when parsing a key document from the key vault.
+ */
+
+/* KMS providers are used in a bit set.
+ *
+ * Check for set membership using bitwise and:
+ *   int kms_set = fn();
+ *   if (kms_set & MONGOCRYPT_KMS_PROVIDER_AWS)
+ * Add to a set using bitwise or:
+ *   kms_set |= MONGOCRYPT_KMS_PROVIDER_LOCAL
+ */
+typedef enum {
+   MONGOCRYPT_KMS_PROVIDER_NONE = 0,
+   MONGOCRYPT_KMS_PROVIDER_AWS = 1 << 0,
+   MONGOCRYPT_KMS_PROVIDER_LOCAL = 1 << 1,
+   MONGOCRYPT_KMS_PROVIDER_AZURE = 1 << 2,
+   MONGOCRYPT_KMS_PROVIDER_GCP = 1 << 3
+} _mongocrypt_kms_provider_t;
+
+typedef struct {
+   _mongocrypt_endpoint_t *key_vault_endpoint;
+   char *key_name;
+   char *key_version;
+} _mongocrypt_azure_kek_t;
+
+typedef struct {
+   char *project_id;
+   char *location;
+   char *key_ring;
+   char *key_name;
+   char *key_version;                /* optional */
+   _mongocrypt_endpoint_t *endpoint; /* optional. */
+} _mongocrypt_gcp_kek_t;
+
+typedef struct {
+   char *region;
+   char *cmk;
+   _mongocrypt_endpoint_t *endpoint; /* optional. */
+} _mongocrypt_aws_kek_t;
+
+typedef struct {
+   _mongocrypt_kms_provider_t kms_provider;
+   union {
+      _mongocrypt_azure_kek_t azure;
+      _mongocrypt_gcp_kek_t gcp;
+      _mongocrypt_aws_kek_t aws;
+   } provider;
+} _mongocrypt_kek_t;
+
+/* Parse a document describing a key encryption key.
+ * This may can come from two places:
+ * 1. The option passed for creating a data key via
+ * mongocrypt_ctx_setopt_key_encryption_key
+ * 2. The "masterKey" document from a data encryption key document.
+ */
+bool
+_mongocrypt_kek_parse_owned (const bson_t *bson,
+                             _mongocrypt_kek_t *out,
+                             mongocrypt_status_t *status)
+   MONGOCRYPT_WARN_UNUSED_RESULT;
+
+bool
+_mongocrypt_kek_append (const _mongocrypt_kek_t *kek,
+                        bson_t *out,
+                        mongocrypt_status_t *status)
+   MONGOCRYPT_WARN_UNUSED_RESULT;
+
+void
+_mongocrypt_kek_cleanup (_mongocrypt_kek_t *kek);
+
+
+#endif /* MONGOCRYPT_KEK_PRIVATE_H */

--- a/src/mongocrypt-kek-private.h
+++ b/src/mongocrypt-kek-private.h
@@ -93,6 +93,9 @@ _mongocrypt_kek_append (const _mongocrypt_kek_t *kek,
    MONGOCRYPT_WARN_UNUSED_RESULT;
 
 void
+_mongocrypt_kek_copy_to (const _mongocrypt_kek_t *src, mongocrypt_kek_t *dst);
+
+void
 _mongocrypt_kek_cleanup (_mongocrypt_kek_t *kek);
 
 

--- a/src/mongocrypt-kek-private.h
+++ b/src/mongocrypt-kek-private.h
@@ -93,7 +93,7 @@ _mongocrypt_kek_append (const _mongocrypt_kek_t *kek,
    MONGOCRYPT_WARN_UNUSED_RESULT;
 
 void
-_mongocrypt_kek_copy_to (const _mongocrypt_kek_t *src, mongocrypt_kek_t *dst);
+_mongocrypt_kek_copy_to (const _mongocrypt_kek_t *src, _mongocrypt_kek_t *dst);
 
 void
 _mongocrypt_kek_cleanup (_mongocrypt_kek_t *kek);

--- a/src/mongocrypt-kek.c
+++ b/src/mongocrypt-kek.c
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2020-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mongocrypt-kek-private.h"
+#include "mongocrypt-private.h"
+#include "mongocrypt-opts-private.h"
+
+/* Possible documents to parse:
+ * AWS
+ *    provider: "aws"
+ *    region: <string>
+ *    key: <string>
+ *    endpoint: <optional string>
+ * Azure
+ *    provider: "azure"
+ *    keyVaultEndpoint: <string>
+ *    keyName: <string>
+ *    keyVersion: <optional string>
+ * GCP
+ *    projectId: <string>
+ *    location: <string>
+ *    keyRing: <string>
+ *    keyName: <string>
+ *    keyVersion: <string>
+ *    endpoint: <optional string>
+ * Local
+ *    provider: "local"
+ */
+bool
+_mongocrypt_kek_parse_owned (const bson_t *bson,
+                             _mongocrypt_kek_t *kek,
+                             mongocrypt_status_t *status)
+{
+   char *kms_provider = NULL;
+   bool ret = false;
+
+   if (!_mongocrypt_parse_required_utf8 (
+          bson, "provider", &kms_provider, status)) {
+      goto done;
+   }
+
+   if (0 == strcmp (kms_provider, "aws")) {
+      kek->kms_provider = MONGOCRYPT_KMS_PROVIDER_AWS;
+      if (!_mongocrypt_parse_required_utf8 (
+             bson, "key", &kek->provider.aws.cmk, status)) {
+         goto done;
+      }
+      if (!_mongocrypt_parse_required_utf8 (
+             bson, "region", &kek->provider.aws.region, status)) {
+         goto done;
+      }
+      if (!_mongocrypt_parse_optional_endpoint (
+             bson, "endpoint", &kek->provider.aws.endpoint, status)) {
+         goto done;
+      }
+   } else if (0 == strcmp (kms_provider, "local")) {
+      kek->kms_provider = MONGOCRYPT_KMS_PROVIDER_LOCAL;
+   } else if (0 == strcmp (kms_provider, "azure")) {
+      kek->kms_provider = MONGOCRYPT_KMS_PROVIDER_AZURE;
+      if (!_mongocrypt_parse_required_endpoint (
+             bson,
+             "keyVaultEndpoint",
+             &kek->provider.azure.key_vault_endpoint,
+             status)) {
+         goto done;
+      }
+
+      if (!_mongocrypt_parse_required_utf8 (
+             bson, "keyName", &kek->provider.azure.key_name, status)) {
+         goto done;
+      }
+
+      if (!_mongocrypt_parse_optional_utf8 (bson,
+                                            "keyVersion",
+                                            &kek->provider.azure.key_version,
+                                            status)) {
+         goto done;
+      }
+   } else if (0 == strcmp (kms_provider, "gcp")) {
+      kek->kms_provider = MONGOCRYPT_KMS_PROVIDER_GCP;
+      if (!_mongocrypt_parse_optional_endpoint (
+             bson, "endpoint", &kek->provider.gcp.endpoint, status)) {
+         goto done;
+      }
+
+      if (!_mongocrypt_parse_required_utf8 (bson,
+                                            "projectId",
+                                            &kek->provider.gcp.project_id,
+                                            status)) {
+         goto done;
+      }
+
+      if (!_mongocrypt_parse_required_utf8 (
+             bson, "location", &kek->provider.gcp.location, status)) {
+         goto done;
+      }
+
+      if (!_mongocrypt_parse_required_utf8 (
+             bson, "keyRing", &kek->provider.gcp.key_ring, status)) {
+         goto done;
+      }
+
+      if (!_mongocrypt_parse_required_utf8 (
+             bson, "keyName", &kek->provider.gcp.key_name, status)) {
+         goto done;
+      }
+
+      if (!_mongocrypt_parse_optional_utf8 (bson,
+                                            "keyVersion",
+                                            &kek->provider.gcp.key_version,
+                                            status)) {
+         goto done;
+      }
+   } else {
+      CLIENT_ERR ("unrecognized KMS provider: %s", kms_provider);
+      goto done;
+   }
+
+   ret = true;
+done:
+   bson_free (kms_provider);
+   return ret;
+}
+
+bool
+_mongocrypt_kek_append (const _mongocrypt_kek_t *kek,
+                        bson_t *bson,
+                        mongocrypt_status_t *status)
+{
+   if (kek->kms_provider == MONGOCRYPT_KMS_PROVIDER_AWS) {
+      BSON_APPEND_UTF8 (bson, "provider", "aws");
+      BSON_APPEND_UTF8 (bson, "region", kek->provider.aws.region);
+      BSON_APPEND_UTF8 (bson, "key", kek->provider.aws.cmk);
+      if (kek->provider.aws.endpoint) {
+         BSON_APPEND_UTF8 (bson, "endpoint", kek->provider.aws.endpoint->host_and_port);
+      }
+   } else if (kek->kms_provider == MONGOCRYPT_KMS_PROVIDER_LOCAL) {
+      BSON_APPEND_UTF8 (bson, "provider", "local");
+   } else if (kek->kms_provider == MONGOCRYPT_KMS_PROVIDER_AZURE) {
+      BSON_APPEND_UTF8 (bson, "provider", "azure");
+      BSON_APPEND_UTF8 (bson, "keyVaultEndpoint", kek->provider.azure.key_vault_endpoint->host_and_port);
+      BSON_APPEND_UTF8 (bson, "keyName", kek->provider.azure.key_name);
+      if (kek->provider.azure.key_version) {
+         BSON_APPEND_UTF8 (bson, "keyVersion", kek->provider.azure.key_version);
+      }
+   } else if (kek->kms_provider == MONGOCRYPT_KMS_PROVIDER_GCP) {
+      BSON_APPEND_UTF8 (bson, "provider", "gcp");
+      BSON_APPEND_UTF8 (bson, "projectId", kek->provider.gcp.project_id);
+      BSON_APPEND_UTF8 (bson, "location", kek->provider.gcp.location);
+      BSON_APPEND_UTF8 (bson, "keyRing", kek->provider.gcp.key_ring);
+      BSON_APPEND_UTF8 (bson, "keyName", kek->provider.gcp.key_name);
+      if (kek->provider.gcp.key_version) {
+         BSON_APPEND_UTF8 (bson, "keyVersion", kek->provider.gcp.key_version);
+      }
+      if (kek->provider.gcp.endpoint) {
+         BSON_APPEND_UTF8 (bson, "endpoint", kek->provider.gcp.endpoint->host_and_port);
+      }
+   }
+   return true;
+}
+
+void
+_mongocrypt_kek_cleanup (_mongocrypt_kek_t *kek)
+{
+   if (kek->kms_provider == MONGOCRYPT_KMS_PROVIDER_AWS) {
+      bson_free (kek->provider.aws.cmk);
+      bson_free (kek->provider.aws.region);
+      _mongocrypt_endpoint_destroy (kek->provider.aws.endpoint);
+   } else if (kek->kms_provider == MONGOCRYPT_KMS_PROVIDER_AZURE) {
+      _mongocrypt_endpoint_destroy (kek->provider.azure.key_vault_endpoint);
+      bson_free (kek->provider.azure.key_name);
+      bson_free (kek->provider.azure.key_version);
+   } else if (kek->kms_provider == MONGOCRYPT_KMS_PROVIDER_GCP) {
+      bson_free (kek->provider.gcp.project_id);
+      bson_free (kek->provider.gcp.location);
+      bson_free (kek->provider.gcp.key_ring);
+      bson_free (kek->provider.gcp.key_name);
+      bson_free (kek->provider.gcp.key_version);
+      _mongocrypt_endpoint_destroy (kek->provider.gcp.endpoint);
+   }
+   return;
+}

--- a/src/mongocrypt-kek.c
+++ b/src/mongocrypt-kek.c
@@ -83,10 +83,8 @@ _mongocrypt_kek_parse_owned (const bson_t *bson,
          goto done;
       }
 
-      if (!_mongocrypt_parse_optional_utf8 (bson,
-                                            "keyVersion",
-                                            &kek->provider.azure.key_version,
-                                            status)) {
+      if (!_mongocrypt_parse_optional_utf8 (
+             bson, "keyVersion", &kek->provider.azure.key_version, status)) {
          goto done;
       }
    } else if (0 == strcmp (kms_provider, "gcp")) {
@@ -96,10 +94,8 @@ _mongocrypt_kek_parse_owned (const bson_t *bson,
          goto done;
       }
 
-      if (!_mongocrypt_parse_required_utf8 (bson,
-                                            "projectId",
-                                            &kek->provider.gcp.project_id,
-                                            status)) {
+      if (!_mongocrypt_parse_required_utf8 (
+             bson, "projectId", &kek->provider.gcp.project_id, status)) {
          goto done;
       }
 
@@ -118,10 +114,8 @@ _mongocrypt_kek_parse_owned (const bson_t *bson,
          goto done;
       }
 
-      if (!_mongocrypt_parse_optional_utf8 (bson,
-                                            "keyVersion",
-                                            &kek->provider.gcp.key_version,
-                                            status)) {
+      if (!_mongocrypt_parse_optional_utf8 (
+             bson, "keyVersion", &kek->provider.gcp.key_version, status)) {
          goto done;
       }
    } else {
@@ -145,13 +139,16 @@ _mongocrypt_kek_append (const _mongocrypt_kek_t *kek,
       BSON_APPEND_UTF8 (bson, "region", kek->provider.aws.region);
       BSON_APPEND_UTF8 (bson, "key", kek->provider.aws.cmk);
       if (kek->provider.aws.endpoint) {
-         BSON_APPEND_UTF8 (bson, "endpoint", kek->provider.aws.endpoint->host_and_port);
+         BSON_APPEND_UTF8 (
+            bson, "endpoint", kek->provider.aws.endpoint->host_and_port);
       }
    } else if (kek->kms_provider == MONGOCRYPT_KMS_PROVIDER_LOCAL) {
       BSON_APPEND_UTF8 (bson, "provider", "local");
    } else if (kek->kms_provider == MONGOCRYPT_KMS_PROVIDER_AZURE) {
       BSON_APPEND_UTF8 (bson, "provider", "azure");
-      BSON_APPEND_UTF8 (bson, "keyVaultEndpoint", kek->provider.azure.key_vault_endpoint->host_and_port);
+      BSON_APPEND_UTF8 (bson,
+                        "keyVaultEndpoint",
+                        kek->provider.azure.key_vault_endpoint->host_and_port);
       BSON_APPEND_UTF8 (bson, "keyName", kek->provider.azure.key_name);
       if (kek->provider.azure.key_version) {
          BSON_APPEND_UTF8 (bson, "keyVersion", kek->provider.azure.key_version);
@@ -166,10 +163,38 @@ _mongocrypt_kek_append (const _mongocrypt_kek_t *kek,
          BSON_APPEND_UTF8 (bson, "keyVersion", kek->provider.gcp.key_version);
       }
       if (kek->provider.gcp.endpoint) {
-         BSON_APPEND_UTF8 (bson, "endpoint", kek->provider.gcp.endpoint->host_and_port);
+         BSON_APPEND_UTF8 (
+            bson, "endpoint", kek->provider.gcp.endpoint->host_and_port);
       }
    }
    return true;
+}
+
+void
+_mongocrypt_kek_copy_to (const _mongocrypt_kek_t *src, _mongocrypt_kek_t *dst)
+{
+   if (src->kms_provider == MONGOCRYPT_KMS_PROVIDER_AWS) {
+      dst->provider.aws.cmk = bson_strdup (src->provider.aws.cmk);
+      dst->provider.aws.region = bson_strdup (src->provider.aws.region);
+      dst->provider.aws.endpoint =
+         _mongocrypt_endpoint_copy (src->provider.aws.endpoint);
+   } else if (src->kms_provider == MONGOCRYPT_KMS_PROVIDER_AZURE) {
+      dst->provider.azure.key_vault_endpoint =
+         _mongocrypt_endpoint_copy (src->provider.azure.key_vault_endpoint);
+      dst->provider.azure.key_name = bson_strdup (src->provider.azure.key_name);
+      dst->provider.azure.key_version =
+         bson_strdup (src->provider.azure.key_version);
+   } else if (src->kms_provider == MONGOCRYPT_KMS_PROVIDER_GCP) {
+      dst->provider.gcp.project_id = bson_strdup (src->provider.gcp.project_id);
+      dst->provider.gcp.location = bson_strdup (src->provider.gcp.location);
+      dst->provider.gcp.key_ring = bson_strdup (src->provider.gcp.key_ring);
+      dst->provider.gcp.key_name = bson_strdup (src->provider.gcp.key_name);
+      dst->provider.gcp.key_version =
+         bson_strdup (src->provider.gcp.key_version);
+      dst->provider.gcp.endpoint =
+         _mongocrypt_endpoint_copy (src->provider.gcp.endpoint);
+   }
+   dst->kms_provider = src->kms_provider;
 }
 
 void

--- a/src/mongocrypt-kek.c
+++ b/src/mongocrypt-kek.c
@@ -166,6 +166,8 @@ _mongocrypt_kek_append (const _mongocrypt_kek_t *kek,
          BSON_APPEND_UTF8 (
             bson, "endpoint", kek->provider.gcp.endpoint->host_and_port);
       }
+   } else {
+      BSON_ASSERT (kek->kms_provider == MONGOCRYPT_KMS_PROVIDER_NONE);
    }
    return true;
 }
@@ -193,6 +195,9 @@ _mongocrypt_kek_copy_to (const _mongocrypt_kek_t *src, _mongocrypt_kek_t *dst)
          bson_strdup (src->provider.gcp.key_version);
       dst->provider.gcp.endpoint =
          _mongocrypt_endpoint_copy (src->provider.gcp.endpoint);
+   } else {
+      BSON_ASSERT (src->kms_provider == MONGOCRYPT_KMS_PROVIDER_NONE ||
+                   src->kms_provider == MONGOCRYPT_KMS_PROVIDER_LOCAL);
    }
    dst->kms_provider = src->kms_provider;
 }
@@ -215,6 +220,9 @@ _mongocrypt_kek_cleanup (_mongocrypt_kek_t *kek)
       bson_free (kek->provider.gcp.key_name);
       bson_free (kek->provider.gcp.key_version);
       _mongocrypt_endpoint_destroy (kek->provider.gcp.endpoint);
+   } else {
+      BSON_ASSERT (kek->kms_provider == MONGOCRYPT_KMS_PROVIDER_NONE ||
+                   kek->kms_provider == MONGOCRYPT_KMS_PROVIDER_LOCAL);
    }
    return;
 }

--- a/src/mongocrypt-key-broker.c
+++ b/src/mongocrypt-key-broker.c
@@ -428,7 +428,7 @@ _decrypt_with_local_kms (_mongocrypt_key_broker_t *kb,
 
    crypt_ret = _mongocrypt_do_decryption (kb->crypt->crypto,
                                           NULL /* associated data. */,
-                                          &kb->crypt->opts.kms_local_key,
+                                          &kb->crypt->opts.kms_provider_local.key,
                                           key_material,
                                           decrypted_key_material,
                                           &bytes_written,

--- a/src/mongocrypt-key-private.h
+++ b/src/mongocrypt-key-private.h
@@ -32,16 +32,9 @@ typedef struct {
    _mongocrypt_buffer_t id;
    _mongocrypt_key_alt_name_t *key_alt_names;
    _mongocrypt_buffer_t key_material;
-   _mongocrypt_kms_provider_t masterkey_provider;
-   char *masterkey_region;
-   char *masterkey_cmk;
-   char *endpoint;
    uint64_t creation_date;
    uint64_t update_date;
-   union {
-      _mongocrypt_azure_kek_t azure;
-      _mongocrypt_gcp_kek_t gcp;
-   } kek;
+   _mongocrypt_kek_t kek;
 } _mongocrypt_key_doc_t;
 
 _mongocrypt_key_alt_name_t *

--- a/src/mongocrypt-key-private.h
+++ b/src/mongocrypt-key-private.h
@@ -19,27 +19,13 @@
 
 #include "mongocrypt-buffer-private.h"
 #include "mongocrypt-opts-private.h"
+#include "mongocrypt-kek-private.h"
 
 /* A linked list of key alt names */
 typedef struct __mongocrypt_key_alt_name_t {
    struct __mongocrypt_key_alt_name_t *next;
    bson_value_t value;
 } _mongocrypt_key_alt_name_t;
-
-typedef struct {
-   _mongocrypt_endpoint_t *key_vault_endpoint;
-   char *key_name;
-   char *key_version;
-} _mongocrypt_azure_kek_t;
-
-typedef struct {
-   _mongocrypt_endpoint_t *endpoint;
-   char *project_id;
-   char *location;
-   char *key_ring;
-   char *key_name;
-   char *key_version;
-} _mongocrypt_gcp_kek_t;
 
 typedef struct {
    bson_t bson; /* original BSON for this key. */

--- a/src/mongocrypt-kms-ctx.c
+++ b/src/mongocrypt-kms-ctx.c
@@ -145,12 +145,12 @@ _mongocrypt_kms_ctx_init_aws_decrypt (mongocrypt_kms_ctx_t *kms,
       return false;
    }
 
-   if (!crypt_opts->kms_aws_access_key_id) {
+   if (!crypt_opts->kms_provider_aws.access_key_id) {
       CLIENT_ERR ("aws access key id not provided");
       return false;
    }
 
-   if (!crypt_opts->kms_aws_secret_access_key) {
+   if (!crypt_opts->kms_provider_aws.secret_access_key) {
       CLIENT_ERR ("aws secret access key not provided");
       return false;
    }
@@ -190,12 +190,12 @@ _mongocrypt_kms_ctx_init_aws_decrypt (mongocrypt_kms_ctx_t *kms,
    }
 
    if (!kms_request_set_access_key_id (kms->req,
-                                       crypt_opts->kms_aws_access_key_id)) {
+                                       crypt_opts->kms_provider_aws.access_key_id)) {
       CLIENT_ERR ("failed to set aws access key id");
       return false;
    }
    if (!kms_request_set_secret_key (kms->req,
-                                    crypt_opts->kms_aws_secret_access_key)) {
+                                    crypt_opts->kms_provider_aws.secret_access_key)) {
       CLIENT_ERR ("failed to set aws secret access key");
    }
 
@@ -255,12 +255,12 @@ _mongocrypt_kms_ctx_init_aws_encrypt (
       return false;
    }
 
-   if (!crypt_opts->kms_aws_access_key_id) {
+   if (!crypt_opts->kms_provider_aws.access_key_id) {
       CLIENT_ERR ("aws access key id not provided");
       return false;
    }
 
-   if (!crypt_opts->kms_aws_secret_access_key) {
+   if (!crypt_opts->kms_provider_aws.secret_access_key) {
       CLIENT_ERR ("aws secret access key not provided");
       return false;
    }
@@ -301,12 +301,12 @@ _mongocrypt_kms_ctx_init_aws_encrypt (
    }
 
    if (!kms_request_set_access_key_id (kms->req,
-                                       crypt_opts->kms_aws_access_key_id)) {
+                                       crypt_opts->kms_provider_aws.access_key_id)) {
       CLIENT_ERR ("failed to set aws access key id");
       return false;
    }
    if (!kms_request_set_secret_key (kms->req,
-                                    crypt_opts->kms_aws_secret_access_key)) {
+                                    crypt_opts->kms_provider_aws.secret_access_key)) {
       CLIENT_ERR ("failed to set aws secret access key");
    }
 

--- a/src/mongocrypt-opts-private.h
+++ b/src/mongocrypt-opts-private.h
@@ -23,22 +23,7 @@
 #include "mongocrypt-buffer-private.h"
 #include "mongocrypt-log-private.h"
 #include "mongocrypt-endpoint-private.h"
-
-/* KMS providers are used in a bit set.
- *
- * Check for set membership using bitwise and:
- *   int kms_set = fn();
- *   if (kms_set & MONGOCRYPT_KMS_PROVIDER_AWS)
- * Add to a set using bitwise or:
- *   kms_set |= MONGOCRYPT_KMS_PROVIDER_LOCAL
- */
-typedef enum {
-   MONGOCRYPT_KMS_PROVIDER_NONE = 0,
-   MONGOCRYPT_KMS_PROVIDER_AWS = 1 << 0,
-   MONGOCRYPT_KMS_PROVIDER_LOCAL = 1 << 1,
-   MONGOCRYPT_KMS_PROVIDER_AZURE = 1 << 2,
-   MONGOCRYPT_KMS_PROVIDER_GCP = 1 << 3
-} _mongocrypt_kms_provider_t;
+#include "mongocrypt-kek-private.h"
 
 typedef struct {
    char *tenant_id;
@@ -89,7 +74,7 @@ _mongocrypt_opts_validate (_mongocrypt_opts_t *opts,
  * Returns true if no error occured.
  */
 bool
-_mongocrypt_parse_optional_utf8 (bson_t *bson,
+_mongocrypt_parse_optional_utf8 (const bson_t *bson,
                                  const char *dotkey,
                                  char **out,
                                  mongocrypt_status_t *status);
@@ -102,7 +87,7 @@ _mongocrypt_parse_optional_utf8 (bson_t *bson,
  * Returns true if no error occured.
  */
 bool
-_mongocrypt_parse_required_utf8 (bson_t *bson,
+_mongocrypt_parse_required_utf8 (const bson_t *bson,
                                  const char *dotkey,
                                  char **out,
                                  mongocrypt_status_t *status);
@@ -115,7 +100,7 @@ _mongocrypt_parse_required_utf8 (bson_t *bson,
  * Returns true if no error occured.
  */
 bool
-_mongocrypt_parse_optional_endpoint (bson_t *bson,
+_mongocrypt_parse_optional_endpoint (const bson_t *bson,
                                      const char *dotkey,
                                      _mongocrypt_endpoint_t **out,
                                      mongocrypt_status_t *status);
@@ -128,7 +113,7 @@ _mongocrypt_parse_optional_endpoint (bson_t *bson,
  * Returns true if no error occured.
  */
 bool
-_mongocrypt_parse_required_endpoint (bson_t *bson,
+_mongocrypt_parse_required_endpoint (const bson_t *bson,
                                      const char *dotkey,
                                      _mongocrypt_endpoint_t **out,
                                      mongocrypt_status_t *status);
@@ -145,7 +130,7 @@ _mongocrypt_parse_required_endpoint (bson_t *bson,
  * Returns true if no error occurred.
  */
 bool
-_mongocrypt_parse_optional_binary (bson_t *bson,
+_mongocrypt_parse_optional_binary (const bson_t *bson,
                                    const char *dotkey,
                                    _mongocrypt_buffer_t *out,
                                    mongocrypt_status_t *status);
@@ -162,7 +147,7 @@ _mongocrypt_parse_optional_binary (bson_t *bson,
  * Returns true if no error occurred.
  */
 bool
-_mongocrypt_parse_required_binary (bson_t *bson,
+_mongocrypt_parse_required_binary (const bson_t *bson,
                                    const char *dotkey,
                                    _mongocrypt_buffer_t *out,
                                    mongocrypt_status_t *status);

--- a/src/mongocrypt-opts-private.h
+++ b/src/mongocrypt-opts-private.h
@@ -39,13 +39,22 @@ typedef struct {
 } _mongocrypt_opts_kms_provider_gcp_t;
 
 typedef struct {
-   int kms_providers; /* A bit set of _mongocrypt_kms_provider_t */
-   char *kms_aws_secret_access_key;    /* Set for AWS provider. */
-   char *kms_aws_access_key_id;        /* Set for AWS provider. */
-   _mongocrypt_buffer_t kms_local_key; /* Set for local provider. */
+   char *secret_access_key;
+   char *access_key_id;
+} _mongocrypt_opts_kms_provider_aws_t;
+
+typedef struct {
+   _mongocrypt_buffer_t key;
+} _mongocrypt_opts_kms_provider_local_t;
+
+typedef struct {
    mongocrypt_log_fn_t log_fn;
    void *log_ctx;
    _mongocrypt_buffer_t schema_map;
+   
+   int kms_providers; /* A bit set of _mongocrypt_kms_provider_t */
+   _mongocrypt_opts_kms_provider_local_t kms_provider_local;
+   _mongocrypt_opts_kms_provider_aws_t kms_provider_aws;
    _mongocrypt_opts_kms_provider_azure_t kms_provider_azure;
    _mongocrypt_opts_kms_provider_gcp_t kms_provider_gcp;
    mongocrypt_hmac_fn sign_rsaes_pkcs1_v1_5;

--- a/src/mongocrypt-opts.c
+++ b/src/mongocrypt-opts.c
@@ -51,9 +51,9 @@ _mongocrypt_opts_kms_provider_gcp_cleanup (
 void
 _mongocrypt_opts_cleanup (_mongocrypt_opts_t *opts)
 {
-   bson_free (opts->kms_aws_secret_access_key);
-   bson_free (opts->kms_aws_access_key_id);
-   _mongocrypt_buffer_cleanup (&opts->kms_local_key);
+   bson_free (opts->kms_provider_aws.secret_access_key);
+   bson_free (opts->kms_provider_aws.access_key_id);
+   _mongocrypt_buffer_cleanup (&opts->kms_provider_local.key);
    _mongocrypt_buffer_cleanup (&opts->schema_map);
    _mongocrypt_opts_kms_provider_azure_cleanup (&opts->kms_provider_azure);
    _mongocrypt_opts_kms_provider_gcp_cleanup (&opts->kms_provider_gcp);
@@ -70,14 +70,14 @@ _mongocrypt_opts_validate (_mongocrypt_opts_t *opts,
    }
 
    if (opts->kms_providers & MONGOCRYPT_KMS_PROVIDER_AWS) {
-      if (!opts->kms_aws_access_key_id || !opts->kms_aws_secret_access_key) {
+      if (!opts->kms_provider_aws.access_key_id || !opts->kms_provider_aws.secret_access_key) {
          CLIENT_ERR ("aws credentials unset");
          return false;
       }
    }
 
    if (opts->kms_providers & MONGOCRYPT_KMS_PROVIDER_LOCAL) {
-      if (_mongocrypt_buffer_empty (&opts->kms_local_key)) {
+      if (_mongocrypt_buffer_empty (&opts->kms_provider_local.key)) {
          CLIENT_ERR ("local data key unset");
          return false;
       }

--- a/src/mongocrypt-opts.c
+++ b/src/mongocrypt-opts.c
@@ -87,7 +87,7 @@ _mongocrypt_opts_validate (_mongocrypt_opts_t *opts,
 }
 
 bool
-_mongocrypt_parse_optional_utf8 (bson_t *bson,
+_mongocrypt_parse_optional_utf8 (const bson_t *bson,
                                  const char *dotkey,
                                  char **out,
                                  mongocrypt_status_t *status)
@@ -116,7 +116,7 @@ _mongocrypt_parse_optional_utf8 (bson_t *bson,
 
 
 bool
-_mongocrypt_parse_required_utf8 (bson_t *bson,
+_mongocrypt_parse_required_utf8 (const bson_t *bson,
                                  const char *dotkey,
                                  char **out,
                                  mongocrypt_status_t *status)
@@ -134,7 +134,7 @@ _mongocrypt_parse_required_utf8 (bson_t *bson,
 }
 
 bool
-_mongocrypt_parse_optional_endpoint (bson_t *bson,
+_mongocrypt_parse_optional_endpoint (const bson_t *bson,
                                      const char *dotkey,
                                      _mongocrypt_endpoint_t **out,
                                      mongocrypt_status_t *status)
@@ -158,7 +158,7 @@ _mongocrypt_parse_optional_endpoint (bson_t *bson,
 }
 
 bool
-_mongocrypt_parse_required_endpoint (bson_t *bson,
+_mongocrypt_parse_required_endpoint (const bson_t *bson,
                                      const char *dotkey,
                                      _mongocrypt_endpoint_t **out,
                                      mongocrypt_status_t *status)
@@ -177,7 +177,7 @@ _mongocrypt_parse_required_endpoint (bson_t *bson,
 
 
 bool
-_mongocrypt_parse_optional_binary (bson_t *bson,
+_mongocrypt_parse_optional_binary (const bson_t *bson,
                                    const char *dotkey,
                                    _mongocrypt_buffer_t *out,
                                    mongocrypt_status_t *status)
@@ -221,7 +221,7 @@ _mongocrypt_parse_optional_binary (bson_t *bson,
 }
 
 bool
-_mongocrypt_parse_required_binary (bson_t *bson,
+_mongocrypt_parse_required_binary (const bson_t *bson,
                                    const char *dotkey,
                                    _mongocrypt_buffer_t *out,
                                    mongocrypt_status_t *status)

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -185,7 +185,7 @@ mongocrypt_setopt_kms_provider_aws (mongocrypt_t *crypt,
    if (!_mongocrypt_validate_and_copy_string (
           aws_access_key_id,
           aws_access_key_id_len,
-          &crypt->opts.kms_aws_access_key_id)) {
+          &crypt->opts.kms_provider_aws.access_key_id)) {
       CLIENT_ERR ("invalid aws access key id");
       return false;
    }
@@ -193,7 +193,7 @@ mongocrypt_setopt_kms_provider_aws (mongocrypt_t *crypt,
    if (!_mongocrypt_validate_and_copy_string (
           aws_secret_access_key,
           aws_secret_access_key_len,
-          &crypt->opts.kms_aws_secret_access_key)) {
+          &crypt->opts.kms_provider_aws.secret_access_key)) {
       CLIENT_ERR ("invalid aws secret access key");
       return false;
    }
@@ -204,11 +204,11 @@ mongocrypt_setopt_kms_provider_aws (mongocrypt_t *crypt,
                        "%s (%s=\"%s\", %s=%d, %s=\"%s\", %s=%d)",
                        BSON_FUNC,
                        "aws_access_key_id",
-                       crypt->opts.kms_aws_access_key_id,
+                       crypt->opts.kms_provider_aws.access_key_id,
                        "aws_access_key_id_len",
                        aws_access_key_id_len,
                        "aws_secret_access_key",
-                       crypt->opts.kms_aws_secret_access_key,
+                       crypt->opts.kms_provider_aws.secret_access_key,
                        "aws_secret_access_key_len",
                        aws_secret_access_key_len);
    }
@@ -348,7 +348,7 @@ mongocrypt_setopt_kms_provider_local (mongocrypt_t *crypt,
       bson_free (key_val);
    }
 
-   _mongocrypt_buffer_copy_from_binary (&crypt->opts.kms_local_key, key);
+   _mongocrypt_buffer_copy_from_binary (&crypt->opts.kms_provider_local.key, key);
    crypt->opts.kms_providers |= MONGOCRYPT_KMS_PROVIDER_LOCAL;
    return true;
 }
@@ -668,6 +668,19 @@ mongocrypt_setopt_kms_providers (mongocrypt_t *crypt,
          }
 
          crypt->opts.kms_providers |= MONGOCRYPT_KMS_PROVIDER_GCP;
+      } else if (0 == strcmp (field_name, "local")) {
+         if (!_mongocrypt_parse_required_binary (&as_bson, "local.key", &crypt->opts.kms_provider_local.key, crypt->status)) {
+            return false;
+         }
+         crypt->opts.kms_providers |= MONGOCRYPT_KMS_PROVIDER_LOCAL;
+      } else if (0 == strcmp (field_name, "aws")) {
+         if (!_mongocrypt_parse_required_utf8 (&as_bson, "aws.accessKeyId", &crypt->opts.kms_provider_aws.secret_access_key, crypt->status)) {
+            return false;
+         }
+         if (!_mongocrypt_parse_required_utf8 (&as_bson, "aws.secretAccessKey", &crypt->opts.kms_provider_aws.secret_access_key, crypt->status)) {
+            return false;
+         }
+         crypt->opts.kms_providers |= MONGOCRYPT_KMS_PROVIDER_LOCAL;
       } else {
          CLIENT_ERR ("unsupported KMS provider: %s", field_name);
          return false;

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -348,7 +348,8 @@ mongocrypt_setopt_kms_provider_local (mongocrypt_t *crypt,
       bson_free (key_val);
    }
 
-   _mongocrypt_buffer_copy_from_binary (&crypt->opts.kms_provider_local.key, key);
+   _mongocrypt_buffer_copy_from_binary (&crypt->opts.kms_provider_local.key,
+                                        key);
    crypt->opts.kms_providers |= MONGOCRYPT_KMS_PROVIDER_LOCAL;
    return true;
 }
@@ -591,7 +592,6 @@ mongocrypt_setopt_kms_providers (mongocrypt_t *crypt,
       return false;
    }
 
-   /* TODO: just Azure and GCP for now. AWS, and local later. */
    while (bson_iter_next (&iter)) {
       const char *field_name;
 
@@ -669,18 +669,30 @@ mongocrypt_setopt_kms_providers (mongocrypt_t *crypt,
 
          crypt->opts.kms_providers |= MONGOCRYPT_KMS_PROVIDER_GCP;
       } else if (0 == strcmp (field_name, "local")) {
-         if (!_mongocrypt_parse_required_binary (&as_bson, "local.key", &crypt->opts.kms_provider_local.key, crypt->status)) {
+         if (!_mongocrypt_parse_required_binary (
+                &as_bson,
+                "local.key",
+                &crypt->opts.kms_provider_local.key,
+                crypt->status)) {
             return false;
          }
          crypt->opts.kms_providers |= MONGOCRYPT_KMS_PROVIDER_LOCAL;
       } else if (0 == strcmp (field_name, "aws")) {
-         if (!_mongocrypt_parse_required_utf8 (&as_bson, "aws.accessKeyId", &crypt->opts.kms_provider_aws.secret_access_key, crypt->status)) {
+         if (!_mongocrypt_parse_required_utf8 (
+                &as_bson,
+                "aws.accessKeyId",
+                &crypt->opts.kms_provider_aws.access_key_id,
+                crypt->status)) {
             return false;
          }
-         if (!_mongocrypt_parse_required_utf8 (&as_bson, "aws.secretAccessKey", &crypt->opts.kms_provider_aws.secret_access_key, crypt->status)) {
+         if (!_mongocrypt_parse_required_utf8 (
+                &as_bson,
+                "aws.secretAccessKey",
+                &crypt->opts.kms_provider_aws.secret_access_key,
+                crypt->status)) {
             return false;
          }
-         crypt->opts.kms_providers |= MONGOCRYPT_KMS_PROVIDER_LOCAL;
+         crypt->opts.kms_providers |= MONGOCRYPT_KMS_PROVIDER_AWS;
       } else {
          CLIENT_ERR ("unsupported KMS provider: %s", field_name);
          return false;

--- a/src/mongocrypt.h.in
+++ b/src/mongocrypt.h.in
@@ -377,7 +377,6 @@ mongocrypt_setopt_kms_provider_local (mongocrypt_t *crypt,
 
 /**
  * Configure KMS providers with a BSON document.
- * Currently only applies to Azure.
  *
  * @param[in] crypt The @ref mongocrypt_t object.
  * @param[in] kms_providers A BSON document mapping the KMS provider names
@@ -626,7 +625,6 @@ mongocrypt_ctx_setopt_masterkey_local (mongocrypt_ctx_t *ctx);
 
 /**
  * Set key encryption key document for creating a data key.
- * Currently only applies to Azure.
  *
  * @param[in] ctx The @ref mongocrypt_ctx_t object.
  * @param[in] bin BSON representing the key encryption key document.

--- a/src/mongocrypt.h.in
+++ b/src/mongocrypt.h.in
@@ -328,6 +328,9 @@ mongocrypt_setopt_log_handler (mongocrypt_t *crypt,
 
 /**
  * Configure an AWS KMS provider on the @ref mongocrypt_t object.
+ * 
+ * This has been superseded by the more flexible:
+ * @ref mongocrypt_setopt_kms_providers
  *
  * @param[in] crypt The @ref mongocrypt_t object.
  * @param[in] aws_access_key_id The AWS access key ID used to generate KMS
@@ -355,6 +358,9 @@ mongocrypt_setopt_kms_provider_aws (mongocrypt_t *crypt,
 
 /**
  * Configure a local KMS provider on the @ref mongocrypt_t object.
+ * 
+ * This has been superseded by the more flexible:
+ * @ref mongocrypt_setopt_kms_providers
  *
  * @param[in] crypt The @ref mongocrypt_t object.
  * @param[in] key A 96 byte master key used to encrypt and decrypt key vault
@@ -556,6 +562,9 @@ mongocrypt_ctx_setopt_algorithm (mongocrypt_ctx_t *ctx,
 
 /**
  * Identify the AWS KMS master key to use for creating a data key.
+ * 
+ * This has been superseded by the more flexible:
+ * @ref mongocrypt_ctx_setopt_key_encryption_key
  *
  * @param[in] ctx The @ref mongocrypt_ctx_t object.
  * @param[in] region The AWS region.
@@ -584,6 +593,9 @@ mongocrypt_ctx_setopt_masterkey_aws (mongocrypt_ctx_t *ctx,
  * (with the Host header set to this endpoint). This endpoint
  * is persisted in the new data key, and will be returned via
  * @ref mongocrypt_kms_ctx_endpoint.
+ * 
+ * This has been superseded by the more flexible:
+ * @ref mongocrypt_ctx_setopt_key_encryption_key
  *
  * @param[in] ctx The @ref mongocrypt_ctx_t object.
  * @param[in] endpoint The endpoint.
@@ -600,6 +612,8 @@ mongocrypt_ctx_setopt_masterkey_aws_endpoint (mongocrypt_ctx_t *ctx,
 
 /**
  * Set the master key to "local" for creating a data key.
+ * This has been superseded by the more flexible:
+ * @ref mongocrypt_ctx_setopt_key_encryption_key
  *
  * @param[in] ctx The @ref mongocrypt_ctx_t object.
  * @pre @p ctx has not been initialized.

--- a/test/data/kek-tests.json
+++ b/test/data/kek-tests.json
@@ -1,0 +1,94 @@
+[
+    {
+        "input": {
+            "keyVaultEndpoint": "keyvault.example.com", 
+            "keyVersion": "example keyVersion", 
+            "keyName": "example keyName", 
+            "provider": "azure"
+        }, 
+        "expect": "ok"
+    }, 
+    {
+        "input": {
+            "keyVaultEndpoint": "invalid endpoint", 
+            "keyVersion": "example keyVersion", 
+            "keyName": "example keyName", 
+            "provider": "azure"
+        }, 
+        "expect": "invalid endpoint"
+    }, 
+    {
+        "input": {
+            "keyVaultEndpoint": "keyvault.example.com", 
+            "keyName": "example keyName", 
+            "provider": "azure"
+        }, 
+        "expect": "ok"
+    }, 
+    {
+        "input": {
+            "provider": "local"
+        }, 
+        "expect": "ok"
+    }, 
+    {
+        "input": {
+            "region": "example region", 
+            "endpoint": "example.com", 
+            "key": "example arn", 
+            "provider": "aws"
+        }, 
+        "expect": "ok"
+    }, 
+    {
+        "input": {
+            "region": "example region", 
+            "endpoint": "invalid endpoint", 
+            "key": "example arn", 
+            "provider": "aws"
+        }, 
+        "expect": "invalid endpoint"
+    }, 
+    {
+        "input": {
+            "region": "example region", 
+            "key": "example arn", 
+            "provider": "aws"
+        }, 
+        "expect": "ok"
+    }, 
+    {
+        "input": {
+            "keyVersion": "example keyVersion", 
+            "endpoint": "example.com", 
+            "projectId": "example projectId", 
+            "keyRing": "example keyRing", 
+            "keyName": "example keyName", 
+            "location": "example location", 
+            "provider": "gcp"
+        }, 
+        "expect": "ok"
+    }, 
+    {
+        "input": {
+            "keyVersion": "example keyVersion", 
+            "endpoint": "invalid endpoint", 
+            "location": "example location", 
+            "provider": "gcp", 
+            "projectId": "example projectId", 
+            "keyRing": "example keyRing", 
+            "keyName": "example keyName"
+        }, 
+        "expect": "invalid endpoint"
+    }, 
+    {
+        "input": {
+            "projectId": "example projectId", 
+            "keyName": "example keyName", 
+            "keyRing": "example keyRing", 
+            "location": "example location", 
+            "provider": "gcp"
+        }, 
+        "expect": "ok"
+    }
+]

--- a/test/test-conveniences.c
+++ b/test/test-conveniences.c
@@ -16,6 +16,18 @@
 
 #include "test-conveniences.h"
 
+#ifndef _WIN32
+#define MONGOCRYPT_PRINTF_FORMAT(a, b) __attribute__ ((format (__printf__, a, b)))
+#else
+#define MONGOCRYPT_PRINTF_FORMAT(a, b) /* no-op */
+#endif
+
+/* string comparison functions for Windows */
+#ifdef _WIN32
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
+#endif
+
 void
 bson_iter_bson (bson_iter_t *iter, bson_t *bson)
 {
@@ -29,4 +41,1054 @@ bson_iter_bson (bson_iter_t *iter, bson_t *bson)
    }
    BSON_ASSERT (data);
    bson_init_static (bson, data, len);
+}
+
+/* The following matching logic is copied from libmongoc. */
+bool
+bson_init_from_value (bson_t *b, const bson_value_t *v);
+
+char *
+single_quotes_to_double (const char *str);
+
+/* match_action_t determines if default check for a field is overridden. */
+typedef enum {
+   MATCH_ACTION_SKIP,    /* do not use the default check. */
+   MATCH_ACTION_ABORT,   /* an error occurred, stop checking. */
+   MATCH_ACTION_CONTINUE /* use the default check. */
+} match_action_t;
+
+struct _match_ctx_t;
+/* doc_iter may be null if the pattern field is not found. */
+typedef match_action_t (*match_visitor_fn) (struct _match_ctx_t *ctx,
+                                            bson_iter_t *pattern_iter,
+                                            bson_iter_t *doc_iter);
+
+typedef struct _match_ctx_t {
+   char errmsg[1000];
+   bool strict_numeric_types;
+   /* if retain_dots_in_keys is true, then don't consider a path with dots to
+    * indicate recursing into a sub document. */
+   bool retain_dots_in_keys;
+   /* if allow_placeholders is true, treats 42 and "42" as placeholders. I.e.
+    * comparing 42 to anything is ok. */
+   bool allow_placeholders;
+   /* path is the dot separated breadcrumb trail of keys. */
+   char path[1000];
+   /* if visitor_fn is not NULL, this is called on for every key in the pattern.
+    * The returned match_action_t can override the default match behavior. */
+   match_visitor_fn visitor_fn;
+   void *visitor_ctx;
+   /* if is_command is true, then compare the first key case insensitively. */
+   bool is_command;
+} match_ctx_t;
+
+void
+assert_match_bson (const bson_t *doc, const bson_t *pattern, bool is_command);
+
+bool
+match_bson (const bson_t *doc, const bson_t *pattern, bool is_command);
+
+int64_t
+bson_value_as_int64 (const bson_value_t *value);
+
+bool
+match_bson_value (const bson_value_t *doc,
+                  const bson_value_t *pattern,
+                  match_ctx_t *ctx);
+
+bool
+match_bson_with_ctx (const bson_t *doc,
+                     const bson_t *pattern,
+                     match_ctx_t *ctx);
+
+bool
+match_json (const bson_t *doc,
+            bool is_command,
+            const char *filename,
+            int lineno,
+            const char *funcname,
+            const char *json_pattern,
+            ...);
+
+#define ASSERT_MATCH(doc, ...)                                                 \
+   do {                                                                        \
+      BSON_ASSERT (                                                            \
+         match_json (doc, false, __FILE__, __LINE__, BSON_FUNC, __VA_ARGS__)); \
+   } while (0)
+
+const char *
+_mongoc_bson_type_to_str (bson_type_t t);
+
+static bool
+get_exists_operator (const bson_value_t *value, bool *exists);
+
+static bool
+get_empty_operator (const bson_value_t *value, bool *exists);
+
+static bool
+get_type_operator (const bson_value_t *value, bson_type_t *out);
+
+static bool
+is_empty_doc_or_array (const bson_value_t *value);
+
+static bool
+find (bson_iter_t *iter,
+      const bson_t *doc,
+      const char *key,
+      bool is_command,
+      bool is_first,
+      bool retain_dots_in_keys);
+
+
+/*--------------------------------------------------------------------------
+ *
+ * single_quotes_to_double --
+ *
+ *       Copy str with single-quotes replaced by double.
+ *
+ * Returns:
+ *       A string you must bson_free.
+ *
+ * Side effects:
+ *       None.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+char *
+single_quotes_to_double (const char *str)
+{
+   char *result = bson_strdup (str);
+   char *p;
+
+   for (p = result; *p; p++) {
+      if (*p == '\'') {
+         *p = '"';
+      }
+   }
+
+   return result;
+}
+
+
+/*--------------------------------------------------------------------------
+ *
+ * match_json --
+ *
+ *       Call match_bson on "doc" and "json_pattern".
+ *       For convenience, single-quotes are synonymous with double-quotes.
+ *
+ *       A NULL doc or NULL json_pattern means "{}".
+ *
+ * Returns:
+ *       True or false.
+ *
+ * Side effects:
+ *       Logs if no match. Aborts if json is malformed.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+MONGOCRYPT_PRINTF_FORMAT (6, 7)
+bool
+match_json (const bson_t *doc,
+            bool is_command,
+            const char *filename,
+            int lineno,
+            const char *funcname,
+            const char *json_pattern,
+            ...)
+{
+   va_list args;
+   char *json_pattern_formatted;
+   char *double_quoted;
+   bson_error_t error;
+   bson_t *pattern;
+   match_ctx_t ctx = {{0}};
+   bool matches;
+
+   va_start (args, json_pattern);
+   json_pattern_formatted =
+      bson_strdupv_printf (json_pattern ? json_pattern : "{}", args);
+   va_end (args);
+
+   double_quoted = single_quotes_to_double (json_pattern_formatted);
+   pattern = bson_new_from_json ((const uint8_t *) double_quoted, -1, &error);
+
+   if (!pattern) {
+      fprintf (stderr, "couldn't parse JSON: %s\n", error.message);
+      abort ();
+   }
+
+   ctx.is_command = is_command;
+   matches = match_bson_with_ctx (doc, pattern, &ctx);
+
+   if (!matches) {
+      char *as_string =
+         doc ? bson_as_canonical_extended_json (doc, NULL) : NULL;
+      fprintf (stderr,
+               "ASSERT_MATCH failed with document:\n\n"
+               "%s\n"
+               "pattern:\n%s\n"
+               "%s\n"
+               "%s:%d %s()\n",
+               as_string ? as_string : "{}",
+               double_quoted,
+               ctx.errmsg,
+               filename,
+               lineno,
+               funcname);
+      bson_free (as_string);
+   }
+
+   bson_destroy (pattern);
+   bson_free (json_pattern_formatted);
+   bson_free (double_quoted);
+
+   return matches;
+}
+
+
+/*--------------------------------------------------------------------------
+ *
+ * match_bson --
+ *
+ *       Does "doc" match "pattern"?
+ *
+ *       See match_bson_with_ctx for details.
+ *
+ * Returns:
+ *       True or false.
+ *
+ * Side effects:
+ *       None.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+bool
+match_bson (const bson_t *doc, const bson_t *pattern, bool is_command)
+{
+   match_ctx_t ctx = {{0}};
+
+   ctx.strict_numeric_types = true;
+   ctx.is_command = is_command;
+
+   return match_bson_with_ctx (doc, pattern, &ctx);
+}
+
+
+MONGOCRYPT_PRINTF_FORMAT (2, 3)
+void
+match_err (match_ctx_t *ctx, const char *fmt, ...)
+{
+   va_list args;
+   char *formatted;
+
+   BSON_ASSERT (ctx);
+
+   va_start (args, fmt);
+   formatted = bson_strdupv_printf (fmt, args);
+   va_end (args);
+
+   bson_snprintf (
+      ctx->errmsg, sizeof ctx->errmsg, "%s: %s", ctx->path, formatted);
+
+   bson_free (formatted);
+}
+
+
+/* When matching two docs, and preparing to recurse to match two subdocs with
+ * the given key, derive context for matching them from the current context. */
+static void
+derive (match_ctx_t *ctx, match_ctx_t *derived, const char *key)
+{
+   BSON_ASSERT (ctx);
+   BSON_ASSERT (derived);
+   BSON_ASSERT (key);
+
+   derived->strict_numeric_types = ctx->strict_numeric_types;
+
+   if (strlen (ctx->path) > 0) {
+      bson_snprintf (
+         derived->path, sizeof derived->path, "%s.%s", ctx->path, key);
+   } else {
+      bson_snprintf (derived->path, sizeof derived->path, "%s", key);
+   }
+   derived->retain_dots_in_keys = ctx->retain_dots_in_keys;
+   derived->allow_placeholders = ctx->allow_placeholders;
+   derived->visitor_ctx = ctx->visitor_ctx;
+   derived->visitor_fn = ctx->visitor_fn;
+   derived->is_command = false;
+   derived->errmsg[0] = 0;
+}
+
+
+/*--------------------------------------------------------------------------
+ *
+ * match_bson_with_ctx --
+ *
+ *       Does "doc" match "pattern"?
+ *
+ *       mongoc_matcher_t prohibits $-prefixed keys, which is something
+ *       we need to test in e.g. test_mongoc_client_read_prefs, so this
+ *       does *not* use mongoc_matcher_t. Instead, "doc" matches "pattern"
+ *       if its key-value pairs are a simple superset of pattern's. Order
+ *       matters.
+ *
+ *       The only special pattern syntaxes are:
+ *         "field": {"$exists": true/false}
+ *         "field": {"$empty": true/false}
+ *         "field": {"$$type": "type string"}
+ *
+ *       The first key matches case-insensitively if ctx->is_command.
+ *
+ *       An optional match visitor (match_visitor_fn and match_visitor_ctx)
+ *       can be set in ctx to provide custom matching behavior.
+ *
+ *       A NULL doc or NULL pattern means "{}".
+ *
+ * Returns:
+ *       True or false.
+ *
+ * Side effects:
+ *       None.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+bool
+match_bson_with_ctx (const bson_t *doc, const bson_t *pattern, match_ctx_t *ctx)
+{
+   bson_iter_t pattern_iter;
+   const char *key;
+   const bson_value_t *value;
+   bool is_first = true;
+   bool is_exists_operator;
+   bool is_empty_operator;
+   bool is_type_operator;
+   bool exists;
+   bool empty = false;
+   bson_type_t bson_type = (bson_type_t) 0;
+   bool found;
+   bson_iter_t doc_iter;
+   bson_value_t doc_value;
+   match_ctx_t derived;
+
+   if (bson_empty0 (pattern)) {
+      /* matches anything */
+      return true;
+   }
+
+   BSON_ASSERT (bson_iter_init (&pattern_iter, pattern));
+
+   while (bson_iter_next (&pattern_iter)) {
+      key = bson_iter_key (&pattern_iter);
+      value = bson_iter_value (&pattern_iter);
+
+      found = find (&doc_iter,
+                    doc,
+                    key,
+                    ctx->is_command,
+                    is_first,
+                    ctx->retain_dots_in_keys);
+      if (found) {
+         bson_value_copy (bson_iter_value (&doc_iter), &doc_value);
+      }
+
+      /* is value {"$exists": true} or {"$exists": false} ? */
+      is_exists_operator = get_exists_operator (value, &exists);
+
+      /* is value {"$empty": true} or {"$empty": false} ? */
+      is_empty_operator = get_empty_operator (value, &empty);
+
+      /* is value {"$$type": "string" } ? */
+      is_type_operator = get_type_operator (value, &bson_type);
+
+      derive (ctx, &derived, key);
+
+      if (ctx->visitor_fn) {
+         match_action_t action =
+            ctx->visitor_fn (ctx, &pattern_iter, found ? &doc_iter : NULL);
+         if (action == MATCH_ACTION_ABORT) {
+            goto fail;
+         } else if (action == MATCH_ACTION_SKIP) {
+            goto next;
+         }
+      }
+
+      if (value->value_type == BSON_TYPE_NULL && found) {
+         /* pattern has "key": null, and "key" is in doc */
+         if (doc_value.value_type != BSON_TYPE_NULL) {
+            match_err (&derived, "%s should be null or absent", key);
+            goto fail;
+         }
+      } else if (is_exists_operator) {
+         if (exists != found) {
+            match_err (&derived, "%s found", found ? "" : "not");
+            goto fail;
+         }
+      } else if (!found) {
+         match_err (&derived, "not found");
+         goto fail;
+      } else if (is_empty_operator) {
+         if (empty != is_empty_doc_or_array (&doc_value)) {
+            match_err (&derived, "%s found", empty ? "" : " not");
+            goto fail;
+         }
+      } else if (is_type_operator) {
+         if (doc_value.value_type != bson_type) {
+            match_err (&derived, "incorrect type");
+            goto fail;
+         }
+      } else if (!match_bson_value (&doc_value, value, &derived)) {
+         goto fail;
+      }
+
+   next:
+      is_first = false;
+      if (found) {
+         bson_value_destroy (&doc_value);
+      }
+   }
+
+   return true;
+
+fail:
+   if (found) {
+      bson_value_destroy (&doc_value);
+   }
+
+   if (strlen (derived.errmsg) > 0) {
+      memcpy (ctx->errmsg, derived.errmsg, sizeof (derived.errmsg));
+   }
+
+   return false;
+}
+
+
+/*--------------------------------------------------------------------------
+ *
+ * find --
+ *
+ *       Find the value for a key.
+ *
+ * Returns:
+ *       Whether the key was found.
+ *
+ * Side effects:
+ *       Copies the found value into "iter_out".
+ *
+ *--------------------------------------------------------------------------
+ */
+
+static bool
+find (bson_iter_t *iter_out,
+      const bson_t *doc,
+      const char *key,
+      bool is_command,
+      bool is_first,
+      bool retain_dots_in_keys)
+{
+   bson_iter_t iter;
+   bson_iter_t descendent;
+
+   bson_iter_init (&iter, doc);
+
+   if (!retain_dots_in_keys && strchr (key, '.')) {
+      if (!bson_iter_find_descendant (&iter, key, &descendent)) {
+         return false;
+      }
+
+      memcpy (iter_out, &descendent, sizeof (bson_iter_t));
+      return true;
+   } else if (is_command && is_first) {
+      if (!bson_iter_find_case (&iter, key)) {
+         return false;
+      }
+   } else if (!bson_iter_find (&iter, key)) {
+      return false;
+   }
+
+   memcpy (iter_out, &iter, sizeof (bson_iter_t));
+   return true;
+}
+
+
+bool
+bson_init_from_value (bson_t *b, const bson_value_t *v)
+{
+   BSON_ASSERT (v->value_type == BSON_TYPE_ARRAY ||
+                v->value_type == BSON_TYPE_DOCUMENT);
+
+   return bson_init_static (b, v->value.v_doc.data, v->value.v_doc.data_len);
+}
+
+
+static bool
+_is_operator (const char *op_name, const bson_value_t *value, bool *op_val)
+{
+   bson_t bson;
+   bson_iter_t iter;
+
+   if (value->value_type == BSON_TYPE_DOCUMENT &&
+       bson_init_from_value (&bson, value) &&
+       bson_iter_init_find (&iter, &bson, op_name)) {
+      *op_val = bson_iter_as_bool (&iter);
+      return true;
+   }
+
+   return false;
+}
+
+
+/*--------------------------------------------------------------------------
+ *
+ * get_exists_operator --
+ *
+ *       Is value a subdocument like {"$exists": bool}?
+ *
+ * Returns:
+ *       True if the value is a subdocument with the first key "$exists",
+ *       or if value is BSON null.
+ *
+ * Side effects:
+ *       If the function returns true, *exists is set to true or false,
+ *       the value of the bool.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+static bool
+get_exists_operator (const bson_value_t *value, bool *exists)
+{
+   if (_is_operator ("$exists", value, exists)) {
+      return true;
+   }
+
+   if (value->value_type == BSON_TYPE_NULL) {
+      *exists = false;
+      return true;
+   }
+
+   return false;
+}
+
+
+/*--------------------------------------------------------------------------
+ *
+ * get_empty_operator --
+ *
+ *       Is value a subdocument like {"$empty": bool}?
+ *
+ * Returns:
+ *       True if the value is a subdocument with the first key "$empty".
+ *
+ * Side effects:
+ *       If the function returns true, *empty is set to true or false,
+ *       the value of the bool.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+bool
+get_empty_operator (const bson_value_t *value, bool *empty)
+{
+   return _is_operator ("$empty", value, empty);
+}
+
+
+/*--------------------------------------------------------------------------
+ *
+ * get_type_operator --
+ *
+ *       Is value a subdocument like {"$$type": "BSON type string"}?
+ *
+ * Returns:
+ *       True if the value is a subdocument with the first key "$$type",
+ *       and sets the @bson_type.
+ *
+ * Side effects:
+ *       If the function returns true, *@bson_type is set.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+static bool
+get_type_operator (const bson_value_t *value, bson_type_t *out)
+{
+   bson_t bson;
+   bson_iter_t iter;
+   const char *value_string;
+
+   /* See list of aliases on this page:
+    * https://docs.mongodb.com/manual/reference/bson-types/ */
+   if (value->value_type == BSON_TYPE_DOCUMENT &&
+       bson_init_from_value (&bson, value) &&
+       bson_iter_init_find (&iter, &bson, "$$type")) {
+      value_string = bson_iter_utf8 (&iter, NULL);
+      if (0 == strcasecmp ("double", value_string)) {
+         *out = BSON_TYPE_DOUBLE;
+      } else if (0 == strcasecmp ("string", value_string)) {
+         *out = BSON_TYPE_UTF8;
+      } else if (0 == strcasecmp ("object", value_string)) {
+         *out = BSON_TYPE_DOCUMENT;
+      } else if (0 == strcasecmp ("array", value_string)) {
+         *out = BSON_TYPE_ARRAY;
+      } else if (0 == strcasecmp ("binData", value_string)) {
+         *out = BSON_TYPE_BINARY;
+      } else if (0 == strcasecmp ("undefined", value_string)) {
+         *out = BSON_TYPE_UNDEFINED;
+      } else if (0 == strcasecmp ("objectId", value_string)) {
+         *out = BSON_TYPE_OID;
+      } else if (0 == strcasecmp ("bool", value_string)) {
+         *out = BSON_TYPE_BOOL;
+      } else if (0 == strcasecmp ("date", value_string)) {
+         *out = BSON_TYPE_DATE_TIME;
+      } else if (0 == strcasecmp ("null", value_string)) {
+         *out = BSON_TYPE_NULL;
+      } else if (0 == strcasecmp ("regex", value_string)) {
+         *out = BSON_TYPE_REGEX;
+      } else if (0 == strcasecmp ("dbPointer", value_string)) {
+         *out = BSON_TYPE_DBPOINTER;
+      } else if (0 == strcasecmp ("javascript", value_string)) {
+         *out = BSON_TYPE_CODE;
+      } else if (0 == strcasecmp ("symbol", value_string)) {
+         *out = BSON_TYPE_SYMBOL;
+      } else if (0 == strcasecmp ("javascriptWithScope", value_string)) {
+         *out = BSON_TYPE_CODEWSCOPE;
+      } else if (0 == strcasecmp ("int", value_string)) {
+         *out = BSON_TYPE_INT32;
+      } else if (0 == strcasecmp ("timestamp", value_string)) {
+         *out = BSON_TYPE_TIMESTAMP;
+      } else if (0 == strcasecmp ("long", value_string)) {
+         *out = BSON_TYPE_INT64;
+      } else if (0 == strcasecmp ("decimal", value_string)) {
+         *out = BSON_TYPE_DECIMAL128;
+      } else if (0 == strcasecmp ("minKey", value_string)) {
+         *out = BSON_TYPE_MINKEY;
+      } else if (0 == strcasecmp ("maxKey", value_string)) {
+         *out = BSON_TYPE_MAXKEY;
+      } else {
+         fprintf (stderr, "unrecognized $$type value: %s\n", value_string);
+         abort ();
+      }
+      return true;
+   }
+
+   return false;
+}
+
+
+/*--------------------------------------------------------------------------
+ *
+ * is_empty_doc_or_array --
+ *
+ *       Is value the subdocument {} or the array []?
+ *
+ *--------------------------------------------------------------------------
+ */
+
+static bool
+is_empty_doc_or_array (const bson_value_t *value)
+{
+   bson_t doc;
+
+   if (!(value->value_type == BSON_TYPE_ARRAY ||
+         value->value_type == BSON_TYPE_DOCUMENT)) {
+      return false;
+   }
+   BSON_ASSERT (bson_init_static (
+      &doc, value->value.v_doc.data, value->value.v_doc.data_len));
+
+   return bson_count_keys (&doc) == 0;
+}
+
+
+static bool
+match_bson_arrays (const bson_t *array, const bson_t *pattern, match_ctx_t *ctx)
+{
+   uint32_t array_count;
+   uint32_t pattern_count;
+   bson_iter_t array_iter;
+   bson_iter_t pattern_iter;
+   const bson_value_t *array_value;
+   const bson_value_t *pattern_value;
+   match_ctx_t derived;
+
+   array_count = bson_count_keys (array);
+   pattern_count = bson_count_keys (pattern);
+
+   if (array_count != pattern_count) {
+      match_err (ctx,
+                 "expected %" PRIu32 " keys, not %" PRIu32,
+                 pattern_count,
+                 array_count);
+      return false;
+   }
+
+   BSON_ASSERT (bson_iter_init (&array_iter, array));
+   BSON_ASSERT (bson_iter_init (&pattern_iter, pattern));
+
+   while (bson_iter_next (&array_iter)) {
+      BSON_ASSERT (bson_iter_next (&pattern_iter));
+      array_value = bson_iter_value (&array_iter);
+      pattern_value = bson_iter_value (&pattern_iter);
+
+      derive (ctx, &derived, bson_iter_key (&array_iter));
+
+      if (!match_bson_value (array_value, pattern_value, &derived)) {
+         return false;
+      }
+   }
+
+   return true;
+}
+
+
+static bool
+is_number_type (bson_type_t t)
+{
+   if (t == BSON_TYPE_DOUBLE || t == BSON_TYPE_INT32 || t == BSON_TYPE_INT64) {
+      return true;
+   }
+
+   return false;
+}
+
+
+int64_t
+bson_value_as_int64 (const bson_value_t *value)
+{
+   if (value->value_type == BSON_TYPE_DOUBLE) {
+      return (int64_t) value->value.v_double;
+   } else if (value->value_type == BSON_TYPE_INT32) {
+      return (int64_t) value->value.v_int32;
+   } else if (value->value_type == BSON_TYPE_INT64) {
+      return value->value.v_int64;
+   } else {
+      return -123;
+   }
+}
+
+
+bool
+match_bson_value (const bson_value_t *doc,
+                  const bson_value_t *pattern,
+                  match_ctx_t *ctx)
+{
+   bson_t subdoc;
+   bson_t pattern_subdoc;
+   int64_t doc_int64;
+   int64_t pattern_int64;
+   bool ret = false;
+
+   if (ctx && ctx->allow_placeholders) {
+      /* The change streams spec tests use the value 42 as a placeholder. */
+      bool is_placeholder = false;
+      if (is_number_type (pattern->value_type) &&
+          bson_value_as_int64 (pattern) == 42) {
+         is_placeholder = true;
+      }
+      if (pattern->value_type == BSON_TYPE_UTF8 &&
+          !strcmp (pattern->value.v_utf8.str, "42")) {
+         is_placeholder = true;
+      }
+      if (is_placeholder) {
+         return true;
+      }
+   }
+
+   if (is_number_type (doc->value_type) &&
+       is_number_type (pattern->value_type) && ctx &&
+       !ctx->strict_numeric_types) {
+      doc_int64 = bson_value_as_int64 (doc);
+      pattern_int64 = bson_value_as_int64 (pattern);
+
+      if (doc_int64 != pattern_int64) {
+         match_err (ctx,
+                    "expected %" PRId64 ", got %" PRId64,
+                    pattern_int64,
+                    doc_int64);
+         return false;
+      }
+
+      return true;
+   }
+
+   if (doc->value_type != pattern->value_type) {
+      match_err (ctx,
+                 "expected type %s, got %s",
+                 _mongoc_bson_type_to_str (pattern->value_type),
+                 _mongoc_bson_type_to_str (doc->value_type));
+      return false;
+   }
+
+   switch (doc->value_type) {
+   case BSON_TYPE_ARRAY:
+   case BSON_TYPE_DOCUMENT:
+
+      if (!bson_init_from_value (&subdoc, doc)) {
+         return false;
+      }
+
+      if (!bson_init_from_value (&pattern_subdoc, pattern)) {
+         bson_destroy (&subdoc);
+         return false;
+      }
+
+      if (doc->value_type == BSON_TYPE_ARRAY) {
+         ret = match_bson_arrays (&subdoc, &pattern_subdoc, ctx);
+      } else {
+         ret = match_bson_with_ctx (&subdoc, &pattern_subdoc, ctx);
+      }
+
+      bson_destroy (&subdoc);
+      bson_destroy (&pattern_subdoc);
+
+      return ret;
+
+   case BSON_TYPE_BINARY:
+      ret = doc->value.v_binary.data_len == pattern->value.v_binary.data_len &&
+            !memcmp (doc->value.v_binary.data,
+                     pattern->value.v_binary.data,
+                     doc->value.v_binary.data_len);
+      break;
+
+   case BSON_TYPE_BOOL:
+      ret = doc->value.v_bool == pattern->value.v_bool;
+
+      if (!ret) {
+         match_err (ctx,
+                    "expected %d, got %d",
+                    pattern->value.v_bool,
+                    doc->value.v_bool);
+      }
+
+      return ret;
+
+   case BSON_TYPE_CODE:
+      ret = doc->value.v_code.code_len == pattern->value.v_code.code_len &&
+            !memcmp (doc->value.v_code.code,
+                     pattern->value.v_code.code,
+                     doc->value.v_code.code_len);
+
+      break;
+
+   case BSON_TYPE_CODEWSCOPE:
+      ret = doc->value.v_codewscope.code_len ==
+               pattern->value.v_codewscope.code_len &&
+            !memcmp (doc->value.v_codewscope.code,
+                     pattern->value.v_codewscope.code,
+                     doc->value.v_codewscope.code_len) &&
+            doc->value.v_codewscope.scope_len ==
+               pattern->value.v_codewscope.scope_len &&
+            !memcmp (doc->value.v_codewscope.scope_data,
+                     pattern->value.v_codewscope.scope_data,
+                     doc->value.v_codewscope.scope_len);
+
+      break;
+
+   case BSON_TYPE_DATE_TIME:
+      ret = doc->value.v_datetime == pattern->value.v_datetime;
+
+      if (!ret) {
+         match_err (ctx,
+                    "expected %" PRId64 ", got %" PRId64,
+                    pattern->value.v_datetime,
+                    doc->value.v_datetime);
+      }
+
+      return ret;
+
+   case BSON_TYPE_DOUBLE:
+      ret = doc->value.v_double == pattern->value.v_double;
+
+      if (!ret) {
+         match_err (ctx,
+                    "expected %f, got %f",
+                    pattern->value.v_double,
+                    doc->value.v_double);
+      }
+
+      return ret;
+
+   case BSON_TYPE_INT32:
+      ret = doc->value.v_int32 == pattern->value.v_int32;
+
+      if (!ret) {
+         match_err (ctx,
+                    "expected %" PRId32 ", got %" PRId32,
+                    pattern->value.v_int32,
+                    doc->value.v_int32);
+      }
+
+      return ret;
+
+   case BSON_TYPE_INT64:
+      ret = doc->value.v_int64 == pattern->value.v_int64;
+
+      if (!ret) {
+         match_err (ctx,
+                    "expected %" PRId64 ", got %" PRId64,
+                    pattern->value.v_int64,
+                    doc->value.v_int64);
+      }
+
+      return ret;
+
+   case BSON_TYPE_OID:
+      ret = bson_oid_equal (&doc->value.v_oid, &pattern->value.v_oid);
+      break;
+
+   case BSON_TYPE_REGEX:
+      ret =
+         !strcmp (doc->value.v_regex.regex, pattern->value.v_regex.regex) &&
+         !strcmp (doc->value.v_regex.options, pattern->value.v_regex.options);
+
+      break;
+
+   case BSON_TYPE_SYMBOL:
+      ret = doc->value.v_symbol.len == pattern->value.v_symbol.len &&
+            !strncmp (doc->value.v_symbol.symbol,
+                      pattern->value.v_symbol.symbol,
+                      doc->value.v_symbol.len);
+
+      break;
+
+   case BSON_TYPE_TIMESTAMP:
+      ret = doc->value.v_timestamp.timestamp ==
+               pattern->value.v_timestamp.timestamp &&
+            doc->value.v_timestamp.increment ==
+               pattern->value.v_timestamp.increment;
+
+      break;
+
+   case BSON_TYPE_UTF8:
+      ret = doc->value.v_utf8.len == pattern->value.v_utf8.len &&
+            !strncmp (doc->value.v_utf8.str,
+                      pattern->value.v_utf8.str,
+                      doc->value.v_utf8.len);
+
+      if (!ret) {
+         match_err (ctx,
+                    "expected \"%s\", got \"%s\"",
+                    pattern->value.v_utf8.str,
+                    doc->value.v_utf8.str);
+      }
+
+      return ret;
+
+
+   /* these are empty types, if "a" and "b" are the same type they're equal */
+   case BSON_TYPE_EOD:
+   case BSON_TYPE_MAXKEY:
+   case BSON_TYPE_MINKEY:
+   case BSON_TYPE_NULL:
+   case BSON_TYPE_UNDEFINED:
+      return true;
+
+   case BSON_TYPE_DBPOINTER:
+      ret = (0 == strcmp (doc->value.v_dbpointer.collection,
+                          pattern->value.v_dbpointer.collection) &&
+             bson_oid_equal (&doc->value.v_dbpointer.oid,
+                             &pattern->value.v_dbpointer.oid));
+      break;
+
+   case BSON_TYPE_DECIMAL128:
+      ret = (doc->value.v_decimal128.low == pattern->value.v_decimal128.low &&
+             doc->value.v_decimal128.high == pattern->value.v_decimal128.high);
+      if (!ret) {
+         match_err (ctx,
+                    "Decimal128 is not an exact binary match (though "
+                    "numeric values may be equal)");
+      }
+      break;
+   default:
+      match_err (ctx, "unexpected value type %d: %s",
+                  doc->value_type,
+                  _mongoc_bson_type_to_str (doc->value_type));
+   }
+
+   if (!ret) {
+      match_err (ctx,
+                 "%s values mismatch",
+                 _mongoc_bson_type_to_str (pattern->value_type));
+   }
+
+   return ret;
+}
+
+const char *
+_mongoc_bson_type_to_str (bson_type_t t)
+{
+   switch (t) {
+   case BSON_TYPE_EOD:
+      return "EOD";
+   case BSON_TYPE_DOUBLE:
+      return "DOUBLE";
+   case BSON_TYPE_UTF8:
+      return "UTF8";
+   case BSON_TYPE_DOCUMENT:
+      return "DOCUMENT";
+   case BSON_TYPE_ARRAY:
+      return "ARRAY";
+   case BSON_TYPE_BINARY:
+      return "BINARY";
+   case BSON_TYPE_UNDEFINED:
+      return "UNDEFINED";
+   case BSON_TYPE_OID:
+      return "OID";
+   case BSON_TYPE_BOOL:
+      return "BOOL";
+   case BSON_TYPE_DATE_TIME:
+      return "DATE_TIME";
+   case BSON_TYPE_NULL:
+      return "NULL";
+   case BSON_TYPE_REGEX:
+      return "REGEX";
+   case BSON_TYPE_DBPOINTER:
+      return "DBPOINTER";
+   case BSON_TYPE_CODE:
+      return "CODE";
+   case BSON_TYPE_SYMBOL:
+      return "SYMBOL";
+   case BSON_TYPE_CODEWSCOPE:
+      return "CODEWSCOPE";
+   case BSON_TYPE_INT32:
+      return "INT32";
+   case BSON_TYPE_TIMESTAMP:
+      return "TIMESTAMP";
+   case BSON_TYPE_INT64:
+      return "INT64";
+   case BSON_TYPE_MAXKEY:
+      return "MAXKEY";
+   case BSON_TYPE_MINKEY:
+      return "MINKEY";
+   case BSON_TYPE_DECIMAL128:
+      return "DECIMAL128";
+   default:
+      return "Unknown";
+   }
+}
+
+void
+_assert_match_bson (const bson_t *doc, const bson_t *pattern) {
+   match_ctx_t ctx;
+
+   memset (&ctx, 0, sizeof (match_ctx_t));
+   if (!match_bson_with_ctx (doc, pattern, &ctx)) {
+      char *doc_str = doc ? bson_as_json (doc, NULL) : NULL;
+      char *pattern_str = bson_as_json (pattern, NULL);
+      fprintf (stderr,
+               "ASSERT_MATCH failed with document:\n\n"
+               "%s\n"
+               "pattern:\n%s\n"
+               "%s\n",
+               doc_str ? doc_str : "{}",
+               pattern_str,
+               ctx.errmsg);
+      bson_free (doc_str);
+      bson_free (pattern_str);
+   }
 }

--- a/test/test-conveniences.h
+++ b/test/test-conveniences.h
@@ -19,3 +19,7 @@
 /* Iterate a document or array into a bson_t. */
 void
 bson_iter_bson (bson_iter_t *iter, bson_t *bson);
+
+/* Copied from libmongoc. */
+void
+_assert_match_bson (const bson_t *doc, const bson_t *pattern);

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -737,7 +737,7 @@ _test_key_missing_region (_mongocrypt_tester_t *tester)
    ASSERT_FAILS (mongocrypt_ctx_mongo_feed (
                     ctx, TEST_FILE ("./test/data/key-document-no-region.json")),
                  ctx,
-                 "no 'region'");
+                 "expected UTF-8 region");
    BSON_ASSERT (mongocrypt_ctx_state (ctx) == MONGOCRYPT_CTX_ERROR);
 
    mongocrypt_ctx_destroy (ctx);

--- a/test/test-mongocrypt-ctx-setopt.c
+++ b/test/test-mongocrypt-ctx-setopt.c
@@ -429,8 +429,7 @@ _test_setopt_for_datakey (_mongocrypt_tester_t *tester)
 
    REFRESH;
    MASTERKEY_LOCAL_OK;
-   ENDPOINT_OK ("example.com:80", -1);
-   DATAKEY_INIT_FAILS ("endpoint not supported for local masterkey");
+   ENDPOINT_FAILS ("example.com:80", -1, "endpoint prohibited");
 
    mongocrypt_ctx_destroy (ctx);
    mongocrypt_destroy (crypt);
@@ -484,10 +483,6 @@ _test_setopt_for_encrypt (_mongocrypt_tester_t *tester)
    REFRESH;
    ENCRYPT_INIT_OK ("a", -1, cmd);
    MASTERKEY_LOCAL_FAILS ("cannot set options after init");
-
-   REFRESH;
-   ENDPOINT_OK ("example.com:80", -1);
-   ENCRYPT_INIT_FAILS ("a", -1, cmd, "endpoint prohibited");
 
    mongocrypt_ctx_destroy (ctx);
    mongocrypt_destroy (crypt);
@@ -589,12 +584,6 @@ _test_setopt_for_explicit_encrypt (_mongocrypt_tester_t *tester)
    ALGORITHM_FAILS ("bad-algo", -1, "unsupported algorithm");
    EX_ENCRYPT_INIT_FAILS (bson, "unsupported algorithm");
 
-   REFRESH;
-   KEY_ID_OK (uuid);
-   ALGORITHM_OK (RAND, -1);
-   ENDPOINT_OK ("example.com:80", -1);
-   EX_ENCRYPT_INIT_FAILS (bson, "endpoint prohibited");
-
    mongocrypt_ctx_destroy (ctx);
    mongocrypt_destroy (crypt);
 }
@@ -645,10 +634,6 @@ _test_setopt_for_decrypt (_mongocrypt_tester_t *tester)
    DECRYPT_INIT_OK (bson);
    MASTERKEY_LOCAL_FAILS ("cannot set options after init");
 
-   REFRESH;
-   ENDPOINT_OK ("example.com:80", -1);
-   DECRYPT_INIT_FAILS (bson, "endpoint prohibited");
-
    mongocrypt_ctx_destroy (ctx);
    mongocrypt_destroy (crypt);
 }
@@ -694,10 +679,6 @@ _test_setopt_for_explicit_decrypt (_mongocrypt_tester_t *tester)
    ALGORITHM_OK (DET, -1);
    EX_DECRYPT_INIT_FAILS (bson, "algorithm prohibited");
 
-   REFRESH;
-   ENDPOINT_OK ("example.com:80", -1);
-   EX_DECRYPT_INIT_FAILS (bson, "endpoint prohibited");
-
    mongocrypt_ctx_destroy (ctx);
    mongocrypt_destroy (crypt);
 }
@@ -737,17 +718,18 @@ _test_setopt_endpoint (_mongocrypt_tester_t *tester)
    crypt = _mongocrypt_tester_mongocrypt ();
 
    REFRESH;
-   ENDPOINT_FAILS ("example.com", -2, "invalid masterkey endpoint");
+   ENDPOINT_FAILS ("example.com", -2, "Invalid endpoint");
 
    REFRESH;
    ENDPOINT_OK ("example.com", -1);
-   BSON_ASSERT (0 == strcmp (ctx->opts.kek.provider.aws.endpoint->host_and_port, "example.com"));
+   BSON_ASSERT (0 == strcmp (ctx->opts.kek.provider.aws.endpoint->host_and_port,
+                             "example.com"));
 
    /* Including a port is ok. */
    REFRESH;
    ENDPOINT_OK ("example.com:80", -1);
-   BSON_ASSERT (0 ==
-                strcmp (ctx->opts.kek.provider.aws.endpoint->host_and_port, "example.com:80"));
+   BSON_ASSERT (0 == strcmp (ctx->opts.kek.provider.aws.endpoint->host_and_port,
+                             "example.com:80"));
 
    /* Test double setting. */
    REFRESH;

--- a/test/test-mongocrypt-ctx-setopt.c
+++ b/test/test-mongocrypt-ctx-setopt.c
@@ -741,13 +741,13 @@ _test_setopt_endpoint (_mongocrypt_tester_t *tester)
 
    REFRESH;
    ENDPOINT_OK ("example.com", -1);
-   BSON_ASSERT (0 == strcmp (ctx->opts.masterkey_aws_endpoint, "example.com"));
+   BSON_ASSERT (0 == strcmp (ctx->opts.kek.provider.aws.endpoint->host_and_port, "example.com"));
 
    /* Including a port is ok. */
    REFRESH;
    ENDPOINT_OK ("example.com:80", -1);
    BSON_ASSERT (0 ==
-                strcmp (ctx->opts.masterkey_aws_endpoint, "example.com:80"));
+                strcmp (ctx->opts.kek.provider.aws.endpoint->host_and_port, "example.com:80"));
 
    /* Test double setting. */
    REFRESH;
@@ -756,7 +756,7 @@ _test_setopt_endpoint (_mongocrypt_tester_t *tester)
 
    /* Test NULL input */
    REFRESH;
-   ENDPOINT_FAILS (NULL, 0, "invalid masterkey endpoint");
+   ENDPOINT_FAILS (NULL, 0, "Invalid endpoint");
 
    REFRESH;
    _mongocrypt_ctx_fail_w_msg (ctx, "test");

--- a/test/test-mongocrypt-kek.c
+++ b/test/test-mongocrypt-kek.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bson/bson.h>
+#include "test-mongocrypt.h"
+#include "test-conveniences.h"
+#include "mongocrypt-kek-private.h"
+
+static void _run_one_test (_mongocrypt_tester_t *tester, bson_t *test) {
+    bson_iter_t iter;
+    bson_t input;
+    char *input_str;
+    mongocrypt_status_t *status;
+    _mongocrypt_kek_t kek;
+    const char* expect;
+    bool ret;
+    bson_t out;
+
+    status = mongocrypt_status_new ();
+    memset (&kek, 0, sizeof (_mongocrypt_kek_t));
+    BSON_ASSERT (bson_iter_init_find (&iter, test, "input"));
+    bson_iter_bson (&iter, &input);
+    BSON_ASSERT (bson_iter_init_find (&iter, test, "expect"));
+    expect = bson_iter_utf8 (&iter, NULL);
+
+    input_str = bson_as_json (&input, NULL);
+    printf ("- testcase: %s\n", input_str);
+    bson_free (input_str);
+
+    ret = _mongocrypt_kek_parse_owned (&input, &kek, status);
+    if (0 == strcmp (expect, "ok")) {
+        ASSERT_OK_STATUS (ret, status);
+        bson_init (&out);
+        ret = _mongocrypt_kek_append (&kek, &out, status);
+        ASSERT_OK_STATUS (ret, status);
+        /* This should round trip. */
+        _assert_match_bson (&out, &input);
+        bson_destroy (&out);
+    } else {
+        ASSERT_FAILS_STATUS (ret, status, expect);
+    }
+
+    _mongocrypt_kek_cleanup (&kek);
+    mongocrypt_status_destroy (status);
+}
+
+void
+test_mongocrypt_kek_parsing (_mongocrypt_tester_t *tester) {
+   bson_t test_file;
+   bson_iter_t iter;
+
+   _load_json_as_bson ("./test/data/kek-tests.json", &test_file);
+   for (bson_iter_init (&iter, &test_file); bson_iter_next (&iter);) {
+      bson_t test;
+
+      bson_iter_bson (&iter, &test);
+      _run_one_test (tester, &test);
+      bson_destroy (&test);
+   }
+   bson_destroy (&test_file);
+}
+
+void
+_mongocrypt_tester_install_kek (_mongocrypt_tester_t *tester)
+{
+   INSTALL_TEST (test_mongocrypt_kek_parsing);
+}

--- a/test/test-mongocrypt-key.c
+++ b/test/test-mongocrypt-key.c
@@ -63,6 +63,7 @@ static void
 _parse_fails (bson_t *key_bson, mongocrypt_status_t *status, const char *msg)
 {
    _mongocrypt_key_doc_t *key_doc = _mongocrypt_key_new ();
+
    ASSERT_FAILS_STATUS (
       _mongocrypt_key_parse_owned (key_bson, key_doc, status), status, msg);
    _mongocrypt_key_destroy (key_doc);
@@ -143,38 +144,29 @@ test_mongocrypt_key_parsing (_mongocrypt_tester_t *tester)
    /* masterKey: missing provider. */
    _recreate_and_reset (tester, &key_bson, status, "masterKey", NULL);
    bson_concat (&key_bson, TMP_BSON ("{'masterKey': { }}"));
-   _parse_fails (&key_bson, status, "invalid 'masterKey', no 'provider'");
+   _parse_fails (&key_bson, status, "expected UTF-8 provider");
    /* masterKey: wrong provider. */
    _recreate_and_reset (tester, &key_bson, status, "masterKey", NULL);
    bson_concat (&key_bson, TMP_BSON ("{'masterKey': { 'provider': 'bad' }}"));
-   _parse_fails (&key_bson,
-                 status,
-                 "invalid 'masterKey.provider', expected 'aws' or 'local' or "
-                 "'azure' or 'gcp'");
+   _parse_fails (&key_bson, status, "unrecognized KMS provider");
    /* masterKey: provider=aws, missing key */
    _recreate_and_reset (tester, &key_bson, status, "masterKey", NULL);
    bson_concat (
       &key_bson,
       TMP_BSON ("{'masterKey': { 'provider': 'aws', 'region': 'us-east-1' }}"));
-   _parse_fails (&key_bson, status, "invalid 'masterKey', no 'key'");
+   _parse_fails (&key_bson, status, "expected UTF-8 key");
    /* masterKey: provider=aws, missing region */
    _recreate_and_reset (tester, &key_bson, status, "masterKey", NULL);
    bson_concat (
       &key_bson,
       TMP_BSON ("{'masterKey': { 'provider': 'aws', 'key': 'cmk-string' }}"));
-   _parse_fails (&key_bson, status, "invalid 'masterKey', no 'region'");
+   _parse_fails (&key_bson, status, "expected UTF-8 region");
    /* masterKey: provider=aws, bad region */
    _recreate_and_reset (tester, &key_bson, status, "masterKey", NULL);
    bson_concat (&key_bson,
                 TMP_BSON ("{'masterKey': { 'provider': 'aws', "
                           "'key': 'cmk-string', 'region': 1 }}"));
-   _parse_fails (
-      &key_bson, status, "invalid 'masterKey.region', expected string");
-   /* masterKey: unrecognized field */
-   _recreate_and_reset (tester, &key_bson, status, "masterKey", NULL);
-   bson_concat (&key_bson,
-                TMP_BSON ("{'masterKey': { 'provider': 'local', 'bad': 1 }}"));
-   _parse_fails (&key_bson, status, "unrecognized provider field");
+   _parse_fails (&key_bson, status, "expected UTF-8 region");
 
    /* creationDate: missing */
    _recreate_and_reset (tester, &key_bson, status, "creationDate", NULL);

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -638,8 +638,12 @@ _test_setopt_kms_providers (_mongocrypt_tester_t *tester)
        "'identityPlatformEndpoint': 'example' }}",
        "Invalid endpoint"},
       {"{'azure': {'tenantId': '', 'clientSecret': '' }}", "clientId"},
-      {"{'aws': {}}", "unsupported KMS provider"},
-      {"{'local': {}}", "unsupported KMS provider"},
+      {"{'aws': {'accessKeyId': 'abc', 'secretAccessKey': 'def'}}", NULL},
+      {"{'aws': {}}", "expected UTF-8 aws.accessKeyId"},
+      {"{'local': {'key': {'$binary': {'base64': 'AAAA', 'subType': '00'}} }}", NULL},
+      {"{'local': {'key': 'AAAA' }}", NULL},
+      {"{'local': {'key': 'invalid base64' }}", "unable to parse base64"},
+      {"{'local': {}}", "expected UTF-8 or binary local.key"},
       /* either base64 string or binary is acceptable for privateKey */
       {"{'gcp': {'endpoint': 'oauth2.googleapis.com', 'email': 'test', "
        "'privateKey': 'AAAA' }}"},

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -556,7 +556,6 @@ _assert_bin_bson_equal (mongocrypt_binary_t *bin_a, mongocrypt_binary_t *bin_b)
    bson_free (msg);
 }
 
-
 static void
 _test_setopt_schema (_mongocrypt_tester_t *tester)
 {
@@ -718,6 +717,7 @@ main (int argc, char **argv)
                                "_test_setopt_kms_providers",
                                _test_setopt_kms_providers,
                                CRYPTO_OPTIONAL);
+   _mongocrypt_tester_install_kek (&tester);
 
 
    printf ("Running tests...\n");

--- a/test/test-mongocrypt.h
+++ b/test/test-mongocrypt.h
@@ -172,6 +172,9 @@ _mongocrypt_tester_mongocrypt (void);
 void
 _assert_bin_bson_equal (mongocrypt_binary_t *bin_a, mongocrypt_binary_t *bin_b);
 
+void
+_assert_match_bson (const bson_t *doc, const bson_t *pattern);
+
 typedef enum {
    CRYPTO_REQUIRED,
    CRYPTO_OPTIONAL,
@@ -255,6 +258,8 @@ _mongocrypt_tester_install_status (_mongocrypt_tester_t *tester);
 void
 _mongocrypt_tester_install_endpoint (_mongocrypt_tester_t *tester);
 
+void _mongocrypt_tester_install_kek (_mongocrypt_tester_t *tester);
+
 /* Conveniences for getting test data. */
 
 /* Get a temporary bson_t from a JSON string. Do not free it. */
@@ -289,5 +294,6 @@ _mongocrypt_tester_file (_mongocrypt_tester_t *tester, const char *path);
 
 void
 _load_json_as_bson (const char *path, bson_t *out);
+
 
 #endif


### PR DESCRIPTION
- Adds support for "local" and "aws" to the new API `mongocrypt_setopt_kms_providers` and `mongocrypt_ctx_setopt_key_encryption_key`
- Splits out key encryption key parsing/appending into a separate type, `_mongocrypt_kek_t`