### PR TITLE
Release pymongocrypt 1.1.0b0

### DIFF
--- a/bindings/python/README.rst
+++ b/bindings/python/README.rst
@@ -144,36 +144,19 @@ Linux::
   1.0.4
 
 
-Installing a Beta or Release Candidate
---------------------------------------
+Installing the Azure and GCP beta release
+-----------------------------------------
 
-Installing Beta and RC releases of PyMongoCrypt follows much the same process as
-`Installing from source`_ as we do not publish wheels for these releases
-to PyPI. Instead, these releases are available as
-`tags <https://git-scm.com/book/en/v2/Git-Basics-Tagging>`_ in the project's
-`GitHub repository <https://github.com/mongodb/libmongocrypt/>`_. Tags are
-usually named as follows::
+To install the beta release, first checkout the ``pymongocrypt-1.1.0b0`` tag
+and install it::
 
-  pymongocrypt-<version>
-
-where ``<version>`` is the Beta/RC version string (e.g. ``1.1.0b0``).
-
-Start by identifying the tag corresponding to the release you want to install
-(in this example, we install ``pymongocrypt-1.1.0b0``) and exporting it as an
-environment variable::
-
-  $ export PYMONGOCRYPT_TAG='pymongocrypt-1.1.0b0'
-
-Now, install PyMongoCrypt from source::
-
-  $ git clone --branch $PYMONGOCRYPT_TAG git@github.com:mongodb/libmongocrypt.git
+  $ git clone --branch 1.1.0b0 git@github.com:mongodb/libmongocrypt.git
   $ python -m pip install ./libmongocrypt/bindings/python
 
-Next, we identify the required version of libmongocrypt, download the corresponding
-tarball, and extract it::
+Next, download the tarball containing the ``1.1.0-beta1`` version of the libmongocrypt
+binaries, and extract it::
 
-  $ export LIBMONGOCRYPT_TAG=$(python -c "import pymongocrypt; print(pymongocrypt.version._MIN_LIBMONGOCRYPT_VERSION)")
-  $ export LIBMONGOCRYPT_REVISION=$(git -C ./libmongocrypt rev-list -n 1 $LIBMONGOCRYPT_TAG)
+  $ export LIBMONGOCRYPT_REVISION=$(git -C ./libmongocrypt rev-list -n 1 1.1.0-beta1)
   $ curl -O https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/$LIBMONGOCRYPT_REVISION/libmongocrypt-all.tar.gz
   $ mkdir libmongocrypt-all && tar xzf libmongocrypt-all.tar.gz -C libmongocrypt-all
 

--- a/bindings/python/README.rst
+++ b/bindings/python/README.rst
@@ -172,7 +172,7 @@ Now, install PyMongoCrypt from source::
 Next, we identify the required version of libmongocrypt, download the corresponding
 tarball, and extract it::
 
-  $ export LIBMONGOCRYPT_TAG=$(python -c "import pymongocrypt; print(pymongocrypt.version.MIN_LIBMONGOCRYPT_VERSION)")
+  $ export LIBMONGOCRYPT_TAG=$(python -c "import pymongocrypt; print(pymongocrypt.version._MIN_LIBMONGOCRYPT_VERSION)")
   $ export LIBMONGOCRYPT_REVISION=$(git -C ./libmongocrypt rev-list -n 1 $LIBMONGOCRYPT_TAG)
   $ curl -O https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/$LIBMONGOCRYPT_REVISION/libmongocrypt-all.tar.gz
   $ mkdir libmongocrypt-all && tar xzf libmongocrypt-all.tar.gz -C libmongocrypt-all

--- a/bindings/python/README.rst
+++ b/bindings/python/README.rst
@@ -104,10 +104,10 @@ First, install PyMongoCrypt from source::
 
 Next, install libmongocrypt.
 
