### PR TITLE
MONGOCRYPT-372 make macos M1 builds universal builds

### DIFF
--- a/.evergreen/build_all.sh
+++ b/.evergreen/build_all.sh
@@ -61,6 +61,18 @@ $CMAKE --build . --target test-mongocrypt --config RelWithDebInfo
 $CMAKE --build ./kms-message --target test_kms_request --config RelWithDebInfo
 cd $evergreen_root
 
+# MONGOCRYPT-372, ensure macOS universal builds contain both x86_64 and arm64 architectures.
+if [ "$MACOS_UNIVERSAL" = "ON" ]; then
+    echo "Checking if libmongocrypt.dylib contains both x86_64 and arm64 architectures..."
+    ARCHS=$(lipo -archs $MONGOCRYPT_INSTALL_PREFIX/lib/libmongocrypt.dylib)
+    if [[ "$ARCHS" == *"x86_64"* && "$ARCHS" == *"arm64"* ]]; then
+        echo "Checking if libmongocrypt.dylib contains both x86_64 and arm64 architectures... OK"
+    else
+        echo "Checking if libmongocrypt.dylib contains both x86_64 and arm64 architectures... ERROR. Got: $ARCHS"
+        exit
+    fi
+fi
+
 if [ "$PPA_BUILD_ONLY" ]; then
     echo "Only building/installing for PPA";
     exit 0;

--- a/.evergreen/build_install_bson.sh
+++ b/.evergreen/build_install_bson.sh
@@ -27,6 +27,10 @@ else
     fi
 fi
 
+if [ "$MACOS_UNIVERSAL" = "ON" ]; then
+    ADDITIONAL_CMAKE_FLAGS="$ADDITIONAL_CMAKE_FLAGS -DCMAKE_OSX_ARCHITECTURES='arm64;x86_64'"
+fi
+
 $CMAKE --version
 
 # Remove remnants of any earlier build

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -472,7 +472,7 @@ tasks:
       name: build-and-test-and-upload
     - variant: ubuntu2004-arm64
       name: build-and-test-and-upload
-    - variant: macos_universal
+    - variant: macos
       name: build-and-test-and-upload
   commands:
     - command: shell.exec
@@ -521,7 +521,7 @@ tasks:
     - func: "download tarball"
       vars: { variant_name: "ubuntu2004-arm64" }
     - func: "download tarball"
-      vars: { variant_name: "macos_universal" }
+      vars: { variant_name: "macos" }
     - command: archive.targz_pack
       params:
         target: libmongocrypt-all.tar.gz
@@ -1065,7 +1065,7 @@ buildvariants:
   run_on: ubuntu2004-small
   tasks:
   - name: debian-package-build
-- name: macos_universal
+- name: macos
   display_name: macOS m1 (Apple LLVM)
   run_on: macos-1100-arm64
   expansions:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -754,7 +754,6 @@ buildvariants:
   - build-and-test-node
   - build-and-test-csharp
   - test-python
-
 - name: rhel72-zseries-test
   display_name: "RHEL 7.2 on zSeries"
   run_on: rhel72-zseries-test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -288,19 +288,6 @@ tasks:
   - func: "tar and upload libmongocrypt libraries"
   - func: "create packages and repos"
 
-- name: build-and-test-universal-mac
-  depends_on:
-  - variant: ubuntu2004-64
-    name: prep-c-driver-source
-  commands:
-  - func: "fetch source"
-  - func: "build and test"
-    vars:
-      compile_env: MACOS_UNIVERSAL=ON
-      test_env: MACOS_UNIVERSAL=ON
-  - func: "tar and upload libmongocrypt libraries"
-  - func: "create packages and repos"
-
 - name: clang-tidy
   depends_on:
   - variant: ubuntu2004-64
@@ -1080,7 +1067,9 @@ buildvariants:
 - name: macos_m1
   display_name: macOS m1 (Apple LLVM)
   run_on: macos-1100-arm64
+  expansions:
+    compile_env: MACOS_UNIVERSAL=ON
+    test_env: MACOS_UNIVERSAL=ON
   tasks:
-  # - build-and-test-and-upload
-  - build-and-test-universal-mac
+  - build-and-test-and-upload
   

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -288,6 +288,19 @@ tasks:
   - func: "tar and upload libmongocrypt libraries"
   - func: "create packages and repos"
 
