### PR TITLE
MONGOCRYPT-279 disable test-python on RHEL 6.2

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -829,7 +829,7 @@ buildvariants:
   - build-and-test-and-upload
   - build-and-test-shared-bson
   - build-and-test-java
-  - test-python
+  # - test-python TODO: add back after MONGOCRYPT-279 is resolved.
   - name: publish-packages
     distros:
     - rhel70-small


### PR DESCRIPTION
Disabling this task for now, so patch builds can succeed until MONGOCRYPT-279 is resolved.