### PR TITLE
MONGOCRYPT-382 Add support for providing per-KMS-request credentials

### DIFF
--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -192,6 +192,11 @@ export interface ClientEncryptionOptions {
   kmsProviders?: KMSProviders;
 
   /**
+   * Optional callback to override KMS providers per-context.
+   */
+  onKmsProviderRefresh?: () => KMSProviders | Promise<KMSProviders>;
+
+  /**
    * Options for specifying a Socks5 proxy to use for connecting to the KMS.
    */
   proxyOptions?: ProxyOptions;

--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -194,7 +194,7 @@ export interface ClientEncryptionOptions {
   /**
    * Optional callback to override KMS providers per-context.
    */
-  onKmsProviderRefresh?: () => KMSProviders | Promise<KMSProviders>;
+  onKmsProviderRefresh?: () => Promise<KMSProviders>;
 
   /**
    * Options for specifying a Socks5 proxy to use for connecting to the KMS.

--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -107,6 +107,7 @@ module.exports = function (modules) {
       this._metaDataClient = options.metadataClient || client;
       this._proxyOptions = options.proxyOptions || {};
       this._tlsOptions = options.tlsOptions || {};
+      this._onKmsProviderRefresh = options.onKmsProviderRefresh;
 
       const mongoCryptOptions = {};
       if (options.schemaMap) {
@@ -119,6 +120,8 @@ module.exports = function (modules) {
         mongoCryptOptions.kmsProviders = !Buffer.isBuffer(options.kmsProviders)
           ? this._bson.serialize(options.kmsProviders)
           : options.kmsProviders;
+      } else if (!options.onKmsProviderRefresh) {
+        throw new TypeError('Need to specify either kmsProviders ahead of time or when requested');
       }
 
       if (options.logger) {
@@ -262,11 +265,11 @@ module.exports = function (modules) {
     /**
      * Ask the user for KMS credentials.
      */
-    askForKMSCredentials() {
+    async askForKMSCredentials() {
       /* This returns anything that looks like the kmsProviders original input
        * option. It can be empty, and any provider specified here will override
        * the original ones. */
-      return Promise.resolve({});
+      return this._onKmsProviderRefresh ? this._onKmsProviderRefresh() : {};
     }
   }
 

--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -258,6 +258,16 @@ module.exports = function (modules) {
       });
       stateMachine.execute(this, context, callback);
     }
+
+    /**
+     * Ask the user for KMS credentials.
+     */
+    askForKMSCredentials() {
+      /* This returns anything that looks like the kmsProviders original input
+       * option. It can be empty, and any provider specified here will override
+       * the original ones. */
+      return Promise.resolve({});
+    }
   }
 
   return { AutoEncrypter };

--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -264,11 +264,12 @@ module.exports = function (modules) {
 
     /**
      * Ask the user for KMS credentials.
+     *
+     * This returns anything that looks like the kmsProviders original input
+     * option. It can be empty, and any provider specified here will override
+     * the original ones.
      */
     async askForKMSCredentials() {
-      /* This returns anything that looks like the kmsProviders original input
-       * option. It can be empty, and any provider specified here will override
-       * the original ones. */
       return this._onKmsProviderRefresh ? this._onKmsProviderRefresh() : {};
     }
   }

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -78,8 +78,11 @@ module.exports = function (modules) {
       // kmsProviders will be parsed by libmongocrypt, must be provided as BSON binary data
       if (options.kmsProviders && !Buffer.isBuffer(options.kmsProviders)) {
         options.kmsProviders = this._bson.serialize(options.kmsProviders);
+      } else if (!options.onKmsProviderRefresh) {
+        throw new TypeError('Need to specify either kmsProviders ahead of time or when requested');
       }
 
+      this._onKmsProviderRefresh = options.onKmsProviderRefresh;
       this._keyVaultNamespace = options.keyVaultNamespace;
       this._keyVaultClient = options.keyVaultClient || client;
       this._mongoCrypt = new mc.MongoCrypt(options);
@@ -367,11 +370,11 @@ module.exports = function (modules) {
     /**
      * Ask the user for KMS credentials.
      */
-    askForKMSCredentials() {
+    async askForKMSCredentials() {
       /* This returns anything that looks like the kmsProviders original input
        * option. It can be empty, and any provider specified here will override
        * the original ones. */
-      return Promise.resolve({});
+      return this._onKmsProviderRefresh ? this._onKmsProviderRefresh() : {};
     }
   }
 

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -363,6 +363,16 @@ module.exports = function (modules) {
         });
       });
     }
