### PR TITLE
check for beta in GetVersion.cmake

### DIFF
--- a/cmake/GetVersion.cmake
+++ b/cmake/GetVersion.cmake
@@ -68,7 +68,7 @@ function (GetVersion OUTVAR)
     if (VERSION_LENGTH GREATER 3)
         # The version we are starting with is already a pre-release of the next
         list (GET VERSION_PARTS 3 PRERELEASE_VERSION)
-        string (REGEX MATCHALL "(rc|[0-9]+)" PRERELEASE_PARTS ${PRERELEASE_VERSION})
+        string (REGEX MATCHALL "(beta|rc|[0-9]+)" PRERELEASE_PARTS ${PRERELEASE_VERSION})
         list (LENGTH PRERELEASE_PARTS PRERELEASE_LENGTH)
         if (PRERELEASE_LENGTH EQUAL 2)
             list (GET PRERELEASE_PARTS 0 PRE_PT_ONE)


### PR DESCRIPTION
Running `cmake -P ./cmake/GetVersion.cmake` was returning:
`1.1.0beta1+20201102git80202647fc` though the pre-release tag was `1.1.0-beta1`.

After this change, it has the form `1.1.0-pre2+20201104gitf6765152f6`

This fixes the `publish-packages` tasks.