### PR TITLE
test(NODE-3777): increase encrypter test timeout

### DIFF
--- a/bindings/node/test/autoEncrypter.test.js
+++ b/bindings/node/test/autoEncrypter.test.js
@@ -47,6 +47,7 @@ class MockClient {
 
 const AutoEncrypter = require('../lib/autoEncrypter')({ mongodb, stateMachine }).AutoEncrypter;
 describe('AutoEncrypter', function() {
+  this.timeout(12000);
   let ENABLE_LOG_TEST = false;
   let sandbox = sinon.createSandbox();
   beforeEach(() => {


### PR DESCRIPTION
Increases the test timeout in the node bindings for the auto encrypter tests as the default 2000ms is getting hit before the new server selection timeout is reached.