### PR TITLE
fix: always authorize TLS endpoints, use servername for SNI

### DIFF
--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -217,7 +217,7 @@ module.exports = function(modules) {
     kmsRequest(request) {
       const parsedUrl = request.endpoint.split(':');
       const port = parsedUrl[1] != null ? Number.parseInt(parsedUrl[1], 10) : HTTPS_PORT;
-      const options = { host: parsedUrl[0], port, rejectUnauthorized: false };
+      const options = { host: parsedUrl[0], servername: parsedUrl[0], port };
       const message = request.message;
 
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
TLS endpoints should always be authorized in order to prevent MITM
attacks. In order to properly communicate with GCP's KMS servers
we need to provide a `servername`, so the endpoint can serve the
correct TLS certificate.