### PR TITLE
PYTHON-2451 Reenable PyPy testing, add Python 3.9, test cryptography 3

### DIFF
--- a/bindings/python/.evergreen/test.sh
+++ b/bindings/python/.evergreen/test.sh
@@ -46,7 +46,7 @@ for PYTHON_BINARY in "${PYTHONS[@]}"; do
     echo "Running test with python: $PYTHON_BINARY"
     $PYTHON_BINARY -c 'import sys; print(sys.version)'
     createvirtualenv $PYTHON_BINARY .venv
-    python -m pip install -r test-requirements.txt
+    python -m pip install --prefer-binary -r test-requirements.txt
     python setup.py test
     deactivate
     rm -rf .venv

--- a/bindings/python/.evergreen/test.sh
+++ b/bindings/python/.evergreen/test.sh
@@ -14,22 +14,31 @@ MONGOCRYPT_DIR="$MONGOCRYPT_DIR"
 if [ "Windows_NT" = "$OS" ]; then # Magic variable in cygwin
     PYMONGOCRYPT_LIB=${MONGOCRYPT_DIR}/nocrypto/bin/mongocrypt.dll
     export PYMONGOCRYPT_LIB=$(cygpath -m $PYMONGOCRYPT_LIB)
-    PYTHONS=("C:/python/Python27/python.exe" \
-             "C:/python/Python34/python.exe" \
-             "C:/python/Python35/python.exe" \
-             "C:/python/Python36/python.exe" \
-             "C:/python/Python37/python.exe" \
-             "C:/python/Python38/python.exe")
+    PYTHONS=("C:/python/Python27/python.exe"
+             "C:/python/Python34/python.exe"
+             "C:/python/Python35/python.exe"
+             "C:/python/Python36/python.exe"
+             "C:/python/Python37/python.exe"
+             "C:/python/Python38/python.exe"
+             "C:/python/Python39/python.exe")
 elif [ "Darwin" = "$(uname -s)" ]; then
     export PYMONGOCRYPT_LIB=${MONGOCRYPT_DIR}/nocrypto/lib/libmongocrypt.dylib
-    PYTHONS=("python")
+    PYTHONS=("python"   # Python 2.7 from brew
+             "python3"  # Python 3 from brew
+             "/System/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
+             "/Library/Frameworks/Python.framework/Versions/3.4/bin/python3"
+             "/Library/Frameworks/Python.framework/Versions/3.5/bin/python3"
+             "/Library/Frameworks/Python.framework/Versions/3.6/bin/python3"
+             "/Library/Frameworks/Python.framework/Versions/3.7/bin/python3"
+             "/Library/Frameworks/Python.framework/Versions/3.8/bin/python3"
+             "/Library/Frameworks/Python.framework/Versions/3.9/bin/python3")
 else
     export PYMONGOCRYPT_LIB=${MONGOCRYPT_DIR}/nocrypto/lib64/libmongocrypt.so
-    PYTHONS=("/opt/python/2.7/bin/python" \
-             "/opt/python/3.4/bin/python3" \
-             "/opt/python/3.5/bin/python3" \
-             "/opt/python/3.6/bin/python3" \
-             "/opt/python/pypy/bin/pypy" \
+    PYTHONS=("/opt/python/2.7/bin/python"
+             "/opt/python/3.4/bin/python3"
+             "/opt/python/3.5/bin/python3"
+             "/opt/python/3.6/bin/python3"
+             "/opt/python/pypy/bin/pypy"
              "/opt/python/pypy3.6/bin/pypy3")
 fi
 

--- a/bindings/python/.evergreen/test.sh
+++ b/bindings/python/.evergreen/test.sh
@@ -28,17 +28,16 @@ else
     PYTHONS=("/opt/python/2.7/bin/python" \
              "/opt/python/3.4/bin/python3" \
              "/opt/python/3.5/bin/python3" \
-             "/opt/python/3.6/bin/python3")
-             # Enable when MONGOCRYPT-279 is fixed.
-             #"/opt/python/pypy/bin/pypy" \
-             #"/opt/python/pypy3.6/bin/pypy3")
+             "/opt/python/3.6/bin/python3" \
+             "/opt/python/pypy/bin/pypy" \
+             "/opt/python/pypy3.6/bin/pypy3")
 fi
 
 for PYTHON_BINARY in "${PYTHONS[@]}"; do
     echo "Running test with python: $PYTHON_BINARY"
     $PYTHON_BINARY -c 'import sys; print(sys.version)'
     createvirtualenv $PYTHON_BINARY .venv
