### PR TITLE
MONGOCRYPT-336 move key wrap and unwrap functions

### DIFF
--- a/src/mongocrypt-crypto-private.h
+++ b/src/mongocrypt-crypto-private.h
@@ -77,6 +77,43 @@ _mongocrypt_random (_mongocrypt_crypto_t *crypto,
 int
 _mongocrypt_memequal (const void *const b1, const void *const b2, size_t len);
 
+
+/*
+ * _mongocrypt_wrap_key encrypts a DEK with a KEK.
+
+ * kek is an input Key Encryption Key.
+ * dek is an input Data Encryption Key.
+ * encrypted_dek the result of encrypting dek with kek.
+ * encrypted_dek is always initialized.
+ * Returns true if no error occurred.
+ * Returns false and sets @status if an error occurred.
+ */
+bool
+_mongocrypt_wrap_key (_mongocrypt_crypto_t *crypto,
+                      _mongocrypt_buffer_t *kek,
+                      _mongocrypt_buffer_t *dek,
+                      _mongocrypt_buffer_t *encrypted_dek,
+                      mongocrypt_status_t *status)
+   MONGOCRYPT_WARN_UNUSED_RESULT;
+
+/*
+ * _mongocrypt_unwrap_key decrypts an encrypted DEK with a KEK.
+ * 
+ * kek is an input Key Encryption Key.
+ * encrypted_dek is an input encrypted Data Encryption Key.
+ * dek is the result of decrypting encrypted_dek with kek.
+ * dek is always initialized.
+ * Returns true if no error occurred.
+ * Returns false and sets @status if an error occurred.
+ */
+bool
+_mongocrypt_unwrap_key (_mongocrypt_crypto_t *crypto,
+                        _mongocrypt_buffer_t *kek,
+                        _mongocrypt_buffer_t *encrypted_dek,
+                        _mongocrypt_buffer_t *dek,
+                        mongocrypt_status_t *status)
+   MONGOCRYPT_WARN_UNUSED_RESULT;
+
 bool
 _mongocrypt_calculate_deterministic_iv (
    _mongocrypt_crypto_t *crypto,

--- a/src/mongocrypt-crypto.c
+++ b/src/mongocrypt-crypto.c
@@ -28,6 +28,8 @@
 #include "mongocrypt-private.h"
 #include "mongocrypt-status-private.h"
 
+#include <inttypes.h>
+
 /* Crypto primitives. These either call the native built in crypto primitives or
  * user supplied hooks. */
 static bool


### PR DESCRIPTION
See MONGOCRYPT-336 for more information. There are no functional changes. This is in preparation of the key wrap / unwrap functions being used by the upcoming KMIP KMS provider.

New task failures on the Debian 9.2, Linux Distro Packaging, and SLES 12 64-bit variants appear due to BUILD-14027.