### PR TITLE
MONGOCRYPT-257 propagate errors from KMS message hooks

### DIFF
--- a/src/mongocrypt-kms-ctx.c
+++ b/src/mongocrypt-kms-ctx.c
@@ -180,7 +180,7 @@ _mongocrypt_kms_ctx_init_aws_decrypt (mongocrypt_kms_ctx_t *kms,
    if (kms_request_get_error (kms->req)) {
       CLIENT_ERR ("error constructing KMS message: %s",
                   kms_request_get_error (kms->req));
-      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
 
@@ -190,27 +190,27 @@ _mongocrypt_kms_ctx_init_aws_decrypt (mongocrypt_kms_ctx_t *kms,
              kms->req, "Host", key->kek.provider.aws.endpoint->host_and_port)) {
          CLIENT_ERR ("error constructing KMS message: %s",
                      kms_request_get_error (kms->req));
-         _mongocrypt_status_wrap (status, ctx_with_status.status);
+         _mongocrypt_status_append (status, ctx_with_status.status);
          goto done;
       }
    }
 
    if (!kms_request_set_region (kms->req, key->kek.provider.aws.region)) {
       CLIENT_ERR ("failed to set region");
-      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
 
    if (!kms_request_set_access_key_id (
           kms->req, crypt_opts->kms_provider_aws.access_key_id)) {
       CLIENT_ERR ("failed to set aws access key id");
-      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
    if (!kms_request_set_secret_key (
           kms->req, crypt_opts->kms_provider_aws.secret_access_key)) {
       CLIENT_ERR ("failed to set aws secret access key");
-      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
 
@@ -218,7 +218,7 @@ _mongocrypt_kms_ctx_init_aws_decrypt (mongocrypt_kms_ctx_t *kms,
    kms->msg.data = (uint8_t *) kms_request_get_signed (kms->req);
    if (!kms->msg.data) {
       CLIENT_ERR ("failed to create KMS message");
-      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
    kms->msg.len = (uint32_t) strlen ((char *) kms->msg.data);
@@ -309,7 +309,7 @@ _mongocrypt_kms_ctx_init_aws_encrypt (
    if (kms_request_get_error (kms->req)) {
       CLIENT_ERR ("error constructing KMS message: %s",
                   kms_request_get_error (kms->req));
-      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
 
@@ -319,27 +319,27 @@ _mongocrypt_kms_ctx_init_aws_encrypt (
              kms->req, "Host", ctx_opts->kek.provider.aws.endpoint->host)) {
          CLIENT_ERR ("error constructing KMS message: %s",
                      kms_request_get_error (kms->req));
-         _mongocrypt_status_wrap (status, ctx_with_status.status);
+         _mongocrypt_status_append (status, ctx_with_status.status);
          goto done;
       }
    }
 
    if (!kms_request_set_region (kms->req, ctx_opts->kek.provider.aws.region)) {
       CLIENT_ERR ("failed to set region");
-      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
 
    if (!kms_request_set_access_key_id (
           kms->req, crypt_opts->kms_provider_aws.access_key_id)) {
       CLIENT_ERR ("failed to set aws access key id");
-      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
    if (!kms_request_set_secret_key (
           kms->req, crypt_opts->kms_provider_aws.secret_access_key)) {
       CLIENT_ERR ("failed to set aws secret access key");
-      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
 
@@ -347,7 +347,7 @@ _mongocrypt_kms_ctx_init_aws_encrypt (
    kms->msg.data = (uint8_t *) kms_request_get_signed (kms->req);
    if (!kms->msg.data) {
       CLIENT_ERR ("failed to create KMS message");
-      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
    kms->msg.len = (uint32_t) strlen ((char *) kms->msg.data);
@@ -1203,7 +1203,7 @@ _mongocrypt_kms_ctx_init_gcp_auth (mongocrypt_kms_ctx_t *kms,
    if (kms_request_get_error (kms->req)) {
       CLIENT_ERR ("error constructing KMS message: %s",
                   kms_request_get_error (kms->req));
-      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      _mongocrypt_status_append (status, ctx_with_status.status);
       goto fail;
    }
 
@@ -1211,7 +1211,7 @@ _mongocrypt_kms_ctx_init_gcp_auth (mongocrypt_kms_ctx_t *kms,
    if (!request_string) {
       CLIENT_ERR ("error getting GCP OAuth KMS message: %s",
                   kms_request_get_error (kms->req));
-      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      _mongocrypt_status_append (status, ctx_with_status.status);
       goto fail;
    }
    _mongocrypt_buffer_init (&kms->msg);

--- a/src/mongocrypt-kms-ctx.c
+++ b/src/mongocrypt-kms-ctx.c
@@ -27,6 +27,11 @@
 #include <kms_message/kms_gcp_request.h>
 #include "mongocrypt.h"
 
+typedef struct {
+   mongocrypt_status_t *status;
+   void *ctx;
+} ctx_with_status_t;
+
 /* Before we've read the Content-Length header in an HTTP response,
  * we don't know how many bytes we'll need. So return this value
  * in kms_ctx_bytes_needed until we are fed the Content-Length.
@@ -38,11 +43,10 @@ static bool
 _sha256 (void *ctx, const char *input, size_t len, unsigned char *hash_out)
 {
    bool ret;
-   mongocrypt_status_t *status;
-   _mongocrypt_crypto_t *crypto = (_mongocrypt_crypto_t *) ctx;
+   ctx_with_status_t *ctx_with_status = (ctx_with_status_t *) ctx;
+   _mongocrypt_crypto_t *crypto = (_mongocrypt_crypto_t *) ctx_with_status->ctx;
    mongocrypt_binary_t *plaintext, *out;
 
-   status = mongocrypt_status_new ();
    plaintext =
       mongocrypt_binary_new_from_data ((uint8_t *) input, (uint32_t) len);
    out = mongocrypt_binary_new ();
@@ -50,9 +54,8 @@ _sha256 (void *ctx, const char *input, size_t len, unsigned char *hash_out)
    out->data = hash_out;
    out->len = SHA256_LEN;
 
-   ret = crypto->sha_256 (crypto->ctx, plaintext, out, status);
+   ret = crypto->sha_256 (crypto->ctx, plaintext, out, ctx_with_status->status);
 
-   mongocrypt_status_destroy (status);
    mongocrypt_binary_destroy (plaintext);
    mongocrypt_binary_destroy (out);
    return ret;
@@ -66,14 +69,13 @@ _sha256_hmac (void *ctx,
               size_t len,
               unsigned char *hash_out)
 {
-   mongocrypt_status_t *status;
-   _mongocrypt_crypto_t *crypto = (_mongocrypt_crypto_t *) ctx;
+   ctx_with_status_t *ctx_with_status = (ctx_with_status_t *) ctx;
+   _mongocrypt_crypto_t *crypto = (_mongocrypt_crypto_t *) ctx_with_status->ctx;
    mongocrypt_binary_t *key, *plaintext, *out;
    bool ret;
 
    (void) crypto;
 
-   status = mongocrypt_status_new ();
    key = mongocrypt_binary_new_from_data ((uint8_t *) key_input,
                                           (uint32_t) key_len);
    plaintext =
@@ -83,9 +85,9 @@ _sha256_hmac (void *ctx,
    out->data = hash_out;
    out->len = SHA256_LEN;
 
-   ret = crypto->hmac_sha_256 (crypto->ctx, key, plaintext, out, status);
+   ret = crypto->hmac_sha_256 (
+      crypto->ctx, key, plaintext, out, ctx_with_status->status);
 
-   mongocrypt_status_destroy (status);
    mongocrypt_binary_destroy (key);
    mongocrypt_binary_destroy (plaintext);
    mongocrypt_binary_destroy (out);
@@ -93,10 +95,13 @@ _sha256_hmac (void *ctx,
 }
 
 static void
-_set_kms_crypto_hooks (_mongocrypt_crypto_t *crypto, kms_request_opt_t *opts)
+_set_kms_crypto_hooks (_mongocrypt_crypto_t *crypto,
+                       ctx_with_status_t *ctx_with_status,
+                       kms_request_opt_t *opts)
 {
    if (crypto->hooks_enabled) {
-      kms_request_opt_set_crypto_hooks (opts, _sha256, _sha256_hmac, crypto);
+      kms_request_opt_set_crypto_hooks (
+         opts, _sha256, _sha256_hmac, ctx_with_status);
    }
 }
 
@@ -121,45 +126,49 @@ _mongocrypt_kms_ctx_init_aws_decrypt (mongocrypt_kms_ctx_t *kms,
 {
    kms_request_opt_t *opt;
    mongocrypt_status_t *status;
+   ctx_with_status_t ctx_with_status;
+   bool ret = false;
 
    _init_common (kms, log, MONGOCRYPT_KMS_AWS_DECRYPT);
    status = kms->status;
+   ctx_with_status.ctx = crypto;
+   ctx_with_status.status = mongocrypt_status_new ();
 
    if (!key->kek.kms_provider) {
       CLIENT_ERR ("no kms provider specified on key");
-      return false;
+      goto done;
    }
 
    if (MONGOCRYPT_KMS_PROVIDER_AWS != key->kek.kms_provider) {
       CLIENT_ERR ("expected aws kms provider");
-      return false;
+      goto done;
    }
 
    if (!key->kek.provider.aws.region) {
       CLIENT_ERR ("no key region provided");
-      return false;
+      goto done;
    }
 
    if (0 == (crypt_opts->kms_providers & MONGOCRYPT_KMS_PROVIDER_AWS)) {
       CLIENT_ERR ("aws kms not configured");
-      return false;
+      goto done;
    }
 
    if (!crypt_opts->kms_provider_aws.access_key_id) {
       CLIENT_ERR ("aws access key id not provided");
-      return false;
+      goto done;
    }
 
    if (!crypt_opts->kms_provider_aws.secret_access_key) {
       CLIENT_ERR ("aws secret access key not provided");
-      return false;
+      goto done;
    }
 
    /* create the KMS request. */
    opt = kms_request_opt_new ();
    BSON_ASSERT (opt);
 
-   _set_kms_crypto_hooks (crypto, opt);
+   _set_kms_crypto_hooks (crypto, &ctx_with_status, opt);
    kms_request_opt_set_connection_close (opt, true);
 
    kms->req = kms_decrypt_request_new (
@@ -171,7 +180,8 @@ _mongocrypt_kms_ctx_init_aws_decrypt (mongocrypt_kms_ctx_t *kms,
    if (kms_request_get_error (kms->req)) {
       CLIENT_ERR ("error constructing KMS message: %s",
                   kms_request_get_error (kms->req));
-      return false;
+      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      goto done;
    }
 
    /* If an endpoint was set, override the default Host header. */
@@ -180,30 +190,36 @@ _mongocrypt_kms_ctx_init_aws_decrypt (mongocrypt_kms_ctx_t *kms,
              kms->req, "Host", key->kek.provider.aws.endpoint->host_and_port)) {
          CLIENT_ERR ("error constructing KMS message: %s",
                      kms_request_get_error (kms->req));
-         return false;
+         _mongocrypt_status_wrap (status, ctx_with_status.status);
+         goto done;
       }
    }
 
    if (!kms_request_set_region (kms->req, key->kek.provider.aws.region)) {
       CLIENT_ERR ("failed to set region");
-      return false;
+      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      goto done;
    }
 
-   if (!kms_request_set_access_key_id (kms->req,
-                                       crypt_opts->kms_provider_aws.access_key_id)) {
+   if (!kms_request_set_access_key_id (
+          kms->req, crypt_opts->kms_provider_aws.access_key_id)) {
       CLIENT_ERR ("failed to set aws access key id");
-      return false;
+      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      goto done;
    }
-   if (!kms_request_set_secret_key (kms->req,
-                                    crypt_opts->kms_provider_aws.secret_access_key)) {
+   if (!kms_request_set_secret_key (
+          kms->req, crypt_opts->kms_provider_aws.secret_access_key)) {
       CLIENT_ERR ("failed to set aws secret access key");
+      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      goto done;
    }
 
    _mongocrypt_buffer_init (&kms->msg);
    kms->msg.data = (uint8_t *) kms_request_get_signed (kms->req);
    if (!kms->msg.data) {
       CLIENT_ERR ("failed to create KMS message");
-      return false;
+      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      goto done;
    }
    kms->msg.len = (uint32_t) strlen ((char *) kms->msg.data);
    kms->msg.owned = true;
@@ -216,7 +232,12 @@ _mongocrypt_kms_ctx_init_aws_decrypt (mongocrypt_kms_ctx_t *kms,
       kms->endpoint = bson_strdup_printf ("kms.%s.amazonaws.com",
                                           key->kek.provider.aws.region);
    }
-   return true;
+
+   ret = true;
+done:
+   mongocrypt_status_destroy (ctx_with_status.status);
+
+   return ret;
 }
 
 
@@ -231,45 +252,50 @@ _mongocrypt_kms_ctx_init_aws_encrypt (
 {
    kms_request_opt_t *opt;
    mongocrypt_status_t *status;
+   ctx_with_status_t ctx_with_status;
+   bool ret = false;
 
    _init_common (kms, log, MONGOCRYPT_KMS_AWS_ENCRYPT);
    status = kms->status;
+   ctx_with_status.ctx = crypto;
+   ctx_with_status.status = mongocrypt_status_new ();
 
    if (MONGOCRYPT_KMS_PROVIDER_AWS != ctx_opts->kek.kms_provider) {
       CLIENT_ERR ("expected aws kms provider");
-      return false;
+      goto done;
    }
 
    if (!ctx_opts->kek.provider.aws.region) {
       CLIENT_ERR ("no key region provided");
-      return false;
+      goto done;
    }
 
    if (!ctx_opts->kek.provider.aws.cmk) {
       CLIENT_ERR ("no aws cmk provided");
-      return false;
+      goto done;
    }
 
    if (0 == (crypt_opts->kms_providers & MONGOCRYPT_KMS_PROVIDER_AWS)) {
       CLIENT_ERR ("aws kms not configured");
-      return false;
+      goto done;
    }
 
    if (!crypt_opts->kms_provider_aws.access_key_id) {
       CLIENT_ERR ("aws access key id not provided");
-      return false;
+      goto done;
    }
 
    if (!crypt_opts->kms_provider_aws.secret_access_key) {
       CLIENT_ERR ("aws secret access key not provided");
-      return false;
+      goto done;
    }
 
    /* create the KMS request. */
    opt = kms_request_opt_new ();
    BSON_ASSERT (opt);
 
-   _set_kms_crypto_hooks (crypto, opt);
+
+   _set_kms_crypto_hooks (crypto, &ctx_with_status, opt);
    kms_request_opt_set_connection_close (opt, true);
 
    kms->req = kms_encrypt_request_new (plaintext_key_material->data,
@@ -283,7 +309,8 @@ _mongocrypt_kms_ctx_init_aws_encrypt (
    if (kms_request_get_error (kms->req)) {
       CLIENT_ERR ("error constructing KMS message: %s",
                   kms_request_get_error (kms->req));
-      return false;
+      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      goto done;
    }
 
    /* If an endpoint was set, override the default Host header. */
@@ -292,29 +319,36 @@ _mongocrypt_kms_ctx_init_aws_encrypt (
              kms->req, "Host", ctx_opts->kek.provider.aws.endpoint->host)) {
          CLIENT_ERR ("error constructing KMS message: %s",
                      kms_request_get_error (kms->req));
+         _mongocrypt_status_wrap (status, ctx_with_status.status);
+         goto done;
       }
    }
 
    if (!kms_request_set_region (kms->req, ctx_opts->kek.provider.aws.region)) {
       CLIENT_ERR ("failed to set region");
-      return false;
+      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      goto done;
    }
 
-   if (!kms_request_set_access_key_id (kms->req,
-                                       crypt_opts->kms_provider_aws.access_key_id)) {
+   if (!kms_request_set_access_key_id (
+          kms->req, crypt_opts->kms_provider_aws.access_key_id)) {
       CLIENT_ERR ("failed to set aws access key id");
-      return false;
+      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      goto done;
    }
-   if (!kms_request_set_secret_key (kms->req,
-                                    crypt_opts->kms_provider_aws.secret_access_key)) {
+   if (!kms_request_set_secret_key (
+          kms->req, crypt_opts->kms_provider_aws.secret_access_key)) {
       CLIENT_ERR ("failed to set aws secret access key");
+      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      goto done;
    }
 
    _mongocrypt_buffer_init (&kms->msg);
    kms->msg.data = (uint8_t *) kms_request_get_signed (kms->req);
    if (!kms->msg.data) {
       CLIENT_ERR ("failed to create KMS message");
-      return false;
+      _mongocrypt_status_wrap (status, ctx_with_status.status);
+      goto done;
    }
    kms->msg.len = (uint32_t) strlen ((char *) kms->msg.data);
    kms->msg.owned = true;
@@ -327,7 +361,11 @@ _mongocrypt_kms_ctx_init_aws_encrypt (
       kms->endpoint = bson_strdup_printf ("kms.%s.amazonaws.com",
                                           ctx_opts->kek.provider.aws.region);
    }
-   return true;
+
+   ret = true;
+done:
+   mongocrypt_status_destroy (ctx_with_status.status);
+   return ret;
 }
 
 
@@ -1082,15 +1120,15 @@ _sign_rsaes_pkcs1_v1_5_trampoline (void *ctx,
                                    size_t input_len,
                                    unsigned char *signature_out)
 {
+   ctx_with_status_t *ctx_with_status;
    _mongocrypt_opts_t *crypt_opts;
    mongocrypt_binary_t private_key_bin;
    mongocrypt_binary_t input_bin;
    mongocrypt_binary_t output_bin;
-   mongocrypt_status_t *status;
    bool ret;
 
-   status = mongocrypt_status_new ();
-   crypt_opts = (_mongocrypt_opts_t *) ctx;
+   ctx_with_status = (ctx_with_status_t *) ctx;
+   crypt_opts = (_mongocrypt_opts_t *) ctx_with_status->ctx;
    private_key_bin.data = (uint8_t *) private_key;
    private_key_bin.len = (uint32_t) private_key_len;
    input_bin.data = (uint8_t *) input;
@@ -1098,10 +1136,11 @@ _sign_rsaes_pkcs1_v1_5_trampoline (void *ctx,
    output_bin.data = (uint8_t *) signature_out;
    output_bin.len = RSAES_PKCS1_V1_5_SIGNATURE_LEN;
 
-   ret = crypt_opts->sign_rsaes_pkcs1_v1_5 (
-      crypt_opts->sign_ctx, &private_key_bin, &input_bin, &output_bin, status);
-   /* TODO: MONGOCRYPT-257 status is swallowed. */
-   mongocrypt_status_destroy (status);
+   ret = crypt_opts->sign_rsaes_pkcs1_v1_5 (crypt_opts->sign_ctx,
+                                            &private_key_bin,
+                                            &input_bin,
+                                            &output_bin,
+                                            ctx_with_status->status);
    return ret;
 }
 
@@ -1119,10 +1158,13 @@ _mongocrypt_kms_ctx_init_gcp_auth (mongocrypt_kms_ctx_t *kms,
    const char *host;
    char *request_string;
    bool ret = false;
+   ctx_with_status_t ctx_with_status;
 
    _init_common (kms, log, MONGOCRYPT_KMS_GCP_OAUTH);
    status = kms->status;
    auth_endpoint = crypt_opts->kms_provider_gcp.endpoint;
+   ctx_with_status.ctx = crypt_opts;
+   ctx_with_status.status = mongocrypt_status_new ();
 
    if (auth_endpoint) {
       kms->endpoint = bson_strdup (auth_endpoint->host_and_port);
@@ -1148,7 +1190,7 @@ _mongocrypt_kms_ctx_init_gcp_auth (mongocrypt_kms_ctx_t *kms,
    kms_request_opt_set_provider (opt, KMS_REQUEST_PROVIDER_GCP);
    if (crypt_opts->sign_rsaes_pkcs1_v1_5) {
       kms_request_opt_set_crypto_hook_sign_rsaes_pkcs1_v1_5 (
-         opt, _sign_rsaes_pkcs1_v1_5_trampoline, crypt_opts);
+         opt, _sign_rsaes_pkcs1_v1_5_trampoline, &ctx_with_status);
    }
    kms->req = kms_gcp_request_oauth_new (
       host,
@@ -1161,6 +1203,7 @@ _mongocrypt_kms_ctx_init_gcp_auth (mongocrypt_kms_ctx_t *kms,
    if (kms_request_get_error (kms->req)) {
       CLIENT_ERR ("error constructing KMS message: %s",
                   kms_request_get_error (kms->req));
+      _mongocrypt_status_wrap (status, ctx_with_status.status);
       goto fail;
    }
 
@@ -1168,6 +1211,7 @@ _mongocrypt_kms_ctx_init_gcp_auth (mongocrypt_kms_ctx_t *kms,
    if (!request_string) {
       CLIENT_ERR ("error getting GCP OAuth KMS message: %s",
                   kms_request_get_error (kms->req));
+      _mongocrypt_status_wrap (status, ctx_with_status.status);
       goto fail;
    }
    _mongocrypt_buffer_init (&kms->msg);
@@ -1180,6 +1224,7 @@ fail:
    bson_free (scope);
    bson_free (audience);
    kms_request_opt_destroy (opt);
+   mongocrypt_status_destroy (ctx_with_status.status);
    return ret;
 }
 

--- a/src/mongocrypt-status-private.h
+++ b/src/mongocrypt-status-private.h
@@ -26,8 +26,14 @@ _mongocrypt_status_copy_to (mongocrypt_status_t *src, mongocrypt_status_t *dst);
 void
 _mongocrypt_status_reset (mongocrypt_status_t *status);
 
+/* Append the message of @to_append in @status.
+ * Example:
+ * - @status has the message "status error"
+ * - @to_append has the message "append error"
+ * After calling, @status will have the message: "status error: append error"
+ */
 void
-_mongocrypt_status_wrap (mongocrypt_status_t *status,
-                         mongocrypt_status_t *to_wrap);
+_mongocrypt_status_append (mongocrypt_status_t *status,
+                           mongocrypt_status_t *to_append);
 
 #endif /* MONGOCRYPT_STATUS_PRIVATE_H */

--- a/src/mongocrypt-status-private.h
+++ b/src/mongocrypt-status-private.h
@@ -26,4 +26,8 @@ _mongocrypt_status_copy_to (mongocrypt_status_t *src, mongocrypt_status_t *dst);
 void
 _mongocrypt_status_reset (mongocrypt_status_t *status);
 
+void
+_mongocrypt_status_wrap (mongocrypt_status_t *status,
+                         mongocrypt_status_t *to_wrap);
+
 #endif /* MONGOCRYPT_STATUS_PRIVATE_H */

--- a/src/mongocrypt-status.c
+++ b/src/mongocrypt-status.c
@@ -151,14 +151,14 @@ mongocrypt_status_destroy (mongocrypt_status_t *status)
 
 
 void
-_mongocrypt_status_wrap (mongocrypt_status_t *status,
-                         mongocrypt_status_t *to_wrap)
+_mongocrypt_status_append (mongocrypt_status_t *status,
+                           mongocrypt_status_t *to_append)
 {
    char *orig = status->message;
 
-   if (mongocrypt_status_ok (to_wrap)) {
+   if (mongocrypt_status_ok (to_append)) {
       return;
    }
-   status->message = bson_strdup_printf ("%s: %s", orig, to_wrap->message);
+   status->message = bson_strdup_printf ("%s: %s", orig, to_append->message);
    bson_free (orig);
 }

--- a/src/mongocrypt-status.c
+++ b/src/mongocrypt-status.c
@@ -148,3 +148,17 @@ mongocrypt_status_destroy (mongocrypt_status_t *status)
    bson_free (status->message);
    bson_free (status);
 }
+
+
+void
+_mongocrypt_status_wrap (mongocrypt_status_t *status,
+                         mongocrypt_status_t *to_wrap)
+{
+   char *orig = status->message;
+
+   if (mongocrypt_status_ok (to_wrap)) {
+      return;
+   }
+   status->message = bson_strdup_printf ("%s: %s", orig, to_wrap->message);
+   bson_free (orig);
+}

--- a/test/test-mongocrypt-crypto-hooks.c
+++ b/test/test-mongocrypt-crypto-hooks.c
@@ -80,7 +80,7 @@ _aes_256_cbc_encrypt (void *ctx,
    bson_string_append_printf (call_history, "ret:%s\n", BSON_FUNC);
    if (0 == strcmp ((char *) ctx, "error_on:aes_256_cbc_encrypt")) {
       mongocrypt_status_set (
-         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, "error message", -1);
+         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char*) ctx, -1);
       return false;
    }
    return true;
@@ -106,7 +106,7 @@ _aes_256_cbc_decrypt (void *ctx,
    bson_string_append_printf (call_history, "ret:%s\n", BSON_FUNC);
    if (0 == strcmp ((char *) ctx, "error_on:aes_256_cbc_decrypt")) {
       mongocrypt_status_set (
-         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, "error message", -1);
+         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char*) ctx, -1);
       return false;
    }
    return true;
@@ -133,7 +133,7 @@ _hmac_sha_512 (void *ctx,
    _mongocrypt_buffer_cleanup (&tmp);
    if (0 == strcmp ((char *) ctx, "error_on:hmac_sha512")) {
       mongocrypt_status_set (
-         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, "error message", -1);
+         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char*) ctx, -1);
       return false;
    }
    return true;
@@ -160,7 +160,7 @@ _hmac_sha_256 (void *ctx,
    _mongocrypt_buffer_cleanup (&tmp);
    if (0 == strcmp ((char *) ctx, "error_on:hmac_sha256")) {
       mongocrypt_status_set (
-         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, "error message", -1);
+         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char*) ctx, -1);
       return false;
    }
    return true;
@@ -185,7 +185,7 @@ _sha_256 (void *ctx,
    _mongocrypt_buffer_cleanup (&tmp);
    if (0 == strcmp ((char *) ctx, "error_on:sha256")) {
       mongocrypt_status_set (
-         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, "error message", -1);
+         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char*) ctx, -1);
       return false;
    }
    return true;
@@ -211,7 +211,7 @@ _random (void *ctx,
    _mongocrypt_buffer_cleanup (&tmp);
    if (0 == strcmp ((char *) ctx, "error_on:random")) {
       mongocrypt_status_set (
-         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, "error message", -1);
+         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char*) ctx, -1);
       return false;
    }
    return true;
@@ -239,7 +239,7 @@ _sign_rsaes_pkcs1_v1_5 (void *ctx,
    _mongocrypt_buffer_cleanup (&tmp);
    if (0 == strcmp ((char *) ctx, "error_on:sign_rsaes_pkcs1_v1_5")) {
       mongocrypt_status_set (
-         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, "error message", -1);
+         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char*) ctx, -1);
       return false;
    }
    return true;
@@ -336,7 +336,7 @@ _test_crypto_hooks_encryption_helper (_mongocrypt_tester_t *tester,
                                                             BBBB + padding. */
                  HMAC_HEX_TAG));
    } else {
-      ASSERT_FAILS_STATUS (ret, status, "error message");
+      ASSERT_FAILS_STATUS (ret, status, error_on);
    }
 
 
@@ -413,7 +413,7 @@ _test_crypto_hooks_decryption_helper (_mongocrypt_tester_t *tester,
       /* Check the resulting plaintext */
       BSON_ASSERT (0 == _mongocrypt_buffer_cmp_hex (&plaintext, "BBBB"));
    } else {
-      ASSERT_FAILS_STATUS (ret, status, "error message");
+      ASSERT_FAILS_STATUS (ret, status, error_on);
    }
 
    _mongocrypt_buffer_cleanup (&key);
@@ -472,7 +472,7 @@ _test_crypto_hooks_iv_gen_helper (_mongocrypt_tester_t *tester, char *error_on)
       /* Check the resulting iv */
       BSON_ASSERT (0 == _mongocrypt_buffer_cmp_hex (&iv, expected_iv));
    } else {
-      ASSERT_FAILS_STATUS (ret, status, "error message");
+      ASSERT_FAILS_STATUS (ret, status, error_on);
    }
 
    bson_free (expected_iv);
@@ -524,7 +524,7 @@ _test_crypto_hooks_random_helper (_mongocrypt_tester_t *tester,
       /* Check the resulting iv */
       BSON_ASSERT (0 == _mongocrypt_buffer_cmp_hex (&random, RANDOM_HEX));
    } else {
-      ASSERT_FAILS_STATUS (ret, status, "error message");
+      ASSERT_FAILS_STATUS (ret, status, error_on);
    }
 
    _mongocrypt_buffer_cleanup (&random);
@@ -541,14 +541,15 @@ _test_crypto_hooks_random (_mongocrypt_tester_t *tester)
 }
 
 static void
-_test_kms_request (_mongocrypt_tester_t *tester)
+_test_kms_request_helper (_mongocrypt_tester_t *tester, const char* error_on)
 {
    mongocrypt_t *crypt;
    mongocrypt_status_t *status;
    mongocrypt_ctx_t *ctx;
+   bool ret;
 
    status = mongocrypt_status_new ();
-   crypt = _create_mongocrypt (tester, "error_on:none");
+   crypt = _create_mongocrypt (tester, error_on);
    ctx = mongocrypt_ctx_new (crypt);
 
    call_history = bson_string_new (NULL);
@@ -556,17 +557,31 @@ _test_kms_request (_mongocrypt_tester_t *tester)
    ASSERT_OK (
       mongocrypt_ctx_setopt_masterkey_aws (ctx, "us-east-1", -1, "cmk", -1),
       ctx);
-   ASSERT_OK (mongocrypt_ctx_datakey_init (ctx), ctx);
 
-   /* The call history includes some random data, just assert we've called our
-    * hooks. */
-   BSON_ASSERT (strstr (call_history->str, "call:_hmac_sha_256"));
-   BSON_ASSERT (strstr (call_history->str, "call:_sha_256"));
+   mongocrypt_ctx_datakey_init (ctx);
+   ret = mongocrypt_ctx_status (ctx, status);
+   
+   if (0 == strcmp (error_on, "error_on:none")) {
+      ASSERT_OK_STATUS (ret, status);
+
+      /* The call history includes some random data, just assert we've called our hooks. */
+      BSON_ASSERT (strstr (call_history->str, "call:_hmac_sha_256"));
+      BSON_ASSERT (strstr (call_history->str, "call:_sha_256"));
+   } else {
+      ASSERT_FAILS_STATUS (ret, status, error_on);
+   }
 
    mongocrypt_ctx_destroy (ctx);
    mongocrypt_status_destroy (status);
    mongocrypt_destroy (crypt);
    bson_string_free (call_history, true);
+}
+
+static void
+_test_kms_request (_mongocrypt_tester_t *tester) {
+   _test_kms_request_helper (tester, "error_on:none");
+   _test_kms_request_helper (tester, "error_on:hmac_sha256");
+   _test_kms_request_helper (tester, "error_on:sha256");
 }
 
 
@@ -677,7 +692,7 @@ _test_crypto_hook_sign_rsaes_pkcs1_v1_5 (_mongocrypt_tester_t *tester)
       TEST_BSON ("{'provider': 'gcp', 'projectId': 'test', 'location': "
                  "'global', 'keyRing': 'ring', 'keyName': 'key'}"));
    ASSERT_FAILS (
-      mongocrypt_ctx_datakey_init (ctx), ctx, "error constructing KMS message");
+      mongocrypt_ctx_datakey_init (ctx), ctx, "error_on:sign_rsaes_pkcs1_v1_5");
 
    mongocrypt_ctx_destroy (ctx);
    mongocrypt_destroy (crypt);
@@ -695,7 +710,7 @@ _test_crypto_hook_sign_rsaes_pkcs1_v1_5 (_mongocrypt_tester_t *tester)
    ASSERT_FAILS (mongocrypt_ctx_mongo_feed (
                     ctx, TEST_FILE ("./test/data/key-document-gcp.json")),
                  ctx,
-                 "error constructing KMS message");
+                 "error_on:sign_rsaes_pkcs1_v1_5");
 
    mongocrypt_ctx_destroy (ctx);
    mongocrypt_destroy (crypt);

--- a/test/test-mongocrypt-crypto-hooks.c
+++ b/test/test-mongocrypt-crypto-hooks.c
@@ -80,7 +80,7 @@ _aes_256_cbc_encrypt (void *ctx,
    bson_string_append_printf (call_history, "ret:%s\n", BSON_FUNC);
    if (0 == strcmp ((char *) ctx, "error_on:aes_256_cbc_encrypt")) {
       mongocrypt_status_set (
-         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char*) ctx, -1);
+         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char *) ctx, -1);
       return false;
    }
    return true;
@@ -106,7 +106,7 @@ _aes_256_cbc_decrypt (void *ctx,
    bson_string_append_printf (call_history, "ret:%s\n", BSON_FUNC);
    if (0 == strcmp ((char *) ctx, "error_on:aes_256_cbc_decrypt")) {
       mongocrypt_status_set (
-         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char*) ctx, -1);
+         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char *) ctx, -1);
       return false;
    }
    return true;
@@ -133,7 +133,7 @@ _hmac_sha_512 (void *ctx,
    _mongocrypt_buffer_cleanup (&tmp);
    if (0 == strcmp ((char *) ctx, "error_on:hmac_sha512")) {
       mongocrypt_status_set (
-         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char*) ctx, -1);
+         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char *) ctx, -1);
       return false;
    }
    return true;
@@ -160,7 +160,7 @@ _hmac_sha_256 (void *ctx,
    _mongocrypt_buffer_cleanup (&tmp);
    if (0 == strcmp ((char *) ctx, "error_on:hmac_sha256")) {
       mongocrypt_status_set (
-         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char*) ctx, -1);
+         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char *) ctx, -1);
       return false;
    }
    return true;
