### PR TITLE
MONGOCRYPT-364 Add support for providing custom keyMaterial via DataKeyOpts

### DIFF
--- a/src/mongocrypt-ctx-datakey.c
+++ b/src/mongocrypt-ctx-datakey.c
@@ -471,17 +471,24 @@ mongocrypt_ctx_datakey_init (mongocrypt_ctx_t *ctx)
    ctx->vtable.cleanup = _cleanup;
 
    _mongocrypt_buffer_init (&dkctx->plaintext_key_material);
-   dkctx->plaintext_key_material.data = bson_malloc (MONGOCRYPT_KEY_LEN);
-   BSON_ASSERT (dkctx->plaintext_key_material.data);
 
-   dkctx->plaintext_key_material.len = MONGOCRYPT_KEY_LEN;
-   dkctx->plaintext_key_material.owned = true;
-   if (!_mongocrypt_random (ctx->crypt->crypto,
-                            &dkctx->plaintext_key_material,
-                            MONGOCRYPT_KEY_LEN,
-                            ctx->status)) {
-      _mongocrypt_ctx_fail (ctx);
-      goto done;
+   if (ctx->opts.key_material.owned) {
+      /* Use keyMaterial provided by user via DataKeyOpts. */
+      _mongocrypt_buffer_steal (&dkctx->plaintext_key_material,
+                                &ctx->opts.key_material);
+   } else {
+      /* Generate keyMaterial instead. */
+      dkctx->plaintext_key_material.data = bson_malloc (MONGOCRYPT_KEY_LEN);
+      BSON_ASSERT (dkctx->plaintext_key_material.data);
+      dkctx->plaintext_key_material.len = MONGOCRYPT_KEY_LEN;
+      dkctx->plaintext_key_material.owned = true;
+      if (!_mongocrypt_random (ctx->crypt->crypto,
+                               &dkctx->plaintext_key_material,
+                               MONGOCRYPT_KEY_LEN,
+                               ctx->status)) {
+         _mongocrypt_ctx_fail (ctx);
+         goto done;
+      }
    }
 
    if (!_kms_start (ctx)) {

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -38,6 +38,7 @@ typedef enum {
 typedef struct __mongocrypt_ctx_opts_t {
    _mongocrypt_buffer_t key_id;
    _mongocrypt_key_alt_name_t *key_alt_names;
+   _mongocrypt_buffer_t key_material;
    mongocrypt_encryption_algorithm_t algorithm;
    _mongocrypt_kek_t kek;
 } _mongocrypt_ctx_opts_t;

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -173,6 +173,78 @@ mongocrypt_ctx_setopt_key_alt_name (mongocrypt_ctx_t *ctx,
 
 
 bool
+mongocrypt_ctx_setopt_key_material (mongocrypt_ctx_t *ctx,
+                                    mongocrypt_binary_t *key_material)
+{
+   bson_t as_bson;
+   bson_iter_t iter;
+   const char *key;
+   _mongocrypt_buffer_t buffer;
+
+   if (!ctx) {
+      return false;
+   }
+
+   if (ctx->initialized) {
+      return _mongocrypt_ctx_fail_w_msg (ctx, "cannot set options after init");
+   }
+
+   if (ctx->opts.key_material.owned) {
+      return _mongocrypt_ctx_fail_w_msg (ctx, "keyMaterial already set");
+   }
+
+   if (ctx->state == MONGOCRYPT_CTX_ERROR) {
+      return false;
+   }
+
+   if (!key_material || !key_material->data) {
+      return _mongocrypt_ctx_fail_w_msg (ctx, "option must be non-NULL");
+   }
+
+   if (!_mongocrypt_binary_to_bson (key_material, &as_bson)) {
+      return _mongocrypt_ctx_fail_w_msg (ctx,
+                                         "invalid keyMaterial bson object");
+   }
+
+   if (!bson_iter_init (&iter, &as_bson) || !bson_iter_next (&iter)) {
+      return _mongocrypt_ctx_fail_w_msg (ctx, "invalid bson");
+   }
+
+   key = bson_iter_key (&iter);
+   BSON_ASSERT (key);
+   if (0 != strcmp (key, "keyMaterial")) {
+      return _mongocrypt_ctx_fail_w_msg (
+         ctx, "keyMaterial must have field 'keyMaterial'");
+   }
+
+   if (!_mongocrypt_buffer_from_binary_iter (&buffer, &iter)) {
+      return _mongocrypt_ctx_fail_w_msg (ctx,
+                                         "keyMaterial must be binary data");
+   }
+
+   if (buffer.len != MONGOCRYPT_KEY_LEN) {
+      _mongocrypt_set_error (
+         ctx->status,
+         MONGOCRYPT_STATUS_ERROR_CLIENT,
+         MONGOCRYPT_GENERIC_ERROR_CODE,
+         "keyMaterial should have length %d, but has length %" PRIu32,
+         MONGOCRYPT_KEY_LEN,
+         buffer.len);
+      return _mongocrypt_ctx_fail (ctx);
+   }
+
+   _mongocrypt_buffer_steal (&ctx->opts.key_material, &buffer);
+
+   if (bson_iter_next (&iter)) {
+      return _mongocrypt_ctx_fail_w_msg (
+         ctx, "unrecognized field, only keyMaterial expected");
+   }
+
+   return true;
+}
+
+
+bool
 mongocrypt_ctx_setopt_algorithm (mongocrypt_ctx_t *ctx,
                                  const char *algorithm,
                                  int len)
@@ -547,6 +619,7 @@ mongocrypt_ctx_destroy (mongocrypt_ctx_t *ctx)
    _mongocrypt_kek_cleanup (&ctx->opts.kek);
    mongocrypt_status_destroy (ctx->status);
    _mongocrypt_key_broker_cleanup (&ctx->kb);
+   _mongocrypt_buffer_cleanup (&ctx->opts.key_material);
    _mongocrypt_key_alt_name_destroy_all (ctx->opts.key_alt_names);
    _mongocrypt_buffer_cleanup (&ctx->opts.key_id);
    bson_free (ctx);

--- a/src/mongocrypt.h.in
+++ b/src/mongocrypt.h.in
@@ -533,6 +533,26 @@ mongocrypt_ctx_setopt_key_alt_name (mongocrypt_ctx_t *ctx,
                                     mongocrypt_binary_t *key_alt_name);
 
 /**
+ * Set the keyMaterial to use for encrypting data.
+ *
+ * Pass the binary encoding a BSON document like the following:
+ *
+ *   { "keyMaterial" : (BSON BINARY value) }
+ *
+ * @param[in] ctx The @ref mongocrypt_ctx_t object.
+ * @param[in] key_material The data encryption key to use. The viewed data is
+ * copied. It is valid to destroy @p key_material with @ref
+ * mongocrypt_binary_destroy immediately after.
+ * @pre @p ctx has not been initialized.
+ * @returns A boolean indicating success. If false, an error status is set.
+ * Retrieve it with @ref mongocrypt_ctx_status
+ */
+MONGOCRYPT_EXPORT
+bool
+mongocrypt_ctx_setopt_key_material (mongocrypt_ctx_t *ctx,
+                                    mongocrypt_binary_t *key_material);
+
+/**
  * Set the algorithm used for encryption to either
  * deterministic or random encryption. This value
  * should only be set when using explicit encryption.

--- a/src/mongocrypt.h.in
+++ b/src/mongocrypt.h.in
@@ -328,7 +328,7 @@ mongocrypt_setopt_log_handler (mongocrypt_t *crypt,
 
 /**
  * Configure an AWS KMS provider on the @ref mongocrypt_t object.
- * 
+ *
  * This has been superseded by the more flexible:
  * @ref mongocrypt_setopt_kms_providers
  *
@@ -358,7 +358,7 @@ mongocrypt_setopt_kms_provider_aws (mongocrypt_t *crypt,
 
 /**
  * Configure a local KMS provider on the @ref mongocrypt_t object.
- * 
+ *
  * This has been superseded by the more flexible:
  * @ref mongocrypt_setopt_kms_providers
  *
@@ -561,7 +561,7 @@ mongocrypt_ctx_setopt_algorithm (mongocrypt_ctx_t *ctx,
 
 /**
  * Identify the AWS KMS master key to use for creating a data key.
- * 
+ *
  * This has been superseded by the more flexible:
  * @ref mongocrypt_ctx_setopt_key_encryption_key
  *
@@ -592,7 +592,7 @@ mongocrypt_ctx_setopt_masterkey_aws (mongocrypt_ctx_t *ctx,
  * (with the Host header set to this endpoint). This endpoint
  * is persisted in the new data key, and will be returned via
  * @ref mongocrypt_kms_ctx_endpoint.
- * 
+ *
  * This has been superseded by the more flexible:
  * @ref mongocrypt_ctx_setopt_key_encryption_key
  *
@@ -629,7 +629,7 @@ mongocrypt_ctx_setopt_masterkey_local (mongocrypt_ctx_t *ctx);
  * @param[in] ctx The @ref mongocrypt_ctx_t object.
  * @param[in] bin BSON representing the key encryption key document with
  * an additional "provider" field. The following forms are accepted:
- * 
+ *
  * AWS
  * {
  *    provider: "aws",
@@ -637,7 +637,7 @@ mongocrypt_ctx_setopt_masterkey_local (mongocrypt_ctx_t *ctx);
  *    key: <string>,
  *    endpoint: <optional string>
  * }
- * 
+ *
  * Azure
  * {
  *    provider: "azure",
@@ -645,7 +645,7 @@ mongocrypt_ctx_setopt_masterkey_local (mongocrypt_ctx_t *ctx);
  *    keyName: <string>,
  *    keyVersion: <optional string>
  * }
- * 
+ *
  * GCP
  * {
  *    provider: "gcp",
@@ -656,12 +656,12 @@ mongocrypt_ctx_setopt_masterkey_local (mongocrypt_ctx_t *ctx);
  *    keyVersion: <string>,
  *    endpoint: <optional string>
  * }
- * 
+ *
  * Local
  * {
  *    provider: "local"
  * }
- * 
+ *
  * KMIP
  * {
  *    provider: "kmip",
@@ -924,7 +924,7 @@ mongocrypt_kms_ctx_message (mongocrypt_kms_ctx_t *kms,
  * @param[out] endpoint The output endpoint as a NULL terminated string.
  * The endpoint consists of a hostname and port separated by a colon.
  * E.g. "example.com:123". A port is always present.
- * 
+ *
  * @returns A boolean indicating success. If false, an error status is set.
  * Retrieve it with @ref mongocrypt_kms_ctx_status
  */
@@ -1156,8 +1156,8 @@ mongocrypt_setopt_crypto_hooks (mongocrypt_t *crypt,
  *
  * @param[in] crypt The @ref mongocrypt_t object.
  * @param[in] sign_rsaes_pkcs1_v1_5 The crypto callback function.
- * @param[in] sign_ctx A context passed as an argument to the crypto callback every
- * invocation.
+ * @param[in] sign_ctx A context passed as an argument to the crypto callback
+ * every invocation.
  * @pre @ref mongocrypt_init has not been called on @p crypt.
  * @returns A boolean indicating success. If false, an error status is set.
  * Retrieve it with @ref mongocrypt_status


### PR DESCRIPTION
Per MONGOCRYPT-364, this PR introduces [a new function](https://github.com/mongodb/libmongocrypt/commit/a03cad42e41b45bd61d188d6f816cbb85f903b65#diff-d4ee778bda1cec8fee12a57d4f357ec7f302d090f0338a86fffaf40798c8338dR552) `mongocrypt_ctx_setopt_key_material` corresponding to the new `keyMaterial` field proposed for [DataKeyOpts](https://github.com/mongodb/specifications/blob/6dc6f80026f0f8d99a8c81f996389534b14f6602/source/client-side-encryption/client-side-encryption.rst#datakeyopts) (corresponding spec updates pending at time of writing; see DRIVERS-1951).

The `keyMaterial` field, if provided, is used [in place of](https://github.com/mongodb/libmongocrypt/commit/eb513b5e4b3a4b5168c95449a054c26c22e9cdca#diff-5d8f9ef4f7acf690d866bd858986582003de835e62a326ccef87b3f74fc9e69fR475) the key material currently generated by a cryptographically secure random source. This permits the user to provide their own data encryption key (DEK) used to encrypt and decrypt data, rather than depending on a randomly generated DEK.