### PR TITLE
PYTHON-2409 Allow local.key KMS provider option to be specified as either bytes or a base64-encoded string

### DIFF
--- a/bindings/python/pymongocrypt/compat.py
+++ b/bindings/python/pymongocrypt/compat.py
@@ -35,7 +35,7 @@ def str_to_bytes(string):
     return string.encode('utf-8')
 
 
-def safe_bytearray_or_base64(data, field_identifier):
+def safe_bytearray_or_base64(data):
     """Convert the given value to a type that, when BSON-encoded can be safely
     passed to libmongocrypt functions that expect a BSON document containing
     BSON Binary data or a base64-encoded string.

--- a/bindings/python/pymongocrypt/compat.py
+++ b/bindings/python/pymongocrypt/compat.py
@@ -38,18 +38,13 @@ def str_to_bytes(string):
 def safe_bytearray_or_base64(data, field_identifier):
     """Convert the given value to a type that, when BSON-encoded can be safely
     passed to libmongocrypt functions that expect a BSON document containing
-    BSON Binary data or a base64-encoded string. Also validates that the given
-    value is either bytes or a string.
+    BSON Binary data or a base64-encoded string.
 
     pymongo.bson encodes bytes to BSON string in Python 2, while the
     libmongocrypt API expects BSON Binary or a base64 encoded string.
     To avoid needing to import bson.Binary, we return a base64 encoded string
     when using Python 2.
     """
-    if not isinstance(data, (bytes, unicode_type)):
-        raise TypeError("%s must be an instance of bytes or str (unicode in "
-                        "Python 2)" % (field_identifier, ))
-
     # On Python 3 byte-arrays are encoded as BSON Binary and
     # base64 encoded strings can be passed as-is.
     if PY3:

--- a/bindings/python/pymongocrypt/compat.py
+++ b/bindings/python/pymongocrypt/compat.py
@@ -14,6 +14,7 @@
 
 """Utility functions and definitions for Python compatibility."""
 
+import base64
 import sys
 
 PY3 = sys.version_info[0] == 3
@@ -32,3 +33,34 @@ def str_to_bytes(string):
     if isinstance(string, bytes):
         return string
     return string.encode('utf-8')
+
+
+def safe_bytearray_or_base64(data, field_identifier):
+    """Convert the given value to a type that, when BSON-encoded can be safely
+    passed to libmongocrypt functions that expect a BSON document containing
+    BSON Binary data or a base64-encoded string. Also validates that the given
+    value is either bytes or a string.
+
+    pymongo.bson encodes bytes to BSON string in Python 2, while the
+    libmongocrypt API expects BSON Binary or a base64 encoded string.
+    To avoid needing to import bson.Binary, we return a base64 encoded string
+    when using Python 2.
+    """
+    if not isinstance(data, (bytes, unicode_type)):
+        raise TypeError("%s must be an instance of bytes or str (unicode in "
+                        "Python 2)" % (field_identifier, ))
+
+    # On Python 3 byte-arrays are encoded as BSON Binary and
+    # base64 encoded strings can be passed as-is.
+    if PY3:
+        return data
+
+    # On Python 2 unicode literals are assumed to contain base64-encoded
+    # strings that can be passed to libmongocrypt as-is.
+    if isinstance(data, unicode_type):
+        return data
+
+    # On Python 2, all other types are assumed to contain raw bytes.
+    # To avoid importing bson.binary.Binary, we convert these to
+    # base64 strings.
+    return unicode_type(base64.b64encode(data))

--- a/bindings/python/pymongocrypt/mongocrypt.py
+++ b/bindings/python/pymongocrypt/mongocrypt.py
@@ -42,7 +42,9 @@ class MongoCryptOptions(object):
               - `aws`: Map with "accessKeyId" and "secretAccessKey" as strings.
               - `azure`: Map with "clientId" and "clientSecret" as strings.
               - `gcp`: Map with "email" and "privateKey" as strings.
-              - `local`: Map with "key" as a 96-byte array or string.
+              - `local`: Map with "key" as a 96-byte array or the equivalent
+                base64-encoded string. On Python 2, base64-encoded strings
+                must be passed as a unicode literal.
           - `schema_map`: Optional map of collection namespace ("db.coll") to
             JSON Schema.  By default, a collection's JSONSchema is periodically
             polled with the listCollections command. But a JSONSchema may be
@@ -57,6 +59,10 @@ class MongoCryptOptions(object):
             automatic encryption for client side encryption. Other validation
             rules in the JSON schema will not be enforced by the driver and
             will result in an error.
+
+        .. versionchanged:: 1.1
+           For kmsProvider "local", the "key" field can now be specified
+           as either a 96-byte array or the equivalent base64-encoded string.
         """
         if not isinstance(kms_providers, dict):
             raise ValueError('kms_providers must be a dict')
@@ -95,9 +101,9 @@ class MongoCryptOptions(object):
                 raise ValueError("kms_providers['local'] must contain 'key'")
 
             key = kms_providers['local']['key']
-            if not isinstance(key, bytes):
+            if not isinstance(key, (bytes, unicode_type)):
                 raise TypeError("kms_providers['local']['key'] must be a "
-                                "bytes (or str in Python 2)")
+                                "bytes or str (or unicode in Python 2)")
 
             # TODO: remove this after dropping Python 2 support.
             # pymongo.bson encodes bytes to BSON string in Python 2,

--- a/bindings/python/pymongocrypt/mongocrypt.py
+++ b/bindings/python/pymongocrypt/mongocrypt.py
@@ -162,8 +162,7 @@ class MongoCrypt(object):
         for f1, f2 in base64_or_bytes_fields:
             value = kms_providers.get(f1, {}).get(f2, None)
             if value is not None:
-                safe_value = safe_bytearray_or_base64(
-                    value, "kms_providers['%s']['%s']" % (f1, f2))
+                safe_value = safe_bytearray_or_base64(value)
                 if value != safe_value:
                     kms_providers = copy.deepcopy(kms_providers)
                     kms_providers[f1][f2] = safe_value

--- a/bindings/python/test/test_mongocrypt.py
+++ b/bindings/python/test/test_mongocrypt.py
@@ -157,7 +157,6 @@ class TestMongoCrypt(unittest.TestCase):
                 MongoCryptError, "local key must be 96 bytes"):
             MongoCrypt(invalid_key_len_opts, callback)
 
-    # @unittest.skipUnless(not PY3, 'bytes are encoded to BSON binary on Py 3')
     def test_setopt_kms_provider_base64_or_bytes(self):
         test_fields = [("local", "key"), ("gcp", "privateKey")]
         callback = MockCallback()


### PR DESCRIPTION
Turns out there were some changes needed beyond just adding the testing. These will need to be merged before CI can pass on https://github.com/mongodb/mongo-python-driver/pull/506