### PR TITLE
chore(NODE-3633): update Socks5 support for driver PR feedback

### DIFF
--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -13,10 +13,10 @@ export class MongoCryptError extends Error {
  * A set of options for specifying a Socks5 proxy.
  */
 export interface ProxyOptions {
-  host: string;
-  port?: number;
-  username?: string;
-  password?: string;
+  proxyHost: string;
+  proxyPort?: number;
+  proxyUsername?: string;
+  proxyPassword?: string;
 }
 
 export interface ClientEncryptionCreateDataKeyCallback {

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -254,10 +254,10 @@ module.exports = function(modules) {
           reject(mcError);
         }
 
-        if (this.options.proxyOptions && this.options.proxyOptions.host) {
+        if (this.options.proxyOptions && this.options.proxyOptions.proxyHost) {
           rawSocket = net.connect({
-            host: this.options.proxyOptions.host,
-            port: this.options.proxyOptions.port || 1080
+            host: this.options.proxyOptions.proxyHost,
+            port: this.options.proxyOptions.proxyPort || 1080
           });
 
           rawSocket.on('timeout', ontimeout);
@@ -273,8 +273,8 @@ module.exports = function(modules) {
                   host: 'locahost',
                   port: 0,
                   type: 5,
-                  userId: this.options.proxyOptions.username,
-                  password: this.options.proxyOptions.username
+                  userId: this.options.proxyOptions.proxyUsername,
+                  password: this.options.proxyOptions.proxyPassword
                 }
               })
             ).socket;


### PR DESCRIPTION
- Update the Socks5 options naming to use the connection string
  parameter names as keys, rather than shortened variants,
  for easier integration into the Node.js driver
- Fix and test username/password authentication (noticed while
  addressing the above, this is absolutely my bad)
- [related driver feedback](https://github.com/mongodb/node-mongodb-native/pull/3041#discussion_r772337188)