### PR TITLE
test: fix incorrect done usage in beforeEach hook

### DIFF
--- a/bindings/node/test/autoEncrypter.test.js
+++ b/bindings/node/test/autoEncrypter.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const util = require('util');
 const fs = require('fs');
 const BSON = require('bson');
 const EJSON = require('bson').EJSON;
@@ -390,8 +391,8 @@ describe('AutoEncrypter', function () {
     });
   });
 
-  describe('noAutoSpawn', function (done) {
-    beforeEach('start MongocryptdManager', async function () {
+  describe('noAutoSpawn', function () {
+    beforeEach('start MongocryptdManager', function (done) {
       if (requirements.SKIP_LIVE_TESTS) {
         this.currentTest.skipReason = `requirements.SKIP_LIVE_TESTS=${requirements.SKIP_LIVE_TESTS}`;
         this.skip();

--- a/bindings/node/test/autoEncrypter.test.js
+++ b/bindings/node/test/autoEncrypter.test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const util = require('util');
 const fs = require('fs');
 const BSON = require('bson');
 const EJSON = require('bson').EJSON;


### PR DESCRIPTION
Fixes test when they run in live mode, will attach link to patch run in driver for proof

[patch](https://spruce.mongodb.com/version/62016c73c9ec446b917b4b5d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

[test running and passing here](https://evergreen.mongodb.com/task_log_raw/mongo_node_driver_next_ubuntu1804_custom_dependency_tests_run_custom_csfle_tests_patch_12c6835155c256eefac8fed7bd36c41120731b91_62016c73c9ec446b917b4b5d_22_02_07_19_01_59/0?type=T#L1049)