### PR TITLE
Dynamic library loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,7 +336,7 @@ target_include_directories (test-mongocrypt PRIVATE ${BSON_INCLUDES} "${CMAKE_CU
 target_compile_definitions (test-mongocrypt PRIVATE ${BSON_DEFINITIONS})
 
 # Set a definition so that testcases can know where test-mongocrypt.exe was written to
-target_compile_definitions(test-mongocrypt PRIVATE "TEST_MONGOCRYPT_OUTPUT_PATH=\"$<TARGET_FILE:test-mongocrypt>\"")
+target_compile_definitions (test-mongocrypt PRIVATE "TEST_MONGOCRYPT_OUTPUT_PATH=\"$<TARGET_FILE:test-mongocrypt>\"")
 
 add_test (
    NAME mongocrypt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ add_subdirectory (bindings/cs)
 include (GenerateExportHeader)
 include (GNUInstallDirs)
 
-enable_testing ()
+include (CTest)
 
 set (MONGOCRYPT_PUBLIC_HEADERS
    src/mongocrypt-compat.h
@@ -287,6 +287,16 @@ set_target_properties (mongocrypt_static PROPERTIES
    OUTPUT_NAME "mongocrypt-static"
 )
 
+if (BUILD_TESTING)
+   # Use C++ in the testing DLL to ensure we can load a library with the C++ runtime
+   enable_language (CXX)
+   add_library (test-dll MODULE test/test-dll.cpp)
+   set_target_properties (test-dll PROPERTIES
+      SUFFIX ".dll"
+      PREFIX ""
+      )
+endif ()
+
 set (TEST_MONGOCRYPT_SOURCES
    test/test-mongocrypt-assert-match-bson.c
    test/test-mongocrypt-buffer.c
@@ -299,6 +309,7 @@ set (TEST_MONGOCRYPT_SOURCES
    test/test-mongocrypt-ctx-encrypt.c
    test/test-mongocrypt-ctx-setopt.c
    test/test-mongocrypt-datakey.c
+   test/test-mongocrypt-dll.c
    test/test-mongocrypt-endpoint.c
    test/test-mongocrypt-kek.c
    test/test-mongocrypt-key.c
@@ -320,11 +331,18 @@ add_executable (test-mongocrypt ${TEST_MONGOCRYPT_SOURCES})
 # Use the static version since it allows the test binary to use private symbols
 target_link_libraries (test-mongocrypt PRIVATE mongocrypt_static)
 target_include_directories (test-mongocrypt PRIVATE ./src "${CMAKE_CURRENT_SOURCE_DIR}/kms-message/src")
-target_link_libraries (test-mongocrypt PRIVATE ${BSON_TARGET})
+target_link_libraries (test-mongocrypt PRIVATE ${BSON_TARGET} mongo::mlib)
 target_include_directories (test-mongocrypt PRIVATE ${BSON_INCLUDES} "${CMAKE_CURRENT_LIST_DIR}/test")
 target_compile_definitions (test-mongocrypt PRIVATE ${BSON_DEFINITIONS})
 
-add_test (mongocrypt test-mongocrypt WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+# Set a definition so that testcases can know where test-mongocrypt.exe was written to
+target_compile_definitions(test-mongocrypt PRIVATE "TEST_MONGOCRYPT_OUTPUT_PATH=\"$<TARGET_FILE:test-mongocrypt>\"")
+
+add_test (
+   NAME mongocrypt
+   COMMAND test-mongocrypt
+   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+   )
 
 foreach (test IN ITEMS path str)
    add_executable (mlib.${test}.test src/mlib/${test}.test.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,8 @@ set (MONGOCRYPT_SOURCES
    src/mongocrypt.c
    src/os_win/os_mutex.c
    src/os_posix/os_mutex.c
+   src/os_win/os_dll.c
+   src/os_posix/os_dll.c
    )
 
 if ( MSVC )
@@ -189,6 +191,7 @@ target_link_libraries (
       ${CMAKE_THREAD_LIBS_INIT}
       kms_message_static
       $<BUILD_INTERFACE:mongo::mlib>
+      ${CMAKE_DL_LIBS}
    )
 
 if (NOT ENABLE_SHARED_BSON)
@@ -237,6 +240,7 @@ target_link_libraries (
       kms_message_static
       $<BUILD_INTERFACE:mongo::mlib>
       ${CMAKE_THREAD_LIBS_INIT}
+      ${CMAKE_DL_LIBS}
    )
 set (PKG_CONFIG_STATIC_LIBS "\${prefix}/${CMAKE_INSTALL_LIBDIR}/libmongocrypt-static.a")
 set (PKG_CONFIG_STATIC_LIBS "${PKG_CONFIG_STATIC_LIBS} ${CMAKE_THREAD_LIBS_INIT}")

--- a/src/mlib/error.h
+++ b/src/mlib/error.h
@@ -1,0 +1,55 @@
+#ifndef MLIB_ERROR_PRIVATE_H
+#define MLIB_ERROR_PRIVATE_H
+
+#include "./user-check.h"
+
+#include "./str.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <errno.h>
+#endif
+
+/**
+ * @brief Obtain a string containing an error message corresponding to an error
+ * code from the host platform.
+ *
+ * @param errn An error code for the system. (e.g. GetLastError() on Windows)
+ * @return mstr A new string containing the resulting error. Must be freed with
+ * @ref mstr_free().
+ */
+static inline mstr
+merror_system_error_string (int errn)
+{
+#ifdef _WIN32
+   wchar_t *wbuffer = NULL;
+   DWORD slen = FormatMessageW (FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                                   FORMAT_MESSAGE_FROM_SYSTEM |
+                                   FORMAT_MESSAGE_IGNORE_INSERTS,
+                                NULL,
+                                (DWORD) errn,
+                                0,
+                                (LPWSTR) wbuffer,
+                                0,
+                                NULL);
+   if (slen == 0) {
+      return mstr_copy_cstr (
+         "[Error while getting error string from FormatMessageW()]");
+   }
+   mstr_narrow_result narrow = mstr_win32_narrow (wbuffer);
+   LocalFree (wbuffer);
+   assert (narrow.error == 0);
+   return narrow.string;
+#else
+   errno = 0;
+   char *const str = strerror (errn);
+   if (errno) {
+      return mstr_copy_cstr (
+         "[Error while getting error string from strerror()]");
+   }
+   return mstr_copy_cstr (str);
+#endif
+}
+
+#endif // MLIB_ERROR_PRIVATE_H

--- a/src/mlib/path.h
+++ b/src/mlib/path.h
@@ -25,7 +25,6 @@ typedef enum mpath_format {
 #else
       MPATH_POSIX,
 #endif
-   MPATH_NATIVE_ = 'n'
 } mpath_format;
 
 /**
@@ -371,7 +370,8 @@ mpath_absolute (mstr_view path, mpath_format f)
       return mstr_copy (path);
    }
    mstr cur = mpath_current_path ();
-   mstr ret = mpath_absolute_from (path, cur.view, f);
+   mstr ret = mpath_absolute_from (path, cur.view, MPATH_NATIVE);
+   mstr_assign (&ret, mpath_to_format (MPATH_NATIVE, ret.view, f));
    mstr_free (cur);
    return ret;
 }

--- a/src/mlib/path.h
+++ b/src/mlib/path.h
@@ -7,28 +7,90 @@
 
 #include <inttypes.h>
 
-/**
- * @brief The preferred path separator for the current platform
- */
-static const char MPATH_PREFERRED_PATH_SEPARATOR =
-#ifdef _WIN32
-   '\\'
+#ifndef _WIN32
+#include <unistd.h>
 #else
-   '/'
+#include <windows.h>
 #endif
-   ;
+
+typedef enum mpath_format {
+   /// The POSIX path format
+   MPATH_POSIX = 'p',
+   /// The Win32 path format
+   MPATH_WIN32 = 'w',
+   /// The native path format for the current platform
+   MPATH_NATIVE =
+#ifdef _WIN32
+      MPATH_WIN32,
+#else
+      MPATH_POSIX,
+#endif
+   MPATH_NATIVE_ = 'n'
+} mpath_format;
 
 /**
- * @brief Determine if the given character is a path separator on the current
- * platform.
+ * @brief Determine if the given character is a path separator for the given
+ * path format
+ *
+ * @param c A path character
+ * @param f The path format to use
  */
 static inline bool
-mpath_is_sep (char c)
+mpath_is_sep (char c, mpath_format f)
 {
-#ifdef _WIN32
-   return c == '/' || c == '\\';
+   if (f == MPATH_WIN32) {
+      return c == '/' || c == '\\';
+   } else {
+      return c == '/';
+   }
+}
+
+/**
+ * @brief Obtain the preferred path separator character for the given format
+ */
+static inline char
+mpath_preferred_sep (mpath_format f)
+{
+   if (f == MPATH_WIN32) {
+      return '\\';
+   } else {
+      return '/';
+   }
+}
+
+/**
+ * @brief Obtain the path string denoting the application's current working
+ * directory
+ *
+ * @return mstr A new string which must be freed with mstr_free()
+ */
+static inline mstr
+mpath_current_path ()
+{
+#if _WIN32
+   while (1) {
+      DWORD len = GetCurrentDirectoryW (0, NULL);
+      wchar_t *wstr = calloc (sizeof (wchar_t), len);
+      DWORD got_len = GetCurrentDirectoryW (len, wstr);
+      if (got_len > len) {
+         free (wstr);
+         continue;
+      }
+      mstr_narrow_result nar = mstr_win32_narrow (wstr);
+      free (wstr);
+      assert (nar.error == 0);
+      return nar.string;
+   }
 #else
-   return c == '/';
+   mstr_mut mut = mstr_new (8096);
+   char *p = getcwd (mut.data, mut.len);
+   if (p == NULL) {
+      mstr_free (mut.mstr);
+      return MSTR_NULL;
+   }
+   mstr ret = mstr_copy_cstr (mut.data);
+   mstr_free (mut.mstr);
+   return ret;
 #endif
 }
 
@@ -36,35 +98,58 @@ mpath_is_sep (char c)
  * @brief Determine whether the given path string has a trailing path separator
  */
 static inline bool
-mpath_has_trailing_sep (mstr_view path)
+mpath_has_trailing_sep (mstr_view path, mpath_format f)
 {
-   return path.len && mpath_is_sep (path.data[path.len - 1]);
+   return path.len && mpath_is_sep (path.data[path.len - 1], f);
 }
 
 /**
  * @brief Obtain the parent path of the given path.
- *
- * @param path A path string
- * @return mstr_view A substring of the given path string that views only the
- * parent directory of the given path.
  */
 static inline mstr_view
-mpath_parent (mstr_view path)
+mpath_parent (mstr_view path, mpath_format f)
 {
-   // Remove trailing separators:
-   while (mpath_has_trailing_sep (path)) {
-      path = mstrv_remove_suffix (path, 1);
+   if (mpath_has_trailing_sep (path, f)) {
+      // Remove trailing separators:
+      while (mpath_has_trailing_sep (path, f)) {
+         path = mstrv_remove_suffix (path, 1);
+      }
+      return path;
    }
    // Remove everything that isn't a path separator:
-   while (path.len != 0 && !mpath_has_trailing_sep (path)) {
+   while (path.len != 0 && !mpath_has_trailing_sep (path, f)) {
       path = mstrv_remove_suffix (path, 1);
    }
    // Remove trailing separators again
-   while (mpath_has_trailing_sep (path)) {
+   while (path.len > 1 && mpath_has_trailing_sep (path, f)) {
       path = mstrv_remove_suffix (path, 1);
    }
    // The result is the parent path.
    return path;
+}
+
+/**
+ * @brief Obtain the filename denoted by the given path.
+ *
+ * The returned path will include no directory separators. If the given path
+ * ends with a directory separator, the single-dot '.' path is returned instead.
+ */
+static inline mstr_view
+mpath_filename (mstr_view path, mpath_format f)
+{
+   if (!path.len) {
+      return path;
+   }
+   const char *it = path.data + path.len;
+   while (it != path.data && !mpath_is_sep (it[-1], f)) {
+      --it;
+   }
+   size_t off = it - path.data;
+   mstr_view fname = mstrv_subview (path, off, path.len);
+   if (fname.len == 0) {
+      return mstrv_lit (".");
+   }
+   return fname;
 }
 
 /**
@@ -76,21 +161,22 @@ mpath_parent (mstr_view path)
  *
  * @param base The left-hand of the join
  * @param suffix The right-hand of the join
+ * @param f The path format to use
  * @return mstr A new string resulting from the join
  */
 static inline mstr
-mpath_join (mstr_view base, mstr_view suffix)
+mpath_join (mstr_view base, mstr_view suffix, mpath_format f)
 {
    if (!base.len) {
       return mstr_copy (suffix);
    }
-   if (mpath_has_trailing_sep (base)) {
+   if (mpath_has_trailing_sep (base, f)) {
       return mstr_append (base, suffix);
    }
    if (!suffix.len) {
       return mstr_copy (base);
    }
-   if (mpath_is_sep (suffix.data[0])) {
+   if (mpath_is_sep (suffix.data[0], f)) {
       return mstr_append (base, suffix);
    }
    // We must insert a path separator between the two strings
@@ -98,9 +184,196 @@ mpath_join (mstr_view base, mstr_view suffix)
    char *p = r.data;
    memcpy (p, base.data, base.len);
    p += base.len;
-   *p++ = MPATH_PREFERRED_PATH_SEPARATOR;
+   *p++ = mpath_preferred_sep (f);
    memcpy (p, suffix.data, suffix.len);
    return r.mstr;
+}
+
+/**
+ * @brief Obtain the root name for the given path.
+ *
+ * For the Windows format, this will return the drive letter, if present.
+ * Otherwise, this will return an empty string.
+ */
+static inline mstr_view
+mpath_root_name (mstr_view path, mpath_format f)
+{
+   if (f == MPATH_WIN32 && path.len > 1) {
+      char c = path.data[0];
+      if (path.len > 2 && path.data[1] == ':' &&
+          ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'))) {
+         return mstrv_subview (path, 0, 2);
+      }
+   }
+   return mstrv_subview (path, 0, 0);
+}
+
+/**
+ * @brief Return the root directory of the given path, if present.
+ *
+ * @note This will not include the drive letter of a Win32 path.
+ */
+static inline mstr_view
+mpath_root_directory (mstr_view path, mpath_format f)
+{
+   mstr_view rname = mpath_root_name (path, f);
+   path = mstrv_subview (path, rname.len, path.len);
+   if (path.len && mpath_is_sep (path.data[0], f)) {
+      return mstrv_subview (path, 0, 1);
+   } else {
+      return mstrv_subview (path, 0, 0);
+   }
+}
+
+/**
+ * @brief Obtain the root filepath of the given path.
+ *
+ * This will include both the root name and the root filepath, if present.
+ */
+static inline mstr_view
+mpath_root_path (mstr_view path, mpath_format f)
+{
+   mstr_view rname = mpath_root_name (path, f);
+   mstr_view rdir = mpath_root_directory (path, f);
+   return mstrv_subview (path, 0, rname.len + rdir.len);
+}
+
+/**
+ * @brief Determine whether the given filepath designates a single unambiguous
+ * filesystem location.
+ *
+ * @note A Win32 filepath without a drive letter is not absolute!
+ */
+static inline bool
+mpath_is_absolute (mstr_view path, mpath_format f)
+{
+   if (f == MPATH_WIN32) {
+      // Win32 requires both a root name and a root directory for an absolute
+      // path
+      return mpath_root_name (path, f).len &&
+             mpath_root_directory (path, f).len;
+   } else {
+      // POSIX doesn't have "root names"
+      return mpath_root_directory (path, f).len;
+   }
+}
+
+/**
+ * @brief Obtain a relative path from the given filepath
+ *
+ * If the path has a root path, returns the content of the path following that
+ * root path, otherwise returns the same path itself.
+ */
+static inline mstr_view
+mpath_relative_path (mstr_view path, mpath_format f)
+{
+   mstr_view root = mpath_root_path (path, f);
+   return mstrv_subview (path, root.len, path.len);
+}
+
+/**
+ * @brief Convert the filepath from one format to a preferred form in another
+ * format.
+ *
+ * @note The return value must be freed with mstr_free()
+ */
+static inline mstr
+mpath_to_format (mpath_format from, mstr_view path, mpath_format to)
+{
+   mstr_mut ret = mstr_new (path.len);
+   const char *p = path.data;
+   char *out = ret.data;
+   const char *stop = path.data + path.len;
+   for (; p != stop; ++p, ++out) {
+      if (mpath_is_sep (*p, from)) {
+         *out = mpath_preferred_sep (to);
+      } else {
+         *out = *p;
+      }
+   }
+   return ret.mstr;
+}
+
+/**
+ * @brief Determine whether the given path is relative (not absolute)
+ */
+static inline bool
+mpath_is_relative (mstr_view path, mpath_format f)
+{
+   return !mpath_is_absolute (path, f);
+}
+
+/**
+ * @brief Convert the given path to an absolute path, if it is not already.
+ *
+ * @note The return value must be freed with mstr_free()
+ */
+static inline mstr
+mpath_absolute (mstr_view path, mpath_format f);
+
+/**
+ * @brief Resolve a path to an absolute path from the given base path.
+ *
+ * @note This is not the same as mpath_join(): If the given path is already
+ * absolute, returns that path unchanged. Otherwise, resolves that path as being
+ * relative to `base`.
+ *
+ * @note If `base` is also a relative path, it will also be given to
+ * mpath_absolute() to resolve it.
+ */
+static inline mstr
+mpath_absolute_from (mstr_view path, mstr_view base, mpath_format f)
+{
+   mstr_view rname = mpath_root_name (path, f);
+   mstr_view rdir = mpath_root_directory (path, f);
+   if (rname.len) {
+      if (rdir.len) {
+         // The path is already fully absolute
+         return mstr_copy (path);
+      } else {
+         mstr abs_base = mpath_absolute (base, f);
+         mstr_view base_rdir = mpath_root_directory (abs_base.view, f);
+         mstr_view base_relpath = mpath_relative_path (abs_base.view, f);
+         mstr_view relpath = mpath_relative_path (path, f);
+         mstr ret = mstr_copy (rname);
+         mstr_assign (&ret, mpath_join (ret.view, base_rdir, f));
+         mstr_assign (&ret, mpath_join (ret.view, base_relpath, f));
+         mstr_assign (&ret, mpath_join (ret.view, relpath, f));
+         mstr_free (abs_base);
+         return ret;
+      }
+   } else {
+      // No root name
+      if (rdir.len) {
+         if (f == MPATH_POSIX) {
+            // No root name, but a root directory on a POSIX path indicates an
+            // absolute path
+            return mstr_copy (path);
+         }
+         mstr abs_base = mpath_absolute (base, f);
+         mstr_view base_rname = mpath_root_name (abs_base.view, f);
+         mstr ret = mpath_join (base_rname, path, f);
+         mstr_free (abs_base);
+         return ret;
+      } else {
+         mstr abs_base = mpath_absolute (base, f);
+         mstr r = mpath_join (abs_base.view, path, f);
+         mstr_free (abs_base);
+         return r;
+      }
+   }
+}
+
+static inline mstr
+mpath_absolute (mstr_view path, mpath_format f)
+{
+   if (mpath_is_absolute (path, f)) {
+      return mstr_copy (path);
+   }
+   mstr cur = mpath_current_path ();
+   mstr ret = mpath_absolute_from (path, cur.view, f);
+   mstr_free (cur);
+   return ret;
 }
 
 #endif // MONGOCRYPT_PATH_PRIVATE_H

--- a/src/mlib/path.test.c
+++ b/src/mlib/path.test.c
@@ -9,18 +9,77 @@
                         #Expr),                       \
                abort ()),                             \
               0))
+
+#define TEST_DECOMP(Part, Given, Expect)                                 \
+   MSTR_ASSERT_EQ (mpath_##Part (mstrv_view_cstr (Given), MPATH_NATIVE), \
+                   mstrv_view_cstr (Expect))
+
+static void
+test_make_absolute (mpath_format f,
+                    const char *part,
+                    const char *base,
+                    const char *expect)
+{
+   mstr result =
+      mpath_absolute_from (mstrv_view_cstr (part), mstrv_view_cstr (base), f);
+   MSTR_ASSERT_EQ (result.view, mstrv_view_cstr (expect));
+   mstr_free (result);
+}
+
 int
 main ()
 {
    mstr s = mstr_copy_cstr ("/foo/bar/baz.txt");
-   MSTR_ASSERT_EQ (mpath_parent (s.view), mstrv_lit ("/foo/bar"));
-   MSTR_ASSERT_EQ (mpath_parent (mpath_parent (s.view)), mstrv_lit ("/foo"));
+   MSTR_ASSERT_EQ (mpath_parent (s.view, MPATH_NATIVE), mstrv_lit ("/foo/bar"));
+   MSTR_ASSERT_EQ (
+      mpath_parent (mpath_parent (s.view, MPATH_NATIVE), MPATH_NATIVE),
+      mstrv_lit ("/foo"));
 
-   mstr_assign (&s, mpath_join (mpath_parent (s.view), mstrv_lit ("quux.pdf")));
-#if _WIN32
+   mstr_assign (
+      &s,
+      mpath_join (mpath_parent (mstrv_lit ("/foo/bar/baz.txt"), MPATH_WIN32),
+                  mstrv_lit ("quux.pdf"),
+                  MPATH_WIN32));
    MSTR_ASSERT_EQ (s.view, mstrv_lit ("/foo/bar\\quux.pdf"));
-#else
+   mstr_assign (
+      &s,
+      mpath_join (mpath_parent (mstrv_lit ("/foo/bar/baz.txt"), MPATH_POSIX),
+                  mstrv_lit ("quux.pdf"),
+                  MPATH_POSIX));
    MSTR_ASSERT_EQ (s.view, mstrv_lit ("/foo/bar/quux.pdf"));
-#endif
+
+   TEST_DECOMP (parent, "/foo", "/");
+   TEST_DECOMP (parent, "/foo/", "/foo");
+   TEST_DECOMP (parent, "foo/", "foo");
+   TEST_DECOMP (parent, ".", "");
+   TEST_DECOMP (parent, "..", "");
+   TEST_DECOMP (parent, "foo", "");
+   TEST_DECOMP (parent, "/", "");
+   TEST_DECOMP (parent, "foo/bar", "foo");
+   TEST_DECOMP (parent, "/foo/bar", "/foo");
+   TEST_DECOMP (parent, "///foo///bar", "///foo");
+   TEST_DECOMP (parent, "/.", "/");
+
+   TEST_DECOMP (filename, "foo.exe", "foo.exe");
+   TEST_DECOMP (filename, "/foo.exe", "foo.exe");
+   TEST_DECOMP (filename, "/", ".");
+   TEST_DECOMP (filename, "/foo", "foo");
+   TEST_DECOMP (filename, "/foo/", ".");
+   TEST_DECOMP (filename, "/foo/..", "..");
+   TEST_DECOMP (filename, "/foo/.", ".");
+   TEST_DECOMP (filename, "", "");
+
+   TEST_DECOMP (relative_path, "", "");
+   TEST_DECOMP (relative_path, ".", ".");
+   TEST_DECOMP (relative_path, "..", "..");
+   TEST_DECOMP (relative_path, "foo", "foo");
+   TEST_DECOMP (relative_path, "/", "");
+
+   test_make_absolute (MPATH_POSIX, "foo", "/bar", "/bar/foo");
+   test_make_absolute (MPATH_POSIX, "baz.txt", "/bar/foo/", "/bar/foo/baz.txt");
+   test_make_absolute (MPATH_WIN32, "foo", "C:/bar", "C:/bar\\foo");
+   test_make_absolute (
+      MPATH_WIN32, "baz.txt", "D:/bar/foo/", "D:/bar/foo/baz.txt");
+
    mstr_free (s);
 }

--- a/src/mlib/path.test.c
+++ b/src/mlib/path.test.c
@@ -81,5 +81,13 @@ main ()
    test_make_absolute (
       MPATH_WIN32, "baz.txt", "D:/bar/foo/", "D:/bar/foo/baz.txt");
 
+   // Just test calling with each combo, no validation.
+   mstr_assign (&s, mpath_absolute (mstrv_lit ("foo"), MPATH_WIN32));
+   mstr_assign (&s, mpath_absolute (mstrv_lit ("foo"), MPATH_POSIX));
+   mstr_assign (&s, mpath_absolute (mstrv_lit ("/foo"), MPATH_WIN32));
+   mstr_assign (&s, mpath_absolute (mstrv_lit ("/foo"), MPATH_POSIX));
+   mstr_assign (&s, mpath_absolute (mstrv_lit ("Z:/foo"), MPATH_WIN32));
+   mstr_assign (&s, mpath_absolute (mstrv_lit ("Z:/foo"), MPATH_POSIX));
+
    mstr_free (s);
 }

--- a/src/mlib/str.h
+++ b/src/mlib/str.h
@@ -738,7 +738,7 @@ static inline mstr_narrow_result
 mstr_win32_narrow (const wchar_t *wstring)
 {
    int length = WideCharToMultiByte (CP_UTF8,
-                                     MB_ERR_INVALID_CHARS,
+                                     WC_ERR_INVALID_CHARS,
                                      wstring,
                                      -1 /* wstring is null-terminated */,
                                      NULL,
@@ -751,7 +751,7 @@ mstr_win32_narrow (const wchar_t *wstring)
    }
    mstr_mut ret = mstr_new ((size_t) length);
    int got_len = WideCharToMultiByte (CP_UTF8,
-                                      MB_ERR_INVALID_CHARS,
+                                      WC_ERR_INVALID_CHARS,
                                       wstring,
                                       -1,
                                       ret.data,

--- a/src/mongocrypt-dll-private.h
+++ b/src/mongocrypt-dll-private.h
@@ -1,0 +1,78 @@
+#ifndef MONGOCRYPT_DLL_PRIVATE_H
+#define MONGOCRYPT_DLL_PRIVATE_H
+
+#include <mlib/str.h>
+
+#include <stdlib.h>
+
+#if _WIN32
+#define MCR_DLL_SUFFIX ".dll"
+#elif __APPLE__
+#define MCR_DLL_SUFFIX ".dylib"
+#else
+#define MCR_DLL_SUFFIX ".so"
+#endif
+
+#define MCR_DLL_NULL ((mcr_dll){._native_handle = NULL, .error_string = NULL})
+
+/**
+ * @brief A dynamically-loaded library i.e. returned by LoadLibrary() or
+ * dlopen()
+ */
+typedef struct mcr_dll {
+   // (All supported platforms using a void* as the library handle type)
+   void *_native_handle;
+   mstr error_string;
+} mcr_dll;
+
+/**
+ * @brief Open and load a dynamic library
+ *
+ * @param lib A path or name of a library, suitable for encoding as a
+ * filepath on the host system.
+ *
+ * @return mcr_dll A newly opened dynamic library, which must be
+ * released using @ref mcr_dll_close()
+ *
+ * If the given `lib` is a qualified path (either relative or absolute) and not
+ * just a filename, then the system will search for the library on the system's
+ * default library search paths. If `lib` is a qualified relative path (not just
+ * a filename), it will be resolved relative to the application's working
+ * directory.
+ */
+mcr_dll
+mcr_dll_open (const char *lib);
+
+/**
+ * @brief Close a dynamic library opened with @ref mcr_dll_open
+ *
+ * @param dll A dynamic library handle
+ */
+static inline void
+mcr_dll_close (mcr_dll dll)
+{
+   extern void mcr_dll_close_handle (mcr_dll);
+   mcr_dll_close_handle (dll);
+   mstr_free (dll.error_string);
+}
+
+/**
+ * @brief Obtain a pointer to an exported entity from the given dynamic library.
+ *
+ * @param dll A library opened with @ref mcr_dll_open
+ * @param symbol The name of a symbol to open
+ * @return void* A pointer to that symbol, or NULL if not found
+ */
+void *
+mcr_dll_sym (mcr_dll dll, const char *symbol);
+
+/**
+ * @brief Determine whether the given DLL is a handle to an open library
+ */
+static inline bool
+mcr_dll_is_open (mcr_dll dll)
+{
+   return dll._native_handle != NULL;
+}
+
+#endif // MONGOCRYPT_DLL_PRIVATE_H

--- a/src/mongocrypt-dll-private.h
+++ b/src/mongocrypt-dll-private.h
@@ -20,7 +20,7 @@
  * dlopen()
  */
 typedef struct mcr_dll {
-   // (All supported platforms using a void* as the library handle type)
+   // (All supported platforms use a void* as the library handle type)
    void *_native_handle;
    mstr error_string;
 } mcr_dll;

--- a/src/os_posix/os_dll.c
+++ b/src/os_posix/os_dll.c
@@ -1,0 +1,43 @@
+#include "../mongocrypt-dll-private.h"
+
+#ifndef _WIN32
+
+#include <string.h>
+#include <stdio.h>
+
+#include <dlfcn.h>
+
+mcr_dll
+mcr_dll_open (const char *filepath)
+{
+   void *handle = dlopen (filepath, RTLD_LAZY | RTLD_LOCAL);
+   if (handle == NULL) {
+      // Failed to open. Return NULL and copy the error message
+      return (mcr_dll){
+         ._native_handle = NULL,
+         .error_string = mstr_copy_cstr (dlerror ()),
+      };
+   } else {
+      // Okay
+      return (mcr_dll){
+         ._native_handle = handle,
+         .error_string = MSTR_NULL,
+      };
+   }
+}
+
+void
+mcr_dll_close_handle (mcr_dll dll)
+{
+   if (dll._native_handle) {
+      dlclose (dll._native_handle);
+   }
+}
+
+void *
+mcr_dll_sym (mcr_dll dll, const char *sym)
+{
+   return dlsym (dll._native_handle, sym);
+}
+
+#endif

--- a/src/os_win/os_dll.c
+++ b/src/os_win/os_dll.c
@@ -1,0 +1,60 @@
+#include "../mongocrypt-dll-private.h"
+
+#ifdef _WIN32
+
+#include <mlib/str.h>
+#include <mlib/path.h>
+#include <mlib/error.h>
+
+#include <string.h>
+#include <stdio.h>
+
+#include <windows.h>
+
+mcr_dll
+mcr_dll_open (const char *filepath_)
+{
+   // Convert all slashes to the native Windows separator
+   mstr filepath =
+      mpath_to_format (MPATH_WIN32, mstrv_view_cstr (filepath_), MPATH_WIN32);
+   // Check if the path is just a filename.
+   bool is_just_filename =
+      mstr_eq (mpath_filename (filepath.view, MPATH_WIN32), filepath.view);
+   if (!is_just_filename) {
+      // If the path is only a filename, we'll allow LoadLibrary() to do a
+      // proper full DLL search. If the path is NOT just a filename, resolve the
+      // given path to a single unambiguous absolute path t suppress
+      // LoadLibrary()'s DLL search behavior.
+      mstr_assign (&filepath, mpath_absolute (filepath.view, MPATH_WIN32));
+   }
+   mstr_widen_result wide = mstr_win32_widen (filepath.view);
+   mstr_free (filepath);
+   if (wide.error) {
+      return (mcr_dll){._native_handle = NULL,
+                       .error_string = merror_system_error_string (wide.error)};
+   }
+   HMODULE lib = LoadLibraryW (wide.wstring);
+   if (lib == NULL) {
+      return (mcr_dll){._native_handle = NULL,
+                       .error_string =
+                          merror_system_error_string (GetLastError ())};
+   }
+   free (wide.wstring);
+   return (mcr_dll){.error_string = NULL, ._native_handle = lib};
+}
+
+void
+mcr_dll_close_handle (mcr_dll dll)
+{
+   if (dll._native_handle) {
+      FreeLibrary (dll._native_handle);
+   }
+}
+
+void *
+mcr_dll_sym (mcr_dll dll, const char *sym)
+{
+   return GetProcAddress (dll._native_handle, sym);
+}
+
+#endif

--- a/src/os_win/os_dll.c
+++ b/src/os_win/os_dll.c
@@ -23,7 +23,7 @@ mcr_dll_open (const char *filepath_)
    if (!is_just_filename) {
       // If the path is only a filename, we'll allow LoadLibrary() to do a
       // proper full DLL search. If the path is NOT just a filename, resolve the
-      // given path to a single unambiguous absolute path t suppress
+      // given path to a single unambiguous absolute path to suppress
       // LoadLibrary()'s DLL search behavior.
       mstr_assign (&filepath, mpath_absolute (filepath.view, MPATH_WIN32));
    }

--- a/test/test-dll.cpp
+++ b/test/test-dll.cpp
@@ -1,0 +1,22 @@
+/**
+ * This file is not a test case. This file is to generate a dynamic library for
+ * testing the dll loading code.
+ */
+
+#include <string>
+#include <iostream>
+
+static std::string global_str;
+
+extern "C"
+#if _MSC_VER
+   __declspec(dllexport)
+#else
+__attribute__ ((visibility ("default")))
+#endif
+      int say_hello ()
+{
+   global_str = "Hello, DLL!";
+   std::cout << global_str << "\n";
+   return 42;
+}

--- a/test/test-mongocrypt-dll.c
+++ b/test/test-mongocrypt-dll.c
@@ -27,6 +27,7 @@ _test_load_simple_library (_mongocrypt_tester_t *t)
 
    mcr_dll_close (lib);
    mstr_free (dll_path);
+   mstr_free (self_path);
 }
 
 static void

--- a/test/test-mongocrypt-dll.c
+++ b/test/test-mongocrypt-dll.c
@@ -1,0 +1,47 @@
+#include "mongocrypt.h"
+
+#include "mongocrypt-dll-private.h"
+
+#include <mlib/path.h>
+
+#include "test-mongocrypt.h"
+
+static void
+_test_load_simple_library (_mongocrypt_tester_t *t)
+{
+   (void) t;
+   mstr self_path = mstr_copy_cstr (TEST_MONGOCRYPT_OUTPUT_PATH);
+
+   mstr dll_path = mpath_join (mpath_parent (self_path.view, MPATH_NATIVE),
+                               mstrv_view_cstr ("test-dll.dll"),
+                               MPATH_NATIVE);
+
+   mcr_dll lib = mcr_dll_open (dll_path.data);
+   BSON_ASSERT (lib.error_string.len == 0);
+
+   int (*say_hello) (void) = mcr_dll_sym (lib, "say_hello");
+   BSON_ASSERT (say_hello != NULL);
+
+   int rval = say_hello ();
+   ASSERT_CMPINT (rval, ==, 42);
+
+   mcr_dll_close (lib);
+   mstr_free (dll_path);
+}
+
+static void
+_test_load_nonesuch (_mongocrypt_tester_t *t)
+{
+   (void) t;
+   mcr_dll lib = mcr_dll_open ("no-such-directory/no-such-lib.dll");
+   BSON_ASSERT (lib._native_handle == NULL);
+   BSON_ASSERT (lib.error_string.len > 0);
+   mcr_dll_close (lib);
+}
+
+void
+_mongocrypt_tester_install_dll (_mongocrypt_tester_t *tester)
+{
+   INSTALL_TEST (_test_load_simple_library);
+   INSTALL_TEST (_test_load_nonesuch);
+}

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -788,6 +788,7 @@ main (int argc, char **argv)
    _mongocrypt_tester_install_kek (&tester);
    _mongocrypt_tester_install_cache_oauth (&tester);
    _mongocrypt_tester_install_kms_ctx (&tester);
+   _mongocrypt_tester_install_dll (&tester);
 
 
    printf ("Running tests...\n");

--- a/test/test-mongocrypt.h
+++ b/test/test-mongocrypt.h
@@ -174,6 +174,9 @@ void
 _mongocrypt_tester_install_status (_mongocrypt_tester_t *tester);
 
 void
+_mongocrypt_tester_install_dll (_mongocrypt_tester_t *tester);
+
+void
 _mongocrypt_tester_install_endpoint (_mongocrypt_tester_t *tester);
 
 void


### PR DESCRIPTION
This is a prereq for MONGOCRYPT-373. This introduces private components that can be used to load a dynamic library at runtime. This changes also include tweaks to the mlib path APIs added in #243 

Each commit can be reviewed individually for easier reading.