### PR TITLE
Fix node js security issue

### DIFF
--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -40,7 +40,7 @@
     "bindings": "^1.5.0",
     "bl": "^2.2.1",
     "node-addon-api": "^4.1.0",
-    "prebuild-install": "6.1.2",
+    "prebuild-install": "^7.0.1",
     "socks": "^2.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Npm audit:
```txt
simple-get  <4.0.1
Severity: high
Exposure of Sensitive Information in simple-get - https://github.com/advisories/GHSA-wpg7-2c88-r8xv
fix available via `npm audit fix --force`
Will install mongodb-client-encryption@0.2.0, which is a breaking change
node_modules/mongodb-client-encryption/node_modules/simple-get
  prebuild-install  <=6.1.4
  Depends on vulnerable versions of simple-get
  node_modules/mongodb-client-encryption/node_modules/prebuild-install
    mongodb-client-encryption  >=0.3.0
    Depends on vulnerable versions of prebuild-install
    node_modules/mongodb-client-encryption
```
https://github.com/advisories/GHSA-wpg7-2c88-r8xv