### PR TITLE
MONGOCRYPT-297 fix publish-packages on Debian and Ubuntu

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -563,6 +563,13 @@ tasks:
             exit 0
           fi
 
+          # Need requests and poster for notary-client.py
+          python -m virtualenv venv
+          cd venv
+          . bin/activate
+          ./bin/pip install requests
+          ./bin/pip install poster
+          cd ..
           pkg_version=$mongocrypt_version
           CURATOR_RELEASE=${curator_release|"latest"}
           curl -L -O http://boxes.10gen.com/build/curator/curator-dist-rhel70-$CURATOR_RELEASE.tar.gz
@@ -716,7 +723,7 @@ buildvariants:
   - build-and-test-node
   - name: publish-packages
     distros:
-    - ubuntu1804-test
+    - ubuntu2004-large
 - name: macos
   display_name: "macOS 10.14"
   run_on: macos-1014
@@ -801,7 +808,7 @@ buildvariants:
   - build-and-test-node
   - name: publish-packages
     distros:
-    - ubuntu1804-test
+    - ubuntu2004-large
 - name: debian92
   display_name: "Debian 9.2"
   run_on: debian92-test
@@ -817,7 +824,7 @@ buildvariants:
   - build-and-test-node
   - name: publish-packages
     distros:
-    - ubuntu1804-test
+    - ubuntu2004-large
 - name: rhel-62-64-bit
   display_name: "RHEL 6.2 64-bit"
   run_on: rhel62-small
@@ -952,7 +959,7 @@ buildvariants:
   - build-and-test-node
   - name: publish-packages
     distros:
-    - ubuntu1804-test
+    - ubuntu2004-large
 - name: ubuntu1804-64
   display_name: "Ubuntu 18.04 64-bit"
   run_on: ubuntu1804-test
@@ -970,7 +977,7 @@ buildvariants:
   - build-and-test-node
   - name: publish-packages
     distros:
-    - ubuntu1804-test
+    - ubuntu2004-large
 - name: ubuntu1804-arm64
   display_name: "Ubuntu 18.04 arm64"
   run_on: ubuntu1804-arm64-build
@@ -986,7 +993,7 @@ buildvariants:
   - build-and-test-node
   - name: publish-packages
     distros:
-    - ubuntu1804-test
+    - ubuntu2004-large
 - name: publish-snapshot
   display_name: "Publish"
   run_on: ubuntu1804-test


### PR DESCRIPTION
Note that the patch build does not actually exercise this change, since we don't publish for patch builds.  That said, I did perform an additional patch build to verify that the Python venv sequence worked correctly.  However, the curator invocation still failed because the necessary credentials were not available.