-    python -m pip install --prefer-binary -r test-requirements.txt
+    python -m pip install -r test-requirements.txt
     python setup.py test
     deactivate
     rm -rf .venv

--- a/bindings/python/.evergreen/utils.sh
+++ b/bindings/python/.evergreen/utils.sh
@@ -8,17 +8,22 @@ createvirtualenv () {
     PYTHON=$1
     VENVPATH=$2
     if $PYTHON -m virtualenv --version; then
-        VIRTUALENV="$PYTHON -m virtualenv"
+        VIRTUALENV="$PYTHON -m virtualenv --system-site-packages --never-download"
+    elif $PYTHON -m venv -h>/dev/null; then
+        VIRTUALENV="$PYTHON -m venv --system-site-packages"
     elif command -v virtualenv; then
-        VIRTUALENV="$(command -v virtualenv) -p $PYTHON"
+        VIRTUALENV="$(command -v virtualenv) -p $PYTHON --system-site-packages --never-download"
     else
         echo "Cannot test without virtualenv"
         exit 1
     fi
-    $VIRTUALENV --system-site-packages --never-download $VENVPATH
+    $VIRTUALENV $VENVPATH
     if [ "Windows_NT" = "$OS" ]; then
         . $VENVPATH/Scripts/activate
     else
         . $VENVPATH/bin/activate
     fi
+    # Upgrade to the latest versions of pip setuptools wheel so that
+    # pip can always download the latest cryptography+cffi wheels.
+    python -m pip install --upgrade pip setuptools wheel
 }

--- a/bindings/python/.evergreen/utils.sh
+++ b/bindings/python/.evergreen/utils.sh
@@ -26,5 +26,5 @@ createvirtualenv () {
     # smart enough to know the latest compatible version of pip, setuptools,
     # and wheel.
     python -m pip install --upgrade 'pip<19.2'  # 19.2 dropped support for Python 3.4
-    python -m pip install --upgrade pip, setuptools, wheel
+    python -m pip install --upgrade pip setuptools wheel
 }

--- a/bindings/python/.evergreen/utils.sh
+++ b/bindings/python/.evergreen/utils.sh
@@ -21,4 +21,10 @@ createvirtualenv () {
     else
         . $VENVPATH/bin/activate
     fi
+    # Bootstrap pip to deal with old versions that may install an unsupported
+    # version when told to upgrade. First upgrade to 19.1, which should be
+    # smart enough to know the latest compatible version of pip, setuptools,
+    # and wheel.
+    python -m pip install --upgrade 'pip<19.2'  # 19.2 dropped support for Python 3.4
+    python -m pip install --upgrade pip, setuptools, wheel
 }

