### PR TITLE
chore(node-binding): Add initial typings MONGOSH-527

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -46,6 +46,15 @@ npm test
 <dt><a href="#KMSProviders">KMSProviders</a> : <code>object</code></dt>
 <dd><p>Configuration options that are used by specific KMS providers during key generation, encryption, and decryption.</p>
 </dd>
+<dt><a href="#AWSEncryptionKeyOptions">AWSEncryptionKeyOptions</a> : <code>object</code></dt>
+<dd><p>Configuration options for making an AWS encryption key</p>
+</dd>
+<dt><a href="#GCPEncryptionKeyOptions">GCPEncryptionKeyOptions</a> : <code>object</code></dt>
+<dd><p>Configuration options for making a GCP encryption key</p>
+</dd>
+<dt><a href="#AzureEncryptionKeyOptions">AzureEncryptionKeyOptions</a> : <code>object</code></dt>
+<dd><p>Configuration options for making an Azure encryption key</p>
+</dd>
 </dl>
 
 <a name="AutoEncrypter"></a>
@@ -141,7 +150,7 @@ Configuration options for a automatic client encryption.
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| [mongocryptURI] | <code>string</code> |  | A local process the driver communicates with to determine how to encrypt values in a command. Defaults to "mongodb://%2Fvar%2Fmongocryptd.sock" if domain sockets are available or "mongodb://localhost:27020" otherwise |
+| [mongocryptdURI] | <code>string</code> |  | A local process the driver communicates with to determine how to encrypt values in a command. Defaults to "mongodb://%2Fvar%2Fmongocryptd.sock" if domain sockets are available or "mongodb://localhost:27020" otherwise |
 | [mongocryptdBypassSpawn] | <code>boolean</code> | <code>false</code> | If true, autoEncryption will not attempt to spawn a mongocryptd before connecting |
 | [mongocryptdSpawnPath] | <code>string</code> |  | The path to the mongocryptd executable on the system |
 | [mongocryptdSpawnArgs] | <code>Array.&lt;string&gt;</code> |  | Command line arguments to use when auto-spawning a mongocryptd |
@@ -196,6 +205,7 @@ The public interface for explicit client side encryption
 | client | <code>MongoClient</code> | The client used for encryption |
 | options | <code>object</code> | Optional settings |
 | options.keyVaultNamespace | <code>string</code> | The namespace of the key vault, used to store encryption keys |
