### PR TITLE
feat(NODE-3777): set tls options per kms provider

### DIFF
--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -203,7 +203,13 @@ export interface ClientEncryptionOptions {
   /**
    * TLS options for kms providers to use.
    */
-  tlsOptions?: ClientEncryptionTLSOptions;
+  tlsOptions?: {
+    aws?: ClientEncryptionTLSOptions;
+    local?: ClientEncryptionTLSOptions;
+    azure?: ClientEncryptionTLSOptions;
+    gcp?: ClientEncryptionTLSOptions;
+    kmip?: ClientEncryptionTLSOptions;
+  }
 }
 
 /**

--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -151,11 +151,7 @@ export interface KMSProviders {
  *  - tlsDisableOCSPEndpointCheck
  *  - tlsDisableCertificateRevocationCheck
  */
-export interface ClientEncryptionTLSOptions {
-  /**
-   * Enables or disables TLS/SSL for the connection.
-   */
-  tls?: boolean;
+export interface ClientEncryptionTlsOptions {
   /**
    * Specifies the location of a local .pem file that contains
    * either the client's TLS/SSL certificate and key or only the
@@ -203,13 +199,7 @@ export interface ClientEncryptionOptions {
   /**
    * TLS options for kms providers to use.
    */
-  tlsOptions?: {
-    aws?: ClientEncryptionTLSOptions;
-    local?: ClientEncryptionTLSOptions;
-    azure?: ClientEncryptionTLSOptions;
-    gcp?: ClientEncryptionTLSOptions;
-    kmip?: ClientEncryptionTLSOptions;
-  }
+  tlsOptions?: { [kms in keyof KMSProviders]?: ClientEncryptionTLSOptions };
 }
 
 /**

--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -106,6 +106,7 @@ module.exports = function(modules) {
       this._keyVaultClient = options.keyVaultClient || client;
       this._metaDataClient = options.metadataClient || client;
       this._proxyOptions = options.proxyOptions || {};
+      this._tlsOptions = options.tlsOptions || {};
 
       const mongoCryptOptions = {};
       if (options.schemaMap) {
@@ -213,7 +214,12 @@ module.exports = function(modules) {
       context.ns = ns;
       context.document = cmd;
 
-      const stateMachine = new StateMachine({ bson, ...options, proxyOptions: this._proxyOptions });
+      const stateMachine = new StateMachine({
+        bson,
+        ...options,
+        proxyOptions: this._proxyOptions,
+        tlsOptions: this._tlsOptions
+      });
       stateMachine.execute(this, context, callback);
     }
 
@@ -244,7 +250,12 @@ module.exports = function(modules) {
       // TODO: should this be an accessor from the addon?
       context.id = this._contextCounter++;
 
-      const stateMachine = new StateMachine({ bson, ...options, proxyOptions: this._proxyOptions });
+      const stateMachine = new StateMachine({
+        bson,
+        ...options,
+        proxyOptions: this._proxyOptions,
+        tlsOptions: this._tlsOptions
+      });
       stateMachine.execute(this, context, callback);
     }
   }

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -38,6 +38,7 @@ module.exports = function(modules) {
      * @param {MongoClient} client The client used for encryption
      * @param {object} options Additional settings
      * @param {string} options.keyVaultNamespace The namespace of the key vault, used to store encryption keys
+     * @param {object} options.tlsOptions An object that maps KMS provider names to TLS options.
      * @param {MongoClient} [options.keyVaultClient] A `MongoClient` used to fetch keys from a key vault. Defaults to `client`
      * @param {KMSProviders} [options.kmsProviders] options for specific KMS providers to use
      *

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -66,6 +66,7 @@ module.exports = function(modules) {
       this._client = client;
       this._bson = options.bson || client.topology.bson;
       this._proxyOptions = options.proxyOptions;
+      this._tlsOptions = options.tlsOptions;
 
       if (options.keyVaultNamespace == null) {
         throw new TypeError('Missing required option `keyVaultNamespace`');
@@ -199,7 +200,11 @@ module.exports = function(modules) {
 
       const dataKeyBson = bson.serialize(dataKey);
       const context = this._mongoCrypt.makeDataKeyContext(dataKeyBson, { keyAltNames });
-      const stateMachine = new StateMachine({ bson, proxyOptions: this._proxyOptions });
+      const stateMachine = new StateMachine({
+        bson,
+        proxyOptions: this._proxyOptions,
+        tlsOptions: this._tlsOptions
+      });
 
       return promiseOrCallback(callback, cb => {
         stateMachine.execute(this, context, (err, dataKey) => {
@@ -291,7 +296,11 @@ module.exports = function(modules) {
         contextOptions.keyAltName = bson.serialize({ keyAltName });
       }
 
-      const stateMachine = new StateMachine({ bson, proxyOptions: this._proxyOptions });
+      const stateMachine = new StateMachine({
+        bson,
+        proxyOptions: this._proxyOptions,
+        tlsOptions: this._tlsOptions
+      });
       const context = this._mongoCrypt.makeExplicitEncryptionContext(valueBuffer, contextOptions);
 
       return promiseOrCallback(callback, cb => {
@@ -336,7 +345,11 @@ module.exports = function(modules) {
       const valueBuffer = bson.serialize({ v: value });
       const context = this._mongoCrypt.makeExplicitDecryptionContext(valueBuffer);
 
-      const stateMachine = new StateMachine({ bson, proxyOptions: this._proxyOptions });
+      const stateMachine = new StateMachine({
+        bson,
+        proxyOptions: this._proxyOptions,
+        tlsOptions: this._tlsOptions
+      });
 
       return promiseOrCallback(callback, cb => {
         stateMachine.execute(this, context, (err, result) => {

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -325,6 +325,15 @@ module.exports = function(modules) {
       });
     }
 
+    /**
+     * @ignore
+     * Validates the provided TLS options are secure.
+     *
+     * @param {string} kmsProvider The KMS provider name.
+     * @param {ClientEncryptionTLSOptions} tlsOptions The client TLS options for the provider.
+     *
+     * @returns {Error} If any option is invalid.
+     */
     validateTlsOptions(kmsProvider, tlsOptions) {
       const tlsOptionNames = Object.keys(tlsOptions);
       for (const option of INSECURE_TLS_OPTIONS) {
@@ -334,6 +343,13 @@ module.exports = function(modules) {
       }
     }
 
+    /**
+     * @ignore
+     * Sets only the valid secure TLS options.
+     *
+     * @param {ClientEncryptionTLSOptions} tlsOptions The client TLS options for the provider.
+     * @param {Object} options The existing connection options.
+     */
     setTlsOptions(tlsOptions, options) {
       if (tlsOptions.tlsCertificateKeyFile) {
         const cert = fs.readFileSync(tlsOptions.tlsCertificateKeyFile, {

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -335,7 +335,9 @@ module.exports = function(modules) {
 
     setTlsOptions(tlsOptions, options) {
       if (tlsOptions.tlsCertificateKeyFile) {
-        const cert = fs.readFileSync(tlsOptions.tlsCertificateKeyFile, { encoding: 'ascii' });
+        const cert = fs.readFileSync(tlsOptions.tlsCertificateKeyFile, {
+          encoding: 'ascii'
+        });
         options.cert = options.key = cert;
       }
       if (tlsOptions.tlsCAFile) {

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -3,6 +3,7 @@
 module.exports = function(modules) {
   const tls = require('tls');
   const net = require('net');
+  const { readFile } = require('fs/promises');
   const { once } = require('events');
   const { SocksClient } = require('socks');
 
@@ -283,6 +284,7 @@ module.exports = function(modules) {
           }
         }
 
+        await this.setTlsOptions(request.kmsProvider, options);
         socket = tls.connect(options, () => {
           socket.write(message);
         });
@@ -303,6 +305,28 @@ module.exports = function(modules) {
           }
         });
       });
+    }
+
+    /**
+     * @ignore
+     * Sets the Node TLS options if provided for the specific KMS provider.
+     */
+    async setTlsOptions(kmsProvider, options) {
+      const tlsOptions = this.options.tlsOptions;
+      if (tlsOptions) {
+        const providerTlsOptions = tlsOptions[kmsProvider];
+        if (providerTlsOptions) {
+          if (providerTlsOptions.tlsCertificateKeyFile) {
+            options.cert = await readFile(providerTlsOptions.tlsCertificateKeyFile, { encoding: 'ascii' });
+          }
+          if (providerTlsOptions.tlsCAFile) {
+            options.ca = await readFile(providerTlsOptions.tlsCAFile, { encoding: 'ascii' });
+          }
+          if (providerTlsOptions.tlsCertificateKeyFilePassword) {
+            options.passphrase = providerTlsOptions.tlsCertificateKeyFilePassword;
+          }
+        }
+      }
     }
 
     /**

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -295,9 +295,10 @@ module.exports = function(modules) {
 
         const tlsOptions = this.options.tlsOptions;
         if (tlsOptions) {
-          const providerTlsOptions = tlsOptions[request.kmsProvider];
+          const kmsProvider = request.kmsProvider;
+          const providerTlsOptions = tlsOptions[kmsProvider];
           if (providerTlsOptions) {
-            const error = this.validateTlsOptions(providerTlsOptions);
+            const error = this.validateTlsOptions(kmsProvider, providerTlsOptions);
             if (error) reject(error);
             this.setTlsOptions(providerTlsOptions, options);
           }
@@ -324,11 +325,11 @@ module.exports = function(modules) {
       });
     }
 
-    validateTlsOptions(tlsOptions) {
+    validateTlsOptions(kmsProvider, tlsOptions) {
       const tlsOptionNames = Object.keys(tlsOptions);
       for (const option of INSECURE_TLS_OPTIONS) {
         if (tlsOptionNames.includes(option)) {
-          return new MongoCryptError(`Insecure TLS options prohibited: ${option}`);
+          return new MongoCryptError(`Insecure TLS options prohibited for ${kmsProvider}: ${option}`);
         }
       }
     }

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -352,13 +352,11 @@ module.exports = function(modules) {
      */
     setTlsOptions(tlsOptions, options) {
       if (tlsOptions.tlsCertificateKeyFile) {
-        const cert = fs.readFileSync(tlsOptions.tlsCertificateKeyFile, {
-          encoding: 'ascii'
-        });
+        const cert = fs.readFileSync(tlsOptions.tlsCertificateKeyFile);
         options.cert = options.key = cert;
       }
       if (tlsOptions.tlsCAFile) {
-        options.ca = fs.readFileSync(tlsOptions.tlsCAFile, { encoding: 'ascii' });
+        options.ca = fs.readFileSync(tlsOptions.tlsCAFile);
       }
       if (tlsOptions.tlsCertificateKeyFilePassword) {
         options.passphrase = tlsOptions.tlsCertificateKeyFilePassword;

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -326,7 +326,7 @@ module.exports = function(modules) {
 
     validateTlsOptions(tlsOptions) {
       const tlsOptionNames = Object.keys(tlsOptions);
-      for (const option in INSECURE_TLS_OPTIONS) {
+      for (const option of INSECURE_TLS_OPTIONS) {
         if (tlsOptionNames.includes(option)) {
           return new MongoCryptError(`Insecure TLS options prohibited: ${option}`);
         }

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -3,8 +3,7 @@
 module.exports = function(modules) {
   const tls = require('tls');
   const net = require('net');
-  const path = require('path');
-  const fs = require ('fs');
+  const fs = require('fs');
   const { once } = require('events');
   const { SocksClient } = require('socks');
 
@@ -289,7 +288,6 @@ module.exports = function(modules) {
         socket = tls.connect(options, () => {
           socket.write(message);
         });
-        socket.disableRenegotiation();
 
         socket.once('timeout', ontimeout);
         socket.once('error', onerror);
@@ -319,7 +317,9 @@ module.exports = function(modules) {
         const providerTlsOptions = tlsOptions[kmsProvider];
         if (providerTlsOptions) {
           if (providerTlsOptions.tlsCertificateKeyFile) {
-            const cert = fs.readFileSync(providerTlsOptions.tlsCertificateKeyFile, { encoding: 'ascii' });
+            const cert = fs.readFileSync(providerTlsOptions.tlsCertificateKeyFile, {
+              encoding: 'ascii'
+            });
             options.cert = options.key = cert;
           }
           if (providerTlsOptions.tlsCAFile) {

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mongodb-client-encryption",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/bindings/node/test/stateMachine.test.js
+++ b/bindings/node/test/stateMachine.test.js
@@ -91,6 +91,16 @@ describe('StateMachine', function() {
       });
     });
 
+    context('when tls options are provided', function(done) {
+      context('when the options are insecure', function(done) {
+
+      });
+
+      context('when the options are secure', function(done) {
+
+      });
+    });
+
     afterEach(function() {
       this.sinon.restore();
     });

--- a/bindings/node/test/stateMachine.test.js
+++ b/bindings/node/test/stateMachine.test.js
@@ -91,9 +91,33 @@ describe('StateMachine', function() {
       });
     });
 
-    context('when tls options are provided', function(done) {
-      context('when the options are insecure', function(done) {
+    context('when tls options are provided', function() {
+      context('when the options are insecure', function() {
+        [
+          'tlsInsecure',
+          'tlsAllowInvalidCertificates',
+          'tlsAllowInvalidHostnames',
+          'tlsDisableOCSPEndpointCheck',
+          'tlsDisableCertificateRevocationCheck'
+        ].forEach(function(option) {
+          context(`when the option is ${option}`, function() {
+            const stateMachine = new StateMachine({
+              bson: BSON,
+              tlsOptions: { aws: { [option]: true }}
+            });
+            const request = new MockRequest(Buffer.from('foobar'), 500);
+            let status = 'pending';
 
+            it('rejects with the validation error', function(done) {
+              stateMachine
+                .kmsRequest(request)
+                .catch((err) => {
+                  expect(err.message).to.equal(`Insecure TLS options prohibited: ${option}`);
+                  done();
+                });
+            });
+          });
+        });
       });
 
       context('when the options are secure', function(done) {

--- a/bindings/node/test/stateMachine.test.js
+++ b/bindings/node/test/stateMachine.test.js
@@ -106,13 +106,12 @@ describe('StateMachine', function() {
               tlsOptions: { aws: { [option]: true }}
             });
             const request = new MockRequest(Buffer.from('foobar'), 500);
-            let status = 'pending';
 
             it('rejects with the validation error', function(done) {
               stateMachine
                 .kmsRequest(request)
                 .catch((err) => {
-                  expect(err.message).to.equal(`Insecure TLS options prohibited: ${option}`);
+                  expect(err.message).to.equal(`Insecure TLS options prohibited for aws: ${option}`);
                   done();
                 });
             });

--- a/bindings/node/test/stateMachine.test.js
+++ b/bindings/node/test/stateMachine.test.js
@@ -129,13 +129,13 @@ describe('StateMachine', function() {
             tlsOptions: { aws: { tlsCertificateKeyFile: 'test.pem' }}
           });
           const request = new MockRequest(Buffer.from('foobar'), -1);
+          const buffer = Buffer.from('foobar');
           let connectOptions;
 
           it('sets the cert and key options in the tls connect options', function(done) {
-            this.sinon.stub(fs, 'readFileSync').callsFake((fileName, options) => {
+            this.sinon.stub(fs, 'readFileSync').callsFake((fileName) => {
               expect(fileName).to.equal('test.pem');
-              expect(options.encoding).to.equal('ascii');
-              return 'test';
+              return buffer;
             });
             this.sinon.stub(tls, 'connect').callsFake((options, callback) => {
               connectOptions = options;
@@ -143,8 +143,8 @@ describe('StateMachine', function() {
               return this.fakeSocket;
             });
             stateMachine.kmsRequest(request).then(function() {
-              expect(connectOptions.cert).to.equal('test');
-              expect(connectOptions.key).to.equal('test');
+              expect(connectOptions.cert).to.equal(buffer);
+              expect(connectOptions.key).to.equal(buffer);
               done();
             });
             this.fakeSocket.emit('data', Buffer.alloc(0));
@@ -157,13 +157,13 @@ describe('StateMachine', function() {
             tlsOptions: { aws: { tlsCAFile: 'test.pem' }}
           });
           const request = new MockRequest(Buffer.from('foobar'), -1);
+          const buffer = Buffer.from('foobar');
           let connectOptions;
 
           it('sets the ca options in the tls connect options', function(done) {
-            this.sinon.stub(fs, 'readFileSync').callsFake((fileName, options) => {
+            this.sinon.stub(fs, 'readFileSync').callsFake((fileName) => {
               expect(fileName).to.equal('test.pem');
-              expect(options.encoding).to.equal('ascii');
-              return 'test';
+              return buffer;
             });
             this.sinon.stub(tls, 'connect').callsFake((options, callback) => {
               connectOptions = options;
@@ -171,7 +171,7 @@ describe('StateMachine', function() {
               return this.fakeSocket;
             });
             stateMachine.kmsRequest(request).then(function() {
-              expect(connectOptions.ca).to.equal('test');
+              expect(connectOptions.ca).to.equal(buffer);
               done();
             });
             this.fakeSocket.emit('data', Buffer.alloc(0));


### PR DESCRIPTION
- Changes the TLS provider options to function per KMS provider. This now ensures each KMS provider can customise their TLS settings.
- Adds validation on the TLS options not to support any insecure options.

Note Prose and spec tests are located in the main Node repo. Related PR https://github.com/mongodb/node-mongodb-native/pull/3070

Node CSFLE run against this specific branch: https://spruce.mongodb.com/version/61e753873066153369a025de/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC