### PR TITLE
feat: support Azure and GCP KMS providers [node.js]

### DIFF
--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -111,7 +111,9 @@ module.exports = function(modules) {
       }
 
       if (options.kmsProviders) {
-        mongoCryptOptions.kmsProviders = options.kmsProviders;
+        mongoCryptOptions.kmsProviders = !Buffer.isBuffer(options.kmsProviders)
+          ? this._bson.serialize(options.kmsProviders)
+          : options.kmsProviders;
       }
 
       if (options.logger) {
@@ -129,7 +131,11 @@ module.exports = function(modules) {
      */
     init(callback) {
       const _callback = (err, res) => {
-        if (err && err.message && err.message.match(/timed out after/)) {
+        if (
+          err &&
+          err.message &&
+          (err.message.match(/timed out after/) || err.message.match(/ENOTFOUND/))
+        ) {
           callback(
             new MongoError(
               'Unable to connect to `mongocryptd`, please make sure it is running or in your PATH for auto-spawn'

--- a/bindings/node/lib/cryptoCallbacks.js
+++ b/bindings/node/lib/cryptoCallbacks.js
@@ -83,11 +83,32 @@ function makeHmacHook(algorithm) {
   };
 }
 
+function signRsaSha256Hook(key, input, output) {
+  let result;
+  try {
+    const signer = crypto.createSign('sha256WithRSAEncryption');
+    const privateKey = Buffer.from(
+      `-----BEGIN PRIVATE KEY-----\n${key.toString('base64')}\n-----END PRIVATE KEY-----\n`
+    );
+
+    result = signer
+      .update(input)
+      .end()
+      .sign(privateKey);
+  } catch (e) {
+    return e;
+  }
+
+  result.copy(output);
+  return result.length;
+}
+
 module.exports = {
   aes256CbcEncryptHook,
   aes256CbcDecryptHook,
   randomHook: typeof crypto.randomFillSync === 'function' ? randomHook : randomHookNode4,
   hmacSha512Hook: makeHmacHook('sha512'),
   hmacSha256Hook: makeHmacHook('sha256'),
-  sha256Hook
+  sha256Hook,
+  signRsaSha256Hook
 };

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -23,6 +23,7 @@
   "gypfile": true,
   "dependencies": {
     "bindings": "^1.5.0",
+    "bl": "^2.2.1",
     "nan": "^2.14.0",
     "prebuild-install": "5.3.0"
   },

--- a/bindings/node/src/mongocrypt.h
+++ b/bindings/node/src/mongocrypt.h
@@ -50,6 +50,7 @@ class MongoCrypt : public Nan::ObjectWrap {
         std::unique_ptr<Nan::Callback> hmacSha512Hook;
         std::unique_ptr<Nan::Callback> hmacSha256Hook;
         std::unique_ptr<Nan::Callback> sha256Hook;
+        std::unique_ptr<Nan::Callback> signRsaSha256Hook;
     };
 
     friend class MongoCryptContext;

--- a/bindings/node/test/cryptoCallbacks.test.js
+++ b/bindings/node/test/cryptoCallbacks.test.js
@@ -59,6 +59,28 @@ describe('cryptoCallbacks', function() {
     this.sinon = undefined;
   });
 
+  it('should support suport crypto callback for signing RSA-SHA256', function() {
+    const input = Buffer.from('data to sign');
+    const pemFileData =
+      '-----BEGIN PRIVATE KEY-----\n' +
+      'MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC4JOyv5z05cL18ztpknRC7CFY2gYol4DAKerdVUoDJxCTmFMf39dVUEqD0WDiw/qcRtSO1/FRut08PlSPmvbyKetsLoxlpS8lukSzEFpFK7+L+R4miFOl6HvECyg7lbC1H/WGAhIz9yZRlXhRo9qmO/fB6PV9IeYtU+1xYuXicjCDPp36uuxBAnCz7JfvxJ3mdVc0vpSkbSb141nWuKNYR1mgyvvL6KzxO6mYsCo4hRAdhuizD9C4jDHk0V2gDCFBk0h8SLEdzStX8L0jG90/Og4y7J1b/cPo/kbYokkYisxe8cPlsvGBf+rZex7XPxc1yWaP080qeABJb+S88O//LAgMBAAECggEBAKVxP1m3FzHBUe2NZ3fYCc0Qa2zjK7xl1KPFp2u4CU+9sy0oZJUqQHUdm5CMprqWwIHPTftWboFenmCwrSXFOFzujljBO7Z3yc1WD3NJl1ZNepLcsRJ3WWFH5V+NLJ8Bdxlj1DMEZCwr7PC5+vpnCuYWzvT0qOPTl9RNVaW9VVjHouJ9Fg+s2DrShXDegFabl1iZEDdI4xScHoYBob06A5lw0WOCTayzw0Naf37lM8Y4psRAmI46XLiF/Vbuorna4hcChxDePlNLEfMipICcuxTcei1RBSlBa2t1tcnvoTy6cuYDqqImRYjp1KnMKlKQBnQ1NjS2TsRGm+F0FbreVCECgYEA4IDJlm8q/hVyNcPe4OzIcL1rsdYN3bNm2Y2O/YtRPIkQ446ItyxD06d9VuXsQpFp9jNACAPfCMSyHpPApqlxdc8z/xATlgHkcGezEOd1r4E7NdTpGg8y6Rj9b8kVlED6v4grbRhKcU6moyKUQT3+1B6ENZTOKyxuyDEgTwZHtFECgYEA0fqdv9h9s77d6eWmIioP7FSymq93pC4umxf6TVicpjpMErdD2ZfJGulN37dq8FOsOFnSmFYJdICj/PbJm6p1i8O21lsFCltEqVoVabJ7/0alPfdG2U76OeBqI8ZubL4BMnWXAB/VVEYbyWCNpQSDTjHQYs54qa2I0dJB7OgJt1sCgYEArctFQ02/7H5Rscl1yo3DBXO94SeiCFSPdC8f2Kt3MfOxvVdkAtkjkMACSbkoUsgbTVqTYSEOEc2jTgR3iQ13JgpHaFbbsq64V0QP3TAxbLIQUjYGVgQaF1UfLOBv8hrzgj45z/ST/G80lOl595+0nCUbmBcgG1AEWrmdF0/3RmECgYAKvIzKXXB3+19vcT2ga5Qq2l3TiPtOGsppRb2XrNs9qKdxIYvHmXo/9QP1V3SRW0XoD7ez8FpFabp42cmPOxUNk3FK3paQZABLxH5pzCWI9PzIAVfPDrm+sdnbgG7vAnwfL2IMMJSA3aDYGCbF9EgefG+STcpfqq7fQ6f5TBgLFwKBgCd7gn1xYL696SaKVSm7VngpXlczHVEpz3kStWR5gfzriPBxXgMVcWmcbajRser7ARpCEfbxM1UJyv6oAYZWVSNErNzNVb4POqLYcCNySuC6xKhs9FrEQnyKjyk8wI4VnrEMGrQ8e+qYSwYk9Gh6dKGoRMAPYVXQAO0fIsHF/T0a\n' +
+      '-----END PRIVATE KEY-----';
+    const key = Buffer.from(pemFileData);
+    const output = Buffer.alloc(256);
+    const expectedOutput = Buffer.from(
+      'VocBRhpMmQ2XCzVehWSqheQLnU889gf3dhU4AnVnQTJjsKx/CM23qKDPkZDd2A/BnQsp99SN7ksIX5Raj0TPwyN5OCN/YrNFNGoOFlTsGhgP/hyE8X3Duiq6sNO0SMvRYNPFFGlJFsp1Fw3Z94eYMg4/Wpw5s4+Jo5Zm/qY7aTJIqDKDQ3CNHLeJgcMUOc9sz01/GzoUYKDVODHSxrYEk5ireFJFz9vP8P7Ha+VDUZuQIQdXer9NBbGFtYmWprY3nn4D3Dw93Sn0V0dIqYeIo91oKyslvMebmUM95S2PyIJdEpPb2DJDxjvX/0LLwSWlSXRWy9gapWoBkb4ynqZBsg==',
+      'base64'
+    );
+
+    const { signRsaSha256Hook } = cryptoCallbacks;
+    const err = signRsaSha256Hook(key, input, output);
+    if (err instanceof Error) {
+      expect(err).to.not.exist;
+    }
+
+    expect(output).to.deep.equal(expectedOutput);
+  });
+
   const hookNames = new Set([
     'aes256CbcEncryptHook',
     'aes256CbcDecryptHook',


### PR DESCRIPTION
This patch set updates the Node.js bindings for libmongocrypt to support Azure and GCP as KMS providers for CSFLE. The changes should be straightforward, following the migration guide for this version of libmongocrypt. Notably, the KMS client code introduced a dependency on `BufferList` in order to simplify the logic of reading in chunks, and forwarding those chunks to libmongocrypt.

NODE-2825