### PR TITLE
MONGOCRYPT-317 cache listCollections results with no JSON schema

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -84,6 +84,12 @@ _set_schema_from_collinfo (mongocrypt_ctx_t *ctx, bson_t *collinfo)
       }
    }
 
+   if (!found_jsonschema) {
+      bson_t empty = BSON_INITIALIZER;
+
+      _mongocrypt_buffer_from_bson (&ectx->schema, &empty);
+   }
+
 
    return true;
 }
@@ -120,6 +126,16 @@ _mongo_done_collinfo (mongocrypt_ctx_t *ctx)
    _mongocrypt_ctx_encrypt_t *ectx;
 
    ectx = (_mongocrypt_ctx_encrypt_t *) ctx;
+   if (_mongocrypt_buffer_empty (&ectx->schema)) {
+      bson_t empty_collinfo = BSON_INITIALIZER;
+
+      /* If no collinfo was fed, cache an empty collinfo. */
+      if (!_mongocrypt_cache_add_copy (
+            &ctx->crypt->cache_collinfo, ectx->ns, &empty_collinfo, ctx->status)) {
+         return _mongocrypt_ctx_fail (ctx);
+      }
+   }
+
    ectx->parent.state = MONGOCRYPT_CTX_NEED_MONGO_MARKINGS;
    return true;
 }

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -88,6 +88,7 @@ _set_schema_from_collinfo (mongocrypt_ctx_t *ctx, bson_t *collinfo)
       bson_t empty = BSON_INITIALIZER;
 
       _mongocrypt_buffer_steal_from_bson (&ectx->schema, &empty);
+      bson_destroy (&empty);
    }
 
 
@@ -132,8 +133,10 @@ _mongo_done_collinfo (mongocrypt_ctx_t *ctx)
       /* If no collinfo was fed, cache an empty collinfo. */
       if (!_mongocrypt_cache_add_copy (
             &ctx->crypt->cache_collinfo, ectx->ns, &empty_collinfo, ctx->status)) {
+         bson_destroy (&empty_collinfo);
          return _mongocrypt_ctx_fail (ctx);
       }
+      bson_destroy (&empty_collinfo);
    }
 
    ectx->parent.state = MONGOCRYPT_CTX_NEED_MONGO_MARKINGS;

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -87,7 +87,7 @@ _set_schema_from_collinfo (mongocrypt_ctx_t *ctx, bson_t *collinfo)
    if (!found_jsonschema) {
       bson_t empty = BSON_INITIALIZER;
 
-      _mongocrypt_buffer_from_bson (&ectx->schema, &empty);
+      _mongocrypt_buffer_steal_from_bson (&ectx->schema, &empty);
    }
 
 

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -88,7 +88,6 @@ _set_schema_from_collinfo (mongocrypt_ctx_t *ctx, bson_t *collinfo)
       bson_t empty = BSON_INITIALIZER;
 
       _mongocrypt_buffer_steal_from_bson (&ectx->schema, &empty);
-      bson_destroy (&empty);
    }
 
 

--- a/test/data/collection-info-no-validator.json
+++ b/test/data/collection-info-no-validator.json
@@ -1,0 +1,13 @@
+{
+    "name" : "test",
+    "type" : "collection",
+    "options" : {},
+    "info" : {},
+    "idIndex" : {
+            "v" : 2,
+            "key" : {
+                    "_id" : 1
+            },
+            "name" : "_id_"
+    }
+}

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1506,8 +1506,8 @@ _test_encrypt_caches_collinfo_without_jsonschema (_mongocrypt_tester_t *tester)
       mongocrypt_ctx_mongo_feed (
          ctx, TEST_FILE ("./test/data/collection-info-no-validator.json")),
       ctx);
-   ASSERT_STATE_EQUAL (mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
    ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
    _mongocrypt_tester_run_ctx_to (tester, ctx, MONGOCRYPT_CTX_DONE);
    mongocrypt_ctx_destroy (ctx);
 

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1472,7 +1472,7 @@ _test_encrypt_caches_empty_collinfo (_mongocrypt_tester_t *tester)
                  ctx, "test", -1, TEST_FILE ("./test/example/cmd.json")),
               ctx);
    ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
-   /* Do not feed a anything for collinfo. */
+   /* Do not feed anything for collinfo. */
    ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
    _mongocrypt_tester_run_ctx_to (tester, ctx, MONGOCRYPT_CTX_DONE);
    mongocrypt_ctx_destroy (ctx);

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1506,6 +1506,7 @@ _test_encrypt_caches_collinfo_without_jsonschema (_mongocrypt_tester_t *tester)
       mongocrypt_ctx_mongo_feed (
          ctx, TEST_FILE ("./test/data/collection-info-no-validator.json")),
       ctx);
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
    ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
    _mongocrypt_tester_run_ctx_to (tester, ctx, MONGOCRYPT_CTX_DONE);
    mongocrypt_ctx_destroy (ctx);

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -356,17 +356,17 @@ _mongocrypt_tester_run_ctx_to (_mongocrypt_tester_t *tester,
          fprintf (stderr,
                   "Got error: %s\n",
                   mongocrypt_status_message (status, NULL));
-         BSON_ASSERT (state == stop_state);
+         ASSERT_STATE_EQUAL (state, stop_state);
          mongocrypt_status_destroy (status);
          return;
       case MONGOCRYPT_CTX_DONE:
-         BSON_ASSERT (state == stop_state);
+         ASSERT_STATE_EQUAL (state, stop_state);
          mongocrypt_status_destroy (status);
          return;
       }
       state = mongocrypt_ctx_state (ctx);
    }