+| [options.keyVaultClient] | <code>MongoClient</code> | A `MongoClient` used to fetch keys from a key vault. Defaults to `client` |
 | [options.kmsProviders] | [<code>KMSProviders</code>](#KMSProviders) | options for specific KMS providers to use |
 
 Create a new encryption instance
@@ -229,12 +239,9 @@ new ClientEncryption(mongoClient, {
 
 | Param | Type | Description |
 | --- | --- | --- |
-| provider | <code>string</code> | The KMS provider used for this data key. Must be `'aws'` or `'local'` |
+| provider | <code>string</code> | The KMS provider used for this data key. Must be `'aws'`, `'azure'`, `'gcp'`, or `'local'` |
 | [options] | <code>object</code> | Options for creating the data key |
-| [options.masterKey] | <code>object</code> | Idenfities a new KMS-specific key used to encrypt the new data key. If the kmsProvider is "aws" it is required. |
-| [options.masterKey.region] | <code>string</code> | The AWS region of the KMS |
-| [options.masterKey.key] | <code>string</code> | The Amazon Resource Name (ARN) to the AWS customer master key (CMK) |
-| [options.masterKey.endpoint] | <code>string</code> | An alternate host to send KMS requests to. May include port number. |
+| [options.masterKey] | [<code>AWSEncryptionKeyOptions</code>](#AWSEncryptionKeyOptions) \| [<code>AzureEncryptionKeyOptions</code>](#AzureEncryptionKeyOptions) \| [<code>GCPEncryptionKeyOptions</code>](#GCPEncryptionKeyOptions) | Idenfities a new KMS-specific key used to encrypt the new data key |
 | [options.keyAltNames] | <code>Array.&lt;string&gt;</code> | An optional list of string alternate names used to reference a key. If a key is created with alternate names, then encryption may refer to the key by the unique alternate name instead of by _id. |
 | [callback] | [<code>createDataKeyCallback</code>](#ClientEncryption..createDataKeyCallback) | Optional callback to invoke when key is created |
 
@@ -400,6 +407,57 @@ An error indicating that something went wrong specifically with MongoDB Client E
 | [aws.secretAccessKey] | <code>string</code> | The secret access key used for the AWS KMS provider |
 | [local] | <code>object</code> | Configuration options for using 'local' as your KMS provider |
 | [local.key] | <code>Buffer</code> | The master key used to encrypt/decrypt data keys. A 96-byte long Buffer. |
+| [azure] | <code>object</code> | Configuration options for using 'azure' as your KMS provider |
+| [azure.tenantId] | <code>string</code> | The tenant ID identifies the organization for the account |
+| [azure.clientId] | <code>string</code> | The client ID to authenticate a registered application |
+| [azure.clientSecret] | <code>string</code> | The client secret to authenticate a registered application |
+| [azure.identityPlatformEndpoint] | <code>string</code> | If present, a host with optional port. E.g. "example.com" or "example.com:443". This is optional, and only needed if customer is using a non-commercial Azure instance (e.g. a government or China account, which use different URLs). Defaults to  "login.microsoftonline.com" |
+| [gcp] | <code>object</code> | Configuration options for using 'gcp' as your KMS provider |
+| [gcp.email] | <code>string</code> | The service account email to authenticate |
+| [gcp.privateKey] | <code>string</code> \| <code>Binary</code> | A PKCS#8 encrypted key. This can either be a base64 string or a binary representation |
+| [gcp.endpoint] | <code>string</code> | If present, a host with optional port. E.g. "example.com" or "example.com:443". Defaults to "oauth2.googleapis.com" |
 
 Configuration options that are used by specific KMS providers during key generation, encryption, and decryption.
+
+<a name="AWSEncryptionKeyOptions"></a>
+
+## AWSEncryptionKeyOptions
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| region | <code>string</code> | The AWS region of the KMS |
+| key | <code>string</code> | The Amazon Resource Name (ARN) to the AWS customer master key (CMK) |
+| endpoint | <code>string</code> | An alternate host to send KMS requests to. May include port number |
+
+Configuration options for making an AWS encryption key
+
+<a name="GCPEncryptionKeyOptions"></a>
+
+## GCPEncryptionKeyOptions
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| projectId | <code>string</code> | GCP project id |
+| location | <code>string</code> | Location name (e.g. "global") |
+| keyRing | <code>string</code> | Key ring name |
+| keyName | <code>string</code> | Key name |
+| keyVersion | <code>string</code> | Key version |
+| endpoint | <code>string</code> | KMS URL, defaults to `https://www.googleapis.com/auth/cloudkms` |
+
+Configuration options for making a GCP encryption key
+
+<a name="AzureEncryptionKeyOptions"></a>
+
+## AzureEncryptionKeyOptions
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| keyName | <code>string</code> | Key name |
+| keyVersion | <code>string</code> | Key version |
+| keyVaultEndpoint | <code>string</code> | Key vault URL, typically `<name>.vault.azure.net` |
+
+Configuration options for making an Azure encryption key
 

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -203,7 +203,7 @@ The public interface for explicit client side encryption
 | Param | Type | Description |
 | --- | --- | --- |
 | client | <code>MongoClient</code> | The client used for encryption |
-| options | <code>object</code> | Optional settings |
+| options | <code>object</code> | Additional settings |
 | options.keyVaultNamespace | <code>string</code> | The namespace of the key vault, used to store encryption keys |
 | [options.keyVaultClient] | <code>MongoClient</code> | A `MongoClient` used to fetch keys from a key vault. Defaults to `client` |
 | [options.kmsProviders] | [<code>KMSProviders</code>](#KMSProviders) | options for specific KMS providers to use |
@@ -428,7 +428,7 @@ Configuration options that are used by specific KMS providers during key generat
 | --- | --- | --- |
 | region | <code>string</code> | The AWS region of the KMS |
 | key | <code>string</code> | The Amazon Resource Name (ARN) to the AWS customer master key (CMK) |
-| endpoint | <code>string</code> | An alternate host to send KMS requests to. May include port number |
+| [endpoint] | <code>string</code> | An alternate host to send KMS requests to. May include port number |
 
 Configuration options for making an AWS encryption key
 
@@ -443,8 +443,8 @@ Configuration options for making an AWS encryption key
 | location | <code>string</code> | Location name (e.g. "global") |
 | keyRing | <code>string</code> | Key ring name |
 | keyName | <code>string</code> | Key name |
-| keyVersion | <code>string</code> | Key version |
-| endpoint | <code>string</code> | KMS URL, defaults to `https://www.googleapis.com/auth/cloudkms` |
+| [keyVersion] | <code>string</code> | Key version |
+| [endpoint] | <code>string</code> | KMS URL, defaults to `https://www.googleapis.com/auth/cloudkms` |
 
 Configuration options for making a GCP encryption key
 
@@ -456,8 +456,8 @@ Configuration options for making a GCP encryption key
 | Name | Type | Description |
 | --- | --- | --- |
 | keyName | <code>string</code> | Key name |
-| keyVersion | <code>string</code> | Key version |
 | keyVaultEndpoint | <code>string</code> | Key vault URL, typically `<name>.vault.azure.net` |
+| [keyVersion] | <code>string</code> | Key version |
 
 Configuration options for making an Azure encryption key
 

--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -1,0 +1,225 @@
+import type { Binary } from 'bson';
+
+export type ClientEncryptionDataKeyProvider = 'aws' | 'local';
+
+/**
+ * An error indicating that something went wrong specifically with MongoDB Client Encryption
+ */
+export class MongoCryptError extends Error {
+}
+
+export interface ClientEncryptionCreateDataKeyCallback {
+  /**
+   * @param error If present, indicates an error that occurred in the creation of the data key
+   * @param dataKeyId If present, returns the id of the created data key
+   */
+  (error?: Error, dataKeyId?: Binary): void;
+}
+
+export interface ClientEncryptionEncryptCallback {
+  /**
+   * @param error If present, indicates an error that occurred in the process of encryption
+   * @param result If present, is the encrypted result
+   */
+  (error?: Error, result?: Binary): void;
+}
+
+export interface ClientEncryptionDecryptCallback {
+  /**
+   * @param error If present, indicates an error that occurred in the process of decryption
+   * @param result If present, is the decrypted result
+   */
+  (error?: Error, result?: any): void;
+}
+
+/**
+ * Configuration options that are used by specific KMS providers during key generation, encryption, and decryption.
+ */
+export interface KMSProviders {
+  /**
+   * Configuration options for using 'aws' as your KMS provider
+   */
+  aws?: {
+    /**
+     * The access key used for the AWS KMS provider
+     */
+    accessKeyId?: string | undefined;
+
+    /**
+     * The secret access key used for the AWS KMS provider
+     */
+    secretAccessKey?: string | undefined;
+  };
+
+  /**
+   * Configuration options for using 'local' as your KMS provider
+   */
+  local?: {
+    /**
+     * The master key used to encrypt/decrypt data keys. A 96-byte long Buffer.
+     */
+    key?: Buffer | undefined;
+  };
+}
+
+/**
+ * Optional settings to provide when creating a new `ClientEncryption` instance.
+ */
+export interface ClientEncryptionOptions {
+  /**
+   * The namespace of the key vault, used to store encryption keys
+   */
+  keyVaultNamespace?: string | undefined;
+
+  /**
+   * Options for specific KMS providers to use
+   */
+  kmsProviders?: KMSProviders | undefined;
+}
+
+/**
+ * Options to provide when creating a new data key.
+ */
+export interface ClientEncryptionCreateDataKeyProviderOptions {
+  /**
+   * Idenfities a new KMS-specific key used to encrypt the new data key. If the kmsProvider is "aws" it is required.
+   */
+  masterKey?: {
+    /**
+     * The AWS region of the KMS
+     */
+    region?: string | undefined;
+
+    /**
+     * The Amazon Resource Name (ARN) to the AWS customer master key (CMK)
+     */
+    key?: string | undefined;
+
+    /**
+     * An alternate host to send KMS requests to. May include port number.
+     */
+    endpoint?: string | undefined;
+  };
+
+  /**
+   * An optional list of string alternate names used to reference a key.
+   * If a key is created with alternate names, then encryption may refer to the key by the unique alternate name instead of by _id.
+   */
+  keyAltNames?: string[] | undefined;
+}
+
+/**
+ * Options to provide when encrypting data.
+ */
+export interface ClientEncryptionEncryptOptions {
+  /**
+   * The algorithm to use for encryption.
+   */
+  algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic' | 'AEAD_AES_256_CBC_HMAC_SHA_512-Random';
+
+  /**
+   * The id of the Binary dataKey to use for encryption
+   */
+  keyId?: Binary | undefined;
+
+  /**
+   * A unique string name corresponding to an already existing dataKey.
+   */
+  keyAltName?: string | undefined;
+}
+
+/**
+ * The public interface for explicit client side encrption.
+ */
+export class ClientEncryption {
+  /**
+   * Create a new encryption instance.
+   * @param client The client used for encryption
+   * @param options Optional settings
+   */
+  constructor(client: MongoClient, options?: ClientEncryptionOptions);
+
+  /**
+   * Creates a data key used for explicit encryption and inserts it into the key vault namespace
+   * @param provider The KMS provider used for this data key. Must be 'aws' or 'local'
+   */
+  createDataKey(
+    provider: ClientEncryptionDataKeyProvider
+  ): Promise<Binary>;
+
+  /**
+   * Creates a data key used for explicit encryption and inserts it into the key vault namespace
+   * @param provider The KMS provider used for this data key. Must be 'aws' or 'local'
+   * @param options Options for creating the data key
+   */
+  createDataKey(
+    provider: ClientEncryptionDataKeyProvider,
+    options: ClientEncryptionCreateDataKeyProviderOptions
+  ): Promise<Binary>;
+
+  /**
+   * Creates a data key used for explicit encryption and inserts it into the key vault namespace
+   * @param provider The KMS provider used for this data key. Must be 'aws' or 'local'
+   * @param callback Callback to invoke when key is created
+   */
+  createDataKey(
+    provider: ClientEncryptionDataKeyProvider,
+    callback: ClientEncryptionCreateDataKeyCallback
+  ): void;
+
+  /**
+   * Creates a data key used for explicit encryption and inserts it into the key vault namespace
+   * @param provider The KMS provider used for this data key. Must be 'aws' or 'local'
+   * @param options Options for creating the data key
+   * @param callback Callback to invoke when key is created
+   */
+  createDataKey(
+    provider: ClientEncryptionDataKeyProvider,
+    options: ClientEncryptionCreateDataKeyProviderOptions,
+    callback: ClientEncryptionCreateDataKeyCallback
+  ): void;
+
+  /**
+   * Explicitly encrypt a provided value.
+   * Note that either options.keyId or options.keyAltName must be specified.
+   * Specifying both options.keyId and options.keyAltName is considered an error.
+   * @param value The value that you wish to serialize. Must be of a type that can be serialized into BSON
+   * @param options
+   */
+  encrypt(
+    value: any,
+    options: ClientEncryptionEncryptOptions
+  ): Promise<Binary>;
+
+  /**
+   * Explicitly encrypt a provided value.
+   * Note that either options.keyId or options.keyAltName must be specified.
+   * Specifying both options.keyId and options.keyAltName is considered an error.
+   * @param value The value that you wish to serialize. Must be of a type that can be serialized into BSON
+   * @param options
+   * @param callback Callback to invoke when value is encrypted
+   */
+  encrypt(
+    value: any,
+    options: ClientEncryptionEncryptOptions,
+    callback: ClientEncryptionEncryptCallback
+  ): void;
+
+  /**
+   * Explicitly decrypt a provided encrypted value
+   * @param value An encrypted value
+   */
+  decrypt(
+    value: Binary
+  ): Promise<any>;
+
+  /**
+   * Explicitly decrypt a provided encrypted value
+   * @param value An encrypted value
+   * @param callback Callback to invoke when value is decrypted
+   */
+  decrypt(
+    value: Binary,
+    callback: ClientEncryptionDecryptCallback
+  ): void;
+}

--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -44,12 +44,12 @@ export interface KMSProviders {
     /**
      * The access key used for the AWS KMS provider
      */
-    accessKeyId?: string | undefined;
+    accessKeyId: string;
 
     /**
      * The secret access key used for the AWS KMS provider
      */
-    secretAccessKey?: string | undefined;
+    secretAccessKey: string;
   };
 
   /**
@@ -57,9 +57,10 @@ export interface KMSProviders {
    */
   local?: {
     /**
-     * The master key used to encrypt/decrypt data keys. A 96-byte long Buffer.
+     * The master key used to encrypt/decrypt data keys.
+     * A 96-byte long Buffer or base64 encoded string.
      */
-    key?: Buffer | undefined;
+    key: Buffer | string;
   };
 
   /**
@@ -69,17 +70,17 @@ export interface KMSProviders {
     /**
      * The tenant ID identifies the organization for the account
      */
-    tenantId?: string | undefined;
+    tenantId: string;
 
     /**
      * The client ID to authenticate a registered application
      */
-    clientId?: string | undefined;
+    clientId: string;
 
     /**
      * The client secret to authenticate a registered application
      */
-    clientSecret?: string | undefined;
+    clientSecret: string;
 
     /**
      * If present, a host with optional port. E.g. "example.com" or "example.com:443".
@@ -97,12 +98,12 @@ export interface KMSProviders {
     /**
      * The service account email to authenticate
      */
-    email?: string | undefined;
+    email: string;
 
     /**
      * A PKCS#8 encrypted key. This can either be a base64 string or a binary representation
      */
-    privateKey?: string | Buffer | undefined;
+    privateKey: string | Buffer;
 
     /**
      * If present, a host with optional port. E.g. "example.com" or "example.com:443".
@@ -113,7 +114,7 @@ export interface KMSProviders {
 }
 
 /**
- * Optional settings to provide when creating a new `ClientEncryption` instance.
+ * Additional settings to provide when creating a new `ClientEncryption` instance.
  */
 export interface ClientEncryptionOptions {
   /**
@@ -129,7 +130,7 @@ export interface ClientEncryptionOptions {
   /**
    * Options for specific KMS providers to use
    */
-  kmsProviders?: KMSProviders | undefined;
+  kmsProviders?: KMSProviders;
 }
 
 /**
@@ -139,12 +140,12 @@ export interface AWSEncryptionKeyOptions {
   /**
    * The AWS region of the KMS
    */
-  region?: string | undefined;
+  region: string;
 
   /**
    * The Amazon Resource Name (ARN) to the AWS customer master key (CMK)
    */
-  key?: string | undefined;
+  key: string;
 
   /**
    * An alternate host to send KMS requests to. May include port number.
@@ -159,22 +160,22 @@ export interface GCPEncryptionKeyOptions {
   /**
    * GCP project ID
    */
-  projectId?: string | undefined;
+  projectId: string;
 
   /**
    * Location name (e.g. "global")
    */
-  location?: string | undefined;
+  location: string;
 
   /**
    * Key ring name
    */
-  keyRing?: string | undefined;
+  keyRing: string;
 
   /**
    * Key name
    */
-  keyName?: string | undefined;
+  keyName: string;
 
   /**
    * Key version
@@ -194,17 +195,17 @@ export interface AzureEncryptionKeyOptions {
   /**
    * Key name
    */
-  keyName?: string | undefined;
+  keyName: string;
+
+  /**
+   * Key vault URL, typically `<name>.vault.azure.net`
+   */
+  keyVaultEndpoint: string;
 
   /**
    * Key version
    */
   keyVersion?: string | undefined;
-
-  /**
-   * Key vault URL, typically `<name>.vault.azure.net`
-   */
-  keyVaultEndpoint?: string | undefined;
 }
 
 /**
@@ -250,9 +251,9 @@ export class ClientEncryption {
   /**
    * Create a new encryption instance.
    * @param client The client used for encryption
-   * @param options Optional settings
+   * @param options Additional settings
    */
-  constructor(client: MongoClient, options?: ClientEncryptionOptions);
+  constructor(client: MongoClient, options: ClientEncryptionOptions);
 
   /**
    * Creates a data key used for explicit encryption and inserts it into the key vault namespace

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -73,7 +73,7 @@ module.exports = function(modules) {
      * Create a new encryption instance
      *
      * @param {MongoClient} client The client used for encryption
-     * @param {object} options Optional settings
+     * @param {object} options Additional settings
      * @param {string} options.keyVaultNamespace The namespace of the key vault, used to store encryption keys
      * @param {MongoClient} [options.keyVaultClient] A `MongoClient` used to fetch keys from a key vault. Defaults to `client`
      * @param {KMSProviders} [options.kmsProviders] options for specific KMS providers to use
@@ -137,7 +137,7 @@ module.exports = function(modules) {
      * @description Configuration options for making an AWS encryption key
      * @property {string} region The AWS region of the KMS
      * @property {string} key The Amazon Resource Name (ARN) to the AWS customer master key (CMK)
-     * @property {string} endpoint An alternate host to send KMS requests to. May include port number
+     * @property {string} [endpoint] An alternate host to send KMS requests to. May include port number
      */
 
     /**
@@ -147,16 +147,16 @@ module.exports = function(modules) {
      * @property {string} location Location name (e.g. "global")
      * @property {string} keyRing Key ring name
      * @property {string} keyName Key name
-     * @property {string} keyVersion Key version
-     * @property {string} endpoint KMS URL, defaults to `https://www.googleapis.com/auth/cloudkms`
+     * @property {string} [keyVersion] Key version
+     * @property {string} [endpoint] KMS URL, defaults to `https://www.googleapis.com/auth/cloudkms`
      */
 
     /**
      * @typedef {object} AzureEncryptionKeyOptions
      * @description Configuration options for making an Azure encryption key
      * @property {string} keyName Key name
-     * @property {string} keyVersion Key version
      * @property {string} keyVaultEndpoint Key vault URL, typically `<name>.vault.azure.net`
+     * @property {string} [keyVersion] Key version
      */
 
     /**

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -143,7 +143,7 @@ module.exports = function(modules) {
     /**
      * @typedef {object} GCPEncryptionKeyOptions
      * @description Configuration options for making a GCP encryption key
-     * @property {string} projectId Azue project id
+     * @property {string} projectId GCP project id
      * @property {string} location Location name (e.g. "global")
      * @property {string} keyRing Key ring name
      * @property {string} keyName Key name
@@ -162,7 +162,7 @@ module.exports = function(modules) {
     /**
      * Creates a data key used for explicit encryption and inserts it into the key vault namespace
      *
-     * @param {string} provider The KMS provider used for this data key. Must be `'aws'` or `'local'`
+     * @param {string} provider The KMS provider used for this data key. Must be `'aws'`, `'azure'`, `'gcp'`, or `'local'`
      * @param {object} [options] Options for creating the data key
      * @param {AWSEncryptionKeyOptions|AzureEncryptionKeyOptions|GCPEncryptionKeyOptions} [options.masterKey] Idenfities a new KMS-specific key used to encrypt the new data key
      * @param {string[]} [options.keyAltNames] An optional list of string alternate names used to reference a key. If a key is created with alternate names, then encryption may refer to the key by the unique alternate name instead of by _id.

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.1-beta.0",
   "description": "Official client encryption module for the MongoDB Node.js driver",
   "main": "index.js",
+  "types": "index.d.ts",
   "directories": {
     "lib": "lib"
   },


### PR DESCRIPTION
This PR adds TypeScript definitions to the `mongodb-client-encryption` binding package.

The type definitions were created based on the generated README information from JSDoc as well as going in the source code, as not all comments were entirely precise.

Please have a thorough look.