### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The companion C library for client side encryption in drivers.
 
 If you have encountered a bug, or would like to see a new feature in libmongocrypt, please open a case in our issue management tool, JIRA:
 
-- [Create an account and login](https://jira.mongodb.org>).
+- [Create an account and login](https://jira.mongodb.org).
 - Navigate to [the MONGOCRYPT project](https://jira.mongodb.org/projects/MONGOCRYPT).
 - Click **Create Issue** - Please provide as much information as possible about the issue type and how to reproduce it.
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ The companion C library for client side encryption in drivers.
 
 If you have encountered a bug, or would like to see a new feature in libmongocrypt, please open a case in our issue management tool, JIRA:
 
-- `Create an account and login <https://jira.mongodb.org>`_.
-- Navigate to `the MONGOCRYPT project <https://jira.mongodb.org/browse/MONGOCRYPT>`_.
+- [Create an account and login](https://jira.mongodb.org>).
+- Navigate to [the MONGOCRYPT project](https://jira.mongodb.org/projects/MONGOCRYPT).
 - Click **Create Issue** - Please provide as much information as possible about the issue type and how to reproduce it.
 
 ## Documentation ##


### PR DESCRIPTION
We received a docs ticket that the link to the JIRA project was broken. It's updated, and the links are now in MD format instead of RST so they are clickable in the rendered view.