-libmongocrypt is [continuously built and published on evergreen]
-(https://evergreen.mongodb.com/waterfall/libmongocrypt).
+libmongocrypt is
+`continuously built and published on evergreen <https://evergreen.mongodb.com/waterfall/libmongocrypt>`_.
 The latest tarball containing libmongocrypt built on all supported variants is
-(published here)[https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz].
+`published here <https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz>`_.
 Download and extract ``libmongocrypt-all.tar.gz`` and set
 ``PYMONGOCRYPT_LIB`` to the path to your operating system's libmongocrypt.so file.
 For example::
@@ -142,6 +142,46 @@ Linux::
   $ export PYMONGOCRYPT_LIB=$(pwd)/libmongocrypt-all/rhel-62-64-bit/nocrypto/lib64/libmongocrypt.so
   $ python -c "import pymongocrypt; print(pymongocrypt.libmongocrypt_version())"
   1.0.4
+
+
+Installing a Beta or Release Candidate
+--------------------------------------
+
+Installing Beta and RC releases of PyMongoCrypt follows much the same process as
+`Installing from source`_ as we do not publish wheel for these releases
+to PyPI. Instead, these releases are available as
+`tags <https://git-scm.com/book/en/v2/Git-Basics-Tagging>`_ in the project's
+`GitHub repository <https://github.com/mongodb/libmongocrypt/>`_. Tags are
+usually named as follows::
+
+  pymongocrypt-<version>
+
+where ``<version>>`` is the Beta/RC version string (e.g. `1.1.0b0`).
+
+Start by identifying the tag corresponding to the release you want to install
+(in this example, we install ``pymongocrypt-1.1.0b0``) and exporting it as an
+environment variable::
+
+  $ export PYMONGOCRYPT_TAG='pymongocrypt-1.1.0b0'
+
+Now, install PyMongoCrypt from source::
+
+  $ git clone --branch $PYMONGOCRYPT_TAG git@github.com:mongodb/libmongocrypt.git
+  $ python -m pip install ./libmongocrypt/bindings/python
+
+Next, we identify the required version of libmongocrypt, download the corresponding
+tarball, and extract it::
+
+  $ export LIBMONGOCRYPT_TAG=$(python -c "import pymongocrypt; print(pymongocrypt.version.MIN_LIBMONGOCRYPT_VERSION)")
+  $ cd ./libmongocrypt && export LIBMONGOCRYPT_REVISION=$(git rev-list -n 1 $LIBMONGOCRYPT_TAG)
+  $ curl -O https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/$LIBMONGOCRYPT_REVISION/libmongocrypt-all.tar.gz
+  $ mkdir libmongocrypt-all && tar xzf libmongocrypt-all.tar.gz -C libmongocrypt-all
+
+Finally, set the ``PYMONGOCRPYT_LIB`` environment to the appropriate file
+as per platform-specific instructions in `Installing from source`_::
+
+  $ export PYMONGOCRYPT_LIB=<path to library file corresponding to operating system>
+
 
 Dependencies
 ============

--- a/bindings/python/README.rst
+++ b/bindings/python/README.rst
@@ -148,7 +148,7 @@ Installing a Beta or Release Candidate
 --------------------------------------
 
 Installing Beta and RC releases of PyMongoCrypt follows much the same process as
-`Installing from source`_ as we do not publish wheel for these releases
+`Installing from source`_ as we do not publish wheels for these releases
 to PyPI. Instead, these releases are available as
 `tags <https://git-scm.com/book/en/v2/Git-Basics-Tagging>`_ in the project's
 `GitHub repository <https://github.com/mongodb/libmongocrypt/>`_. Tags are
@@ -156,7 +156,7 @@ usually named as follows::
 
   pymongocrypt-<version>
 
-where ``<version>>`` is the Beta/RC version string (e.g. `1.1.0b0`).
+where ``<version>`` is the Beta/RC version string (e.g. ``1.1.0b0``).
 
 Start by identifying the tag corresponding to the release you want to install
 (in this example, we install ``pymongocrypt-1.1.0b0``) and exporting it as an
@@ -173,7 +173,7 @@ Next, we identify the required version of libmongocrypt, download the correspond
 tarball, and extract it::
 
   $ export LIBMONGOCRYPT_TAG=$(python -c "import pymongocrypt; print(pymongocrypt.version.MIN_LIBMONGOCRYPT_VERSION)")
-  $ cd ./libmongocrypt && export LIBMONGOCRYPT_REVISION=$(git rev-list -n 1 $LIBMONGOCRYPT_TAG)
+  $ export LIBMONGOCRYPT_REVISION=$(git -C ./libmongocrypt rev-list -n 1 $LIBMONGOCRYPT_TAG)
   $ curl -O https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/$LIBMONGOCRYPT_REVISION/libmongocrypt-all.tar.gz
   $ mkdir libmongocrypt-all && tar xzf libmongocrypt-all.tar.gz -C libmongocrypt-all
 

--- a/bindings/python/pymongocrypt/binding.py
+++ b/bindings/python/pymongocrypt/binding.py
@@ -19,7 +19,7 @@ import sys
 import cffi
 
 from pymongocrypt.compat import PY3
-from pymongocrypt.version import MIN_LIBMONGOCRYPT_VERSION
+from pymongocrypt.version import _MIN_LIBMONGOCRYPT_VERSION
 
 try:
     from pkg_resources import parse_version as _parse_version
@@ -1069,8 +1069,8 @@ except OSError as exc:
 else:
     # Check the libmongocrypt version when the library is found.
     _limongocrypt_version = _parse_version(libmongocrypt_version())
-    if _limongocrypt_version < _parse_version(MIN_LIBMONGOCRYPT_VERSION):
+    if _limongocrypt_version < _parse_version(_MIN_LIBMONGOCRYPT_VERSION):
         exc = RuntimeError(
             "Expected libmongocrypt version %s or greater, found %s" % (
-                MIN_LIBMONGOCRYPT_VERSION, libmongocrypt_version()))
+                _MIN_LIBMONGOCRYPT_VERSION, libmongocrypt_version()))
         lib = _Library(exc)