+- name: build-and-test-universal-mac
+  depends_on:
+  - variant: ubuntu2004-64
+    name: prep-c-driver-source
+  commands:
+  - func: "fetch source"
+  - func: "build and test"
+    vars:
+      compile_env: MACOS_UNIVERSAL=ON
+      test_env: MACOS_UNIVERSAL=ON
+  - func: "tar and upload libmongocrypt libraries"
+  - func: "create packages and repos"
+
 - name: clang-tidy
   depends_on:
   - variant: ubuntu2004-64
@@ -754,6 +767,7 @@ buildvariants:
   - build-and-test-node
   - build-and-test-csharp
   - test-python
+  - build-and-test-universal-mac
 - name: rhel72-zseries-test
   display_name: "RHEL 7.2 on zSeries"
   run_on: rhel72-zseries-test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -418,7 +418,9 @@ tasks:
       name: build-and-test-and-upload
     - variant: ubuntu1604-arm64
       name: build-and-test-java
-    - variant: macos
+    # JAVA-4445 use the "macos" univeral build instead of the "macos_x86_64" build.
+    # Currently the variant named "macos" does not run the build-and-test-java task.
+    - variant: macos_x86_64
       name: build-and-test-java
     - variant: windows-test
       name: build-and-test-and-upload # Todo update once java build passing on windows
@@ -430,7 +432,7 @@ tasks:
   depends_on:
     - variant: ubuntu1604
       name: build-and-test-and-upload
-    - variant: macos
+    - variant: macos_x86_64
       name: build-and-test-and-upload
     - variant: rhel72-zseries-test
       name: build-and-test-and-upload
@@ -743,8 +745,8 @@ buildvariants:
   - name: publish-packages
     distros:
     - ubuntu2004-small
-- name: macos
-  display_name: "macOS 10.14"
+- name: macos_x86_64
+  display_name: "macOS (x86_64) 10.14"
   run_on: macos-1014
   tasks:
   - build-and-test-and-upload

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -484,7 +484,7 @@ tasks:
     - variant: ubuntu2004-arm64
       name: build-and-test-and-upload
     - variant: macos_m1
-      name: build-and-test-and-upload
+      name: build-and-test-universal-mac
   commands:
     - command: shell.exec
       params:
@@ -1081,6 +1081,6 @@ buildvariants:
   display_name: macOS m1 (Apple LLVM)
   run_on: macos-1100-arm64
   tasks:
-  - build-and-test-and-upload
+  # - build-and-test-and-upload
   - build-and-test-universal-mac
   

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -470,7 +470,7 @@ tasks:
       name: build-and-test-and-upload
     - variant: ubuntu2004-arm64
       name: build-and-test-and-upload
-    - variant: macos_m1
+    - variant: macos_x86_64
       name: build-and-test-universal-mac
   commands:
     - command: shell.exec
@@ -519,7 +519,7 @@ tasks:
     - func: "download tarball"
       vars: { variant_name: "ubuntu2004-arm64" }
     - func: "download tarball"
-      vars: { variant_name: "macos_m1" }
+      vars: { variant_name: "macos_x86_64" }
     - command: archive.targz_pack
       params:
         target: libmongocrypt-all.tar.gz
@@ -743,7 +743,7 @@ buildvariants:
   - name: publish-packages
     distros:
     - ubuntu2004-small
-- name: macos
+- name: macos_x86_64
   display_name: "macOS 10.14"
   run_on: macos-1014
   tasks:
@@ -1064,7 +1064,7 @@ buildvariants:
   run_on: ubuntu2004-small
   tasks:
   - name: debian-package-build
-- name: macos_m1
+- name: macos
   display_name: macOS m1 (Apple LLVM)
   run_on: macos-1100-arm64
   expansions:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -767,7 +767,7 @@ buildvariants:
   - build-and-test-node
   - build-and-test-csharp
   - test-python
-  - build-and-test-universal-mac
+
 - name: rhel72-zseries-test
   display_name: "RHEL 7.2 on zSeries"
   run_on: rhel72-zseries-test
@@ -1082,4 +1082,5 @@ buildvariants:
   run_on: macos-1100-arm64
   tasks:
   - build-and-test-and-upload
