### PR TITLE
fix(NODE-3320): Explicitly provide list of artifacts to be published with package.files

### DIFF
--- a/bindings/node/.npmignore
+++ b/bindings/node/.npmignore
@@ -1,4 +1,0 @@
-build
-.gitignore
-.clang-format
-test

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -9,6 +9,7 @@
     "README.md",
     "CHANGELOG.md",
     "lib",
+    "src",
     "build",
     "index.d.ts"
   ],

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -4,6 +4,14 @@
   "description": "Official client encryption module for the MongoDB Node.js driver",
   "main": "index.js",
   "types": "index.d.ts",
+  "files": [
+    "index.js",
+    "README.md",
+    "CHANGELOG.md",
+    "lib",
+    "build",
+    "index.d.ts"
+  ],
   "directories": {
     "lib": "lib"
   },


### PR DESCRIPTION
`mongodb-client-encryption@1.2.3` was published with some extraneous files that don't belong in the distribution and this unexpectedly broke the build process of Compass on Windows machines. To avoid something like this in future package releases this PR adds `files` config option to `package.json` file that explicitly specifies which files will make it into the distribution (I asked Neal about what would be the better approach here and he suggested to go with `files` config) and removes `.npmignore` file that is redundant now