--- a/bindings/python/pymongocrypt/binding.py
+++ b/bindings/python/pymongocrypt/binding.py
@@ -19,7 +19,7 @@ import sys
 import cffi
 
 from pymongocrypt.compat import PY3
-from pymongocrypt.version import _MIN_LIBMONGOCRYPT_VERSION
+from pymongocrypt.version import MIN_LIBMONGOCRYPT_VERSION
 
 try:
     from pkg_resources import parse_version as _parse_version
@@ -1069,8 +1069,8 @@ except OSError as exc:
 else:
     # Check the libmongocrypt version when the library is found.
     _limongocrypt_version = _parse_version(libmongocrypt_version())
-    if _limongocrypt_version < _parse_version(_MIN_LIBMONGOCRYPT_VERSION):
+    if _limongocrypt_version < _parse_version(MIN_LIBMONGOCRYPT_VERSION):
         exc = RuntimeError(
             "Expected libmongocrypt version %s or greater, found %s" % (
-                _MIN_LIBMONGOCRYPT_VERSION, libmongocrypt_version()))
+                MIN_LIBMONGOCRYPT_VERSION, libmongocrypt_version()))
         lib = _Library(exc)

--- a/bindings/python/pymongocrypt/version.py
+++ b/bindings/python/pymongocrypt/version.py
@@ -14,4 +14,4 @@
 
 __version__ = '1.1.0b0'
 
-MIN_LIBMONGOCRYPT_VERSION = '1.1.0-beta1'
+_MIN_LIBMONGOCRYPT_VERSION = '1.1.0-beta1'

--- a/bindings/python/pymongocrypt/version.py
+++ b/bindings/python/pymongocrypt/version.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '1.1.0.dev0'
+__version__ = '1.1.0b0'
 
-_MIN_LIBMONGOCRYPT_VERSION = '1.1.0beta1'
+MIN_LIBMONGOCRYPT_VERSION = '1.1.0-beta1'


### PR DESCRIPTION
Once merged, I will tag the release on master and push the tag. Bumping version to `1.1.0b1.dev0` will be done in a separate PR. 