+  - build-and-test-universal-mac
   

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -470,7 +470,7 @@ tasks:
       name: build-and-test-and-upload
     - variant: ubuntu2004-arm64
       name: build-and-test-and-upload
-    - variant: macos_x86_64
+    - variant: macos_universal
       name: build-and-test-and-upload
   commands:
     - command: shell.exec
@@ -519,7 +519,7 @@ tasks:
     - func: "download tarball"
       vars: { variant_name: "ubuntu2004-arm64" }
     - func: "download tarball"
-      vars: { variant_name: "macos_x86_64" }
+      vars: { variant_name: "macos_universal" }
     - command: archive.targz_pack
       params:
         target: libmongocrypt-all.tar.gz
@@ -743,7 +743,7 @@ buildvariants:
   - name: publish-packages
     distros:
     - ubuntu2004-small
-- name: macos_x86_64
+- name: macos
   display_name: "macOS 10.14"
   run_on: macos-1014
   tasks:
@@ -1064,7 +1064,7 @@ buildvariants:
   run_on: ubuntu2004-small
   tasks:
   - name: debian-package-build
-- name: macos
+- name: macos_universal
   display_name: macOS m1 (Apple LLVM)
   run_on: macos-1100-arm64
   expansions:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -471,7 +471,7 @@ tasks:
     - variant: ubuntu2004-arm64
       name: build-and-test-and-upload
     - variant: macos_x86_64
-      name: build-and-test-universal-mac
+      name: build-and-test-and-upload
   commands:
     - command: shell.exec
       params:

--- a/.evergreen/linker-tests.sh
+++ b/.evergreen/linker-tests.sh
@@ -60,6 +60,10 @@ else
     fi
 fi
 
+if [ "$MACOS_UNIVERSAL" = "ON" ]; then
+    ADDITIONAL_CMAKE_FLAGS="$ADDITIONAL_CMAKE_FLAGS -DCMAKE_OSX_ARCHITECTURES='arm64;x86_64'"
+fi
+
 git apply --ignore-whitespace "$(system_path $linker_tests_deps_root/bson_patches/libbson1.patch)"
 mkdir cmake-build
 cd cmake-build

--- a/.evergreen/pkgconfig-tests.sh
+++ b/.evergreen/pkgconfig-tests.sh
@@ -46,6 +46,10 @@ else
     fi
 fi
 
+if [ "$MACOS_UNIVERSAL" = "ON" ]; then
+    ADDITIONAL_CMAKE_FLAGS="$ADDITIONAL_CMAKE_FLAGS -DCMAKE_OSX_ARCHITECTURES='arm64;x86_64'"
+fi
+
 mkdir cmake-build
 cd cmake-build
 INSTALL_PATH="$(system_path $pkgconfig_tests_root/install)"

--- a/bindings/java/mongocrypt/build.gradle.kts
+++ b/bindings/java/mongocrypt/build.gradle.kts
@@ -135,7 +135,7 @@ val jnaMappingList: List<LibMongoCryptS3Data> = listOf(
         LibMongoCryptS3Data("rhel-67-s390x", "linux-s390x"),
         LibMongoCryptS3Data("ubuntu1604-arm64", "linux-aarch64"),
         LibMongoCryptS3Data("windows-test", "win32-x86-64"),
-        LibMongoCryptS3Data("macos", "darwin")
+        LibMongoCryptS3Data("macos_x86_64", "darwin")
 )
 
 jnaMappingList.forEach {


### PR DESCRIPTION
# Summary
- Update `macos_m1` builds to build with both x86_64 and arm64 architecture with `-DCMAKE_OSX_ARCHITECTURES='arm64;x86_64'`
- Rename the `macos_m1` variant to `macos_universal`.

# Notes
The first attempt at using `-DCMAKE_OSX_ARCHITECTURES='arm64;x86_64'` failed on the [macos-1014 distro](https://evergreen.mongodb.com/lobster/evergreen/task/libmongocrypt_macos_build_and_test_universal_mac_patch_03720bce6905a0bc4c3e8fff7bfa5c92f3eb6c14_61f1c49257e85a6a75727184_22_01_26_22_00_50/0/task#bookmarks=0%2C167&l=). That motivated using the `macos-1100-arm64` distro.