### PR TITLE
fix(NODE-3777): destroy socket on end

### DIFF
--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -320,6 +320,9 @@ module.exports = function(modules) {
 
           if (request.bytesNeeded <= 0) {
             socket.end(resolve);
+            if (socket.unref) {
+              socket.unref();
+            }
           }
         });
       });

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -319,10 +319,9 @@ module.exports = function(modules) {
           }
 
           if (request.bytesNeeded <= 0) {
-            socket.end(resolve);
-            if (socket.unref) {
-              socket.unref();
-            }
+            // There's no need for any more activity on this socket at this point.
+            socket.destroy();
+            resolve();
           }
         });
       });

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -320,8 +320,7 @@ module.exports = function(modules) {
 
           if (request.bytesNeeded <= 0) {
             // There's no need for any more activity on this socket at this point.
-            socket.destroy();
-            if (rawSocket) rawSocket.destroy();
+            destroySockets();
             resolve();
           }
         });

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -321,6 +321,7 @@ module.exports = function(modules) {
           if (request.bytesNeeded <= 0) {
             // There's no need for any more activity on this socket at this point.
             socket.destroy();
+            if (rawSocket) rawSocket.destroy();
             resolve();
           }
         });


### PR DESCRIPTION
The TLS socket used to communicate with the KMS provider is short lived (expected only to last a single KMS request). In testing KMIP support, the Node process retained a handle on the TLS socket even after explicitly ending it. Calling `end()` on a socket only "half-closes" it and this PR explicitly destroys the socket now.