### PR TITLE
MONGOCRYPT-340 add macOS m1 variant

### DIFF
--- a/.evergreen/build_install_bson.sh
+++ b/.evergreen/build_install_bson.sh
@@ -19,6 +19,12 @@ else
     chmod u+x ./.evergreen/find-cmake.sh
     # Amazon Linux 2 (arm64) has a very old system CMake we want to ignore
     IGNORE_SYSTEM_CMAKE=1 . ./.evergreen/find-cmake.sh
+    # Check if on macOS with arm64. Use system cmake. See BUILD-14565.
+    OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
+    MARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
+    if [ "darwin" = "$OS_NAME" -a "arm64" = "$MARCH" ]; then
+        CMAKE=cmake
+    fi
 fi
 
 $CMAKE --version

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1068,3 +1068,4 @@ buildvariants:
   run_on: macos-1100-arm64
   tasks:
   - build-and-test-and-upload
+  

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -470,6 +470,8 @@ tasks:
       name: build-and-test-and-upload
     - variant: ubuntu2004-arm64
       name: build-and-test-and-upload
+    - variant: macos_m1
+      name: build-and-test-and-upload
   commands:
     - command: shell.exec
       params:
@@ -516,6 +518,8 @@ tasks:
       vars: { variant_name: "ubuntu2004-64" }
     - func: "download tarball"
       vars: { variant_name: "ubuntu2004-arm64" }
+    - func: "download tarball"
+      vars: { variant_name: "macos_m1" }
     - command: archive.targz_pack
       params:
         target: libmongocrypt-all.tar.gz
@@ -1059,3 +1063,14 @@ buildvariants:
   run_on: ubuntu2004-small
   tasks:
   - name: debian-package-build
+- name: macos_m1
+  display_name: macOS m1 (Apple LLVM)
+  run_on: macos-1100-arm64
+  tasks:
+  - build-and-test-and-upload
+  - build-and-test-shared-bson
+  - build-and-test-asan-mac
+  - build-and-test-java
+  - build-and-test-node
+  - build-and-test-csharp
+  - test-python

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1068,9 +1068,3 @@ buildvariants:
   run_on: macos-1100-arm64
   tasks:
   - build-and-test-and-upload
-  - build-and-test-shared-bson
-  - build-and-test-asan-mac
-  - build-and-test-java
-  - build-and-test-node
-  - build-and-test-csharp
-  - test-python

--- a/.evergreen/linker-tests.sh
+++ b/.evergreen/linker-tests.sh
@@ -52,6 +52,12 @@ else
     chmod u+x ./.evergreen/find-cmake.sh
     # Amazon Linux 2 (arm64) has a very old system CMake we want to ignore
     IGNORE_SYSTEM_CMAKE=1 . ./.evergreen/find-cmake.sh
+    # Check if on macOS with arm64. Use system cmake. See BUILD-14565.
+    OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
+    MARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
+    if [ "darwin" = "$OS_NAME" -a "arm64" = "$MARCH" ]; then
+        CMAKE=cmake
+    fi
 fi
 
 git apply --ignore-whitespace "$(system_path $linker_tests_deps_root/bson_patches/libbson1.patch)"

--- a/.evergreen/pkgconfig-tests.sh
+++ b/.evergreen/pkgconfig-tests.sh
@@ -40,8 +40,15 @@ else
     IGNORE_SYSTEM_CMAKE=1 . ./.evergreen/find-cmake.sh
 fi
 
-if [ "darwin" = "$OS" -a "arm64" = "$MARCH" ]; then
-   ADDITIONAL_CMAKE_FLAGS="$ADDITIONAL_CMAKE_FLAGS -DCMAKE_OSX_ARCHITECTURES=arm64"
+if [ "$OS" != "Windows_NT" ]; then
+    # Check if on macOS with arm64.
+    OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
+    echo "OS_NAME: $OS_NAME"
+    MARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
+
+    if [ "darwin" = "$OS_NAME" -a "arm64" = "$MARCH" ]; then
+        ADDITIONAL_CMAKE_FLAGS="$ADDITIONAL_CMAKE_FLAGS -DCMAKE_OSX_ARCHITECTURES=arm64"
+    fi
 fi
 
 mkdir cmake-build

