### PR TITLE
MONGOCRYPT-411 Support releases from branches

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -643,7 +643,7 @@ tasks:
       params:
         aws_key: '${aws_key}'
         aws_secret: '${aws_secret}'
-        remote_file: '${project}/windows-test/${branch_name}/${libmongocrypt_s3_suffix}/libmongocrypt.tar.gz'
+        remote_file: 'libmongocrypt/windows-test/master/${libmongocrypt_s3_suffix}/libmongocrypt.tar.gz'
         bucket: mciuploads
         extract_to: libmongocrypt_download
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -190,6 +190,10 @@ functions:
           if [ "${is_patch}" = "true" ]; then
             echo "Patch build detected, skipping"
           fi
+          if [ "${branch}" != "master" ]; then
+            echo "publish snapshot is only run on master branch."
+            echo "Detected branch '${branch}', skipping."
+          fi
     - command: shell.exec
       params:
         silent: true

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -539,7 +539,7 @@ tasks:
       params:
         aws_key: '${aws_key}'
         aws_secret: '${aws_secret}'
-        remote_file: '${project}/all/${branch_name}/${libmongocrypt_s3_suffix}/libmongocrypt-all.tar.gz'
+        remote_file: 'libmongocrypt/all/master/${libmongocrypt_s3_suffix}/libmongocrypt-all.tar.gz'
         bucket: mciuploads
         permissions: public-read
         local_file: 'libmongocrypt-all.tar.gz'
@@ -548,7 +548,7 @@ tasks:
       params:
         aws_key: '${aws_key}'
         aws_secret: '${aws_secret}'
-        remote_file: '${project}/all/${branch_name}/${libmongocrypt_s3_suffix_copy}/libmongocrypt-all.tar.gz'
+        remote_file: 'libmongocrypt/all/master/${libmongocrypt_s3_suffix_copy}/libmongocrypt-all.tar.gz'
         bucket: mciuploads
         permissions: public-read
         local_file: 'libmongocrypt-all.tar.gz'

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -201,6 +201,9 @@ functions:
           if [ "${is_patch}" = "true" ]; then
             exit 0
           fi
+          if [ "${branch}" != "master" ]; then
+            exit 0
+          fi
           cd ./libmongocrypt/bindings/java/mongocrypt && PROJECT_DIRECTORY=${project_directory} NEXUS_USERNAME=${nexus_username} NEXUS_PASSWORD=${nexus_password} SIGNING_PASSWORD=${signing_password} SIGNING_KEY_ID=${signing_keyId} RING_FILE_GPG_BASE64=${ring_file_gpg_base64} ./.evergreen/publish.sh
 
   "download tarball":

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -714,10 +714,14 @@ pre:
           # patch build.
           REMOTE_SUFFIX="${revision}/${version_id}"
           REMOTE_SUFFIX_COPY="latest/${version_id}"
-        else
+        elif [ "${branch}" = "master" ]; then
           # waterfall build, no tag.
           REMOTE_SUFFIX="${revision}"
           REMOTE_SUFFIX_COPY="latest"
+        else
+          # waterfall build, not on master branch.
+          REMOTE_SUFFIX="${revision}"
+          REMOTE_SUFFIX_COPY="latest-${branch}"
         fi
 
         PROJECT_DIRECTORY="$(pwd)"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -715,7 +715,7 @@ pre:
           REMOTE_SUFFIX="${revision}/${version_id}"
           REMOTE_SUFFIX_COPY="latest/${version_id}"
         elif [ "${branch}" = "master" ]; then
-          # waterfall build, no tag.
+          # waterfall build.
           REMOTE_SUFFIX="${revision}"
           REMOTE_SUFFIX_COPY="latest"
         else

--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ Version numbers of libmongocrypt must follow the format 1.[0-9].[0-9] for releas
 #### Steps to release ####
 Do the following when releasing:
 - Update CHANGELOG.md with any new changes and update the `[Unreleased]` text to the version being released.
+- If this is a new minor release (e.g. `x.y.0`):
+   - Create a branch named `rx.y`.
+   - Update the [libmongocrypt-release](https://evergreen.mongodb.com/projects##libmongocrypt-release) Evergreen project to set `Branch Name` to `rx.y`.
 - In the Java binding build.gradle.kts, replace `version = "1.0.0-SNAPSHOT"` with `version = "1.0.0-rc123"`.
 - Commit, create a new git tag, like `1.0.0-rc123`, and push.
 - In the Java binding build.gradle.kts, replace `version = "1.0.0-rc123"` with `version = "1.0.0-SNAPSHOT"` (i.e. undo the change). For an example of this, see [this commit](https://github.com/mongodb/libmongocrypt/commit/2336123fbc1f4f5894f49df5e6320040987bb0d3) and its parent commit.


### PR DESCRIPTION
# Summary
This makes several changes to support releases of libmongocrypt from a non-master release branch on a separate Evergreen project.

- Update the URLs in upload-all to set `${project}` to "libmongocrypt" and `${branch_name}` to "master". Use `${libmongocrypt_s3_suffix_copy}` of "latest-${branch}" for non-master branch. This avoids breaking workflows for bindings tasks.
- Update the URL in windows-upload to set `${project}` to "libmongocrypt" to avoid breaking workflows for users.
- Modify the libmongocrypt release process to create a branch before tagging. Update the libmongocrypt-release Evergreen project with the new branch.
- Do not run the publish-snapshot task on non-master branches.

# Background & Motivation
Please see [MONGOCRYPT-411 Proposal](https://docs.google.com/document/d/1QTWrK_w6UciKgDR-pQ2BkAT6Ignzs8uN03Mu_Wxn36E/edit#) for background and motivation. Please leave comments in that document.

After this is merged and a libmongocrypt-release project is created in [EVG-16517](https://jira.mongodb.org/browse/EVG-16517), the next proposed step is to release 1.3.2-rc0 test the process before doing a stable 1.3.2 release.