--- a/bindings/python/.evergreen/utils.sh
+++ b/bindings/python/.evergreen/utils.sh
@@ -21,10 +21,4 @@ createvirtualenv () {
     else
         . $VENVPATH/bin/activate
     fi
-    # Bootstrap pip to deal with old versions that may install an unsupported
-    # version when told to upgrade. First upgrade to 19.1, which should be
-    # smart enough to know the latest compatible version of pip, setuptools,
-    # and wheel.
-    python -m pip install --upgrade 'pip<19.2'  # 19.2 dropped support for Python 3.4
-    python -m pip install --upgrade pip setuptools wheel
 }

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -73,6 +73,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Database"],

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -49,7 +49,7 @@ setup(
     packages=find_packages(exclude=['test']),
     package_data={'pymongocrypt': ['*.dll', '*.so', '*.dylib']},
     zip_safe=False,
-    install_requires=["cffi>=1.12.0,<2", "cryptography>=2.0,<3"],
+    install_requires=["cffi>=1.12.0,<2", "cryptography>=2.0,<4"],
     author="Shane Harvey",
     author_email="mongodb-user@googlegroups.com",
     url="https://github.com/mongodb/libmongocrypt/tree/master/bindings/python",

--- a/bindings/python/test-requirements.txt
+++ b/bindings/python/test-requirements.txt
@@ -2,4 +2,8 @@ pymongo
 # cffi==1.14.3 was the last installable release on RHEL 6.3 with Python 3.4
 cffi==1.14.3;python_version=="3.4"
 cffi>=1.12.0;python_version!="3.4"
-cryptography>=2.0
+# We test PyPy on RHEL 6.2 which has OpenSSL 1.0.1e
+# Pin to cryptography 2.8.* until we figure our how to
+# install cryptography with PyPy with a newer OpenSSL.
+cryptography<2.9;platform_python_implementation=='PyPy'
+cryptography>=2.0;platform_python_implementation!='PyPy'

--- a/bindings/python/test-requirements.txt
+++ b/bindings/python/test-requirements.txt
@@ -6,4 +6,4 @@ cffi>=1.12.0,<2;python_version!="3.4"
 # Pin to cryptography 2.8.* until we figure our how to
 # install cryptography with PyPy with a newer OpenSSL.
 cryptography>=2,<2.9;platform_python_implementation=='PyPy'
-cryptography>=2,<3;platform_python_implementation!='PyPy'
+cryptography>=2,<4;platform_python_implementation!='PyPy'

--- a/bindings/python/test-requirements.txt
+++ b/bindings/python/test-requirements.txt
@@ -1,9 +1,9 @@
 pymongo
 # cffi==1.14.3 was the last installable release on RHEL 6.3 with Python 3.4
 cffi==1.14.3;python_version=="3.4"
-cffi>=1.12.0;python_version!="3.4"
+cffi>=1.12.0,<2;python_version!="3.4"
 # We test PyPy on RHEL 6.2 which has OpenSSL 1.0.1e
 # Pin to cryptography 2.8.* until we figure our how to
 # install cryptography with PyPy with a newer OpenSSL.
-cryptography<2.9;platform_python_implementation=='PyPy'
-cryptography>=2.0;platform_python_implementation!='PyPy'
+cryptography>=2,<2.9;platform_python_implementation=='PyPy'
+cryptography>=2,<3;platform_python_implementation!='PyPy'


### PR DESCRIPTION
This PR fixes 3 tickets:
- PYTHON-2368 Test pymongocrypt with Python 3.9 
- PYTHON-2451 Reenable PyPy testing
- PYTHON-2408 Test with cryptography 3


We fixed PyPy testing on RHEL 6.2 by pinning to cryptography<2.9. It also fixes the follow error on macos:
```
[2020/12/04 00:50:38.033] 2.7.17 (default, Dec 23 2019, 21:25:34)
[2020/12/04 00:50:38.033] [GCC 4.2.1 Compatible Apple LLVM 11.0.0 (clang-1100.0.33.16)]
[2020/12/04 00:50:38.034] + python -c 'import sys; print(sys.version)'
[2020/12/04 00:50:38.034] + createvirtualenv python .venv
[2020/12/04 00:50:38.034] + PYTHON=python
[2020/12/04 00:50:38.034] + VENVPATH=.venv
[2020/12/04 00:50:38.136] + python -m virtualenv --version
[2020/12/04 00:50:38.136] + VIRTUALENV='python -m virtualenv'
[2020/12/04 00:50:38.136] + python -m virtualenv --system-site-packages --never-download .venv
[2020/12/04 00:50:38.272] 15.2.0
[2020/12/04 00:50:38.272] New python executable in /data/mci/21e9fca9cf5f18ed880ffa679d1422c3/libmongocrypt/bindings/python/.venv/bin/python2.7
[2020/12/04 00:50:38.272] Also creating executable in /data/mci/21e9fca9cf5f18ed880ffa679d1422c3/libmongocrypt/bindings/python/.venv/bin/python
[2020/12/04 00:50:40.109] + '[' Windows_NT = '' ']'
[2020/12/04 00:50:40.109] + . .venv/bin/activate
[2020/12/04 00:50:40.109] ++ deactivate nondestructive
[2020/12/04 00:50:40.109] ++ unset -f pydoc
[2020/12/04 00:50:40.109] ++ '[' -z '' ']'
[2020/12/04 00:50:40.109] ++ '[' -z '' ']'
[2020/12/04 00:50:40.109] ++ '[' -n /bin/bash ']'
[2020/12/04 00:50:40.109] ++ hash -r
[2020/12/04 00:50:40.109] ++ '[' -z '' ']'
[2020/12/04 00:50:40.109] ++ unset VIRTUAL_ENV
[2020/12/04 00:50:40.109] ++ '[' '!' nondestructive = nondestructive ']'
[2020/12/04 00:50:40.109] ++ VIRTUAL_ENV=/data/mci/21e9fca9cf5f18ed880ffa679d1422c3/libmongocrypt/bindings/python/.venv
[2020/12/04 00:50:40.109] ++ export VIRTUAL_ENV
[2020/12/04 00:50:40.109] ++ _OLD_VIRTUAL_PATH=/Users/mci/.yarn/bin:/Users/mci/.config/yarn/global/node_modules/.bin:/opt/node/bin:/usr/sbin:/usr/local/opt/python@2/bin:/usr/local/opt/ant@1.9/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/local/go/bin
[2020/12/04 00:50:40.109] ++ PATH=/data/mci/21e9fca9cf5f18ed880ffa679d1422c3/libmongocrypt/bindings/python/.venv/bin:/Users/mci/.yarn/bin:/Users/mci/.config/yarn/global/node_modules/.bin:/opt/node/bin:/usr/sbin:/usr/local/opt/python@2/bin:/usr/local/opt/ant@1.9/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/local/go/bin
[2020/12/04 00:50:40.109] ++ export PATH
[2020/12/04 00:50:40.109] ++ '[' -z '' ']'
[2020/12/04 00:50:40.109] ++ '[' -z '' ']'
[2020/12/04 00:50:40.109] ++ _OLD_VIRTUAL_PS1=
[2020/12/04 00:50:40.109] ++ '[' x '!=' x ']'
[2020/12/04 00:50:40.109] +++ basename /data/mci/21e9fca9cf5f18ed880ffa679d1422c3/libmongocrypt/bindings/python/.venv
[2020/12/04 00:50:40.111] ++ PS1='(.venv) '
[2020/12/04 00:50:40.111] ++ export PS1
[2020/12/04 00:50:40.111] ++ alias pydoc
[2020/12/04 00:50:40.111] ++ '[' -n /bin/bash ']'
[2020/12/04 00:50:40.111] ++ hash -r
[2020/12/04 00:50:40.424] + python -m pip install --prefer-binary -r test-requirements.txt
[2020/12/04 00:50:40.424] Usage:
[2020/12/04 00:50:40.424]   /data/mci/21e9fca9cf5f18ed880ffa679d1422c3/libmongocrypt/bindings/python/.venv/bin/python -m pip install [options] <requirement specifier> [package-index-options] ...
[2020/12/04 00:50:40.424]   /data/mci/21e9fca9cf5f18ed880ffa679d1422c3/libmongocrypt/bindings/python/.venv/bin/python -m pip install [options] -r <requirements file> [package-index-options] ...
[2020/12/04 00:50:40.424]   /data/mci/21e9fca9cf5f18ed880ffa679d1422c3/libmongocrypt/bindings/python/.venv/bin/python -m pip install [options] [-e] <vcs project url> ...
[2020/12/04 00:50:40.424]   /data/mci/21e9fca9cf5f18ed880ffa679d1422c3/libmongocrypt/bindings/python/.venv/bin/python -m pip install [options] [-e] <local project path> ...
[2020/12/04 00:50:40.424]   /data/mci/21e9fca9cf5f18ed880ffa679d1422c3/libmongocrypt/bindings/python/.venv/bin/python -m pip install [options] <archive url/path> ...
[2020/12/04 00:50:40.424] no such option: --prefer-binary
```
https://evergreen.mongodb.com/task/libmongocrypt_macos_test_python_30f58ca1f0dde6c453aa036658163fe3d3f6b85a_20_12_04_00_45_19

