### PR TITLE
PYTHON-2539 Ensure sessionToken is supported for temp AWS credentials

### DIFF
--- a/bindings/python/pymongocrypt/mongocrypt.py
+++ b/bindings/python/pymongocrypt/mongocrypt.py
@@ -40,7 +40,8 @@ class MongoCryptOptions(object):
           - `kms_providers`: Map of KMS provider options. Two KMS providers
             are supported: "aws" and "local". The kmsProviders map values
             differ by provider:
-              - `aws`: Map with "accessKeyId" and "secretAccessKey" as strings.
+              - `aws`: Map with "accessKeyId" and "secretAccessKey" as strings,
+                 and optionally a "sessionToken" for temporary credentials.
               - `azure`: Map with "clientId" and "clientSecret" as strings.
               - `gcp`: Map with "email" as a string and "privateKey" as
                 a byte array or a base64-encoded string. On Python 2,

--- a/bindings/python/test/test_mongocrypt.py
+++ b/bindings/python/test/test_mongocrypt.py
@@ -80,6 +80,8 @@ class TestMongoCryptOptions(unittest.TestCase):
             ({'local': {'key': b'1' * 96}}, None),
             ({'aws': {'accessKeyId': '', 'secretAccessKey': ''}}, schema_map),
             ({'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'foo'}}, None),
+            ({'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'foo',
+                      'sessionToken': 'token'}}, None),
             ({'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'foo'},
               'local': {'key': b'1' * 96}}, None),
             ({'local': {'key': to_base64(b'1' * 96)}}, None),
@@ -132,6 +134,14 @@ class TestMongoCrypt(unittest.TestCase):
         opts = MongoCryptOptions(kms_providers)
         mc = MongoCrypt(opts, MockCallback())
         mc.close()
+        mc.close()
+
+    def test_mongocrypt_aws_session_token(self):
+        kms_providers = {
+            'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'foo',
+                    'sessionToken': 'token'}}
+        opts = MongoCryptOptions(kms_providers)
+        mc = MongoCrypt(opts, MockCallback())
         mc.close()
 
     def test_mongocrypt_validation(self):


### PR DESCRIPTION
We already support `sessionToken` since we use `mongocrypt_setopt_kms_providers`. This change verifies that sessionToken can be passed without error.