--- a/.evergreen/pkgconfig-tests.sh
+++ b/.evergreen/pkgconfig-tests.sh
@@ -38,11 +38,11 @@ else
     chmod u+x ./.evergreen/find-cmake.sh
     # Amazon Linux 2 (arm64) has a very old system CMake we want to ignore
     IGNORE_SYSTEM_CMAKE=1 . ./.evergreen/find-cmake.sh
-    # Check if on macOS with arm64.
+    # Check if on macOS with arm64. Use system cmake. See BUILD-14565.
     OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
     MARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
     if [ "darwin" = "$OS_NAME" -a "arm64" = "$MARCH" ]; then
-        ADDITIONAL_CMAKE_FLAGS="$ADDITIONAL_CMAKE_FLAGS -DCMAKE_OSX_ARCHITECTURES=arm64"
+        CMAKE=cmake
     fi
 fi
 

--- a/.evergreen/pkgconfig-tests.sh
+++ b/.evergreen/pkgconfig-tests.sh
@@ -40,6 +40,10 @@ else
     IGNORE_SYSTEM_CMAKE=1 . ./.evergreen/find-cmake.sh
 fi
 
+if [ "darwin" = "$OS" -a "arm64" = "$MARCH" ]; then
+   ADDITIONAL_CMAKE_FLAGS="$ADDITIONAL_CMAKE_FLAGS -DCMAKE_OSX_ARCHITECTURES=arm64"
+fi
+
 mkdir cmake-build
 cd cmake-build
 INSTALL_PATH="$(system_path $pkgconfig_tests_root/install)"

--- a/.evergreen/pkgconfig-tests.sh
+++ b/.evergreen/pkgconfig-tests.sh
@@ -38,14 +38,9 @@ else
     chmod u+x ./.evergreen/find-cmake.sh
     # Amazon Linux 2 (arm64) has a very old system CMake we want to ignore
     IGNORE_SYSTEM_CMAKE=1 . ./.evergreen/find-cmake.sh
-fi
-
-if [ "$OS" != "Windows_NT" ]; then
     # Check if on macOS with arm64.
     OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
-    echo "OS_NAME: $OS_NAME"
     MARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
-
     if [ "darwin" = "$OS_NAME" -a "arm64" = "$MARCH" ]; then
         ADDITIONAL_CMAKE_FLAGS="$ADDITIONAL_CMAKE_FLAGS -DCMAKE_OSX_ARCHITECTURES=arm64"
     fi

--- a/bindings/node/.evergreen/find_cmake.sh
+++ b/bindings/node/.evergreen/find_cmake.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash -x
-
 # Copied from the mongo-c-driver
 find_cmake ()
 {
+  # Check if on macOS with arm64. Use system cmake. See BUILD-14565.
+  OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
+  MARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
+  if [ "darwin" = "$OS_NAME" -a "arm64" = "$MARCH" ]; then
+      CMAKE=cmake
+      return 0
+  fi
+
   if [ ! -z "$CMAKE" ]; then
     return 0
   elif [ -f "/Applications/cmake-3.2.2-Darwin-x86_64/CMake.app/Contents/bin/cmake" ]; then

--- a/bindings/node/.evergreen/find_cmake.sh
+++ b/bindings/node/.evergreen/find_cmake.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash -x
+
 # Copied from the mongo-c-driver
 find_cmake ()
 {


### PR DESCRIPTION
# Summary
- Add variant named `macos_m1` running on distro `macos-1100-arm64` to run the task `build-and-test-and-upload`.
- Use `/opt/homebrew/bin/cmake` instead of `/Applications/Cmake.app/Contents/bin/cmake`. The former has `arm64` architecture and produces `arm64` builds by default. The latter has `x86_64` architecture and builds with `x86_64` architecture by default. See BUILD-14565.

# Caveats

Bindings tasks, like `build-and-test-node`, `build-and-test-java`, `build-and-test-csharp`, and `test-python` will require further changes. [This Evergreen patch build](https://spruce.mongodb.com/version/61df38b73e8e8655c0380c22) is configured with all tasks and should provide error logs.

The linked patch build includes a failing `build-and-test-node` on Windows 2016. I think it is unrelated to these changes.