-   BSON_ASSERT (state == stop_state);
+   ASSERT_STATE_EQUAL (state, stop_state);
    mongocrypt_status_destroy (status);
 }
 
@@ -745,6 +745,26 @@ _test_setopt_kms_providers (_mongocrypt_tester_t *tester)
    }
 }
 
+const char* mongocrypt_ctx_state_to_string (mongocrypt_ctx_state_t state) {
+   switch (state) {
+   case MONGOCRYPT_CTX_ERROR:
+      return "MONGOCRYPT_CTX_ERROR";
+   case MONGOCRYPT_CTX_NEED_MONGO_COLLINFO:
+      return "MONGOCRYPT_CTX_NEED_MONGO_COLLINFO";
+   case MONGOCRYPT_CTX_NEED_MONGO_MARKINGS:
+      return "MONGOCRYPT_CTX_NEED_MONGO_MARKINGS";
+   case MONGOCRYPT_CTX_NEED_MONGO_KEYS:
+      return "MONGOCRYPT_CTX_NEED_MONGO_KEYS";
+   case MONGOCRYPT_CTX_NEED_KMS:
+      return "MONGOCRYPT_CTX_NEED_KMS";
+   case MONGOCRYPT_CTX_READY:
+      return "MONGOCRYPT_CTX_READY";
+   case MONGOCRYPT_CTX_DONE:
+      return "MONGOCRYPT_CTX_DONE";
+   default:
+      return "UNKNOWN";
+   }
+}
 
 int
 main (int argc, char **argv)

--- a/test/test-mongocrypt.h
+++ b/test/test-mongocrypt.h
@@ -188,6 +188,19 @@ _assert_bin_bson_equal (mongocrypt_binary_t *bin_a, mongocrypt_binary_t *bin_b);
 void
 _assert_match_bson (const bson_t *doc, const bson_t *pattern);
 
+const char* mongocrypt_ctx_state_to_string (mongocrypt_ctx_state_t state);
+
+#define ASSERT_STATE_EQUAL(actual, expected)                    \
+   do {                                                         \
+      if (actual != expected) {                                 \
+         fprintf (stderr,                                       \
+                  "actual state: %s, but expected state: %s\n", \
+                  mongocrypt_ctx_state_to_string (actual),      \
+                  mongocrypt_ctx_state_to_string (expected));   \
+         abort ();                                              \
+      }                                                         \
+   } while (0)
+
 typedef enum {
    CRYPTO_REQUIRED,
    CRYPTO_OPTIONAL,

--- a/test/test-mongocrypt.h
+++ b/test/test-mongocrypt.h
@@ -190,15 +190,18 @@ _assert_match_bson (const bson_t *doc, const bson_t *pattern);
 
 const char* mongocrypt_ctx_state_to_string (mongocrypt_ctx_state_t state);
 
-#define ASSERT_STATE_EQUAL(actual, expected)                    \
-   do {                                                         \
-      if (actual != expected) {                                 \
-         fprintf (stderr,                                       \
-                  "actual state: %s, but expected state: %s\n", \
-                  mongocrypt_ctx_state_to_string (actual),      \
-                  mongocrypt_ctx_state_to_string (expected));   \
-         abort ();                                              \
-      }                                                         \
+#define ASSERT_STATE_EQUAL(actual, expected)                                \
+   do {                                                                     \
+      if (actual != expected) {                                             \
+         fprintf (stderr,                                                   \
+                  "%s:%d  %s() actual state: %s, but expected state: %s\n", \
+                  __FILE__,                                                 \
+                  __LINE__,                                                 \
+                  BSON_FUNC,                                                \
+                  mongocrypt_ctx_state_to_string (actual),                  \
+                  mongocrypt_ctx_state_to_string (expected));               \
+         abort ();                                                          \
+      }                                                                     \
    } while (0)
 
 typedef enum {


### PR DESCRIPTION
**Background**
A `mongocrypt_ctx_t` represents a state machine. The `MONGOCRYPT_CTX_NEEDS_COLLINFO` state signals the driver to send a `{ listCollections: 1}` command to the server and feed the response back to the `mongocrypt_ctx_t`. `listCollections` results may include a JSON schema including metadata about encrypted fields. The state is described in the [integrating guide](https://github.com/mongodb/libmongocrypt/blob/master/integrating.md#state-mongocrypt_ctx_need_mongo_collinfo).

The intended behavior is to cache the response of `listCollections` for one minute to avoid sending repeated `listCollections` commands to the server.

The bug is that the absence of a JSON schema is not cached. That results in repeated `listCollections` commands on collections with no schema from a client configured with automatic encryption.

**Summary**
- If a `mongocrypt_ctx_t` enters `MONGOCRYPT_CTX_NEEDS_COLLINFO`:
	- If no `listCollections` response is returned, cache an empty response.
	- If the `listCollections` response does not contain ` { options: { validator: { $jsonSchema: {...} } }`, cache an empty response.

**Testing**
In addition to the unit tests written here, I ran C driver tests against this branch in this [Evergreen patch](https://spruce.mongodb.com/version/61303e13d6d80a7950045f1d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

The macOS test failure is tracked in [PYTHON-2889](https://jira.mongodb.org/browse/PYTHON-2889).