### PR TITLE
MONGOCRYPT-284 Wrapped new api in the Java binding

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -347,6 +347,8 @@ tasks:
   commands:
     - func: "fetch source"
     - func: "build and test java"
+      vars:
+        test_env: PROJECT_DIRECTORY=${project_directory}
 
 - name: test-python
   depends_on:

--- a/bindings/java/mongocrypt/.evergreen/test.sh
+++ b/bindings/java/mongocrypt/.evergreen/test.sh
@@ -15,4 +15,4 @@ fi
 
 ./gradlew -version
 
-./gradlew clean check --info -Djna.debug_load=true
+./gradlew clean check --info -Djna.debug_load=true -Djna.library.path=${PROJECT_DIRECTORY}/install/libmongocrypt/lib/

--- a/bindings/java/mongocrypt/README.md
+++ b/bindings/java/mongocrypt/README.md
@@ -1,4 +1,4 @@
-# mongocrypt Java Wrapper#
+# mongocrypt Java Wrapper #
 The Java wrapper for the companion C library for client side encryption in drivers.
 
 

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
@@ -321,6 +321,12 @@ public class CAPI {
                                    mongocrypt_hash_fn sha_256,
                                    Pointer ctx);
 
+    public static native boolean
+    mongocrypt_setopt_crypto_hook_sign_rsaes_pkcs1_v1_5(
+            mongocrypt_t crypt,
+            mongocrypt_hmac_fn sign_rsaes_pkcs1_v1_5,
+            Pointer sign_ctx);
+
     /**
      * Set a handler to get called on every log message.
      *
@@ -354,6 +360,18 @@ public class CAPI {
     public static native boolean
     mongocrypt_setopt_kms_provider_local(mongocrypt_t crypt,
                                          mongocrypt_binary_t key);
+
+    /**
+     * Configure KMS providers with a BSON document.
+     *
+     * @param crypt The @ref mongocrypt_t object.
+     * @param kms_providers A BSON document mapping the KMS provider names to credentials.
+     * @return A boolean indicating success. If false, an error status is set.
+     * @since 1.1
+     */
+    public static native boolean
+    mongocrypt_setopt_kms_providers(mongocrypt_t crypt,
+                                    mongocrypt_binary_t kms_providers);
 
     /**
      * Set a local schema map for encryption.
@@ -522,6 +540,18 @@ public class CAPI {
     public static native boolean
     mongocrypt_ctx_setopt_masterkey_local (mongocrypt_ctx_t ctx);
 
+    /**
+     * Set key encryption key document for creating a data key.
+     * Currently only applies to Azure.
+     *
+     * @param ctx The @ref mongocrypt_ctx_t object.
+     * @param keyDocument BSON representing the key encryption key document.
+     * @return A boolean indicating success. If false, and error status is set.
+     * @since 1.1
+     */
+    public static native boolean
+    mongocrypt_ctx_setopt_key_encryption_key(mongocrypt_ctx_t ctx,
+                                             mongocrypt_binary_t keyDocument);
 
     /**
      * Initialize a context to create a data key.

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
@@ -542,7 +542,6 @@ public class CAPI {
 
     /**
      * Set key encryption key document for creating a data key.
-     * Currently only applies to Azure.
      *
      * @param ctx The @ref mongocrypt_ctx_t object.
      * @param keyDocument BSON representing the key encryption key document.

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoCryptImpl.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoCryptImpl.java
@@ -25,11 +25,13 @@ import com.mongodb.crypt.capi.CAPI.mongocrypt_t;
 import com.sun.jna.Pointer;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
+import org.bson.BsonValue;
 
 import javax.crypto.Cipher;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 import static com.mongodb.crypt.capi.CAPI.MONGOCRYPT_LOG_LEVEL_ERROR;
 import static com.mongodb.crypt.capi.CAPI.MONGOCRYPT_LOG_LEVEL_FATAL;
@@ -235,7 +237,9 @@ class MongoCryptImpl implements MongoCrypt {
         } else if (kmsProvider.equals("local")) {
             success = mongocrypt_ctx_setopt_masterkey_local(context);
         } else {
-            success = mongocrypt_ctx_setopt_key_encryption_key(context, toBinary(options.getMasterKey()).getBinary());
+            BsonDocument masterKey = options.getMasterKey().clone();
+            masterKey.put("provider", new BsonString(kmsProvider));
+            success = mongocrypt_ctx_setopt_key_encryption_key(context, toBinary(masterKey).getBinary());
         }
 
         if (!success) {

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoCryptOptions.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoCryptOptions.java
@@ -30,6 +30,8 @@ public class MongoCryptOptions {
 
     private final MongoAwsKmsProviderOptions awsKmsProviderOptions;
     private final MongoLocalKmsProviderOptions localKmsProviderOptions;
+    private final BsonDocument kmsProviderOptions;
+
     private final Map<String, BsonDocument> localSchemaMap;
 
     /**
@@ -60,6 +62,16 @@ public class MongoCryptOptions {
     }
 
     /**
+     * Returns the KMS provider options.
+     *
+     * @return the KMS provider options, which may be null
+     * @since 1.1
+     */
+    public BsonDocument getKmsProviderOptions() {
+        return kmsProviderOptions;
+    }
+
+    /**
      * Gets the local schema map.
      *
      * @return the local schema map
@@ -74,6 +86,7 @@ public class MongoCryptOptions {
     public static class Builder {
         private MongoAwsKmsProviderOptions awsKmsProviderOptions;
         private MongoLocalKmsProviderOptions localKmsProviderOptions;
+        private BsonDocument kmsProviderOptions = null;
         private Map<String, BsonDocument> localSchemaMap = null;
 
         private Builder() {
@@ -102,6 +115,18 @@ public class MongoCryptOptions {
         }
 
         /**
+         * Sets the KMS provider options.
+         *
+         * @param kmsProviderOptions the KMS provider options document
+         * @return this
+         * @since 1.1
+         */
+        public Builder kmsProviderOptions(final BsonDocument kmsProviderOptions) {
+            this.kmsProviderOptions = kmsProviderOptions;
+            return this;
+        }
+
+        /**
          * Sets the local schema map.
          *
          * @param localSchemaMap local schema map
@@ -124,9 +149,11 @@ public class MongoCryptOptions {
 
     private MongoCryptOptions(final Builder builder) {
         isTrue("at least one KMS provider is configured",
-                builder.awsKmsProviderOptions != null || builder.localKmsProviderOptions != null);
+                builder.awsKmsProviderOptions != null || builder.localKmsProviderOptions != null
+                        || builder.kmsProviderOptions != null );
         this.awsKmsProviderOptions = builder.awsKmsProviderOptions;
         this.localKmsProviderOptions = builder.localKmsProviderOptions;
+        this.kmsProviderOptions = builder.kmsProviderOptions;
         this.localSchemaMap = builder.localSchemaMap;
     }
 }

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/SigningRSAESPKCSCallback.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/SigningRSAESPKCSCallback.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.crypt.capi;
+
+import com.mongodb.crypt.capi.CAPI.cstring;
+import com.mongodb.crypt.capi.CAPI.mongocrypt_binary_t;
+import com.mongodb.crypt.capi.CAPI.mongocrypt_hmac_fn;
+import com.mongodb.crypt.capi.CAPI.mongocrypt_status_t;
+import com.sun.jna.Pointer;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import java.security.InvalidKeyException;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+
+import static com.mongodb.crypt.capi.CAPI.MONGOCRYPT_STATUS_ERROR_CLIENT;
+import static com.mongodb.crypt.capi.CAPI.mongocrypt_status_set;
+import static com.mongodb.crypt.capi.CAPIHelper.toByteArray;
+import static com.mongodb.crypt.capi.CAPIHelper.writeByteArrayToBinary;
+
+class SigningRSAESPKCSCallback implements mongocrypt_hmac_fn {
+
+    private static final String KEY_ALGORITHM = "RSA";
+    private static final String SIGN_ALGORITHM = "SHA256withRSA";
+
+    SigningRSAESPKCSCallback() {
+    }
+
+    @Override
+    public boolean hmac(final Pointer ctx, final mongocrypt_binary_t key, final mongocrypt_binary_t in,
+                        final mongocrypt_binary_t out, final mongocrypt_status_t status) {
+        try {
+            byte[] result = getSignature(toByteArray(key), toByteArray(in));
+            writeByteArrayToBinary(out, result);
+            return true;
+        } catch (Exception e) {
+            mongocrypt_status_set(status, MONGOCRYPT_STATUS_ERROR_CLIENT, 0, new cstring(e.toString()), -1);
+            return false;
+        }
+    }
+
+    static byte[] getSignature(final byte[] privateKeyBytes, final byte[] dataToSign) throws NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, SignatureException {
+        KeySpec keySpec = new PKCS8EncodedKeySpec(privateKeyBytes);
+        KeyFactory keyFactory = KeyFactory.getInstance(KEY_ALGORITHM);
+        PrivateKey privateKey = keyFactory.generatePrivate(keySpec);
+
+        Signature privateSignature = Signature.getInstance(SIGN_ALGORITHM);
+        privateSignature.initSign(privateKey);
+        privateSignature.update(dataToSign);
+
+        return privateSignature.sign();
+    }
+}

--- a/bindings/java/mongocrypt/src/test/java/com/mongodb/crypt/capi/SigningRSAESPKCSCallbackTest.java
+++ b/bindings/java/mongocrypt/src/test/java/com/mongodb/crypt/capi/SigningRSAESPKCSCallbackTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.crypt.capi;
+
+import org.junit.Test;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
+
+import static org.junit.Assert.assertEquals;
+
+public class SigningRSAESPKCSCallbackTest {
+
+    @Test
+    public void testGetSignature() throws InvalidKeySpecException, NoSuchAlgorithmException, InvalidKeyException, SignatureException {
+        byte[] privateKeyBytes = Base64.getDecoder().decode(PRIVATE_KEY);
+        byte[] signature = SigningRSAESPKCSCallback.getSignature(privateKeyBytes, DATA_TO_SIGN.getBytes());
+        String output = Base64.getEncoder().encodeToString(signature);
+
+        assertEquals(EXPECTED_SIGNATURE, output);
+    }
+
+    private static final String PRIVATE_KEY = "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC4JOyv5z05cL18ztpknRC7CFY2gYol4DAKerdVUoDJ"
+            + "xCTmFMf39dVUEqD0WDiw/qcRtSO1/FRut08PlSPmvbyKetsLoxlpS8lukSzEFpFK7+L+R4miFOl6HvECyg7lbC1H/WGAhIz9yZRlXhRo9qmO/fB6PV9IeYtU+1xY"
+            + "uXicjCDPp36uuxBAnCz7JfvxJ3mdVc0vpSkbSb141nWuKNYR1mgyvvL6KzxO6mYsCo4hRAdhuizD9C4jDHk0V2gDCFBk0h8SLEdzStX8L0jG90/Og4y7J1b/cPo/"
+            + "kbYokkYisxe8cPlsvGBf+rZex7XPxc1yWaP080qeABJb+S88O//LAgMBAAECggEBAKVxP1m3FzHBUe2NZ3fYCc0Qa2zjK7xl1KPFp2u4CU+9sy0oZJUqQHUdm5CM"
+            + "prqWwIHPTftWboFenmCwrSXFOFzujljBO7Z3yc1WD3NJl1ZNepLcsRJ3WWFH5V+NLJ8Bdxlj1DMEZCwr7PC5+vpnCuYWzvT0qOPTl9RNVaW9VVjHouJ9Fg+s2DrS"
+            + "hXDegFabl1iZEDdI4xScHoYBob06A5lw0WOCTayzw0Naf37lM8Y4psRAmI46XLiF/Vbuorna4hcChxDePlNLEfMipICcuxTcei1RBSlBa2t1tcnvoTy6cuYDqqIm"
+            + "RYjp1KnMKlKQBnQ1NjS2TsRGm+F0FbreVCECgYEA4IDJlm8q/hVyNcPe4OzIcL1rsdYN3bNm2Y2O/YtRPIkQ446ItyxD06d9VuXsQpFp9jNACAPfCMSyHpPApqlx"
+            + "dc8z/xATlgHkcGezEOd1r4E7NdTpGg8y6Rj9b8kVlED6v4grbRhKcU6moyKUQT3+1B6ENZTOKyxuyDEgTwZHtFECgYEA0fqdv9h9s77d6eWmIioP7FSymq93pC4u"
+            + "mxf6TVicpjpMErdD2ZfJGulN37dq8FOsOFnSmFYJdICj/PbJm6p1i8O21lsFCltEqVoVabJ7/0alPfdG2U76OeBqI8ZubL4BMnWXAB/VVEYbyWCNpQSDTjHQYs54"
+            + "qa2I0dJB7OgJt1sCgYEArctFQ02/7H5Rscl1yo3DBXO94SeiCFSPdC8f2Kt3MfOxvVdkAtkjkMACSbkoUsgbTVqTYSEOEc2jTgR3iQ13JgpHaFbbsq64V0QP3TAx"
+            + "bLIQUjYGVgQaF1UfLOBv8hrzgj45z/ST/G80lOl595+0nCUbmBcgG1AEWrmdF0/3RmECgYAKvIzKXXB3+19vcT2ga5Qq2l3TiPtOGsppRb2XrNs9qKdxIYvHmXo/"
+            + "9QP1V3SRW0XoD7ez8FpFabp42cmPOxUNk3FK3paQZABLxH5pzCWI9PzIAVfPDrm+sdnbgG7vAnwfL2IMMJSA3aDYGCbF9EgefG+STcpfqq7fQ6f5TBgLFwKBgCd7"
+            + "gn1xYL696SaKVSm7VngpXlczHVEpz3kStWR5gfzriPBxXgMVcWmcbajRser7ARpCEfbxM1UJyv6oAYZWVSNErNzNVb4POqLYcCNySuC6xKhs9FrEQnyKjyk8wI4V"
+            + "nrEMGrQ8e+qYSwYk9Gh6dKGoRMAPYVXQAO0fIsHF/T0a";
+    private static final String DATA_TO_SIGN = "data to sign";
+    private static final String EXPECTED_SIGNATURE = "VocBRhpMmQ2XCzVehWSqheQLnU889gf3dhU4AnVnQTJjsKx/CM23qKDPkZDd2A/BnQsp99SN7ksIX5Raj0TPw"
+            + "yN5OCN/YrNFNGoOFlTsGhgP/hyE8X3Duiq6sNO0SMvRYNPFFGlJFsp1Fw3Z94eYMg4/Wpw5s4+Jo5Zm/qY7aTJIqDKDQ3CNHLeJgcMUOc9sz01/GzoUYKDVODHSx"
+            + "rYEk5ireFJFz9vP8P7Ha+VDUZuQIQdXer9NBbGFtYmWprY3nn4D3Dw93Sn0V0dIqYeIo91oKyslvMebmUM95S2PyIJdEpPb2DJDxjvX/0LLwSWlSXRWy9gapWoBk"
+            + "b4ynqZBsg==";
+
+}


### PR DESCRIPTION
Wrapped:
* mongocrypt_setopt_kms_providers - to support new KMS provider options.
* mongocrypt_ctx_setopt_key_encryption_key - to support new data key options.
* mongocrypt_setopt_crypto_hook_sign_rsaes_pkcs1_v1_5 - to support signature callback for GCP.

MONGOCRYPT-284