### PR TITLE
feat(NODE-3777): add node bindings for kms provider

### DIFF
--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -1,7 +1,7 @@
 import type { Binary } from 'bson';
 import type { MongoClient } from 'mongodb';
 
-export type ClientEncryptionDataKeyProvider = 'aws' | 'azure' | 'gcp' | 'local';
+export type ClientEncryptionDataKeyProvider = 'aws' | 'azure' | 'gcp' | 'local' | 'kmip';
 
 /**
  * An error indicating that something went wrong specifically with MongoDB Client Encryption
@@ -67,6 +67,18 @@ export interface KMSProviders {
      * A 96-byte long Buffer or base64 encoded string.
      */
     key: Buffer | string;
+  };
+
+  /**
+   * Configuration options for using 'kmip' as your KMS provider
+   */
+  kmip?: {
+    /**
+     * The output endpoint string.
+     * The endpoint consists of a hostname and port separated by a colon.
+     * E.g. "example.com:123". A port is always present.
+     */
+    endpoint?: string;
   };
 
   /**

--- a/bindings/node/src/mongocrypt.cc
+++ b/bindings/node/src/mongocrypt.cc
@@ -711,6 +711,7 @@ Function MongoCryptKMSRequest::Init(Napi::Env env) {
                     InstanceMethod("addResponse", &MongoCryptKMSRequest::AddResponse),
                     InstanceAccessor("status", &MongoCryptKMSRequest::Status, nullptr),
                     InstanceAccessor("bytesNeeded", &MongoCryptKMSRequest::BytesNeeded, nullptr),
+                    InstanceAccessor("kmsProvider", &MongoCryptKMSRequest::KMSProvider, nullptr),
                     InstanceAccessor("endpoint", &MongoCryptKMSRequest::Endpoint, nullptr),
                     InstanceAccessor("message", &MongoCryptKMSRequest::Message, nullptr)
                   });
@@ -735,6 +736,10 @@ Value MongoCryptKMSRequest::Status(const CallbackInfo& info) {
 
 Value MongoCryptKMSRequest::BytesNeeded(const CallbackInfo& info) {
     return Number::New(Env(), mongocrypt_kms_ctx_bytes_needed(_kms_context));
+}
+
+Value MongoCryptKMSRequest::KMSProvider(const CallbackInfo& info) {
+    return String::New(Env(), mongocrypt_kms_ctx_get_kms_provider(_kms_context, nullptr));
 }
 
 Value MongoCryptKMSRequest::Message(const CallbackInfo& info) {

--- a/bindings/node/src/mongocrypt.h
+++ b/bindings/node/src/mongocrypt.h
@@ -97,6 +97,7 @@ class MongoCryptKMSRequest : public Napi::ObjectWrap<MongoCryptKMSRequest> {
     Napi::Value Status(const Napi::CallbackInfo& info);
     Napi::Value Message(const Napi::CallbackInfo& info);
     Napi::Value BytesNeeded(const Napi::CallbackInfo& info);
+    Napi::Value KMSProvider(const Napi::CallbackInfo& info);
     Napi::Value Endpoint(const Napi::CallbackInfo& info);
 
    private:

--- a/bindings/node/test/stateMachine.test.js
+++ b/bindings/node/test/stateMachine.test.js
@@ -15,6 +15,7 @@ describe('StateMachine', function() {
         this._bytesNeeded = typeof bytesNeeded === 'number' ? bytesNeeded : 1024;
         this._message = message;
         this.endpoint = 'some.fake.host.com';
+        this._kmsProvider = 'aws';
       }
       get message() {
         return this._message;
@@ -22,6 +23,10 @@ describe('StateMachine', function() {
 
       get bytesNeeded() {
         return this._bytesNeeded;
+      }
+
+      get kmsProvider() {
+        return this._kmsProvider;
       }
 
       addResponse(buffer) {
@@ -69,6 +74,7 @@ describe('StateMachine', function() {
       setTimeout(() => {
         expect(status).to.equal('pending');
         expect(request.bytesNeeded).to.equal(500);
+        expect(request.kmsProvider).to.equal('aws');
         this.fakeSocket.emit('data', Buffer.alloc(300));
         setTimeout(() => {
           expect(status).to.equal('pending');


### PR DESCRIPTION
Adds Node bindings for KMIP provider support. Bindings now wrap `mongocrypt_kms_ctx_get_kms_provider` and add the typescript definition for the new KMIP provider with a single `endpoint` url.