### PR TITLE
PYTHON-2450 Always use a virtualenv to install test dependencies

### DIFF
--- a/bindings/python/.evergreen/test.sh
+++ b/bindings/python/.evergreen/test.sh
@@ -5,6 +5,9 @@
 set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
+# For createvirtualenv.
+. .evergreen/utils.sh
+
 # MONGOCRYPT_DIR is set by libmongocrypt/.evergreen/config.yml
 MONGOCRYPT_DIR="$MONGOCRYPT_DIR"
 
@@ -32,9 +35,11 @@ else
 fi
 
 for PYTHON_BINARY in "${PYTHONS[@]}"; do
-    # Clear cached eggs for different python versions.
-    rm -rf .eggs
+    echo "Running test with python: $PYTHON_BINARY"
     $PYTHON_BINARY -c 'import sys; print(sys.version)'
-
-    $PYTHON_BINARY setup.py test
+    createvirtualenv $PYTHON_BINARY .venv
+    python -m pip install --prefer-binary -r test-requirements.txt
+    python setup.py test
+    deactivate
+    rm -rf .venv
 done

--- a/bindings/python/.evergreen/utils.sh
+++ b/bindings/python/.evergreen/utils.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -ex
+
+# Usage:
+# createvirtualenv /path/to/python /output/path/for/venv
+# * param1: Python binary to use for the virtualenv
+# * param2: Path to the virtualenv to create
+createvirtualenv () {
+    PYTHON=$1
+    VENVPATH=$2
+    if $PYTHON -m virtualenv --version; then
+        VIRTUALENV="$PYTHON -m virtualenv"
+    elif command -v virtualenv; then
+        VIRTUALENV="$(command -v virtualenv) -p $PYTHON"
+    else
+        echo "Cannot test without virtualenv"
+        exit 1
+    fi
+    $VIRTUALENV --system-site-packages --never-download $VENVPATH
+    if [ "Windows_NT" = "$OS" ]; then
+        . $VENVPATH/Scripts/activate
+    else
+        . $VENVPATH/bin/activate
+    fi
+}

--- a/bindings/python/test-requirements.txt
+++ b/bindings/python/test-requirements.txt
@@ -1,0 +1,5 @@
+pymongo
+# cffi==1.14.3 was the last installable release on RHEL 6.3 with Python 3.4
+cffi==1.14.3;python_version=="3.4"
+cffi>=1.12.0;python_version!="3.4"
+cryptography>=2.0


### PR DESCRIPTION
Use --prefer-binary to prefer older binary packages over newer source packages.
Pin to cffi 1.14.3 on Python 3.4.

This PR fixes the Python 3.4 cffi installation failure on RHEL 6.2:
```

[2020/12/02 15:40:38.595] + /opt/python/3.4/bin/python3 -c 'import sys; print(sys.version)'
--
[2020/12/02 15:40:39.711] running build_ext
[2020/12/02 15:40:39.711] 3.4.10 (default, Oct  6 2020, 00:42:05)
[2020/12/02 15:40:39.711] [GCC 4.4.7 20120313 (Red Hat 4.4.7-23)]
[2020/12/02 15:40:42.622] + /opt/python/3.4/bin/python3 setup.py test
[2020/12/02 15:40:42.622] WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
[2020/12/02 15:40:44.231] DEPRECATION: Python 3.4 support has been deprecated. pip 19.1 will be the last one supporting it. Please upgrade your Python as Python 3.4 won't be maintained after March 2019 (cf PEP 429).
[2020/12/02 15:40:45.937] DEPRECATION: Python 3.4 support has been deprecated. pip 19.1 will be the last one supporting it. Please upgrade your Python as Python 3.4 won't be maintained after March 2019 (cf PEP 429).
[2020/12/02 15:40:47.840]   ERROR: Complete output from command /opt/python/3.4/bin/python3 -u -c 'import setuptools, tokenize;__file__='"'"'/data/mci/84274436dc3acac456a0d438323d747c/tmp/pip-wheel-uxdfg7e3/cffi/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /data/mci/84274436dc3acac456a0d438323d747c/tmp/pip-wheel-r3lev2w4:
[2020/12/02 15:40:47.840]   ERROR: running bdist_wheel
[2020/12/02 15:40:47.840]   running build
[2020/12/02 15:40:47.840]   running build_py
[2020/12/02 15:40:47.840]   creating build
[2020/12/02 15:40:47.840]   creating build/lib.linux-x86_64-3.4
[2020/12/02 15:40:47.840]   creating build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/vengine_cpy.py -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/model.py -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/commontypes.py -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/error.py -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/backend_ctypes.py -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/cparser.py -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/ffiplatform.py -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/pkgconfig.py -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/vengine_gen.py -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/api.py -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/lock.py -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/__init__.py -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/setuptools_ext.py -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/cffi_opcode.py -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/verifier.py -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/recompiler.py -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/_cffi_include.h -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/parse_c_type.h -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/_embedding.h -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   copying cffi/_cffi_errors.h -> build/lib.linux-x86_64-3.4/cffi
[2020/12/02 15:40:47.840]   running build_ext
[2020/12/02 15:40:47.840]   building '_cffi_backend' extension
[2020/12/02 15:40:47.840]   creating build/temp.linux-x86_64-3.4
[2020/12/02 15:40:47.840]   creating build/temp.linux-x86_64-3.4/c
[2020/12/02 15:40:47.840]   gcc -pthread -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/lib64/libffi-3.0.5/include -I/opt/python/3.4/include/python3.4m -c c/_cffi_backend.c -o build/temp.linux-x86_64-3.4/c/_cffi_backend.o
[2020/12/02 15:40:47.840]   c/_cffi_backend.c: In function 'b_callback':
[2020/12/02 15:40:47.840]   c/_cffi_backend.c:6344: error: #pragma GCC diagnostic not allowed inside functions
[2020/12/02 15:40:47.840]   c/_cffi_backend.c:6345: error: #pragma GCC diagnostic not allowed inside functions
[2020/12/02 15:40:47.840]   c/_cffi_backend.c:6352: error: #pragma GCC diagnostic not allowed inside functions
[2020/12/02 15:40:47.840]   error: command 'gcc' failed with exit status 1
[2020/12/02 15:40:47.840]   ----------------------------------------
[2020/12/02 15:40:48.125]   ERROR: Failed building wheel for cffi
[2020/12/02 15:40:48.125] ERROR: Failed to build one or more wheels
[2020/12/02 15:40:48.170] error: Command '['/opt/python/3.4/bin/python3', '-m', 'pip', '--disable-pip-version-check', 'wheel', '--no-deps', '-w', '/data/mci/84274436dc3acac456a0d438323d747c/tmp/tmpcw6q61re', '--quiet', 'cffi<2,>=1.12.0']' returned non-zero exit status 1
```