### PR TITLE
hide openssl 1.0/1.1 helpers

### DIFF
--- a/src/crypto/libcrypto.c
+++ b/src/crypto/libcrypto.c
@@ -35,26 +35,26 @@
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || \
    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L)
-EVP_CIPHER_CTX *
+static EVP_CIPHER_CTX *
 EVP_CIPHER_CTX_new (void)
 {
    return bson_malloc0 (sizeof (EVP_CIPHER_CTX));
 }
 
-void
+static void
 EVP_CIPHER_CTX_free (EVP_CIPHER_CTX *ctx)
 {
    EVP_CIPHER_CTX_cleanup (ctx);
    bson_free (ctx);
 }
 
-HMAC_CTX *
+static HMAC_CTX *
 HMAC_CTX_new (void)
 {
    return bson_malloc0 (sizeof (HMAC_CTX));
 }
 
-void
+static void
 HMAC_CTX_free (HMAC_CTX *ctx)
 {
    HMAC_CTX_cleanup (ctx);


### PR DESCRIPTION
See https://github.com/mongodb/mongo-php-driver/issues/1302 for discussion why having these symbol public is bad