### PR TITLE
PYTHON-2909 pymongocrypt 1.1.2

### DIFF
--- a/bindings/python/CHANGELOG.rst
+++ b/bindings/python/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Changes in Version 1.1.2
+------------------------
+
+- Fix a bug where decrypting from a memoryview was not supported.
+- Bundle libmongocrypt 1.2.2 in release wheels.
+
 Changes in Version 1.1.1
 ------------------------
 

--- a/bindings/python/pymongocrypt/version.py
+++ b/bindings/python/pymongocrypt/version.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '1.1.2.dev0'
+__version__ = '1.1.2'
 
 _MIN_LIBMONGOCRYPT_VERSION = '1.2.0'

--- a/bindings/python/release.sh
+++ b/bindings/python/release.sh
@@ -14,7 +14,7 @@ set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 # The libmongocrypt git revision release to embed in our wheels.
-REVISION=$(git rev-list -n 1 1.2.1)
+REVISION=$(git rev-list -n 1 1.2.2)
 
 if [ "Windows_NT" = "$OS" ]; then # Magic variable in cygwin
     rm -rf venv37


### PR DESCRIPTION
Bugfix release for decrypting from a memoryview + bundle libmongocrypt 1.2.2 in release wheels.

Testing here: https://spruce.mongodb.com/version/6184705c5623431e8d266012