@@ -185,7 +185,7 @@ _sha_256 (void *ctx,
    _mongocrypt_buffer_cleanup (&tmp);
    if (0 == strcmp ((char *) ctx, "error_on:sha256")) {
       mongocrypt_status_set (
-         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char*) ctx, -1);
+         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char *) ctx, -1);
       return false;
    }
    return true;
@@ -211,7 +211,7 @@ _random (void *ctx,
    _mongocrypt_buffer_cleanup (&tmp);
    if (0 == strcmp ((char *) ctx, "error_on:random")) {
       mongocrypt_status_set (
-         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char*) ctx, -1);
+         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char *) ctx, -1);
       return false;
    }
    return true;
@@ -239,7 +239,7 @@ _sign_rsaes_pkcs1_v1_5 (void *ctx,
    _mongocrypt_buffer_cleanup (&tmp);
    if (0 == strcmp ((char *) ctx, "error_on:sign_rsaes_pkcs1_v1_5")) {
       mongocrypt_status_set (
-         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char*) ctx, -1);
+         status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char *) ctx, -1);
       return false;
    }
    return true;
@@ -541,7 +541,7 @@ _test_crypto_hooks_random (_mongocrypt_tester_t *tester)
 }
 
 static void
-_test_kms_request_helper (_mongocrypt_tester_t *tester, const char* error_on)
+_test_kms_request_helper (_mongocrypt_tester_t *tester, const char *error_on)
 {
    mongocrypt_t *crypt;
    mongocrypt_status_t *status;
@@ -560,11 +560,12 @@ _test_kms_request_helper (_mongocrypt_tester_t *tester, const char* error_on)
 
    mongocrypt_ctx_datakey_init (ctx);
    ret = mongocrypt_ctx_status (ctx, status);
-   
+
    if (0 == strcmp (error_on, "error_on:none")) {
       ASSERT_OK_STATUS (ret, status);
 
-      /* The call history includes some random data, just assert we've called our hooks. */
+      /* The call history includes some random data, just assert we've called
+       * our hooks. */
       BSON_ASSERT (strstr (call_history->str, "call:_hmac_sha_256"));
       BSON_ASSERT (strstr (call_history->str, "call:_sha_256"));
    } else {
@@ -578,7 +579,8 @@ _test_kms_request_helper (_mongocrypt_tester_t *tester, const char* error_on)
 }
 
 static void
-_test_kms_request (_mongocrypt_tester_t *tester) {
+_test_kms_request (_mongocrypt_tester_t *tester)
+{
    _test_kms_request_helper (tester, "error_on:none");
    _test_kms_request_helper (tester, "error_on:hmac_sha256");
    _test_kms_request_helper (tester, "error_on:sha256");
@@ -624,7 +626,8 @@ _test_crypto_hooks_explicit_err (_mongocrypt_tester_t *tester)
 
    _mongocrypt_tester_run_ctx_to (tester, ctx, MONGOCRYPT_CTX_READY);
    bin = mongocrypt_binary_new ();
-   ASSERT_FAILS (mongocrypt_ctx_finalize (ctx, bin), ctx, "error message");
+   ASSERT_FAILS (
+      mongocrypt_ctx_finalize (ctx, bin), ctx, "error_on:hmac_sha512");
    BSON_ASSERT (MONGOCRYPT_CTX_ERROR == mongocrypt_ctx_state (ctx));
    mongocrypt_binary_destroy (bin);
    mongocrypt_binary_destroy (key_id);


### PR DESCRIPTION
The KMS message crypto hooks (`kms_sha256`, `kms_sha256_hmac`, `kms_sign_rsaes_pkcs1_v1_5`) did not expose an out parameter for an error message, so an error in one of those hooks would be returned as a generic error message through libmongocrypt like `error constructing KMS message`.

The changes here wrap the passed context with a `mongocrypt_status_t` so the error message is returned through libmongocrypt.