+
+    /**
+     * Ask the user for KMS credentials.
+     */
+    askForKMSCredentials() {
+      /* This returns anything that looks like the kmsProviders original input
+       * option. It can be empty, and any provider specified here will override
+       * the original ones. */
+      return Promise.resolve({});
+    }
   }
 
   return { ClientEncryption };

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -369,11 +369,12 @@ module.exports = function (modules) {
 
     /**
      * Ask the user for KMS credentials.
+     *
+     * This returns anything that looks like the kmsProviders original input
+     * option. It can be empty, and any provider specified here will override
+     * the original ones.
      */
     async askForKMSCredentials() {
-      /* This returns anything that looks like the kmsProviders original input
-       * option. It can be empty, and any provider specified here will override
-       * the original ones. */
       return this._onKmsProviderRefresh ? this._onKmsProviderRefresh() : {};
     }
   }

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -178,15 +178,17 @@ module.exports = function (modules) {
         }
 
         case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS: {
-          autoEncrypter.askForKMSCredentials().then((kmsProviders) => {
-            context.provideKMSProviders(
-              !Buffer.isBuffer(kmsProviders)
-                ? bson.serialize(kmsProviders)
-                : kmsProviders);
-            this.execute(autoEncrypter, context, callback);
-          }).catch(err => {
-            callback(err, null);
-          });
+          autoEncrypter
+            .askForKMSCredentials()
+            .then(kmsProviders => {
+              context.provideKMSProviders(
+                !Buffer.isBuffer(kmsProviders) ? bson.serialize(kmsProviders) : kmsProviders
+              );
+              this.execute(autoEncrypter, context, callback);
+            })
+            .catch(err => {
+              callback(err, null);
+            });
 
           return;
         }

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -23,6 +23,7 @@ module.exports = function (modules) {
   const MONGOCRYPT_CTX_NEED_MONGO_COLLINFO = 1;
   const MONGOCRYPT_CTX_NEED_MONGO_MARKINGS = 2;
   const MONGOCRYPT_CTX_NEED_MONGO_KEYS = 3;
+  const MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS = 7;
   const MONGOCRYPT_CTX_NEED_KMS = 4;
   const MONGOCRYPT_CTX_READY = 5;
   const MONGOCRYPT_CTX_DONE = 6;
@@ -34,6 +35,7 @@ module.exports = function (modules) {
     [MONGOCRYPT_CTX_NEED_MONGO_COLLINFO, 'MONGOCRYPT_CTX_NEED_MONGO_COLLINFO'],
     [MONGOCRYPT_CTX_NEED_MONGO_MARKINGS, 'MONGOCRYPT_CTX_NEED_MONGO_MARKINGS'],
     [MONGOCRYPT_CTX_NEED_MONGO_KEYS, 'MONGOCRYPT_CTX_NEED_MONGO_KEYS'],
+    [MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS, 'MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS'],
     [MONGOCRYPT_CTX_NEED_KMS, 'MONGOCRYPT_CTX_NEED_KMS'],
     [MONGOCRYPT_CTX_READY, 'MONGOCRYPT_CTX_READY'],
     [MONGOCRYPT_CTX_DONE, 'MONGOCRYPT_CTX_DONE']
@@ -170,6 +172,20 @@ module.exports = function (modules) {
 
             context.finishMongoOperation();
             this.execute(autoEncrypter, context, callback);
+          });
+
+          return;
+        }
+
+        case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS: {
+          autoEncrypter.askForKMSCredentials().then((kmsProviders) => {
+            context.provideKMSProviders(
+              !Buffer.isBuffer(kmsProviders)
+                ? bson.serialize(kmsProviders)
+                : kmsProviders);
+            this.execute(autoEncrypter, context, callback);
+          }).catch(err => {
+            callback(err, null);
           });
 
           return;

--- a/bindings/node/src/mongocrypt.h
+++ b/bindings/node/src/mongocrypt.h
@@ -74,6 +74,7 @@ class MongoCryptContext : public Napi::ObjectWrap<MongoCryptContext> {
     void AddMongoOperationResponse(const Napi::CallbackInfo& info);
     void FinishMongoOperation(const Napi::CallbackInfo& info);
     Napi::Value NextKMSRequest(const Napi::CallbackInfo& info);
+    void ProvideKMSProviders(const Napi::CallbackInfo& info);
     void FinishKMSRequests(const Napi::CallbackInfo& info);
     Napi::Value FinalizeContext(const Napi::CallbackInfo& info);
 

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -71,7 +71,9 @@ struct _mongocrypt_ctx_t {
    _mongocrypt_key_broker_t kb;
    _mongocrypt_vtable_t vtable;
    _mongocrypt_ctx_opts_t opts;
-   _mongocrypt_opts_kms_providers_t kms_providers;
+   _mongocrypt_opts_kms_providers_t per_ctx_kms_providers; /* owned */
+   _mongocrypt_opts_kms_providers_t
+      kms_providers; /* not owned, is merged from per-ctx / per-mongocrypt_t */
    bool initialized;
    bool
       nothing_to_do; /* set to true if no encryption/decryption is required. */

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -55,6 +55,7 @@ typedef struct {
    bool (*mongo_op_keys) (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out);
    bool (*mongo_feed_keys) (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *in);
    bool (*mongo_done_keys) (mongocrypt_ctx_t *ctx);
+   bool (*after_kms_credentials_provided) (mongocrypt_ctx_t *ctx);
    mongocrypt_kms_ctx_t *(*next_kms_ctx) (mongocrypt_ctx_t *ctx);
    bool (*kms_done) (mongocrypt_ctx_t *ctx);
    bool (*finalize) (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out);
@@ -70,6 +71,7 @@ struct _mongocrypt_ctx_t {
    _mongocrypt_key_broker_t kb;
    _mongocrypt_vtable_t vtable;
    _mongocrypt_ctx_opts_t opts;
+   _mongocrypt_opts_kms_providers_t kms_providers;
    bool initialized;
    bool
       nothing_to_do; /* set to true if no encryption/decryption is required. */
@@ -170,5 +172,10 @@ _mongocrypt_ctx_init (mongocrypt_ctx_t *ctx,
 bool
 _mongocrypt_ctx_state_from_key_broker (mongocrypt_ctx_t *ctx)
    MONGOCRYPT_WARN_UNUSED_RESULT;
+
+/* Get the KMS providers for the current context, fall back to the ones
+ * from mongocrypt_t if none are provided for the context specifically. */
+_mongocrypt_opts_kms_providers_t *
+_mongocrypt_ctx_kms_providers(mongocrypt_ctx_t *ctx);
 
 #endif /* MONGOCRYPT_CTX_PRIVATE_H */

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -825,7 +825,8 @@ _mongocrypt_ctx_init (mongocrypt_ctx_t *ctx,
       if (!ctx->opts.kek.kms_provider) {
          return _mongocrypt_ctx_fail_w_msg (ctx, "master key required");
       }
-      if (!(ctx->opts.kek.kms_provider &
+      if (!ctx->crypt->opts.use_need_kms_credentials_state &&
+          !(ctx->opts.kek.kms_provider &
             _mongocrypt_ctx_kms_providers(ctx)->configured_providers)) {
          return _mongocrypt_ctx_fail_w_msg (
             ctx, "requested kms provider not configured");

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -366,7 +366,10 @@ _mongo_feed_keys (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *in)
    _mongocrypt_buffer_t buf;
 
    _mongocrypt_buffer_from_binary (&buf, in);
-   if (!_mongocrypt_key_broker_add_doc (&ctx->kb, &buf)) {
+   if (!_mongocrypt_key_broker_add_doc (
+         &ctx->kb,
+         _mongocrypt_ctx_kms_providers(ctx),
+         &buf)) {
       BSON_ASSERT (!_mongocrypt_key_broker_status (&ctx->kb, ctx->status));
       return _mongocrypt_ctx_fail (ctx);
    }
@@ -391,7 +394,9 @@ _next_kms_ctx (mongocrypt_ctx_t *ctx)
 static bool
 _kms_done (mongocrypt_ctx_t *ctx)
 {
-   if (!_mongocrypt_key_broker_kms_done (&ctx->kb)) {
+   _mongocrypt_opts_kms_providers_t* kms_providers =
+      _mongocrypt_ctx_kms_providers(ctx);
+   if (!_mongocrypt_key_broker_kms_done (&ctx->kb, kms_providers)) {
       BSON_ASSERT (!_mongocrypt_key_broker_status (&ctx->kb, ctx->status));
       return _mongocrypt_ctx_fail (ctx);
    }
@@ -539,6 +544,51 @@ mongocrypt_ctx_next_kms_ctx (mongocrypt_ctx_t *ctx)
 
 
 bool
+mongocrypt_ctx_provide_kms_providers (
+   mongocrypt_ctx_t *ctx,
+   mongocrypt_binary_t *kms_providers_definition)
+{
+   if (!ctx) {
+      return false;
+   }
+
+   if (!ctx->initialized) {
+      _mongocrypt_ctx_fail_w_msg (ctx, "ctx NULL or uninitialized");
+      return false;
+   }
+
+   if (ctx->state != MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS) {
+      _mongocrypt_ctx_fail_w_msg (ctx, "wrong state");
+      return false;
+   }
+
+   if (!_mongocrypt_parse_kms_providers(
+          kms_providers_definition,
+          &ctx->kms_providers,
+          ctx->status,
+          &ctx->crypt->log)) {
+      return false;
+   }
+
+   if (!_mongocrypt_opts_kms_providers_validate(
+          &ctx->kms_providers,
+          true,
+          ctx->status)) {
+      /* Remove the parsed KMS providers if they are invalid */
+      _mongocrypt_opts_kms_providers_cleanup(&ctx->kms_providers);
+      memset(&ctx->kms_providers, 0, sizeof(ctx->kms_providers));
+      return false;
+   }
+
+   ctx->state = MONGOCRYPT_CTX_NEED_KMS;
+   if (ctx->vtable.after_kms_credentials_provided) {
+      return ctx->vtable.after_kms_credentials_provided (ctx);
+   }
+   return true;
+}
+
+
+bool
 mongocrypt_ctx_kms_done (mongocrypt_ctx_t *ctx)
 {
    if (!ctx) {
@@ -618,6 +668,7 @@ mongocrypt_ctx_destroy (mongocrypt_ctx_t *ctx)
       ctx->vtable.cleanup (ctx);
    }
 
+   _mongocrypt_opts_kms_providers_cleanup(&ctx->kms_providers);
    _mongocrypt_kek_cleanup (&ctx->opts.kek);
    mongocrypt_status_destroy (ctx->status);
    _mongocrypt_key_broker_cleanup (&ctx->kb);
@@ -762,7 +813,8 @@ _mongocrypt_ctx_init (mongocrypt_ctx_t *ctx,
       if (!ctx->opts.kek.kms_provider) {
          return _mongocrypt_ctx_fail_w_msg (ctx, "master key required");
       }
-      if (!(ctx->opts.kek.kms_provider & ctx->crypt->opts.kms_providers)) {
+      if (!(ctx->opts.kek.kms_provider &
+            _mongocrypt_ctx_kms_providers(ctx)->configured_providers)) {
          return _mongocrypt_ctx_fail_w_msg (
             ctx, "requested kms provider not configured");
       }
@@ -857,7 +909,11 @@ _mongocrypt_ctx_state_from_key_broker (mongocrypt_ctx_t *ctx)
    case KB_AUTHENTICATING:
    case KB_DECRYPTING_KEY_MATERIAL:
       /* Encrypted keys need KMS. */
-      new_state = MONGOCRYPT_CTX_NEED_KMS;
+      if (ctx->crypt->opts.use_need_kms_credentials_state) {
+         new_state = MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS;
+      } else {
+         new_state = MONGOCRYPT_CTX_NEED_KMS;
+      }
       ret = true;
       break;
    case KB_DONE:
@@ -964,4 +1020,11 @@ mongocrypt_ctx_setopt_key_encryption_key (mongocrypt_ctx_t *ctx,
    }
 
    return true;
+}
+
+_mongocrypt_opts_kms_providers_t *
+_mongocrypt_ctx_kms_providers(mongocrypt_ctx_t *ctx) {
+   return ctx->kms_providers.configured_providers ?
+      &ctx->kms_providers :
+      &ctx->crypt->opts.kms_providers;
 }

--- a/src/mongocrypt-key-broker-private.h
+++ b/src/mongocrypt-key-broker-private.h
@@ -142,6 +142,7 @@ _mongocrypt_key_broker_filter (_mongocrypt_key_broker_t *kb,
 /* Add a key document. */
 bool
 _mongocrypt_key_broker_add_doc (_mongocrypt_key_broker_t *kb,
+                                _mongocrypt_opts_kms_providers_t *kms_providers,
                                 const _mongocrypt_buffer_t *doc)
    MONGOCRYPT_WARN_UNUSED_RESULT;
 
@@ -156,7 +157,9 @@ _mongocrypt_key_broker_next_kms (_mongocrypt_key_broker_t *kb)
 
 /* Indicate that all KMS requests are complete. */
 bool
-_mongocrypt_key_broker_kms_done (_mongocrypt_key_broker_t *kb);
+_mongocrypt_key_broker_kms_done (
+   _mongocrypt_key_broker_t *kb,
+   _mongocrypt_opts_kms_providers_t* kms_providers);
 
 
 /* Get the final decrypted key material from a key by looking up with a key_id.

--- a/src/mongocrypt-kms-ctx-private.h
+++ b/src/mongocrypt-kms-ctx-private.h
@@ -55,18 +55,18 @@ struct _mongocrypt_kms_ctx_t {
 
 
 bool
-_mongocrypt_kms_ctx_init_aws_decrypt (mongocrypt_kms_ctx_t *kms,
-                                      _mongocrypt_opts_t *crypt_opts,
-                                      _mongocrypt_key_doc_t *key,
-                                      _mongocrypt_log_t *log,
-                                      _mongocrypt_crypto_t *crypto)
-   MONGOCRYPT_WARN_UNUSED_RESULT;
+_mongocrypt_kms_ctx_init_aws_decrypt (
+   mongocrypt_kms_ctx_t *kms,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
+   _mongocrypt_key_doc_t *key,
+   _mongocrypt_log_t *log,
+   _mongocrypt_crypto_t *crypto) MONGOCRYPT_WARN_UNUSED_RESULT;
 
 
 bool
 _mongocrypt_kms_ctx_init_aws_encrypt (
    mongocrypt_kms_ctx_t *kms,
-   _mongocrypt_opts_t *crypt_opts,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
    struct __mongocrypt_ctx_opts_t *ctx_opts,
    _mongocrypt_buffer_t *decrypted_key_material,
    _mongocrypt_log_t *log,
@@ -81,52 +81,53 @@ void
 _mongocrypt_kms_ctx_cleanup (mongocrypt_kms_ctx_t *kms);
 
 bool
-_mongocrypt_kms_ctx_init_azure_auth (mongocrypt_kms_ctx_t *kms,
-                                     _mongocrypt_log_t *log,
-                                     _mongocrypt_opts_t *crypt_opts,
-                                     _mongocrypt_endpoint_t *key_vault_endpoint)
-   MONGOCRYPT_WARN_UNUSED_RESULT;
+_mongocrypt_kms_ctx_init_azure_auth (
+   mongocrypt_kms_ctx_t *kms,
+   _mongocrypt_log_t *log,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
+   _mongocrypt_endpoint_t *key_vault_endpoint) MONGOCRYPT_WARN_UNUSED_RESULT;
 
 bool
 _mongocrypt_kms_ctx_init_azure_wrapkey (
    mongocrypt_kms_ctx_t *kms,
    _mongocrypt_log_t *log,
-   _mongocrypt_opts_t *crypt_opts,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
    struct __mongocrypt_ctx_opts_t *ctx_opts,
    const char *access_token,
    _mongocrypt_buffer_t *plaintext_key_material) MONGOCRYPT_WARN_UNUSED_RESULT;
 
 bool
-_mongocrypt_kms_ctx_init_azure_unwrapkey (mongocrypt_kms_ctx_t *kms,
-                                          _mongocrypt_opts_t *crypt_opts,
-                                          const char *access_token,
-                                          _mongocrypt_key_doc_t *key,
-                                          _mongocrypt_log_t *log)
-   MONGOCRYPT_WARN_UNUSED_RESULT;
+_mongocrypt_kms_ctx_init_azure_unwrapkey (
+   mongocrypt_kms_ctx_t *kms,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
+   const char *access_token,
+   _mongocrypt_key_doc_t *key,
+   _mongocrypt_log_t *log) MONGOCRYPT_WARN_UNUSED_RESULT;
 
 bool
-_mongocrypt_kms_ctx_init_gcp_auth (mongocrypt_kms_ctx_t *kms,
-                                   _mongocrypt_log_t *log,
-                                   _mongocrypt_opts_t *crypt_opts,
-                                   _mongocrypt_endpoint_t *kms_endpoint)
-   MONGOCRYPT_WARN_UNUSED_RESULT;
+_mongocrypt_kms_ctx_init_gcp_auth (
+   mongocrypt_kms_ctx_t *kms,
+   _mongocrypt_log_t *log,
+   _mongocrypt_opts_t *crypt_opts,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
+   _mongocrypt_endpoint_t *kms_endpoint) MONGOCRYPT_WARN_UNUSED_RESULT;
 
 bool
 _mongocrypt_kms_ctx_init_gcp_encrypt (
    mongocrypt_kms_ctx_t *kms,
    _mongocrypt_log_t *log,
-   _mongocrypt_opts_t *crypt_opts,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
    struct __mongocrypt_ctx_opts_t *ctx_opts,
    const char *access_token,
    _mongocrypt_buffer_t *plaintext_key_material) MONGOCRYPT_WARN_UNUSED_RESULT;
 
 bool
-_mongocrypt_kms_ctx_init_gcp_decrypt (mongocrypt_kms_ctx_t *kms,
-                                      _mongocrypt_opts_t *crypt_opts,
-                                      const char *access_token,
-                                      _mongocrypt_key_doc_t *key,
-                                      _mongocrypt_log_t *log)
-   MONGOCRYPT_WARN_UNUSED_RESULT;
+_mongocrypt_kms_ctx_init_gcp_decrypt (
+   mongocrypt_kms_ctx_t *kms,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
+   const char *access_token,
+   _mongocrypt_key_doc_t *key,
+   _mongocrypt_log_t *log) MONGOCRYPT_WARN_UNUSED_RESULT;
 
 bool
 _mongocrypt_kms_ctx_init_kmip_register (mongocrypt_kms_ctx_t *kms,

--- a/src/mongocrypt-kms-ctx.c
+++ b/src/mongocrypt-kms-ctx.c
@@ -133,11 +133,12 @@ _init_common (mongocrypt_kms_ctx_t *kms,
 }
 
 bool
-_mongocrypt_kms_ctx_init_aws_decrypt (mongocrypt_kms_ctx_t *kms,
-                                      _mongocrypt_opts_t *crypt_opts,
-                                      _mongocrypt_key_doc_t *key,
-                                      _mongocrypt_log_t *log,
-                                      _mongocrypt_crypto_t *crypto)
+_mongocrypt_kms_ctx_init_aws_decrypt (
+   mongocrypt_kms_ctx_t *kms,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
+   _mongocrypt_key_doc_t *key,
+   _mongocrypt_log_t *log,
+   _mongocrypt_crypto_t *crypto)
 {
    kms_request_opt_t *opt;
    mongocrypt_status_t *status;
@@ -164,17 +165,18 @@ _mongocrypt_kms_ctx_init_aws_decrypt (mongocrypt_kms_ctx_t *kms,
       goto done;
    }
 
-   if (0 == (crypt_opts->kms_providers & MONGOCRYPT_KMS_PROVIDER_AWS)) {
+   if (0 ==
+         (kms_providers->configured_providers & MONGOCRYPT_KMS_PROVIDER_AWS)) {
       CLIENT_ERR ("aws kms not configured");
       goto done;
    }
 
-   if (!crypt_opts->kms_provider_aws.access_key_id) {
+   if (!kms_providers->aws.access_key_id) {
       CLIENT_ERR ("aws access key id not provided");
       goto done;
    }
 
-   if (!crypt_opts->kms_provider_aws.secret_access_key) {
+   if (!kms_providers->aws.secret_access_key) {
       CLIENT_ERR ("aws secret access key not provided");
       goto done;
    }
@@ -192,10 +194,10 @@ _mongocrypt_kms_ctx_init_aws_decrypt (mongocrypt_kms_ctx_t *kms,
    kms_request_opt_destroy (opt);
    kms_request_set_service (kms->req, "kms");
 
-   if (crypt_opts->kms_provider_aws.session_token) {
+   if (kms_providers->aws.session_token) {
       kms_request_add_header_field (kms->req,
                                     "X-Amz-Security-Token",
-                                    crypt_opts->kms_provider_aws.session_token);
+                                    kms_providers->aws.session_token);
    }
 
    if (kms_request_get_error (kms->req)) {
@@ -223,13 +225,13 @@ _mongocrypt_kms_ctx_init_aws_decrypt (mongocrypt_kms_ctx_t *kms,
    }
 
    if (!kms_request_set_access_key_id (
-          kms->req, crypt_opts->kms_provider_aws.access_key_id)) {
+          kms->req, kms_providers->aws.access_key_id)) {
       CLIENT_ERR ("failed to set aws access key id");
       _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
    if (!kms_request_set_secret_key (
-          kms->req, crypt_opts->kms_provider_aws.secret_access_key)) {
+          kms->req, kms_providers->aws.secret_access_key)) {
       CLIENT_ERR ("failed to set aws secret access key");
       _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
@@ -266,7 +268,7 @@ done:
 bool
 _mongocrypt_kms_ctx_init_aws_encrypt (
    mongocrypt_kms_ctx_t *kms,
-   _mongocrypt_opts_t *crypt_opts,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
    _mongocrypt_ctx_opts_t *ctx_opts,
    _mongocrypt_buffer_t *plaintext_key_material,
    _mongocrypt_log_t *log,
@@ -297,17 +299,18 @@ _mongocrypt_kms_ctx_init_aws_encrypt (
       goto done;
    }
 
-   if (0 == (crypt_opts->kms_providers & MONGOCRYPT_KMS_PROVIDER_AWS)) {
+   if (0 ==
+         (kms_providers->configured_providers & MONGOCRYPT_KMS_PROVIDER_AWS)) {
       CLIENT_ERR ("aws kms not configured");
       goto done;
    }
 
-   if (!crypt_opts->kms_provider_aws.access_key_id) {
+   if (!kms_providers->aws.access_key_id) {
       CLIENT_ERR ("aws access key id not provided");
       goto done;
    }
 
-   if (!crypt_opts->kms_provider_aws.secret_access_key) {
+   if (!kms_providers->aws.secret_access_key) {
       CLIENT_ERR ("aws secret access key not provided");
       goto done;
    }
@@ -328,10 +331,10 @@ _mongocrypt_kms_ctx_init_aws_encrypt (
    kms_request_opt_destroy (opt);
    kms_request_set_service (kms->req, "kms");
 
-   if (crypt_opts->kms_provider_aws.session_token) {
+   if (kms_providers->aws.session_token) {
       kms_request_add_header_field (kms->req,
                                     "X-Amz-Security-Token",
-                                    crypt_opts->kms_provider_aws.session_token);
+                                    kms_providers->aws.session_token);
    }
 
    if (kms_request_get_error (kms->req)) {
@@ -359,13 +362,13 @@ _mongocrypt_kms_ctx_init_aws_encrypt (
    }
 
    if (!kms_request_set_access_key_id (
-          kms->req, crypt_opts->kms_provider_aws.access_key_id)) {
+          kms->req, kms_providers->aws.access_key_id)) {
       CLIENT_ERR ("failed to set aws access key id");
       _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
    if (!kms_request_set_secret_key (
-          kms->req, crypt_opts->kms_provider_aws.secret_access_key)) {
+          kms->req, kms_providers->aws.secret_access_key)) {
       CLIENT_ERR ("failed to set aws secret access key");
       _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
@@ -1034,10 +1037,11 @@ mongocrypt_kms_ctx_endpoint (mongocrypt_kms_ctx_t *kms, const char **endpoint)
 }
 
 bool
-_mongocrypt_kms_ctx_init_azure_auth (mongocrypt_kms_ctx_t *kms,
-                                     _mongocrypt_log_t *log,
-                                     _mongocrypt_opts_t *crypt_opts,
-                                     _mongocrypt_endpoint_t *key_vault_endpoint)
+_mongocrypt_kms_ctx_init_azure_auth (
+   mongocrypt_kms_ctx_t *kms,
+   _mongocrypt_log_t *log,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
+   _mongocrypt_endpoint_t *key_vault_endpoint)
 {
    kms_request_opt_t *opt = NULL;
    mongocrypt_status_t *status;
@@ -1049,8 +1053,7 @@ _mongocrypt_kms_ctx_init_azure_auth (mongocrypt_kms_ctx_t *kms,
 
    _init_common (kms, log, MONGOCRYPT_KMS_AZURE_OAUTH);
    status = kms->status;
-   identity_platform_endpoint =
-      crypt_opts->kms_provider_azure.identity_platform_endpoint;
+   identity_platform_endpoint = kms_providers->azure.identity_platform_endpoint;
 
    if (identity_platform_endpoint) {
       kms->endpoint = bson_strdup (identity_platform_endpoint->host_and_port);
@@ -1078,9 +1081,9 @@ _mongocrypt_kms_ctx_init_azure_auth (mongocrypt_kms_ctx_t *kms,
    kms->req =
       kms_azure_request_oauth_new (hostname,
                                    scope,
-                                   crypt_opts->kms_provider_azure.tenant_id,
-                                   crypt_opts->kms_provider_azure.client_id,
-                                   crypt_opts->kms_provider_azure.client_secret,
+                                   kms_providers->azure.tenant_id,
+                                   kms_providers->azure.client_id,
+                                   kms_providers->azure.client_secret,
                                    opt);
    if (kms_request_get_error (kms->req)) {
       CLIENT_ERR ("error constructing KMS message: %s",
@@ -1110,7 +1113,7 @@ bool
 _mongocrypt_kms_ctx_init_azure_wrapkey (
    mongocrypt_kms_ctx_t *kms,
    _mongocrypt_log_t *log,
-   _mongocrypt_opts_t *crypt_opts,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
    struct __mongocrypt_ctx_opts_t *ctx_opts,
    const char *access_token,
    _mongocrypt_buffer_t *plaintext_key_material)
@@ -1172,11 +1175,12 @@ fail:
 }
 
 bool
-_mongocrypt_kms_ctx_init_azure_unwrapkey (mongocrypt_kms_ctx_t *kms,
-                                          _mongocrypt_opts_t *crypt_opts,
-                                          const char *access_token,
-                                          _mongocrypt_key_doc_t *key,
-                                          _mongocrypt_log_t *log)
+_mongocrypt_kms_ctx_init_azure_unwrapkey (
+   mongocrypt_kms_ctx_t *kms,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
+   const char *access_token,
+   _mongocrypt_key_doc_t *key,
+   _mongocrypt_log_t *log)
 {
    kms_request_opt_t *opt = NULL;
    mongocrypt_status_t *status;
@@ -1270,10 +1274,12 @@ _sign_rsaes_pkcs1_v1_5_trampoline (void *ctx,
 }
 
 bool
-_mongocrypt_kms_ctx_init_gcp_auth (mongocrypt_kms_ctx_t *kms,
-                                   _mongocrypt_log_t *log,
-                                   _mongocrypt_opts_t *crypt_opts,
-                                   _mongocrypt_endpoint_t *kms_endpoint)
+_mongocrypt_kms_ctx_init_gcp_auth (
+   mongocrypt_kms_ctx_t *kms,
+   _mongocrypt_log_t *log,
+   _mongocrypt_opts_t *crypt_opts,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
+   _mongocrypt_endpoint_t *kms_endpoint)
 {
    kms_request_opt_t *opt = NULL;
    mongocrypt_status_t *status;
@@ -1287,7 +1293,7 @@ _mongocrypt_kms_ctx_init_gcp_auth (mongocrypt_kms_ctx_t *kms,
 
    _init_common (kms, log, MONGOCRYPT_KMS_GCP_OAUTH);
    status = kms->status;
-   auth_endpoint = crypt_opts->kms_provider_gcp.endpoint;
+   auth_endpoint = kms_providers->gcp.endpoint;
    ctx_with_status.ctx = crypt_opts;
    ctx_with_status.status = mongocrypt_status_new ();
 
@@ -1320,11 +1326,11 @@ _mongocrypt_kms_ctx_init_gcp_auth (mongocrypt_kms_ctx_t *kms,
    }
    kms->req = kms_gcp_request_oauth_new (
       hostname,
-      crypt_opts->kms_provider_gcp.email,
+      kms_providers->gcp.email,
       audience,
       scope,
-      (const char *) crypt_opts->kms_provider_gcp.private_key.data,
-      crypt_opts->kms_provider_gcp.private_key.len,
+      (const char *) kms_providers->gcp.private_key.data,
+      kms_providers->gcp.private_key.len,
       opt);
    if (kms_request_get_error (kms->req)) {
       CLIENT_ERR ("error constructing KMS message: %s",
@@ -1358,7 +1364,7 @@ bool
 _mongocrypt_kms_ctx_init_gcp_encrypt (
    mongocrypt_kms_ctx_t *kms,
    _mongocrypt_log_t *log,
-   _mongocrypt_opts_t *crypt_opts,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
    struct __mongocrypt_ctx_opts_t *ctx_opts,
    const char *access_token,
    _mongocrypt_buffer_t *plaintext_key_material)
@@ -1428,11 +1434,12 @@ fail:
 }
 
 bool
-_mongocrypt_kms_ctx_init_gcp_decrypt (mongocrypt_kms_ctx_t *kms,
-                                      _mongocrypt_opts_t *crypt_opts,
-                                      const char *access_token,
-                                      _mongocrypt_key_doc_t *key,
-                                      _mongocrypt_log_t *log)
+_mongocrypt_kms_ctx_init_gcp_decrypt (
+   mongocrypt_kms_ctx_t *kms,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
+   const char *access_token,
+   _mongocrypt_key_doc_t *key,
+   _mongocrypt_log_t *log)
 {
    kms_request_opt_t *opt = NULL;
    mongocrypt_status_t *status;

--- a/src/mongocrypt-opts-private.h
+++ b/src/mongocrypt-opts-private.h
@@ -55,16 +55,20 @@ typedef struct {
 } _mongocrypt_opts_kms_provider_kmip_t;
 
 typedef struct {
+   int configured_providers; /* A bit set of _mongocrypt_kms_provider_t */
+   _mongocrypt_opts_kms_provider_local_t local;
+   _mongocrypt_opts_kms_provider_aws_t aws;
+   _mongocrypt_opts_kms_provider_azure_t azure;
+   _mongocrypt_opts_kms_provider_gcp_t gcp;
+   _mongocrypt_opts_kms_provider_kmip_t kmip;
+} _mongocrypt_opts_kms_providers_t;
+
+typedef struct {
    mongocrypt_log_fn_t log_fn;
    void *log_ctx;
    _mongocrypt_buffer_t schema_map;
 
-   int kms_providers; /* A bit set of _mongocrypt_kms_provider_t */
-   _mongocrypt_opts_kms_provider_local_t kms_provider_local;
-   _mongocrypt_opts_kms_provider_aws_t kms_provider_aws;
-   _mongocrypt_opts_kms_provider_azure_t kms_provider_azure;
-   _mongocrypt_opts_kms_provider_gcp_t kms_provider_gcp;
-   _mongocrypt_opts_kms_provider_kmip_t kms_provider_kmip;
+   _mongocrypt_opts_kms_providers_t kms_providers;
    mongocrypt_hmac_fn sign_rsaes_pkcs1_v1_5;
    void *sign_ctx;
 
@@ -76,7 +80,14 @@ typedef struct {
    /// a specifiy path to the library. If this is set, this suppresses the
    /// search behavior.
    mstr csfle_lib_override_path;
+
+   bool use_need_kms_credentials_state;
 } _mongocrypt_opts_t;
+
+
+void
+_mongocrypt_opts_kms_providers_cleanup (
+   _mongocrypt_opts_kms_providers_t *kms_providers);
 
 
 void
@@ -91,6 +102,13 @@ bool
 _mongocrypt_opts_validate (_mongocrypt_opts_t *opts,
                            mongocrypt_status_t *status)
    MONGOCRYPT_WARN_UNUSED_RESULT;
+
+
+bool
+_mongocrypt_opts_kms_providers_validate (
+   _mongocrypt_opts_kms_providers_t *kms_providers,
+   bool allow_empty_providers,
+   mongocrypt_status_t *status) MONGOCRYPT_WARN_UNUSED_RESULT;
 
 /*
  * Parse an optional UTF-8 value from BSON.
@@ -122,7 +140,7 @@ _mongocrypt_parse_required_utf8 (const bson_t *bson,
  * Parse an optional endpoint UTF-8 from BSON.
  * @dotkey may be a dot separated key like: "a.b.c".
  * @*out is set to a new _mongocrypt_endpoint_t of the if found, NULL otherwise.
- * @*opts may be set to configure endpoint parsing. It is optional and may be NULL. 
+ * @*opts may be set to configure endpoint parsing. It is optional and may be NULL.
  * Caller must clean up with _mongocrypt_endpoint_destroy (*out).
  * Returns true if no error occured.
  */
@@ -137,7 +155,7 @@ _mongocrypt_parse_optional_endpoint (const bson_t *bson,
  * Parse a required endpoint UTF-8 from BSON.
  * @dotkey may be a dot separated key like: "a.b.c".
  * @*out is set to a new _mongocrypt_endpoint_t of the if found, NULL otherwise.
- * @*opts may be set to configure endpoint parsing. It is optional and may be NULL. 
+ * @*opts may be set to configure endpoint parsing. It is optional and may be NULL.
  * Caller must clean up with _mongocrypt_endpoint_destroy (*out).
  * Returns true if no error occured.
  */

--- a/src/mongocrypt-opts-private.h
+++ b/src/mongocrypt-opts-private.h
@@ -90,6 +90,14 @@ _mongocrypt_opts_kms_providers_cleanup (
    _mongocrypt_opts_kms_providers_t *kms_providers);
 
 
+/* Merge `source` into `dest`. Does not perform any memory ownership management;
+ * values in `dest` will be overwritten with values from `source` without
+ * being released. */
+void
+_mongocrypt_opts_merge_kms_providers (
+   _mongocrypt_opts_kms_providers_t* dest,
+   const _mongocrypt_opts_kms_providers_t* source);
+
 void
 _mongocrypt_opts_init (_mongocrypt_opts_t *opts);
 

--- a/src/mongocrypt-opts.c
+++ b/src/mongocrypt-opts.c
@@ -61,6 +61,37 @@ _mongocrypt_opts_kms_providers_cleanup (
    _mongocrypt_endpoint_destroy (kms_providers->kmip.endpoint);
 }
 
+
+void
+_mongocrypt_opts_merge_kms_providers (
+   _mongocrypt_opts_kms_providers_t* dest,
+   const _mongocrypt_opts_kms_providers_t* source)
+{
+   if (source->configured_providers & MONGOCRYPT_KMS_PROVIDER_AWS) {
+      memcpy(&dest->aws, &source->aws, sizeof(source->aws));
+      dest->configured_providers |= MONGOCRYPT_KMS_PROVIDER_AWS;
+   }
+   if (source->configured_providers & MONGOCRYPT_KMS_PROVIDER_LOCAL) {
+      memcpy(&dest->local, &source->local, sizeof(source->local));
+      dest->configured_providers |= MONGOCRYPT_KMS_PROVIDER_LOCAL;
+   }
+   if (source->configured_providers & MONGOCRYPT_KMS_PROVIDER_AZURE) {
+      memcpy(&dest->azure, &source->azure, sizeof(source->azure));
+      dest->configured_providers |= MONGOCRYPT_KMS_PROVIDER_AZURE;
+   }
+   if (source->configured_providers & MONGOCRYPT_KMS_PROVIDER_GCP) {
+      memcpy(&dest->gcp, &source->gcp, sizeof(source->gcp));
+      dest->configured_providers |= MONGOCRYPT_KMS_PROVIDER_GCP;
+   }
+   if (source->configured_providers & MONGOCRYPT_KMS_PROVIDER_KMIP) {
+      memcpy(&dest->kmip, &source->kmip, sizeof(source->kmip));
+      dest->configured_providers |= MONGOCRYPT_KMS_PROVIDER_KMIP;
+   }
+   /* ensure all providers were copied */
+   BSON_ASSERT (!(source->configured_providers &~ dest->configured_providers));
+}
+
+
 void
 _mongocrypt_opts_cleanup (_mongocrypt_opts_t *opts)
 {
@@ -111,7 +142,8 @@ _mongocrypt_opts_validate (_mongocrypt_opts_t *opts,
 {
    return _mongocrypt_opts_kms_providers_validate(
       &opts->kms_providers,
-      false,
+      /* providers list may be empty if on-demand KMS retrieval is used */
+      opts->use_need_kms_credentials_state,
       status);
 }
 

--- a/src/mongocrypt-opts.c
+++ b/src/mongocrypt-opts.c
@@ -49,16 +49,23 @@ _mongocrypt_opts_kms_provider_gcp_cleanup (
 }
 
 void
+_mongocrypt_opts_kms_providers_cleanup (
+   _mongocrypt_opts_kms_providers_t *kms_providers)
+{
+   bson_free (kms_providers->aws.secret_access_key);
+   bson_free (kms_providers->aws.access_key_id);
+   bson_free (kms_providers->aws.session_token);
+   _mongocrypt_buffer_cleanup (&kms_providers->local.key);
+   _mongocrypt_opts_kms_provider_azure_cleanup (&kms_providers->azure);
+   _mongocrypt_opts_kms_provider_gcp_cleanup (&kms_providers->gcp);
+   _mongocrypt_endpoint_destroy (kms_providers->kmip.endpoint);
+}
+
+void
 _mongocrypt_opts_cleanup (_mongocrypt_opts_t *opts)
 {
-   bson_free (opts->kms_provider_aws.secret_access_key);
-   bson_free (opts->kms_provider_aws.access_key_id);
-   bson_free (opts->kms_provider_aws.session_token);
-   _mongocrypt_buffer_cleanup (&opts->kms_provider_local.key);
+   _mongocrypt_opts_kms_providers_cleanup (&opts->kms_providers);
    _mongocrypt_buffer_cleanup (&opts->schema_map);
-   _mongocrypt_opts_kms_provider_azure_cleanup (&opts->kms_provider_azure);
-   _mongocrypt_opts_kms_provider_gcp_cleanup (&opts->kms_provider_gcp);
-   _mongocrypt_endpoint_destroy (opts->kms_provider_kmip.endpoint);
    // Free any lib search paths added by the caller
    for (int i = 0; i < opts->n_cselib_search_paths; ++i) {
       mstr_free (opts->cselib_search_paths[i]);
@@ -69,30 +76,43 @@ _mongocrypt_opts_cleanup (_mongocrypt_opts_t *opts)
 
 
 bool
-_mongocrypt_opts_validate (_mongocrypt_opts_t *opts,
-                           mongocrypt_status_t *status)
+_mongocrypt_opts_kms_providers_validate (
+   _mongocrypt_opts_kms_providers_t *kms_providers,
+   bool allow_empty_providers,
+   mongocrypt_status_t *status)
 {
-   if (!opts->kms_providers) {
+   if (!kms_providers->configured_providers && !allow_empty_providers) {
       CLIENT_ERR ("no kms provider set");
       return false;
    }
 
-   if (opts->kms_providers & MONGOCRYPT_KMS_PROVIDER_AWS) {
-      if (!opts->kms_provider_aws.access_key_id ||
-          !opts->kms_provider_aws.secret_access_key) {
+   if (kms_providers->configured_providers & MONGOCRYPT_KMS_PROVIDER_AWS) {
+      if (!kms_providers->aws.access_key_id ||
+          !kms_providers->aws.secret_access_key) {
          CLIENT_ERR ("aws credentials unset");
          return false;
       }
    }
 
-   if (opts->kms_providers & MONGOCRYPT_KMS_PROVIDER_LOCAL) {
-      if (_mongocrypt_buffer_empty (&opts->kms_provider_local.key)) {
+   if (kms_providers->configured_providers & MONGOCRYPT_KMS_PROVIDER_LOCAL) {
+      if (_mongocrypt_buffer_empty (&kms_providers->local.key)) {
          CLIENT_ERR ("local data key unset");
          return false;
       }
    }
 
    return true;
+}
+
+
+bool
+_mongocrypt_opts_validate (_mongocrypt_opts_t *opts,
+                           mongocrypt_status_t *status)
+{
+   return _mongocrypt_opts_kms_providers_validate(
+      &opts->kms_providers,
+      false,
+      status);
 }
 
 bool

--- a/src/mongocrypt-private.h
+++ b/src/mongocrypt-private.h
@@ -155,4 +155,12 @@ _mongocrypt_new_string_from_bytes (const void *in, int len);
 char *
 _mongocrypt_new_json_string_from_binary (mongocrypt_binary_t *binary);
 
+
+bool
+_mongocrypt_parse_kms_providers (
+   mongocrypt_binary_t *kms_providers_definition,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
+   mongocrypt_status_t *status,
+   _mongocrypt_log_t *log);
+
 #endif /* MONGOCRYPT_PRIVATE_H */

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -173,6 +173,8 @@ mongocrypt_setopt_kms_provider_aws (mongocrypt_t *crypt,
                                     int32_t aws_secret_access_key_len)
 {
    mongocrypt_status_t *status;
+   _mongocrypt_opts_kms_providers_t *const kms_providers =
+      &crypt->opts.kms_providers;
 
    if (!crypt) {
       return false;
@@ -184,7 +186,8 @@ mongocrypt_setopt_kms_provider_aws (mongocrypt_t *crypt,
       return false;
    }
 
-   if (0 != (crypt->opts.kms_providers & MONGOCRYPT_KMS_PROVIDER_AWS)) {
+   if (0 !=
+         (kms_providers->configured_providers & MONGOCRYPT_KMS_PROVIDER_AWS)) {
       CLIENT_ERR ("aws kms provider already set");
       return false;
    }
@@ -192,7 +195,7 @@ mongocrypt_setopt_kms_provider_aws (mongocrypt_t *crypt,
    if (!_mongocrypt_validate_and_copy_string (
           aws_access_key_id,
           aws_access_key_id_len,
-          &crypt->opts.kms_provider_aws.access_key_id)) {
+          &kms_providers->aws.access_key_id)) {
       CLIENT_ERR ("invalid aws access key id");
       return false;
    }
@@ -200,7 +203,7 @@ mongocrypt_setopt_kms_provider_aws (mongocrypt_t *crypt,
    if (!_mongocrypt_validate_and_copy_string (
           aws_secret_access_key,
           aws_secret_access_key_len,
-          &crypt->opts.kms_provider_aws.secret_access_key)) {
+          &kms_providers->aws.secret_access_key)) {
       CLIENT_ERR ("invalid aws secret access key");
       return false;
    }
@@ -211,15 +214,15 @@ mongocrypt_setopt_kms_provider_aws (mongocrypt_t *crypt,
                        "%s (%s=\"%s\", %s=%d, %s=\"%s\", %s=%d)",
                        BSON_FUNC,
                        "aws_access_key_id",
-                       crypt->opts.kms_provider_aws.access_key_id,
+                       kms_providers->aws.access_key_id,
                        "aws_access_key_id_len",
                        aws_access_key_id_len,
                        "aws_secret_access_key",
-                       crypt->opts.kms_provider_aws.secret_access_key,
+                       kms_providers->aws.secret_access_key,
                        "aws_secret_access_key_len",
                        aws_secret_access_key_len);
    }
-   crypt->opts.kms_providers |= MONGOCRYPT_KMS_PROVIDER_AWS;
+   kms_providers->configured_providers |= MONGOCRYPT_KMS_PROVIDER_AWS;
    return true;
 }
 
@@ -316,6 +319,8 @@ mongocrypt_setopt_kms_provider_local (mongocrypt_t *crypt,
                                       mongocrypt_binary_t *key)
 {
    mongocrypt_status_t *status;
+   _mongocrypt_opts_kms_providers_t *const kms_providers =
+      &crypt->opts.kms_providers;
 
    if (!crypt) {
       return false;
@@ -327,7 +332,8 @@ mongocrypt_setopt_kms_provider_local (mongocrypt_t *crypt,
       return false;
    }
 
-   if (0 != (crypt->opts.kms_providers & MONGOCRYPT_KMS_PROVIDER_LOCAL)) {
+   if (0 !=
+         (kms_providers->configured_providers & MONGOCRYPT_KMS_PROVIDER_LOCAL)) {
       CLIENT_ERR ("local kms provider already set");
       return false;
    }
@@ -355,9 +361,9 @@ mongocrypt_setopt_kms_provider_local (mongocrypt_t *crypt,
       bson_free (key_val);
    }
 
-   _mongocrypt_buffer_copy_from_binary (&crypt->opts.kms_provider_local.key,
+   _mongocrypt_buffer_copy_from_binary (&kms_providers->local.key,
                                         key);
-   crypt->opts.kms_providers |= MONGOCRYPT_KMS_PROVIDER_LOCAL;
+   kms_providers->configured_providers |= MONGOCRYPT_KMS_PROVIDER_LOCAL;
    return true;
 }
 
@@ -775,23 +781,36 @@ mongocrypt_setopt_crypto_hook_sign_rsaes_pkcs1_v1_5 (
 
 bool
 mongocrypt_setopt_kms_providers (mongocrypt_t *crypt,
-                                 mongocrypt_binary_t *kms_providers)
+                                 mongocrypt_binary_t *kms_providers_definition)
 {
-   mongocrypt_status_t *status;
-   bson_t as_bson;
-   bson_iter_t iter;
-
+   mongocrypt_status_t *const status = crypt->status;
    if (!crypt) {
       return false;
    }
-   status = crypt->status;
 
    if (crypt->initialized) {
       CLIENT_ERR ("options cannot be set after initialization");
       return false;
    }
 
-   if (!_mongocrypt_binary_to_bson (kms_providers, &as_bson) ||
+   return _mongocrypt_parse_kms_providers (
+      kms_providers_definition,
+      &crypt->opts.kms_providers,
+      crypt->status,
+      &crypt->log);
+}
+
+bool
+_mongocrypt_parse_kms_providers (
+   mongocrypt_binary_t *kms_providers_definition,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
+   mongocrypt_status_t *status,
+   _mongocrypt_log_t *log)
+{
+   bson_t as_bson;
+   bson_iter_t iter;
+
+   if (!_mongocrypt_binary_to_bson (kms_providers_definition, &as_bson) ||
        !bson_iter_init (&iter, &as_bson)) {
       CLIENT_ERR ("invalid BSON");
       return false;
@@ -803,7 +822,9 @@ mongocrypt_setopt_kms_providers (mongocrypt_t *crypt,
       field_name = bson_iter_key (&iter);
 
       if (0 == strcmp (field_name, "azure")) {
-         if (0 != (crypt->opts.kms_providers & MONGOCRYPT_KMS_PROVIDER_AZURE)) {
+         if (0 != (
+               kms_providers->configured_providers &
+               MONGOCRYPT_KMS_PROVIDER_AZURE)) {
             CLIENT_ERR ("azure KMS provider already set");
             return false;
          }
@@ -811,48 +832,50 @@ mongocrypt_setopt_kms_providers (mongocrypt_t *crypt,
          if (!_mongocrypt_parse_required_utf8 (
                 &as_bson,
                 "azure.tenantId",
-                &crypt->opts.kms_provider_azure.tenant_id,
-                crypt->status)) {
+                &kms_providers->azure.tenant_id,
+                status)) {
             return false;
          }
 
          if (!_mongocrypt_parse_required_utf8 (
                 &as_bson,
                 "azure.clientId",
-                &crypt->opts.kms_provider_azure.client_id,
-                crypt->status)) {
+                &kms_providers->azure.client_id,
+                status)) {
             return false;
          }
 
          if (!_mongocrypt_parse_required_utf8 (
                 &as_bson,
                 "azure.clientSecret",
-                &crypt->opts.kms_provider_azure.client_secret,
-                crypt->status)) {
+                &kms_providers->azure.client_secret,
+                status)) {
             return false;
          }
 
          if (!_mongocrypt_parse_optional_endpoint (
                 &as_bson,
                 "azure.identityPlatformEndpoint",
-                &crypt->opts.kms_provider_azure.identity_platform_endpoint,
+                &kms_providers->azure.identity_platform_endpoint,
                 NULL /* opts */,
-                crypt->status)) {
+                status)) {
             return false;
          }
 
          if (!_mongocrypt_check_allowed_fields (&as_bson,
                                                 "azure",
-                                                crypt->status,
+                                                status,
                                                 "tenantId",
                                                 "clientId",
                                                 "clientSecret",
                                                 "identityPlatformEndpoint")) {
             return false;
          }
-         crypt->opts.kms_providers |= MONGOCRYPT_KMS_PROVIDER_AZURE;
+         kms_providers->configured_providers |= MONGOCRYPT_KMS_PROVIDER_AZURE;
       } else if (0 == strcmp (field_name, "gcp")) {
-         if (0 != (crypt->opts.kms_providers & MONGOCRYPT_KMS_PROVIDER_GCP)) {
+         if (0 != (
+               kms_providers->configured_providers &
+               MONGOCRYPT_KMS_PROVIDER_GCP)) {
             CLIENT_ERR ("gcp KMS provider already set");
             return false;
          }
@@ -860,89 +883,89 @@ mongocrypt_setopt_kms_providers (mongocrypt_t *crypt,
          if (!_mongocrypt_parse_required_utf8 (
                 &as_bson,
                 "gcp.email",
-                &crypt->opts.kms_provider_gcp.email,
-                crypt->status)) {
+                &kms_providers->gcp.email,
+                status)) {
             return false;
          }
 
          if (!_mongocrypt_parse_required_binary (
                 &as_bson,
                 "gcp.privateKey",
-                &crypt->opts.kms_provider_gcp.private_key,
-                crypt->status)) {
+                &kms_providers->gcp.private_key,
+                status)) {
             return false;
          }
 
          if (!_mongocrypt_parse_optional_endpoint (
                 &as_bson,
                 "gcp.endpoint",
-                &crypt->opts.kms_provider_gcp.endpoint,
+                &kms_providers->gcp.endpoint,
                 NULL /* opts */,
-                crypt->status)) {
+                status)) {
             return false;
          }
 
          if (!_mongocrypt_check_allowed_fields (&as_bson,
                                                 "gcp",
-                                                crypt->status,
+                                                status,
                                                 "email",
                                                 "privateKey",
                                                 "endpoint")) {
             return false;
          }
-         crypt->opts.kms_providers |= MONGOCRYPT_KMS_PROVIDER_GCP;
+         kms_providers->configured_providers |= MONGOCRYPT_KMS_PROVIDER_GCP;
       } else if (0 == strcmp (field_name, "local")) {
          if (!_mongocrypt_parse_required_binary (
                 &as_bson,
                 "local.key",
-                &crypt->opts.kms_provider_local.key,
-                crypt->status)) {
+                &kms_providers->local.key,
+                status)) {
             return false;
          }
 
-         if (crypt->opts.kms_provider_local.key.len != MONGOCRYPT_KEY_LEN) {
+         if (kms_providers->local.key.len != MONGOCRYPT_KEY_LEN) {
             CLIENT_ERR ("local key must be %d bytes", MONGOCRYPT_KEY_LEN);
             return false;
          }
 
          if (!_mongocrypt_check_allowed_fields (
-                &as_bson, "local", crypt->status, "key")) {
+                &as_bson, "local", status, "key")) {
             return false;
          }
-         crypt->opts.kms_providers |= MONGOCRYPT_KMS_PROVIDER_LOCAL;
+         kms_providers->configured_providers |= MONGOCRYPT_KMS_PROVIDER_LOCAL;
       } else if (0 == strcmp (field_name, "aws")) {
          if (!_mongocrypt_parse_required_utf8 (
                 &as_bson,
                 "aws.accessKeyId",
-                &crypt->opts.kms_provider_aws.access_key_id,
-                crypt->status)) {
+                &kms_providers->aws.access_key_id,
+                status)) {
             return false;
          }
          if (!_mongocrypt_parse_required_utf8 (
                 &as_bson,
                 "aws.secretAccessKey",
-                &crypt->opts.kms_provider_aws.secret_access_key,
-                crypt->status)) {
+                &kms_providers->aws.secret_access_key,
+                status)) {
             return false;
          }
 
          if (!_mongocrypt_parse_optional_utf8 (
                 &as_bson,
                 "aws.sessionToken",
-                &crypt->opts.kms_provider_aws.session_token,
-                crypt->status)) {
+                &kms_providers->aws.session_token,
+                status)) {
             return false;
          }
 
          if (!_mongocrypt_check_allowed_fields (&as_bson,
                                                 "aws",
-                                                crypt->status,
+                                                status,
                                                 "accessKeyId",
                                                 "secretAccessKey",
                                                 "sessionToken")) {
             return false;
          }
-         crypt->opts.kms_providers |= MONGOCRYPT_KMS_PROVIDER_AWS;
+         kms_providers->configured_providers |= MONGOCRYPT_KMS_PROVIDER_AWS;
       } else if (0 == strcmp (field_name, "kmip")) {
          _mongocrypt_endpoint_parse_opts_t opts = {0};
 
@@ -950,26 +973,26 @@ mongocrypt_setopt_kms_providers (mongocrypt_t *crypt,
          if (!_mongocrypt_parse_required_endpoint (
                 &as_bson,
                 "kmip.endpoint",
-                &crypt->opts.kms_provider_kmip.endpoint,
+                &kms_providers->kmip.endpoint,
                 &opts,
-                crypt->status)) {
+                status)) {
             return false;
          }
 
          if (!_mongocrypt_check_allowed_fields (
-                &as_bson, "kmip", crypt->status, "endpoint")) {
+                &as_bson, "kmip", status, "endpoint")) {
             return false;
          }
-         crypt->opts.kms_providers |= MONGOCRYPT_KMS_PROVIDER_KMIP;
+         kms_providers->configured_providers |= MONGOCRYPT_KMS_PROVIDER_KMIP;
       } else {
          CLIENT_ERR ("unsupported KMS provider: %s", field_name);
          return false;
       }
    }
 
-   if (crypt->log.trace_enabled) {
+   if (log->trace_enabled) {
       char *as_str = bson_as_json (&as_bson, NULL);
-      _mongocrypt_log (&crypt->log,
+      _mongocrypt_log (log,
                        MONGOCRYPT_LOG_LEVEL_TRACE,
                        "%s (%s=\"%s\")",
                        BSON_FUNC,
@@ -997,6 +1020,13 @@ mongocrypt_setopt_append_csfle_search_path (mongocrypt_t *crypt,
    // Write back opts
    crypt->opts.cselib_search_paths = new_array;
    crypt->opts.n_cselib_search_paths = new_len;
+}
+
+
+void
+mongocrypt_setopt_use_need_kms_credentials_state (mongocrypt_t *crypt)
+{
+   crypt->opts.use_need_kms_credentials_state = true;
 }
 
 

--- a/src/mongocrypt.h.in
+++ b/src/mongocrypt.h.in
@@ -471,6 +471,21 @@ mongocrypt_setopt_set_csfle_lib_path_override (mongocrypt_t *crypt,
 
 
 /**
+ * @brief Opt-into setting KMS providers before each KMS request.
+ *
+ * If set, before entering the MONGOCRYPT_CTX_NEED_KMS state,
+ * contexts will enter the MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS state
+ * and then wait for credentials to be supplied through
+ * @ref mongocrypt_ctx_provide_kms_providers.
+ *
+ * @param[in] crypt The @ref mongocrypt_t object to update
+ */
+MONGOCRYPT_EXPORT
+void
+mongocrypt_setopt_use_need_kms_credentials_state (mongocrypt_t *crypt);
+
+
+/**
  * Initialize new @ref mongocrypt_t object.
  *
  * Set options before using @ref mongocrypt_setopt_kms_provider_local, @ref
@@ -873,8 +888,9 @@ typedef enum {
    MONGOCRYPT_CTX_NEED_MONGO_MARKINGS = 2, /* run on mongocryptd. */
    MONGOCRYPT_CTX_NEED_MONGO_KEYS = 3,     /* run on key vault */
    MONGOCRYPT_CTX_NEED_KMS = 4,
+   MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS = 7, /* fetch/renew KMS credentials */
    MONGOCRYPT_CTX_READY = 5, /* ready for encryption/decryption */
-   MONGOCRYPT_CTX_DONE = 6
+   MONGOCRYPT_CTX_DONE = 6,
 } mongocrypt_ctx_state_t;
 
 
@@ -1088,6 +1104,25 @@ MONGOCRYPT_EXPORT
 bool
 mongocrypt_ctx_kms_done (mongocrypt_ctx_t *ctx);
 
+
+/**
+ * Call in response to the MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS state
+ * to set per-context KMS provider settings. These follow the same format
+ * as @ref mongocrypt_setopt_kms_providers. If no keys are present in the
+ * BSON input, the KMS provider settings configured for the @ref mongocrypt_t
+ * at initialization are used.
+ *
+ * @param[in] ctx The @ref mongocrypt_ctx_t object.
+ * @param[in] kms_providers A BSON document mapping the KMS provider names
+ * to credentials.
+ *
+ * @returns A boolean indicating success. If false, an error status is set.
+ * Retrieve it with @ref mongocrypt_ctx_status.
+ */
+bool
+mongocrypt_ctx_provide_kms_providers (
+   mongocrypt_ctx_t *ctx,
+   mongocrypt_binary_t *kms_providers_definition);
 
 /**
  * Perform the final encryption or decryption.

--- a/test/example-state-machine.c
+++ b/test/example-state-machine.c
@@ -195,7 +195,7 @@ _run_state_machine (mongocrypt_ctx_t *ctx, bson_t *result)
          CHECK (mongocrypt_ctx_mongo_done (ctx));
          break;
       case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS:
-         // TODO
+         BSON_ASSERT (0);
          break;
       case MONGOCRYPT_CTX_NEED_KMS:
          while ((kms = mongocrypt_ctx_next_kms_ctx (ctx))) {

--- a/test/example-state-machine.c
+++ b/test/example-state-machine.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2019-present MongoDB, Inc.
  *
@@ -192,6 +193,9 @@ _run_state_machine (mongocrypt_ctx_t *ctx, bson_t *result)
          mongocrypt_binary_destroy (input);
          bson_free (data);
          CHECK (mongocrypt_ctx_mongo_done (ctx));
+         break;
+      case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS:
+         // TODO
          break;
       case MONGOCRYPT_CTX_NEED_KMS:
          while ((kms = mongocrypt_ctx_next_kms_ctx (ctx))) {

--- a/test/test-mongocrypt-ctx-decrypt.c
+++ b/test/test-mongocrypt-ctx-decrypt.c
@@ -201,6 +201,53 @@ _test_decrypt_empty_binary (_mongocrypt_tester_t *tester)
    mongocrypt_destroy (crypt);
 }
 
+static void
+_test_decrypt_per_ctx_credentials (_mongocrypt_tester_t *tester)
+{
+   mongocrypt_t *crypt;
+   mongocrypt_ctx_t *ctx;
+   mongocrypt_binary_t *bin;
+   _mongocrypt_buffer_t encrypted;
+
+   bin = mongocrypt_binary_new ();
+   crypt = mongocrypt_new ();
+   mongocrypt_setopt_use_need_kms_credentials_state (crypt);
+   ASSERT_OK (mongocrypt_init (crypt), crypt);
+   ctx = mongocrypt_ctx_new (crypt);
+
+   /* Encrypt an empty binary value. */
+   mongocrypt_ctx_setopt_key_alt_name (
+      ctx, TEST_BSON ("{'keyAltName': 'keyDocumentName'}"));
+   mongocrypt_ctx_setopt_algorithm (
+      ctx, "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic", -1);
+   mongocrypt_ctx_explicit_encrypt_init (
+      ctx,
+      TEST_BSON ("{'v': { '$binary': { 'base64': '', 'subType': '00' } } }"));
+   _mongocrypt_tester_run_ctx_to (
+      tester, ctx, MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
+   ASSERT_OK (
+      mongocrypt_ctx_provide_kms_providers (ctx,
+         TEST_BSON ("{'aws':{'accessKeyId': 'example',"
+                            "'secretAccessKey': 'example'}}")), ctx);
+   _mongocrypt_tester_run_ctx_to (tester, ctx, MONGOCRYPT_CTX_READY);
+   mongocrypt_ctx_finalize (ctx, bin);
+   /* Copy the encrypted ciphertext since it is tied to the lifetime of ctx. */
+   _mongocrypt_buffer_copy_from_binary (&encrypted, bin);
+   mongocrypt_ctx_destroy (ctx);
+
+   /* Decrypt it back. */
+   ctx = mongocrypt_ctx_new (crypt);
+   mongocrypt_ctx_explicit_decrypt_init (
+      ctx, _mongocrypt_buffer_as_binary (&encrypted));
+   _mongocrypt_tester_run_ctx_to (tester, ctx, MONGOCRYPT_CTX_READY);
+   mongocrypt_ctx_finalize (ctx, bin);
+
+   mongocrypt_binary_destroy (bin);
+   mongocrypt_ctx_destroy (ctx);
+   _mongocrypt_buffer_cleanup (&encrypted);
+   mongocrypt_destroy (crypt);
+}
+
 void
 _mongocrypt_tester_install_ctx_decrypt (_mongocrypt_tester_t *tester)
 {
@@ -210,4 +257,5 @@ _mongocrypt_tester_install_ctx_decrypt (_mongocrypt_tester_t *tester)
    INSTALL_TEST (_test_decrypt_ready);
    INSTALL_TEST (_test_decrypt_empty_aws);
    INSTALL_TEST (_test_decrypt_empty_binary);
+   INSTALL_TEST (_test_decrypt_per_ctx_credentials);
 }

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1424,6 +1424,49 @@ _test_encrypt_custom_endpoint (_mongocrypt_tester_t *tester)
 }
 
 static void
+_test_encrypt_per_ctx_credentials (_mongocrypt_tester_t *tester)
+{
+   mongocrypt_t *crypt;
+   mongocrypt_ctx_t *ctx;
+   mongocrypt_kms_ctx_t *kms_ctx;
+   mongocrypt_binary_t *bin;
+   const char *endpoint;
+
+   /* Success. */
+   crypt = mongocrypt_new ();
+   mongocrypt_setopt_use_need_kms_credentials_state (crypt);
+   ASSERT_OK (mongocrypt_init (crypt), crypt);
+   ctx = mongocrypt_ctx_new (crypt);
+   ASSERT_OK (mongocrypt_ctx_encrypt_init (
+                 ctx, "test", -1, TEST_FILE ("./test/example/cmd.json")),
+              ctx);
+   _mongocrypt_tester_run_ctx_to (
+      tester, ctx, MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
+   ASSERT_OK (
+      mongocrypt_ctx_provide_kms_providers (ctx,
+         TEST_BSON ("{'aws':{'accessKeyId': 'example',"
+                            "'secretAccessKey': 'example'}}")), ctx);
+   _mongocrypt_tester_run_ctx_to (tester, ctx, MONGOCRYPT_CTX_NEED_MONGO_KEYS);
+   ASSERT_OK (
+      mongocrypt_ctx_mongo_feed (
+         ctx, TEST_FILE ("./test/example/key-document-custom-endpoint.json")),
+      ctx);
+   ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
+   BSON_ASSERT (mongocrypt_ctx_state (ctx) == MONGOCRYPT_CTX_NEED_KMS);
+   kms_ctx = mongocrypt_ctx_next_kms_ctx (ctx);
+   BSON_ASSERT (kms_ctx);
+   ASSERT_OK (mongocrypt_kms_ctx_endpoint (kms_ctx, &endpoint), ctx);
+   BSON_ASSERT (0 == strcmp ("example.com:443", endpoint));
+   bin = mongocrypt_binary_new ();
+   ASSERT_OK (mongocrypt_kms_ctx_message (kms_ctx, bin), ctx);
+   BSON_ASSERT (NULL != strstr ((char *) bin->data, "Host:example.com"));
+
+   mongocrypt_binary_destroy (bin);
+   mongocrypt_ctx_destroy (ctx);
+   mongocrypt_destroy (crypt);
+}
+
+static void
 _test_encrypt_with_aws_session_token (_mongocrypt_tester_t *tester)
 {
    mongocrypt_t *crypt;
@@ -1550,4 +1593,5 @@ _mongocrypt_tester_install_ctx_encrypt (_mongocrypt_tester_t *tester)
    INSTALL_TEST (_test_encrypt_with_aws_session_token);
    INSTALL_TEST (_test_encrypt_caches_empty_collinfo);
    INSTALL_TEST (_test_encrypt_caches_collinfo_without_jsonschema);
+   INSTALL_TEST (_test_encrypt_per_ctx_credentials);
 }

--- a/test/test-mongocrypt-datakey.c
+++ b/test/test-mongocrypt-datakey.c
@@ -301,7 +301,7 @@ _test_datakey_custom_key_material (_mongocrypt_tester_t *tester)
       mongocrypt_binary_t decrypted_dek;
 
       ASSERT (_mongocrypt_unwrap_key (crypt->crypto,
-                                      &crypt->opts.kms_provider_local.key,
+                                      &crypt->opts.kms_providers.local.key,
                                       &encrypted_dek_buf,
                                       &decrypted_dek_buf,
                                       crypt->status));

--- a/test/test-mongocrypt-datakey.c
+++ b/test/test-mongocrypt-datakey.c
@@ -226,6 +226,62 @@ _test_datakey_custom_endpoint (_mongocrypt_tester_t *tester)
    mongocrypt_destroy (crypt);
 }
 
+static void
+_test_datakey_kms_per_ctx_credentials (_mongocrypt_tester_t *tester)
+{
+   mongocrypt_t *crypt;
+   mongocrypt_ctx_t *ctx;
+   mongocrypt_kms_ctx_t *kms_ctx;
+   mongocrypt_binary_t *bin;
+   const char *endpoint;
+   bson_t key_bson;
+   bson_iter_t iter;
+
+   /* Success. */
+   crypt = mongocrypt_new ();
+   mongocrypt_setopt_use_need_kms_credentials_state (crypt);
+   ASSERT_OK (mongocrypt_init (crypt), crypt);
+   ctx = mongocrypt_ctx_new (crypt);
+   ASSERT_OK (
+      mongocrypt_ctx_setopt_masterkey_aws (ctx, "region", -1, "cmk", -1), ctx);
+   ASSERT_OK (
+      mongocrypt_ctx_setopt_masterkey_aws_endpoint (ctx, "example.com", -1),
+      ctx);
+   ASSERT_OK (mongocrypt_ctx_datakey_init (ctx), ctx);
+   BSON_ASSERT (
+      mongocrypt_ctx_state (ctx) == MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
+   ASSERT_OK (
+      mongocrypt_ctx_provide_kms_providers (ctx,
+         TEST_BSON ("{'aws':{'accessKeyId': 'example',"
+                            "'secretAccessKey': 'example'}}")), ctx);
+   BSON_ASSERT (
+      mongocrypt_ctx_state (ctx) == MONGOCRYPT_CTX_NEED_KMS);
+   kms_ctx = mongocrypt_ctx_next_kms_ctx (ctx);
+   BSON_ASSERT (kms_ctx);
+   ASSERT_OK (mongocrypt_kms_ctx_endpoint (kms_ctx, &endpoint), ctx);
+   BSON_ASSERT (0 == strcmp ("example.com:443", endpoint));
+   bin = mongocrypt_binary_new ();
+   ASSERT_OK (mongocrypt_kms_ctx_message (kms_ctx, bin), ctx);
+   BSON_ASSERT (NULL != strstr ((char *) bin->data, "Host:example.com"));
+   ASSERT_OK (mongocrypt_kms_ctx_feed (
+                 kms_ctx, TEST_FILE ("./test/data/kms-encrypt-reply.txt")),
+              kms_ctx);
+   BSON_ASSERT (0 == mongocrypt_kms_ctx_bytes_needed (kms_ctx));
+   ASSERT_OK (mongocrypt_ctx_kms_done (ctx), ctx);
+
+   BSON_ASSERT (mongocrypt_ctx_state (ctx) == MONGOCRYPT_CTX_READY);
+   ASSERT_OK (mongocrypt_ctx_finalize (ctx, bin), ctx);
+   /* Check the BSON document created. */
+   BSON_ASSERT (_mongocrypt_binary_to_bson (bin, &key_bson));
+   BSON_ASSERT (bson_iter_init (&iter, &key_bson));
+   BSON_ASSERT (bson_iter_find_descendant (&iter, "masterKey.endpoint", &iter));
+   BSON_ASSERT (0 == strcmp (bson_iter_utf8 (&iter, NULL), "example.com"));
+
+   mongocrypt_binary_destroy (bin);
+   mongocrypt_ctx_destroy (ctx);
+   mongocrypt_destroy (crypt);
+}
+
 
 static void
 _test_datakey_custom_key_material (_mongocrypt_tester_t *tester)
@@ -342,4 +398,5 @@ _mongocrypt_tester_install_data_key (_mongocrypt_tester_t *tester)
    INSTALL_TEST (_test_create_data_key);
    INSTALL_TEST (_test_datakey_custom_endpoint);
    INSTALL_TEST (_test_datakey_custom_key_material);
+   INSTALL_TEST (_test_datakey_kms_per_ctx_credentials);
 }

--- a/test/test-mongocrypt-key-broker.c
+++ b/test/test-mongocrypt-key-broker.c
@@ -332,10 +332,12 @@ _test_key_broker_add_key (_mongocrypt_tester_t *tester)
    _mongocrypt_key_doc_t *key_x;
    bson_t key_bson_x;
    bson_t *malformed;
+   _mongocrypt_opts_kms_providers_t *kms_providers;
    _mongocrypt_key_broker_t key_broker;
 
    status = mongocrypt_status_new ();
    crypt = _mongocrypt_tester_mongocrypt ();
+   kms_providers = &crypt->opts.kms_providers;
    _gen_uuid_and_key (tester, 1, &key_id1, &key_doc1);
    _gen_uuid_and_key (tester, 2, &key_id2, &key_doc2);
 
@@ -346,9 +348,15 @@ _test_key_broker_add_key (_mongocrypt_tester_t *tester)
    ASSERT_OK (_mongocrypt_key_broker_request_id (&key_broker, &key_id2),
               &key_broker);
    ASSERT_OK (_mongocrypt_key_broker_requests_done (&key_broker), &key_broker);
-   ASSERT_OK (_mongocrypt_key_broker_add_doc (&key_broker, &key_doc2),
+   ASSERT_OK (_mongocrypt_key_broker_add_doc (
+                 &key_broker,
+                 kms_providers,
+                 &key_doc2),
               &key_broker);
-   ASSERT_OK (_mongocrypt_key_broker_add_doc (&key_broker, &key_doc1),
+   ASSERT_OK (_mongocrypt_key_broker_add_doc (
+                 &key_broker,
+                 kms_providers,
+                 &key_doc1),
               &key_broker);
    ASSERT_OK (_mongocrypt_key_broker_docs_done (&key_broker), &key_broker);
    _mongocrypt_key_broker_cleanup (&key_broker);
@@ -360,7 +368,10 @@ _test_key_broker_add_key (_mongocrypt_tester_t *tester)
       &key_doc_names,
       TEST_FILE ("./test/data/key-document-with-alt-name.json"));
    ASSERT_OK (_mongocrypt_key_broker_requests_done (&key_broker), &key_broker);
-   ASSERT_OK (_mongocrypt_key_broker_add_doc (&key_broker, &key_doc_names),
+   ASSERT_OK (_mongocrypt_key_broker_add_doc (
+                 &key_broker,
+                 kms_providers,
+                 &key_doc_names),
               &key_broker);
    _mongocrypt_key_broker_cleanup (&key_broker);
 
@@ -371,7 +382,10 @@ _test_key_broker_add_key (_mongocrypt_tester_t *tester)
               &key_broker);
    ASSERT_OK (_mongocrypt_key_broker_requests_done (&key_broker), &key_broker);
    _mongocrypt_buffer_from_bson (&malformed_buf, malformed);
-   ASSERT_FAILS (_mongocrypt_key_broker_add_doc (&key_broker, &malformed_buf),
+   ASSERT_FAILS (_mongocrypt_key_broker_add_doc (
+                    &key_broker,
+                    kms_providers,
+                    &malformed_buf),
                  &key_broker,
                  "unrecognized field");
    _mongocrypt_key_broker_cleanup (&key_broker);
@@ -381,7 +395,10 @@ _test_key_broker_add_key (_mongocrypt_tester_t *tester)
    _mongocrypt_key_broker_init (&key_broker, crypt);
    BSON_ASSERT (_mongocrypt_key_broker_request_id (&key_broker, &key_id1));
    ASSERT_OK (_mongocrypt_key_broker_requests_done (&key_broker), &key_broker);
-   ASSERT_FAILS (_mongocrypt_key_broker_add_doc (&key_broker, NULL),
+   ASSERT_FAILS (_mongocrypt_key_broker_add_doc (
+                    &key_broker,
+                    kms_providers,
+                    NULL),
                  &key_broker,
                  "invalid key");
    _mongocrypt_key_broker_cleanup (&key_broker);
@@ -391,7 +408,10 @@ _test_key_broker_add_key (_mongocrypt_tester_t *tester)
    ASSERT_OK (_mongocrypt_key_broker_request_id (&key_broker, &key_id1),
               &key_broker);
    ASSERT_OK (_mongocrypt_key_broker_requests_done (&key_broker), &key_broker);
-   ASSERT_FAILS (_mongocrypt_key_broker_add_doc (&key_broker, &key_doc2),
+   ASSERT_FAILS (_mongocrypt_key_broker_add_doc (
+                    &key_broker,
+                    kms_providers,
+                    &key_doc2),
                  &key_broker,
                  "unexpected key returned");
    _mongocrypt_key_broker_cleanup (&key_broker);
@@ -424,11 +444,17 @@ _test_key_broker_add_key (_mongocrypt_tester_t *tester)
    ASSERT_OK (_mongocrypt_key_broker_requests_done (&key_broker), &key_broker);
 
    /* Add { id : Y, name : "Sharlene" }, should pass. */
-   ASSERT_OK (_mongocrypt_key_broker_add_doc (&key_broker, &key_buf_y),
+   ASSERT_OK (_mongocrypt_key_broker_add_doc (
+                 &key_broker,
+                 kms_providers,
+                 &key_buf_y),
               &key_broker);
 
    /* Add { id : X, name : "Sharlene" }, should fail, it shares an alt name. */
-   ASSERT_FAILS (_mongocrypt_key_broker_add_doc (&key_broker, &key_buf_x),
+   ASSERT_FAILS (_mongocrypt_key_broker_add_doc (
+                    &key_broker,
+                    kms_providers,
+                    &key_buf_x),
                  &key_broker,
                  "duplicate keyAltNames");
 
@@ -462,6 +488,7 @@ _test_key_broker_add_decrypted_key (_mongocrypt_tester_t *tester)
       key_id_names;
    _mongocrypt_key_broker_t key_broker;
    mongocrypt_kms_ctx_t *kms;
+   _mongocrypt_opts_kms_providers_t *kms_providers;
    bson_iter_t iter;
    bson_t key_doc_names_bson;
 
@@ -471,15 +498,22 @@ _test_key_broker_add_decrypted_key (_mongocrypt_tester_t *tester)
 
    /* Success. With key ids. */
    crypt = _mongocrypt_tester_mongocrypt ();
+   kms_providers = &crypt->opts.kms_providers;
    _mongocrypt_key_broker_init (&key_broker, crypt);
    ASSERT_OK (_mongocrypt_key_broker_request_id (&key_broker, &key_id1),
               &key_broker);
    ASSERT_OK (_mongocrypt_key_broker_request_id (&key_broker, &key_id2),
               &key_broker);
    ASSERT_OK (_mongocrypt_key_broker_requests_done (&key_broker), &key_broker);
-   ASSERT_OK (_mongocrypt_key_broker_add_doc (&key_broker, &key_doc2),
+   ASSERT_OK (_mongocrypt_key_broker_add_doc (
+                 &key_broker,
+                 kms_providers,
+                 &key_doc2),
               &key_broker);
-   ASSERT_OK (_mongocrypt_key_broker_add_doc (&key_broker, &key_doc1),
+   ASSERT_OK (_mongocrypt_key_broker_add_doc (
+                 &key_broker,
+                 kms_providers,
+                 &key_doc1),
               &key_broker);
    ASSERT_OK (_mongocrypt_key_broker_docs_done (&key_broker), &key_broker);
    kms = _mongocrypt_key_broker_next_kms (&key_broker);
@@ -489,7 +523,10 @@ _test_key_broker_add_decrypted_key (_mongocrypt_tester_t *tester)
    BSON_ASSERT (kms);
    _mongocrypt_tester_satisfy_kms (tester, kms);
    BSON_ASSERT (!_mongocrypt_key_broker_next_kms (&key_broker));
-   ASSERT_OK (_mongocrypt_key_broker_kms_done (&key_broker), &key_broker);
+   ASSERT_OK (_mongocrypt_key_broker_kms_done (
+                 &key_broker,
+                 kms_providers),
+              &key_broker);
    _mongocrypt_key_broker_cleanup (&key_broker);
    mongocrypt_destroy (crypt); /* destroy crypt to reset cache. */
 
@@ -502,7 +539,10 @@ _test_key_broker_add_decrypted_key (_mongocrypt_tester_t *tester)
    _mongocrypt_buffer_from_binary (
       &key_doc_names,
       TEST_FILE ("./test/data/key-document-with-alt-name.json"));
-   ASSERT_OK (_mongocrypt_key_broker_add_doc (&key_broker, &key_doc_names),
+   ASSERT_OK (_mongocrypt_key_broker_add_doc (
+                 &key_broker,
+                 kms_providers,
+                 &key_doc_names),
               &key_broker);
    ASSERT_OK (_mongocrypt_key_broker_docs_done (&key_broker), &key_broker);
    kms = _mongocrypt_key_broker_next_kms (&key_broker);
@@ -510,7 +550,10 @@ _test_key_broker_add_decrypted_key (_mongocrypt_tester_t *tester)
 
    _mongocrypt_tester_satisfy_kms (tester, kms);
    BSON_ASSERT (!_mongocrypt_key_broker_next_kms (&key_broker));
-   ASSERT_OK (_mongocrypt_key_broker_kms_done (&key_broker), &key_broker);
+   ASSERT_OK (_mongocrypt_key_broker_kms_done (
+                 &key_broker,
+                 kms_providers),
+              &key_broker);
    _mongocrypt_key_broker_cleanup (&key_broker);
    mongocrypt_destroy (crypt); /* destroy crypt to reset cache. */
 
@@ -527,14 +570,20 @@ _test_key_broker_add_decrypted_key (_mongocrypt_tester_t *tester)
    _key_broker_add_name (&key_broker, "Sharlene");
    _key_broker_add_name (&key_broker, "Kasey");
    ASSERT_OK (_mongocrypt_key_broker_requests_done (&key_broker), &key_broker);
-   ASSERT_OK (_mongocrypt_key_broker_add_doc (&key_broker, &key_doc_names),
+   ASSERT_OK (_mongocrypt_key_broker_add_doc (
+                 &key_broker,
+                 kms_providers,
+                 &key_doc_names),
               &key_broker);
    ASSERT_OK (_mongocrypt_key_broker_docs_done (&key_broker), &key_broker);
    kms = _mongocrypt_key_broker_next_kms (&key_broker);
    BSON_ASSERT (kms);
    _mongocrypt_tester_satisfy_kms (tester, kms);
    BSON_ASSERT (!_mongocrypt_key_broker_next_kms (&key_broker));
-   ASSERT_OK (_mongocrypt_key_broker_kms_done (&key_broker), &key_broker);
+   ASSERT_OK (_mongocrypt_key_broker_kms_done (
+                 &key_broker,
+                 kms_providers),
+              &key_broker);
    _mongocrypt_key_broker_cleanup (&key_broker);
 
    bson_destroy (&key_doc_names_bson);
@@ -580,6 +629,7 @@ _test_key_broker_multi_match (_mongocrypt_tester_t *tester)
 {
    mongocrypt_t *crypt;
    mongocrypt_status_t *status;
+   _mongocrypt_opts_kms_providers_t *kms_providers;
    _mongocrypt_key_broker_t key_broker;
    status = mongocrypt_status_new ();
    _mongocrypt_buffer_t key_id1, key_id2, key_doc1, key_doc2;
@@ -589,6 +639,7 @@ _test_key_broker_multi_match (_mongocrypt_tester_t *tester)
 
 
    crypt = _mongocrypt_tester_mongocrypt ();
+   kms_providers = &crypt->opts.kms_providers;
    _mongocrypt_key_broker_init (&key_broker, crypt);
 
    /* Add two ids and two alt names */
@@ -602,11 +653,17 @@ _test_key_broker_multi_match (_mongocrypt_tester_t *tester)
    BSON_ASSERT (0 == _key_broker_num_satisfied (&key_broker));
 
    /* Add one doc, should satisfy two requests. */
-   BSON_ASSERT (_mongocrypt_key_broker_add_doc (&key_broker, &key_doc1));
+   BSON_ASSERT (_mongocrypt_key_broker_add_doc (
+                   &key_broker,
+                   kms_providers,
+                   &key_doc1));
    BSON_ASSERT (2 == _key_broker_num_satisfied (&key_broker));
 
    /* Add other doc, should satisfy all. */
-   BSON_ASSERT (_mongocrypt_key_broker_add_doc (&key_broker, &key_doc2));
+   BSON_ASSERT (_mongocrypt_key_broker_add_doc (
+                   &key_broker,
+                   kms_providers,
+                   &key_doc2));
    BSON_ASSERT (4 == _key_broker_num_satisfied (&key_broker));
 
    _mongocrypt_buffer_cleanup (&key_id1);
@@ -734,10 +791,12 @@ _test_key_broker_kmip (_mongocrypt_tester_t *tester)
    _mongocrypt_buffer_t keydoc;
    mongocrypt_kms_ctx_t *kms;
    mongocrypt_binary_t *msg;
+   _mongocrypt_opts_kms_providers_t *kms_providers;
    _mongocrypt_buffer_t secretdata;
 
    crypt = _mongocrypt_tester_mongocrypt ();
    status = mongocrypt_status_new ();
+   kms_providers = &crypt->opts.kms_providers;
    _mongocrypt_key_broker_init (&kb, crypt);
    _load_json_as_bson ("./test/data/key-document-kmip.json", &keydoc_bson);
 
@@ -749,7 +808,11 @@ _test_key_broker_kmip (_mongocrypt_tester_t *tester)
 
    /* Add the key document. */
    _mongocrypt_buffer_from_bson (&keydoc, &keydoc_bson);
-   ASSERT_OK (_mongocrypt_key_broker_add_doc (&kb, &keydoc), &kb);
+   ASSERT_OK (_mongocrypt_key_broker_add_doc (
+                 &kb,
+                 kms_providers,
+                 &keydoc),
+              &kb);
    ASSERT_OK (_mongocrypt_key_broker_docs_done (&kb), &kb);
 
    /* There should be exactly one KMS request for KMIP. */
@@ -766,7 +829,7 @@ _test_key_broker_kmip (_mongocrypt_tester_t *tester)
    ASSERT_OK (kms_ctx_feed_all (
                  kms, SUCCESS_GET_RESPONSE, sizeof (SUCCESS_GET_RESPONSE)),
               kms);
-   ASSERT_OK (_mongocrypt_key_broker_kms_done (&kb), &kb);
+   ASSERT_OK (_mongocrypt_key_broker_kms_done (&kb, kms_providers), &kb);
 
    BSON_ASSERT (
       _mongocrypt_key_broker_decrypted_key_by_id (&kb, &id, &secretdata));
@@ -831,10 +894,12 @@ _test_key_broker_kmip_notfound (_mongocrypt_tester_t *tester)
    _mongocrypt_buffer_t id;
    _mongocrypt_buffer_t keydoc;
    mongocrypt_kms_ctx_t *kms;
+   _mongocrypt_opts_kms_providers_t *kms_providers;
    mongocrypt_binary_t *msg;
 
    crypt = _mongocrypt_tester_mongocrypt ();
    status = mongocrypt_status_new ();
+   kms_providers = &crypt->opts.kms_providers;
    _mongocrypt_key_broker_init (&kb, crypt);
    _load_json_as_bson ("./test/data/key-document-kmip.json", &keydoc_bson);
 
@@ -846,7 +911,11 @@ _test_key_broker_kmip_notfound (_mongocrypt_tester_t *tester)
 
    /* Add the key document. */
    _mongocrypt_buffer_from_bson (&keydoc, &keydoc_bson);
-   ASSERT_OK (_mongocrypt_key_broker_add_doc (&kb, &keydoc), &kb);
+   ASSERT_OK (_mongocrypt_key_broker_add_doc (
+                 &kb,
+                 kms_providers,
+                 &keydoc),
+              &kb);
    ASSERT_OK (_mongocrypt_key_broker_docs_done (&kb), &kb);
 
    /* There should be exactly one KMS request for KMIP. */

--- a/test/test-mongocrypt-key-broker.c
+++ b/test/test-mongocrypt-key-broker.c
@@ -532,6 +532,7 @@ _test_key_broker_add_decrypted_key (_mongocrypt_tester_t *tester)
 
    /* Success. With key alt names. */
    crypt = _mongocrypt_tester_mongocrypt ();
+   kms_providers = &crypt->opts.kms_providers;
    _mongocrypt_key_broker_init (&key_broker, crypt);
    _key_broker_add_name (&key_broker, "Sharlene");
    ASSERT_OK (_mongocrypt_key_broker_requests_done (&key_broker), &key_broker);
@@ -559,6 +560,7 @@ _test_key_broker_add_decrypted_key (_mongocrypt_tester_t *tester)
 
    /* With both key ids and key alt names, some referring to the same key */
    crypt = _mongocrypt_tester_mongocrypt ();
+   kms_providers = &crypt->opts.kms_providers;
    _mongocrypt_key_broker_init (&key_broker, crypt);
    BSON_ASSERT (
       _mongocrypt_buffer_to_bson (&key_doc_names, &key_doc_names_bson));

--- a/test/test-mongocrypt-util.c
+++ b/test/test-mongocrypt-util.c
@@ -33,6 +33,8 @@ mongocrypt_ctx_state_to_string (mongocrypt_ctx_state_t state)
       return "MONGOCRYPT_CTX_NEED_MONGO_MARKINGS";
    case MONGOCRYPT_CTX_NEED_MONGO_KEYS:
       return "MONGOCRYPT_CTX_NEED_MONGO_KEYS";
+   case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS:
+      return "MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS";
    case MONGOCRYPT_CTX_NEED_KMS:
       return "MONGOCRYPT_CTX_NEED_KMS";
    case MONGOCRYPT_CTX_READY:

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -335,7 +335,8 @@ _mongocrypt_tester_run_ctx_to (_mongocrypt_tester_t *tester,
          BSON_ASSERT (mongocrypt_ctx_mongo_done (ctx));
          break;
       case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS:
-         // TODO
+         bin = TEST_BSON ("{}");
+         mongocrypt_ctx_provide_kms_providers (ctx, bin);
          break;
       case MONGOCRYPT_CTX_NEED_KMS:
          kms = mongocrypt_ctx_next_kms_ctx (ctx);

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -334,6 +334,9 @@ _mongocrypt_tester_run_ctx_to (_mongocrypt_tester_t *tester,
          ASSERT_OR_PRINT (res, status);
          BSON_ASSERT (mongocrypt_ctx_mongo_done (ctx));
          break;
+      case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS:
+         // TODO
+         break;
       case MONGOCRYPT_CTX_NEED_KMS:
          kms = mongocrypt_ctx_next_kms_ctx (ctx);
          while (kms) {

--- a/test/util/util.c
+++ b/test/util/util.c
@@ -798,6 +798,8 @@ _state_string (mongocrypt_ctx_state_t state)
       return "MONGOCRYPT_CTX_NEED_MONGO_MARKINGS";
    case MONGOCRYPT_CTX_NEED_MONGO_KEYS:
       return "MONGOCRYPT_CTX_NEED_MONGO_KEYS";
+   case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS:
+      return "MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS";
    case MONGOCRYPT_CTX_NEED_KMS:
       return "MONGOCRYPT_CTX_NEED_KMS";
    case MONGOCRYPT_CTX_READY:
@@ -855,6 +857,9 @@ _state_machine_run (_state_machine_t *state_machine,
          if (!_state_need_mongo_keys (state_machine, error)) {
             goto fail;
          }
+         break;
+      case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS:
+         // TODO
          break;
       case MONGOCRYPT_CTX_NEED_KMS:
          if (!_state_need_kms (state_machine, error)) {

--- a/test/util/util.c
+++ b/test/util/util.c
@@ -636,6 +636,13 @@ _mongoc_stream_writev_full (mongoc_stream_t *stream,
 static bool
 _state_need_kms (_state_machine_t *state_machine, bson_error_t *error)
 {
+   bin = TEST_BSON ("{}");
+   mongocrypt_ctx_provide_kms_providers (state_machine->ctx, bin);
+}
+
+static bool
+_state_need_kms (_state_machine_t *state_machine, bson_error_t *error)
+{
    mongocrypt_kms_ctx_t *kms_ctx = NULL;
    mongoc_stream_t *tls_stream = NULL;
    bool ret = false;
@@ -859,7 +866,9 @@ _state_machine_run (_state_machine_t *state_machine,
          }
          break;
       case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS:
-         // TODO
+         if (!_state_need_kms_credentials (state_machine, error)) {
+            goto fail;
+         }
          break;
       case MONGOCRYPT_CTX_NEED_KMS:
          if (!_state_need_kms (state_machine, error)) {

--- a/test/util/util.c
+++ b/test/util/util.c
@@ -634,10 +634,15 @@ _mongoc_stream_writev_full (mongoc_stream_t *stream,
 }
 
 static bool
-_state_need_kms (_state_machine_t *state_machine, bson_error_t *error)
+_state_need_kms_credentials (
+   _state_machine_t *state_machine,
+   bson_error_t *error)
 {
-   bin = TEST_BSON ("{}");
+   bson_t empty = BSON_INITIALIZER;
+   mongocrypt_binary_t* bin = util_bson_to_bin (&empty);
    mongocrypt_ctx_provide_kms_providers (state_machine->ctx, bin);
+   mongocrypt_binary_destroy (bin);
+   return true;
 }
 
 static bool


### PR DESCRIPTION
~~WIP, no tests yet~~

- Add a function `mongocrypt_setopt_use_need_kms_credentials_state()` to opt into the following features
- Add a new `MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS` state that is always entered before `MONGOCRYPT_CTX_NEED_KMS` if that opt-in has occurred
- Add a function `mongocrypt_ctx_provide_kms_providers()` to set the KMS providers on a per-context basis
- Internally:
  - Move the KMS provider settings into their own struct
  - Extract associated code from the `_mongocrypt_opts_t` functions into separate functions
  - Pass along the per-context KMS provider settings explicitly where they were specified per-context