### PR TITLE
MONGOCRYPT-304 Fix base64 URL safe padding

### DIFF
--- a/kms-message/src/kms_b64.c
+++ b/kms-message/src/kms_b64.c
@@ -519,10 +519,6 @@ kms_message_b64_to_b64url (const char *src,
    size_t i;
 
    for (i = 0; i < srclength; i++) {
-      if (src[i] == '=') {
-         break;
-      }
-
       if (i >= targsize) {
          return -1;
       }
@@ -553,10 +549,6 @@ kms_message_b64url_to_b64 (const char *src,
    size_t boundary;
 
    for (i = 0; i < srclength; i++) {
-      if (src[i] == '=') {
-         break;
-      }
-
       if (i >= targsize) {
          return -1;
       }

--- a/kms-message/test/test_kms_request.c
+++ b/kms-message/test/test_kms_request.c
@@ -788,8 +788,8 @@ b64_b64url_test (void)
                                     strlen (base64_data),
                                     base64url_data,
                                     sizeof (base64url_data));
-   ASSERT (ret == 10);
-   ASSERT_CMPSTR (base64url_data, "PDw_Pz8-Pg");
+   ASSERT (ret == 12);
+   ASSERT_CMPSTR (base64url_data, "PDw_Pz8-Pg==");
 
    memset (base64_data, 0, sizeof (base64_data));
    ret = kms_message_b64url_to_b64 (base64url_data,
@@ -802,8 +802,8 @@ b64_b64url_test (void)
    /* Convert to base64url in-place. */
    ret = kms_message_b64_to_b64url (
       base64_data, strlen (base64_data), base64_data, sizeof (base64_data));
-   ASSERT (ret == 10);
-   ASSERT_CMPSTR (base64_data, "PDw_Pz8-Pg");
+   ASSERT (ret == 12);
+   ASSERT_CMPSTR (base64_data, "PDw_Pz8-Pg==");
 }
 
 void

--- a/test/util/util.c
+++ b/test/util/util.c
@@ -677,7 +677,7 @@ _state_need_kms (_state_machine_t *state_machine, bson_error_t *error)
 
       if (state_machine->trace) {
          MONGOC_DEBUG (
-            "--> sending KMS message: \n%.*s", (int) iov.iov_len, iov.iov_base);
+            "--> sending KMS message: \n%.*s", (int) iov.iov_len, (char*) iov.iov_base);
       }
 
       if (!_mongoc_stream_writev_full (


### PR DESCRIPTION
The functions that convert regular base64 to url safe base64 terminate their loops on '=' which trims the '=' padding from the final output. While the Azure base64 decoder tolerates the missing padding, python does not accept it and was discovered while testing against a python mock server.

Also fixed a sprintf warning from clang.