### PR TITLE
update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.1.0-beta1
 ### Deprecated
 - mongocrypt_setopt_kms_provider_aws and mongocrypt_setopt_kms_provider_local are deprecated in favor of the more flexible mongocrypt_setopt_kms_providers, which supports configuration of all KMS providers.
-- mongocrypt_ctx_setopt_masterkey_aws and mongocrypt_ctx_setopt_masterkey_aws_endpoint are deprecated in favor of the more flexible mongocrypt_ctx_setopt_key_encryption_key, which supports configuration for all KMS providers.
+- mongocrypt_ctx_setopt_masterkey_aws, mongocrypt_ctx_setopt_masterkey_aws_endpoint, and mongocrypt_ctx_setopt_masterkey_local are deprecated in favor of the more flexible mongocrypt_ctx_setopt_key_encryption_key, which supports configuration for all KMS providers.
 ### Added
 - Introduces a new crypto hook for signing the JSON Web Token (JWT) for Google Cloud Platform (GCP) requests:
     - mongocrypt_setopt_crypto_hook_sign_rsaes_pkcs1_v1_5

--- a/src/mongocrypt-kek.c
+++ b/src/mongocrypt-kek.c
@@ -30,6 +30,7 @@
  *    keyName: <string>
  *    keyVersion: <optional string>
  * GCP
+ *    provider: "gcp"
  *    projectId: <string>
  *    location: <string>
  *    keyRing: <string>

--- a/src/mongocrypt.h.in
+++ b/src/mongocrypt.h.in
@@ -627,7 +627,41 @@ mongocrypt_ctx_setopt_masterkey_local (mongocrypt_ctx_t *ctx);
  * Set key encryption key document for creating a data key.
  *
  * @param[in] ctx The @ref mongocrypt_ctx_t object.
- * @param[in] bin BSON representing the key encryption key document.
+ * @param[in] bin BSON representing the key encryption key document with
+ * an additional "provider" field. The following forms are accepted:
+ * 
+ * AWS
+ * {
+ *    provider: "aws",
+ *    region: <string>,
+ *    key: <string>,
+ *    endpoint: <optional string>
+ * }
+ * 
+ * Azure
+ * {
+ *    provider: "azure",
+ *    keyVaultEndpoint: <string>,
+ *    keyName: <string>,
+ *    keyVersion: <optional string>
+ * }
+ * 
+ * GCP
+ * {
+ *    provider: "gcp",
+ *    projectId: <string>,
+ *    location: <string>,
+ *    keyRing: <string>,
+ *    keyName: <string>,
+ *    keyVersion: <string>,
+ *    endpoint: <optional string>
+ * }
+ * 
+ * Local
+ * {
+ *    provider: "local"
+ * }
+ * 
  * @pre @p ctx has not been initialized.
  * @returns A boolean indicating success. If false, and error status is set.
  * Retrieve it with @ref mongocrypt_ctx_status.


### PR DESCRIPTION
- Note that mongocrypt_ctx_setopt_masterkey_local is deprecated in CHANGELOG
- Note form of expected document for mongocrypt_ctx_setopt_key_encryption_key