### PR TITLE
MONGOCRYPT-382 require `aws: {}` to enter NEED_KMS_CREDENTIALS

### DIFF
--- a/bindings/node/test/autoEncrypter.test.js
+++ b/bindings/node/test/autoEncrypter.test.js
@@ -198,6 +198,9 @@ describe('AutoEncrypter', function () {
       const mc = new AutoEncrypter(client, {
         keyVaultNamespace: 'admin.datakeys',
         logger: () => {},
+        kmsProviders: {
+          aws: {}
+        },
         async onKmsProviderRefresh() {
           return { aws: { accessKeyId: 'example', secretAccessKey: 'example' } };
         }

--- a/bindings/node/test/autoEncrypter.test.js
+++ b/bindings/node/test/autoEncrypter.test.js
@@ -149,6 +149,9 @@ describe('AutoEncrypter', function () {
       const mc = new AutoEncrypter(client, {
         keyVaultNamespace: 'admin.datakeys',
         logger: () => {},
+        kmsProviders: {
+          aws: {}
+        },
         async onKmsProviderRefresh() {
           return { aws: { accessKeyId: 'example', secretAccessKey: 'example' } };
         }

--- a/src/mongocrypt-ctx-datakey.c
+++ b/src/mongocrypt-ctx-datakey.c
@@ -496,7 +496,10 @@ mongocrypt_ctx_datakey_init (mongocrypt_ctx_t *ctx)
       }
    }
 
-   if (ctx->crypt->opts.use_need_kms_credentials_state) {
+   /* Only enter the MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS if needed for AWS. */
+   if (ctx->crypt->opts.use_need_kms_credentials_state &&
+       ctx->crypt->opts.kms_providers.need_credentials ==
+          MONGOCRYPT_KMS_PROVIDER_AWS) {
       ctx->state = MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS;
    } else if (!_kms_start (ctx)) {
       goto done;

--- a/src/mongocrypt-ctx-datakey.c
+++ b/src/mongocrypt-ctx-datakey.c
@@ -499,7 +499,8 @@ mongocrypt_ctx_datakey_init (mongocrypt_ctx_t *ctx)
    /* Only enter the MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS if needed for AWS. */
    if (ctx->crypt->opts.use_need_kms_credentials_state &&
        ctx->crypt->opts.kms_providers.need_credentials ==
-          MONGOCRYPT_KMS_PROVIDER_AWS) {
+          MONGOCRYPT_KMS_PROVIDER_AWS &&
+       ctx->opts.kek.kms_provider == MONGOCRYPT_KMS_PROVIDER_AWS) {
       ctx->state = MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS;
    } else if (!_kms_start (ctx)) {
       goto done;

--- a/src/mongocrypt-ctx-datakey.c
+++ b/src/mongocrypt-ctx-datakey.c
@@ -496,11 +496,8 @@ mongocrypt_ctx_datakey_init (mongocrypt_ctx_t *ctx)
       }
    }
 
-   /* Only enter the MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS if needed for AWS. */
-   if (ctx->crypt->opts.use_need_kms_credentials_state &&
-       ctx->crypt->opts.kms_providers.need_credentials ==
-          MONGOCRYPT_KMS_PROVIDER_AWS &&
-       ctx->opts.kek.kms_provider == MONGOCRYPT_KMS_PROVIDER_AWS) {
+   if (_mongocrypt_needs_credentials_for_provider (
+          ctx->crypt, ctx->opts.kek.kms_provider)) {
       ctx->state = MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS;
    } else if (!_kms_start (ctx)) {
       goto done;

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -917,7 +917,9 @@ _mongocrypt_ctx_state_from_key_broker (mongocrypt_ctx_t *ctx)
    case KB_ADDING_DOCS:
       /* Encrypted keys need KMS, which need to be provided before
        * adding docs. */
-      if (ctx->crypt->opts.use_need_kms_credentials_state) {
+      if (ctx->crypt->opts.use_need_kms_credentials_state &&
+          ctx->crypt->opts.kms_providers.need_credentials ==
+             MONGOCRYPT_KMS_PROVIDER_AWS) {
          new_state = MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS;
       } else {
          /* Require key documents from driver. */

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -916,9 +916,7 @@ _mongocrypt_ctx_state_from_key_broker (mongocrypt_ctx_t *ctx)
    case KB_ADDING_DOCS:
       /* Encrypted keys need KMS, which need to be provided before
        * adding docs. */
-      if (ctx->crypt->opts.use_need_kms_credentials_state &&
-          ctx->crypt->opts.kms_providers.need_credentials ==
-             MONGOCRYPT_KMS_PROVIDER_AWS) {
+      if (_mongocrypt_needs_credentials (ctx->crypt)) {
          new_state = MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS;
       } else {
          /* Require key documents from driver. */

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -572,7 +572,6 @@ mongocrypt_ctx_provide_kms_providers (
 
    if (!_mongocrypt_opts_kms_providers_validate(
           &ctx->per_ctx_kms_providers,
-          true,
           ctx->status)) {
       /* Remove the parsed KMS providers if they are invalid */
       _mongocrypt_opts_kms_providers_cleanup(&ctx->per_ctx_kms_providers);

--- a/src/mongocrypt-opts-private.h
+++ b/src/mongocrypt-opts-private.h
@@ -56,6 +56,7 @@ typedef struct {
 
 typedef struct {
    int configured_providers; /* A bit set of _mongocrypt_kms_provider_t */
+   int need_credentials; /* A bit set of _mongocrypt_kms_provider_t */
    _mongocrypt_opts_kms_provider_local_t local;
    _mongocrypt_opts_kms_provider_aws_t aws;
    _mongocrypt_opts_kms_provider_azure_t azure;

--- a/src/mongocrypt-opts-private.h
+++ b/src/mongocrypt-opts-private.h
@@ -116,7 +116,6 @@ _mongocrypt_opts_validate (_mongocrypt_opts_t *opts,
 bool
 _mongocrypt_opts_kms_providers_validate (
    _mongocrypt_opts_kms_providers_t *kms_providers,
-   bool allow_empty_providers,
    mongocrypt_status_t *status) MONGOCRYPT_WARN_UNUSED_RESULT;
 
 /*

--- a/src/mongocrypt-opts.c
+++ b/src/mongocrypt-opts.c
@@ -109,10 +109,10 @@ _mongocrypt_opts_cleanup (_mongocrypt_opts_t *opts)
 bool
 _mongocrypt_opts_kms_providers_validate (
    _mongocrypt_opts_kms_providers_t *kms_providers,
-   bool allow_empty_providers,
    mongocrypt_status_t *status)
 {
-   if (!kms_providers->configured_providers && !allow_empty_providers) {
+   if (!kms_providers->configured_providers &&
+       !kms_providers->need_credentials) {
       CLIENT_ERR ("no kms provider set");
       return false;
    }
@@ -142,8 +142,6 @@ _mongocrypt_opts_validate (_mongocrypt_opts_t *opts,
 {
    return _mongocrypt_opts_kms_providers_validate(
       &opts->kms_providers,
-      /* providers list may be empty if on-demand KMS retrieval is used */
-      opts->use_need_kms_credentials_state,
       status);
 }
 

--- a/src/mongocrypt-private.h
+++ b/src/mongocrypt-private.h
@@ -160,4 +160,15 @@ _mongocrypt_parse_kms_providers (
    mongocrypt_status_t *status,
    _mongocrypt_log_t *log);
 
+/* _mongocrypt_needs_credentials returns true if @crypt was configured to
+request credentials for any KMS provider. */
+bool
+_mongocrypt_needs_credentials (mongocrypt_t *crypt);
+
+/* _mongocrypt_needs_credentials returns true if @crypt was configured to
+request credentials for @provider. */
+bool
+_mongocrypt_needs_credentials_for_provider (
+   mongocrypt_t *crypt, _mongocrypt_kms_provider_t provider);
+
 #endif /* MONGOCRYPT_PRIVATE_H */

--- a/src/mongocrypt-private.h
+++ b/src/mongocrypt-private.h
@@ -161,12 +161,12 @@ _mongocrypt_parse_kms_providers (
    _mongocrypt_log_t *log);
 
 /* _mongocrypt_needs_credentials returns true if @crypt was configured to
-request credentials for any KMS provider. */
+ * request credentials for any KMS provider. */
 bool
 _mongocrypt_needs_credentials (mongocrypt_t *crypt);
 
 /* _mongocrypt_needs_credentials returns true if @crypt was configured to
-request credentials for @provider. */
+ * request credentials for @provider. */
 bool
 _mongocrypt_needs_credentials_for_provider (
    mongocrypt_t *crypt, _mongocrypt_kms_provider_t provider);

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -847,7 +847,7 @@ _mongocrypt_parse_kms_providers (
       bson_t field_bson;
 
       field_name = bson_iter_key (&iter);
-      if (BSON_ITER_HOLDS_DOCUMENT(&iter)) {
+      if (BSON_ITER_HOLDS_DOCUMENT (&iter)) {
          uint32_t len;
          const uint8_t *data = NULL;
          bson_iter_document (&iter, &len, &data);

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -1074,3 +1074,24 @@ mongocrypt_setopt_set_csfle_lib_path_override (mongocrypt_t *crypt,
 {
    mstr_assign (&crypt->opts.csfle_lib_override_path, mstr_copy_cstr (path));
 }
+
+bool
+_mongocrypt_needs_credentials (mongocrypt_t *crypt)
+{
+   if (!crypt->opts.use_need_kms_credentials_state) {
+      return false;
+   }
+
+   return crypt->opts.kms_providers.need_credentials != 0;
+}
+
+bool
+_mongocrypt_needs_credentials_for_provider (mongocrypt_t *crypt,
+                               _mongocrypt_kms_provider_t provider)
+{
+   if (!crypt->opts.use_need_kms_credentials_state) {
+      return false;
+   }
+
+   return (crypt->opts.kms_providers.need_credentials & provider) != 0;
+}

--- a/src/mongocrypt.h.in
+++ b/src/mongocrypt.h.in
@@ -380,7 +380,8 @@ mongocrypt_setopt_kms_provider_local (mongocrypt_t *crypt,
  *
  * @param[in] crypt The @ref mongocrypt_t object.
  * @param[in] kms_providers A BSON document mapping the KMS provider names
- * to credentials.
+ * to credentials. Set "aws" to an empty document to supply AWS credentials
+ * on-demand with @ref mongocrypt_ctx_provide_kms_providers.
  * @pre @ref mongocrypt_init has not been called on @p crypt.
  * @returns A boolean indicating success. If false, an error status is set.
  * Retrieve it with @ref mongocrypt_ctx_status
@@ -471,12 +472,16 @@ mongocrypt_setopt_set_csfle_lib_path_override (mongocrypt_t *crypt,
 
 
 /**
- * @brief Opt-into setting KMS providers before each KMS request.
+ * @brief Opt-into handling the MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS state.
  *
  * If set, before entering the MONGOCRYPT_CTX_NEED_KMS state,
- * contexts will enter the MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS state
+ * contexts may enter the MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS state
  * and then wait for credentials to be supplied through
  * @ref mongocrypt_ctx_provide_kms_providers.
+ *
+ * A context will only enter MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS
+ * if an empty `aws: {}` document was set in @ref
+ * mongocrypt_setopt_kms_providers.
  *
  * @param[in] crypt The @ref mongocrypt_t object to update
  */

--- a/test/test-mongocrypt-ctx-decrypt.c
+++ b/test/test-mongocrypt-ctx-decrypt.c
@@ -212,6 +212,7 @@ _test_decrypt_per_ctx_credentials (_mongocrypt_tester_t *tester)
    bin = mongocrypt_binary_new ();
    crypt = mongocrypt_new ();
    mongocrypt_setopt_use_need_kms_credentials_state (crypt);
+   mongocrypt_setopt_kms_providers (crypt, TEST_BSON ("{'aws': {}}"));
    ASSERT_OK (mongocrypt_init (crypt), crypt);
    ctx = mongocrypt_ctx_new (crypt);
 

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1435,6 +1435,7 @@ _test_encrypt_per_ctx_credentials (_mongocrypt_tester_t *tester)
    /* Success. */
    crypt = mongocrypt_new ();
    mongocrypt_setopt_use_need_kms_credentials_state (crypt);
+   mongocrypt_setopt_kms_providers (crypt, TEST_BSON ("{'aws': {}}"));
    ASSERT_OK (mongocrypt_init (crypt), crypt);
    ctx = mongocrypt_ctx_new (crypt);
    ASSERT_OK (mongocrypt_ctx_encrypt_init (

--- a/test/test-mongocrypt-datakey.c
+++ b/test/test-mongocrypt-datakey.c
@@ -240,6 +240,7 @@ _test_datakey_kms_per_ctx_credentials (_mongocrypt_tester_t *tester)
    /* Success. */
    crypt = mongocrypt_new ();
    mongocrypt_setopt_use_need_kms_credentials_state (crypt);
+   ASSERT_OK (mongocrypt_setopt_kms_providers (crypt, TEST_BSON ("{'aws': {}}")), crypt);
    ASSERT_OK (mongocrypt_init (crypt), crypt);
    ctx = mongocrypt_ctx_new (crypt);
    ASSERT_OK (

--- a/test/test-mongocrypt-datakey.c
+++ b/test/test-mongocrypt-datakey.c
@@ -240,7 +240,9 @@ _test_datakey_kms_per_ctx_credentials (_mongocrypt_tester_t *tester)
    /* Success. */
    crypt = mongocrypt_new ();
    mongocrypt_setopt_use_need_kms_credentials_state (crypt);
-   ASSERT_OK (mongocrypt_setopt_kms_providers (crypt, TEST_BSON ("{'aws': {}}")), crypt);
+   ASSERT_OK (
+      mongocrypt_setopt_kms_providers (crypt, TEST_BSON ("{'aws': {}}")),
+      crypt);
    ASSERT_OK (mongocrypt_init (crypt), crypt);
    ctx = mongocrypt_ctx_new (crypt);
    ASSERT_OK (

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -686,7 +686,6 @@ _test_setopt_kms_providers (_mongocrypt_tester_t *tester)
        "Invalid endpoint"},
       {"{'azure': {'tenantId': '', 'clientSecret': '' }}", "clientId"},
       {"{'aws': {'accessKeyId': 'abc', 'secretAccessKey': 'def'}}", NULL},
-      {"{'aws': {}}", "expected UTF-8 aws.accessKeyId"},
       {"{'local': {'key': {'$binary': {'base64': '" EXAMPLE_LOCAL_MATERIAL
        "', 'subType': '00'}} }}",
        NULL},

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -686,6 +686,7 @@ _test_setopt_kms_providers (_mongocrypt_tester_t *tester)
        "Invalid endpoint"},
       {"{'azure': {'tenantId': '', 'clientSecret': '' }}", "clientId"},
       {"{'aws': {'accessKeyId': 'abc', 'secretAccessKey': 'def'}}", NULL},
+      {"{'aws': {}}", NULL},
       {"{'local': {'key': {'$binary': {'base64': '" EXAMPLE_LOCAL_MATERIAL
        "', 'subType': '00'}} }}",
        NULL},

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -658,6 +658,12 @@ _test_setopt_invalid_kms_providers (_mongocrypt_tester_t *tester)
    mongocrypt_status_destroy (status);
    mongocrypt_ctx_destroy (ctx);
    mongocrypt_destroy (crypt);
+
+   crypt = mongocrypt_new ();
+   mongocrypt_setopt_use_need_kms_credentials_state (crypt);
+   ASSERT_OK (mongocrypt_setopt_kms_providers (crypt, TEST_BSON ("{}")), crypt);
+   ASSERT_FAILS (mongocrypt_init (crypt), crypt, "no kms provider set");
+   mongocrypt_destroy (crypt);
 }
 
 typedef struct {


### PR DESCRIPTION
# Background & Motivation
https://github.com/mongodb/libmongocrypt/pull/252 introduced a new context state, `MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS`. In the `NEED_KMS_CREDENTIALS` state, `mongocrypt_ctx_provide_kms_providers()` may be called to provide credentials on-demand. This PR is a follow-up to address two caveats:

1. Users are expected to configure `aws: {}` in the KMS providers in the driver to opt into on-demand credentials. libmongocrypt errors on `aws: {}` set in the KMS providers. Drivers need to remove, and remember, if an empty `aws: {}` is configured on the KMS providers.
2. Drivers request aws credentials without needing them in data key contexts. For example: suppose `aws: {}` and `azure` are configured as KMS providers. Calling `createDataKey("azure")` from the driver will result in the libmongocrypt entering the `NEED_KMS_CREDENTIALS` state, and the driver will refresh `aws` credentials.


# Summary
- Require `aws: {}` to be set in `mongocrypt_setopt_kms_providers` to enter the `NEED_KMS_CREDENTIALS` state.
- Only enter the `NEED_KMS_CREDENTIALS` state for a data key context if creating an "aws" data key.
- Require a non-empty document for `mongocrypt_setopt_kms_providers` and `mongocrypt_ctx_provide_kms_providers`.

# Notes
I did not add a function like `mongocrypt_ctx_get_requested_kms_provider`. It was proposed in https://github.com/kevinAlbs/mongo-go-driver/pull/1#issuecomment-1058214761. I did not think it provided value to add now. I filed MONGOCRYPT-394 to track supporting on-demand credentials for other KMS providers. If / when we do it, libmongocrypt and drivers will both need additive changes.

The [Go POC has been updated](https://github.com/kevinAlbs/mongo-go-driver/pull/1). It no longer needs to check and remove `aws: {}` from the KMS providers.