### PR TITLE
PYTHON-2913 Remove unneeded copy when feeding binary data into libmongocrypt

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -353,8 +353,6 @@ tasks:
 
 - name: test-python
   depends_on:
-  - variant: ubuntu2004-64
-    name: prep-c-driver-source
   - build-and-test-and-upload
   commands:
     - func: "fetch source"
@@ -365,8 +363,6 @@ tasks:
 
 - name: test-python-windows
   depends_on:
-  - variant: ubuntu2004-64
-    name: prep-c-driver-source
   # Depends on the windows-64-vs2017-test upload.
   - variant: windows-test
     name: build-and-test-and-upload

--- a/bindings/python/.evergreen/utils.sh
+++ b/bindings/python/.evergreen/utils.sh
@@ -26,12 +26,11 @@ createvirtualenv () {
     # Upgrade to the latest versions of pip setuptools wheel so that
     # pip can always download the latest cryptography+cffi wheels.
     PYTHON_VERSION=$(python -c 'import sys;print("%s.%s" % sys.version_info[:2])')
-    if [[ $PYTHON_VERSION == "3.4" ]]; then
+    if [[ $PYTHON_VERSION == "2.7" || $PYTHON_VERSION == "3.4" || $PYTHON_VERSION == "3.5" ]]; then
         # pip 19.2 dropped support for Python 3.4.
-        python -m pip install --upgrade 'pip<19.2'
-    elif [[ $PYTHON_VERSION == "2.7" || $PYTHON_VERSION == "3.5" ]]; then
         # pip 21 dropped support for Python 2.7 and 3.5.
-        python -m pip install --upgrade 'pip<21'
+        curl -sSL https://bootstrap.pypa.io/pip/${PYTHON_VERSION}/get-pip.py -o get-pip.py
+        python get-pip.py
     else
         python -m pip install --upgrade pip
     fi

--- a/bindings/python/.evergreen/utils.sh
+++ b/bindings/python/.evergreen/utils.sh
@@ -25,5 +25,15 @@ createvirtualenv () {
     fi
     # Upgrade to the latest versions of pip setuptools wheel so that
     # pip can always download the latest cryptography+cffi wheels.
+    PYTHON_VERSION=$(python -c 'import sys;print("%s.%s" % sys.version_info[:2])')
+    if [[ $PYTHON_VERSION == "3.4" ]]; then
+        # pip 19.2 dropped support for Python 3.4.
+        python -m pip install --upgrade 'pip<19.2'
+    elif [[ $PYTHON_VERSION == "2.7" || $PYTHON_VERSION == "3.5" ]]; then
+        # pip 21 dropped support for Python 2.7 and 3.5.
+        python -m pip install --upgrade 'pip<21'
+    else
+        python -m pip install --upgrade pip
+    fi
     python -m pip install --upgrade pip setuptools wheel
 }

--- a/bindings/python/pymongocrypt/binary.py
+++ b/bindings/python/pymongocrypt/binary.py
@@ -76,19 +76,19 @@ class MongoCryptBinaryOut(_MongoCryptBinary):
 
 
 class MongoCryptBinaryIn(_MongoCryptBinary):
-    __slots__ = ("__copy",)
+    __slots__ = ("cref",)
 
     def __init__(self, data):
         """Creates a mongocrypt_binary_t from binary data."""
         # mongocrypt_binary_t does not own the data it is passed so we need to
-        # create a copy to keep the data alive.
-        self.__copy = ffi.new("uint8_t[]", data)
+        # create a separate reference to keep the data alive.
+        self.cref = ffi.from_buffer("uint8_t[]", data)
         super(MongoCryptBinaryIn, self).__init__(
-            lib.mongocrypt_binary_new_from_data(self.__copy, len(data)))
+            lib.mongocrypt_binary_new_from_data(self.cref, len(data)))
 
     def _close(self):
         """Cleanup resources."""
         super(MongoCryptBinaryIn, self)._close()
-        if self.__copy is None:
-            ffi.release(self.__copy)
-            self.__copy = None
+        if self.cref is not None:
+            ffi.release(self.cref)
+            self.cref = None

--- a/bindings/python/test/test_mongocrypt.py
+++ b/bindings/python/test/test_mongocrypt.py
@@ -65,6 +65,12 @@ class TestMongoCryptBinary(unittest.TestCase):
             self.assertEqual(binary.to_bytes(), b'')
         self.assertIsNone(binary.bin)
 
+        # Memoryview
+        with MongoCryptBinaryIn(memoryview(b'1\x0023')) as binary:
+            self.assertIsNotNone(binary.bin)
+            self.assertEqual(binary.to_bytes(), b'1\x0023')
+        self.assertIsNone(binary.bin)
+
     def test_mongocrypt_binary_out(self):
         with MongoCryptBinaryOut() as binary:
             self.assertIsNotNone(binary.bin)


### PR DESCRIPTION
Also fixes the macOS Python 3.5 issue (PYTHON-2889) and removes some unneeded depends_on.

Here's a patch that confirms that this change fixes PYTHON-2913: https://spruce.mongodb.com/version/6148e5ff3627e023d2a76dfa