### PR TITLE
feat(NODE-3177): increase serverSelectionTimeout in client

### DIFF
--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -98,7 +98,7 @@ module.exports = function(modules) {
         this._mongocryptdClient = new MongoClient(this._mongocryptdManager.uri, {
           useNewUrlParser: true,
           useUnifiedTopology: true,
-          serverSelectionTimeoutMS: 1000
+          serverSelectionTimeoutMS: 10000
         });
       }
 

--- a/bindings/node/test/autoEncrypter.test.js
+++ b/bindings/node/test/autoEncrypter.test.js
@@ -108,6 +108,23 @@ describe('AutoEncrypter', function() {
     });
   });
 
+  context('when checking serverSelectionTimeoutMS on the mongocryptd client', function() {
+    const client = new MockClient();
+    const autoEncrypter = new AutoEncrypter(client, {
+      mongocryptdBypassSpawn: true,
+      keyVaultNamespace: 'admin.datakeys',
+      logger: () => {},
+      kmsProviders: {
+        aws: { accessKeyId: 'example', secretAccessKey: 'example' },
+        local: { key: Buffer.alloc(96) }
+      }
+    });
+
+    it('defaults to 10000', function() {
+      expect(autoEncrypter._mongocryptdClient.s.options.serverSelectionTimeoutMS).to.equal(10000);
+    });
+  });
+
   describe('state machine', function() {
     it('should decrypt mock data', function(done) {
       const input = readExtendedJsonToBuffer(`${__dirname}/data/encrypted-document.json`);


### PR DESCRIPTION
Increases the value of `serverSelectionTimeoutMS` to the `MongoClient` that the connects to mongocryptd to 10 seconds.