### PR TITLE
MONGOCRYPT-302 support sessionToken

### DIFF
--- a/src/mongocrypt-kms-ctx.c
+++ b/src/mongocrypt-kms-ctx.c
@@ -168,6 +168,12 @@ _mongocrypt_kms_ctx_init_aws_decrypt (mongocrypt_kms_ctx_t *kms,
    kms_request_opt_destroy (opt);
    kms_request_set_service (kms->req, "kms");
 
+   if (crypt_opts->kms_provider_aws.session_token) {
+      kms_request_add_header_field (kms->req,
+                                    "X-Amz-Security-Token",
+                                    crypt_opts->kms_provider_aws.session_token);
+   }
+
    if (kms_request_get_error (kms->req)) {
       CLIENT_ERR ("error constructing KMS message: %s",
                   kms_request_get_error (kms->req));

--- a/src/mongocrypt-kms-ctx.c
+++ b/src/mongocrypt-kms-ctx.c
@@ -280,6 +280,12 @@ _mongocrypt_kms_ctx_init_aws_encrypt (
    kms_request_opt_destroy (opt);
    kms_request_set_service (kms->req, "kms");
 
+   if (crypt_opts->kms_provider_aws.session_token) {
+      kms_request_add_header_field (kms->req,
+                                    "X-Amz-Security-Token",
+                                    crypt_opts->kms_provider_aws.session_token);
+   }
+
    if (kms_request_get_error (kms->req)) {
       CLIENT_ERR ("error constructing KMS message: %s",
                   kms_request_get_error (kms->req));

--- a/src/mongocrypt-opts-private.h
+++ b/src/mongocrypt-opts-private.h
@@ -41,6 +41,7 @@ typedef struct {
 typedef struct {
    char *secret_access_key;
    char *access_key_id;
+   char *session_token;
 } _mongocrypt_opts_kms_provider_aws_t;
 
 typedef struct {

--- a/src/mongocrypt-opts.c
+++ b/src/mongocrypt-opts.c
@@ -53,6 +53,7 @@ _mongocrypt_opts_cleanup (_mongocrypt_opts_t *opts)
 {
    bson_free (opts->kms_provider_aws.secret_access_key);
    bson_free (opts->kms_provider_aws.access_key_id);
+   bson_free (opts->kms_provider_aws.session_token);
    _mongocrypt_buffer_cleanup (&opts->kms_provider_local.key);
    _mongocrypt_buffer_cleanup (&opts->schema_map);
    _mongocrypt_opts_kms_provider_azure_cleanup (&opts->kms_provider_azure);

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -719,11 +719,20 @@ mongocrypt_setopt_kms_providers (mongocrypt_t *crypt,
             return false;
          }
 
+         if (!_mongocrypt_parse_optional_utf8 (
+                &as_bson,
+                "aws.sessionToken",
+                &crypt->opts.kms_provider_aws.session_token,
+                crypt->status)) {
+            return false;
+         }
+
          if (!_mongocrypt_check_allowed_fields (&as_bson,
                                                 "aws",
                                                 crypt->status,
                                                 "accessKeyId",
-                                                "secretAccessKey")) {
+                                                "secretAccessKey",
+                                                "sessionToken")) {
             return false;
          }
          crypt->opts.kms_providers |= MONGOCRYPT_KMS_PROVIDER_AWS;

--- a/test/test-mongocrypt.h
+++ b/test/test-mongocrypt.h
@@ -171,6 +171,17 @@ _mongocrypt_tester_mongocrypt (void);
       BSON_ASSERT (0 == _ret);                                            \
    } while (0);
 
+#define ASSERT_STRCONTAINS(_expr_a, _expr_b)                                  \
+   do {                                                                       \
+      const char *_str_a = (_expr_a);                                         \
+      const char *_str_b = (_expr_b);                                         \
+      char *_ret = strstr (_str_a, _str_b);                                   \
+      if (_ret == NULL) {                                                     \
+         fprintf (stderr, "string %s does not contain %s\n", _str_a, _str_b); \
+      }                                                                       \
+      BSON_ASSERT (NULL != _ret);                                             \
+   } while (0);
+
 void
 _assert_bin_bson_equal (mongocrypt_binary_t *bin_a, mongocrypt_binary_t *bin_b);
 


### PR DESCRIPTION
Adds support for passing an AWS session token through to KMS requests.

This includes a unit test to ensure the correct `X-Amz-Security-Token` header is produced. libmongocrypt currently does not run integration tests on Evergreen. MONGOCRYPT-268 added a small command-line utility that uses libmongoc to  run the full state machine. It is not currently built in evergreen. But I used this to run a manual end-to-end test of the session token support with this script: https://gist.github.com/kevinAlbs/e6ba83450427577971beba3c5a417a77