### PR TITLE
MONGOCRYPT-307 fix compile on VS 2015

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -752,6 +752,12 @@ buildvariants:
   - name: publish-packages
     distros:
     - rhel70-small
+- name: windows-vs2015-compile
+  display_name: "Windows VS 2015 compile"
+  run_on: windows-64-vs2015-test
+  tasks:
+  - build-and-test-and-upload
+  - build-and-test-shared-bson
 - name: windows-test
   display_name: "Windows 2016"
   run_on: windows-64-vs2017-test

--- a/kms-message/src/kms_message/kms_response.h
+++ b/kms-message/src/kms_message/kms_response.h
@@ -19,6 +19,7 @@
 
 #include "kms_message_defines.h"
 
+#include <stddef.h>
 #include <sys/types.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
This adds a VS 2015 variant to compile to prevent future regressions.