### PR TITLE
MONGOCRYPT-394 Allow on-demand credentials for KMS providers other than AWS

### DIFF
--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -857,7 +857,9 @@ _mongocrypt_parse_kms_providers (
          return false;
       }
 
-      if (0 == strcmp (field_name, "azure")) {
+      if (0 == strcmp (field_name, "azure") && bson_empty (&field_bson)) {
+         kms_providers->need_credentials |= MONGOCRYPT_KMS_PROVIDER_AZURE;
+      } else if (0 == strcmp (field_name, "azure")) {
          if (0 != (
                kms_providers->configured_providers &
                MONGOCRYPT_KMS_PROVIDER_AZURE)) {
@@ -908,6 +910,8 @@ _mongocrypt_parse_kms_providers (
             return false;
          }
          kms_providers->configured_providers |= MONGOCRYPT_KMS_PROVIDER_AZURE;
+      } else if (0 == strcmp (field_name, "gcp") && bson_empty (&field_bson)) {
+         kms_providers->need_credentials |= MONGOCRYPT_KMS_PROVIDER_GCP;
       } else if (0 == strcmp (field_name, "gcp")) {
          if (0 != (
                kms_providers->configured_providers &
@@ -950,6 +954,8 @@ _mongocrypt_parse_kms_providers (
             return false;
          }
          kms_providers->configured_providers |= MONGOCRYPT_KMS_PROVIDER_GCP;
+      } else if (0 == strcmp (field_name, "local") && bson_empty (&field_bson)) {
+         kms_providers->need_credentials |= MONGOCRYPT_KMS_PROVIDER_LOCAL;
       } else if (0 == strcmp (field_name, "local")) {
          if (!_mongocrypt_parse_required_binary (
                 &as_bson,
@@ -1004,6 +1010,8 @@ _mongocrypt_parse_kms_providers (
             return false;
          }
          kms_providers->configured_providers |= MONGOCRYPT_KMS_PROVIDER_AWS;
+      } else if (0 == strcmp (field_name, "kmip") && bson_empty (&field_bson)) {
+         kms_providers->need_credentials |= MONGOCRYPT_KMS_PROVIDER_KMIP;
       } else if (0 == strcmp (field_name, "kmip")) {
          _mongocrypt_endpoint_parse_opts_t opts = {0};
 

--- a/src/mongocrypt.h.in
+++ b/src/mongocrypt.h.in
@@ -380,7 +380,7 @@ mongocrypt_setopt_kms_provider_local (mongocrypt_t *crypt,
  *
  * @param[in] crypt The @ref mongocrypt_t object.
  * @param[in] kms_providers A BSON document mapping the KMS provider names
- * to credentials. Set "aws" to an empty document to supply AWS credentials
+ * to credentials. Set a KMS provider value to an empty document to supply credentials
  * on-demand with @ref mongocrypt_ctx_provide_kms_providers.
  * @pre @ref mongocrypt_init has not been called on @p crypt.
  * @returns A boolean indicating success. If false, an error status is set.
@@ -480,7 +480,7 @@ mongocrypt_setopt_set_csfle_lib_path_override (mongocrypt_t *crypt,
  * @ref mongocrypt_ctx_provide_kms_providers.
  *
  * A context will only enter MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS
- * if an empty `aws: {}` document was set in @ref
+ * if an empty document was set for a KMS provider in @ref
  * mongocrypt_setopt_kms_providers.
  *
  * @param[in] crypt The @ref mongocrypt_t object to update

--- a/test/test-mongocrypt-ctx-decrypt.c
+++ b/test/test-mongocrypt-ctx-decrypt.c
@@ -249,6 +249,71 @@ _test_decrypt_per_ctx_credentials (_mongocrypt_tester_t *tester)
    mongocrypt_destroy (crypt);
 }
 
+static void
+_test_decrypt_per_ctx_credentials_local (_mongocrypt_tester_t *tester)
+{
+   mongocrypt_t *crypt;
+   mongocrypt_ctx_t *ctx;
+   mongocrypt_binary_t *bin;
+   _mongocrypt_buffer_t encrypted;
+   /* local_kek is the KEK used to encrypt the keyMaterial in
+    * ./test/data/key-document-local.json */
+   const char *local_kek =
+      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+   /* local_uuid is the hex of the UUID of the key in
+    * ./test/data/key-document-local.json */
+   const char *local_uuid = "61616161616161616161616161616161";
+   _mongocrypt_buffer_t local_uuid_buf;
+
+   bin = mongocrypt_binary_new ();
+   crypt = mongocrypt_new ();
+   mongocrypt_setopt_use_need_kms_credentials_state (crypt);
+   mongocrypt_setopt_kms_providers (crypt, TEST_BSON ("{'local': {}}"));
+   ASSERT_OK (mongocrypt_init (crypt), crypt);
+   ctx = mongocrypt_ctx_new (crypt);
+
+   /* Encrypt an empty binary value. */
+   _mongocrypt_buffer_copy_from_hex (&local_uuid_buf, local_uuid);
+   mongocrypt_ctx_setopt_key_id (ctx, _mongocrypt_buffer_as_binary (&local_uuid_buf));
+   mongocrypt_ctx_setopt_algorithm (
+      ctx, "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic", -1);
+   mongocrypt_ctx_explicit_encrypt_init (
+      ctx,
+      TEST_BSON ("{'v': { '$binary': { 'base64': '', 'subType': '00' } } }"));
+   _mongocrypt_tester_run_ctx_to (
+      tester, ctx, MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
+   ASSERT_OK (mongocrypt_ctx_provide_kms_providers (
+                 ctx,
+                 TEST_BSON ("{'local':{'key': { '$binary': {'base64': '%s', "
+                            "'subType': '00'}}}}",
+                            local_kek)),
+              ctx);
+   _mongocrypt_tester_run_ctx_to (tester, ctx, MONGOCRYPT_CTX_NEED_MONGO_KEYS);
+   ASSERT_OK (mongocrypt_ctx_mongo_feed (
+                 ctx, TEST_FILE ("./test/data/key-document-local.json")),
+              ctx);
+   ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
+   _mongocrypt_tester_run_ctx_to (tester, ctx, MONGOCRYPT_CTX_READY);
+   mongocrypt_ctx_finalize (ctx, bin);
+   /* Copy the encrypted ciphertext since it is tied to the lifetime of ctx. */
+   _mongocrypt_buffer_copy_from_binary (&encrypted, bin);
+   mongocrypt_ctx_destroy (ctx);
+
+   /* Decrypt it back. */
+   ctx = mongocrypt_ctx_new (crypt);
+   mongocrypt_ctx_explicit_decrypt_init (
+      ctx, _mongocrypt_buffer_as_binary (&encrypted));
+   _mongocrypt_tester_run_ctx_to (tester, ctx, MONGOCRYPT_CTX_READY);
+   mongocrypt_ctx_finalize (ctx, bin);
+
+   _mongocrypt_buffer_cleanup (&local_uuid_buf);
+   mongocrypt_binary_destroy (bin);
+   mongocrypt_ctx_destroy (ctx);
+   _mongocrypt_buffer_cleanup (&encrypted);
+   mongocrypt_destroy (crypt);
+}
+
 void
 _mongocrypt_tester_install_ctx_decrypt (_mongocrypt_tester_t *tester)
 {
@@ -259,4 +324,5 @@ _mongocrypt_tester_install_ctx_decrypt (_mongocrypt_tester_t *tester)
    INSTALL_TEST (_test_decrypt_empty_aws);
    INSTALL_TEST (_test_decrypt_empty_binary);
    INSTALL_TEST (_test_decrypt_per_ctx_credentials);
+   INSTALL_TEST (_test_decrypt_per_ctx_credentials_local);
 }

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1491,8 +1491,8 @@ _test_encrypt_per_ctx_credentials_local (_mongocrypt_tester_t *tester)
       mongocrypt_ctx_provide_kms_providers (
          ctx,
          TEST_BSON (
-            "{'local':{'key': { '$binary': {'base64': " TEST_LOCAL_KEK_BASE64
-            ", 'subType': '00'}}}}")),
+            "{'local':{'key': { '$binary': {'base64': '" TEST_LOCAL_KEK_BASE64
+            "', 'subType': '00'}}}}")),
       ctx);
    _mongocrypt_tester_run_ctx_to (tester, ctx, MONGOCRYPT_CTX_NEED_MONGO_KEYS);
    ASSERT_OK (mongocrypt_ctx_mongo_feed (

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1472,6 +1472,8 @@ _test_encrypt_per_ctx_credentials_local (_mongocrypt_tester_t *tester)
 {
    mongocrypt_t *crypt;
    mongocrypt_ctx_t *ctx;
+   /* local_kek is the KEK used to encrypt the keyMaterial in
+    * ./test/data/key-document-local.json */
    const char *local_kek =
       "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
       "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1467,6 +1467,43 @@ _test_encrypt_per_ctx_credentials (_mongocrypt_tester_t *tester)
    mongocrypt_destroy (crypt);
 }
 
+#define TEST_LOCAL_KEK_BASE64                                                  \
+   "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" \
+   "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+static void
+_test_encrypt_per_ctx_credentials_local (_mongocrypt_tester_t *tester)
+{
+   mongocrypt_t *crypt;
+   mongocrypt_ctx_t *ctx;
+
+   crypt = mongocrypt_new ();
+   mongocrypt_setopt_use_need_kms_credentials_state (crypt);
+   mongocrypt_setopt_kms_providers (crypt, TEST_BSON ("{'local': {}}"));
+   ASSERT_OK (mongocrypt_init (crypt), crypt);
+   ctx = mongocrypt_ctx_new (crypt);
+   ASSERT_OK (mongocrypt_ctx_encrypt_init (
+                 ctx, "test", -1, TEST_FILE ("./test/example/cmd.json")),
+              ctx);
+   _mongocrypt_tester_run_ctx_to (
+      tester, ctx, MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
+   ASSERT_OK (
+      mongocrypt_ctx_provide_kms_providers (
+         ctx,
+         TEST_BSON (
+            "{'local':{'key': { '$binary': {'base64': " TEST_LOCAL_KEK_BASE64
+            ", 'subType': '00'}}}}")),
+      ctx);
+   _mongocrypt_tester_run_ctx_to (tester, ctx, MONGOCRYPT_CTX_NEED_MONGO_KEYS);
+   ASSERT_OK (mongocrypt_ctx_mongo_feed (
+                 ctx, TEST_FILE ("./test/data/key-document-local.json")),
+              ctx);
+   ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
+
+   mongocrypt_ctx_destroy (ctx);
+   mongocrypt_destroy (crypt);
+}
+
 static void
 _test_encrypt_with_aws_session_token (_mongocrypt_tester_t *tester)
 {
@@ -1595,4 +1632,5 @@ _mongocrypt_tester_install_ctx_encrypt (_mongocrypt_tester_t *tester)
    INSTALL_TEST (_test_encrypt_caches_empty_collinfo);
    INSTALL_TEST (_test_encrypt_caches_collinfo_without_jsonschema);
    INSTALL_TEST (_test_encrypt_per_ctx_credentials);
+   INSTALL_TEST (_test_encrypt_per_ctx_credentials_local);
 }

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1467,15 +1467,14 @@ _test_encrypt_per_ctx_credentials (_mongocrypt_tester_t *tester)
    mongocrypt_destroy (crypt);
 }
 
-#define TEST_LOCAL_KEK_BASE64                                                  \
-   "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" \
-   "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-
 static void
 _test_encrypt_per_ctx_credentials_local (_mongocrypt_tester_t *tester)
 {
    mongocrypt_t *crypt;
    mongocrypt_ctx_t *ctx;
+   const char *local_kek =
+      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
    crypt = mongocrypt_new ();
    mongocrypt_setopt_use_need_kms_credentials_state (crypt);
@@ -1487,13 +1486,12 @@ _test_encrypt_per_ctx_credentials_local (_mongocrypt_tester_t *tester)
               ctx);
    _mongocrypt_tester_run_ctx_to (
       tester, ctx, MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
-   ASSERT_OK (
-      mongocrypt_ctx_provide_kms_providers (
-         ctx,
-         TEST_BSON (
-            "{'local':{'key': { '$binary': {'base64': '" TEST_LOCAL_KEK_BASE64
-            "', 'subType': '00'}}}}")),
-      ctx);
+   ASSERT_OK (mongocrypt_ctx_provide_kms_providers (
+                 ctx,
+                 TEST_BSON ("{'local':{'key': { '$binary': {'base64': '%s', "
+                            "'subType': '00'}}}}",
+                            local_kek)),
+              ctx);
    _mongocrypt_tester_run_ctx_to (tester, ctx, MONGOCRYPT_CTX_NEED_MONGO_KEYS);
    ASSERT_OK (mongocrypt_ctx_mongo_feed (
                  ctx, TEST_FILE ("./test/data/key-document-local.json")),

--- a/test/test-mongocrypt-datakey.c
+++ b/test/test-mongocrypt-datakey.c
@@ -251,14 +251,14 @@ _test_datakey_kms_per_ctx_credentials (_mongocrypt_tester_t *tester)
       mongocrypt_ctx_setopt_masterkey_aws_endpoint (ctx, "example.com", -1),
       ctx);
    ASSERT_OK (mongocrypt_ctx_datakey_init (ctx), ctx);
-   BSON_ASSERT (mongocrypt_ctx_state (ctx) ==
-                MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
-   ASSERT_OK (mongocrypt_ctx_provide_kms_providers (
-                 ctx,
-                 TEST_BSON ("{'aws':{'accessKeyId': 'example',"
-                            "'secretAccessKey': 'example'}}")),
-              ctx);
-   BSON_ASSERT (mongocrypt_ctx_state (ctx) == MONGOCRYPT_CTX_NEED_KMS);
+   BSON_ASSERT (
+      mongocrypt_ctx_state (ctx) == MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
+   ASSERT_OK (
+      mongocrypt_ctx_provide_kms_providers (ctx,
+         TEST_BSON ("{'aws':{'accessKeyId': 'example',"
+                            "'secretAccessKey': 'example'}}")), ctx);
+   BSON_ASSERT (
+      mongocrypt_ctx_state (ctx) == MONGOCRYPT_CTX_NEED_KMS);
    kms_ctx = mongocrypt_ctx_next_kms_ctx (ctx);
    BSON_ASSERT (kms_ctx);
    ASSERT_OK (mongocrypt_kms_ctx_endpoint (kms_ctx, &endpoint), ctx);

--- a/test/test-mongocrypt-datakey.c
+++ b/test/test-mongocrypt-datakey.c
@@ -251,14 +251,14 @@ _test_datakey_kms_per_ctx_credentials (_mongocrypt_tester_t *tester)
       mongocrypt_ctx_setopt_masterkey_aws_endpoint (ctx, "example.com", -1),
       ctx);
    ASSERT_OK (mongocrypt_ctx_datakey_init (ctx), ctx);
-   BSON_ASSERT (
-      mongocrypt_ctx_state (ctx) == MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
-   ASSERT_OK (
-      mongocrypt_ctx_provide_kms_providers (ctx,
-         TEST_BSON ("{'aws':{'accessKeyId': 'example',"
-                            "'secretAccessKey': 'example'}}")), ctx);
-   BSON_ASSERT (
-      mongocrypt_ctx_state (ctx) == MONGOCRYPT_CTX_NEED_KMS);
+   BSON_ASSERT (mongocrypt_ctx_state (ctx) ==
+                MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
+   ASSERT_OK (mongocrypt_ctx_provide_kms_providers (
+                 ctx,
+                 TEST_BSON ("{'aws':{'accessKeyId': 'example',"
+                            "'secretAccessKey': 'example'}}")),
+              ctx);
+   BSON_ASSERT (mongocrypt_ctx_state (ctx) == MONGOCRYPT_CTX_NEED_KMS);
    kms_ctx = mongocrypt_ctx_next_kms_ctx (ctx);
    BSON_ASSERT (kms_ctx);
    ASSERT_OK (mongocrypt_kms_ctx_endpoint (kms_ctx, &endpoint), ctx);
@@ -285,11 +285,12 @@ _test_datakey_kms_per_ctx_credentials (_mongocrypt_tester_t *tester)
    mongocrypt_destroy (crypt);
 }
 
-/* Test creating a data key with a non "aws" KMS provider.
+/* Test creating a data key with "azure" when only "aws" credentials are needed.
  * Expect the context not to enter the MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS
  * state. */
 static void
-_test_datakey_kms_per_ctx_credentials_non_aws (_mongocrypt_tester_t *tester)
+_test_datakey_kms_per_ctx_credentials_not_requested (
+   _mongocrypt_tester_t *tester)
 {
    mongocrypt_t *crypt;
    mongocrypt_ctx_t *ctx;
@@ -311,6 +312,58 @@ _test_datakey_kms_per_ctx_credentials_non_aws (_mongocrypt_tester_t *tester)
    ASSERT_OK (mongocrypt_ctx_datakey_init (ctx), ctx);
    ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_NEED_KMS);
 
+   mongocrypt_ctx_destroy (ctx);
+   mongocrypt_destroy (crypt);
+}
+
+#define TEST_LOCAL_KEK_BASE64 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+/* Test creating a data key with "local" when "local" credentials are required.
+ * Expect the context to enter the MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS
+ * state. */
+static void
+_test_datakey_kms_per_ctx_credentials_local (_mongocrypt_tester_t *tester)
+{
+   mongocrypt_t *crypt;
+   mongocrypt_ctx_t *ctx;
+   mongocrypt_binary_t *bin;
+   bson_t key_bson;
+   bson_iter_t iter;
+
+   crypt = mongocrypt_new ();
+   mongocrypt_setopt_use_need_kms_credentials_state (crypt);
+   ASSERT_OK (
+      mongocrypt_setopt_kms_providers (crypt, TEST_BSON ("{'local': {}}")),
+      crypt);
+   ASSERT_OK (mongocrypt_init (crypt), crypt);
+   ctx = mongocrypt_ctx_new (crypt);
+   ASSERT_OK (mongocrypt_ctx_setopt_key_encryption_key (
+                 ctx, TEST_BSON ("{'provider': 'local' }")),
+              ctx);
+   ASSERT_OK (mongocrypt_ctx_datakey_init (ctx), ctx);
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
+                       MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
+
+   ASSERT_OK (
+      mongocrypt_ctx_provide_kms_providers (
+         ctx,
+         TEST_BSON (
+            "{'local':{'key': { '$binary': {'base64': " TEST_LOCAL_KEK_BASE64
+            ", 'subType': '00'}}}}")),
+      ctx);
+
+   BSON_ASSERT (mongocrypt_ctx_state (ctx) == MONGOCRYPT_CTX_READY);
+
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_READY);
+   bin = mongocrypt_binary_new ();
+   ASSERT_OK (mongocrypt_ctx_finalize (ctx, bin), ctx);
+   /* Check the BSON document created. */
+   BSON_ASSERT (_mongocrypt_binary_to_bson (bin, &key_bson));
+   BSON_ASSERT (bson_iter_init (&iter, &key_bson));
+   BSON_ASSERT (bson_iter_find_descendant (&iter, "masterKey.provider", &iter));
+   BSON_ASSERT (0 == strcmp (bson_iter_utf8 (&iter, NULL), "local"));
+
+   mongocrypt_binary_destroy (bin);
    mongocrypt_ctx_destroy (ctx);
    mongocrypt_destroy (crypt);
 }
@@ -432,5 +485,6 @@ _mongocrypt_tester_install_data_key (_mongocrypt_tester_t *tester)
    INSTALL_TEST (_test_datakey_custom_endpoint);
    INSTALL_TEST (_test_datakey_custom_key_material);
    INSTALL_TEST (_test_datakey_kms_per_ctx_credentials);
-   INSTALL_TEST (_test_datakey_kms_per_ctx_credentials_non_aws);
+   INSTALL_TEST (_test_datakey_kms_per_ctx_credentials_not_requested);
+   INSTALL_TEST (_test_datakey_kms_per_ctx_credentials_local);
 }

--- a/test/test-mongocrypt-datakey.c
+++ b/test/test-mongocrypt-datakey.c
@@ -352,8 +352,6 @@ _test_datakey_kms_per_ctx_credentials_local (_mongocrypt_tester_t *tester)
                             local_kek)),
               ctx);
 
-   BSON_ASSERT (mongocrypt_ctx_state (ctx) == MONGOCRYPT_CTX_READY);
-
    ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_READY);
    bin = mongocrypt_binary_new ();
    ASSERT_OK (mongocrypt_ctx_finalize (ctx, bin), ctx);

--- a/test/test-mongocrypt-datakey.c
+++ b/test/test-mongocrypt-datakey.c
@@ -316,10 +316,6 @@ _test_datakey_kms_per_ctx_credentials_not_requested (
    mongocrypt_destroy (crypt);
 }
 
-#define TEST_LOCAL_KEK_BASE64                                                  \
-   "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" \
-   "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-
 /* Test creating a data key with "local" when "local" credentials are required.
  * Expect the context to enter the MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS
  * state. */
@@ -331,6 +327,9 @@ _test_datakey_kms_per_ctx_credentials_local (_mongocrypt_tester_t *tester)
    mongocrypt_binary_t *bin;
    bson_t key_bson;
    bson_iter_t iter;
+   const char *local_kek =
+      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
    crypt = mongocrypt_new ();
    mongocrypt_setopt_use_need_kms_credentials_state (crypt);
@@ -346,13 +345,12 @@ _test_datakey_kms_per_ctx_credentials_local (_mongocrypt_tester_t *tester)
    ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
                        MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
 
-   ASSERT_OK (
-      mongocrypt_ctx_provide_kms_providers (
-         ctx,
-         TEST_BSON (
-            "{'local':{'key': { '$binary': {'base64': '" TEST_LOCAL_KEK_BASE64
-            "', 'subType': '00'}}}}")),
-      ctx);
+   ASSERT_OK (mongocrypt_ctx_provide_kms_providers (
+                 ctx,
+                 TEST_BSON ("{'local':{'key': { '$binary': {'base64': '%s', "
+                            "'subType': '00'}}}}",
+                            local_kek)),
+              ctx);
 
    BSON_ASSERT (mongocrypt_ctx_state (ctx) == MONGOCRYPT_CTX_READY);
 

--- a/test/test-mongocrypt-datakey.c
+++ b/test/test-mongocrypt-datakey.c
@@ -316,7 +316,9 @@ _test_datakey_kms_per_ctx_credentials_not_requested (
    mongocrypt_destroy (crypt);
 }
 
-#define TEST_LOCAL_KEK_BASE64 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+#define TEST_LOCAL_KEK_BASE64                                                  \
+   "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" \
+   "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 
 /* Test creating a data key with "local" when "local" credentials are required.
  * Expect the context to enter the MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS
@@ -348,8 +350,8 @@ _test_datakey_kms_per_ctx_credentials_local (_mongocrypt_tester_t *tester)
       mongocrypt_ctx_provide_kms_providers (
          ctx,
          TEST_BSON (
-            "{'local':{'key': { '$binary': {'base64': " TEST_LOCAL_KEK_BASE64
-            ", 'subType': '00'}}}}")),
+            "{'local':{'key': { '$binary': {'base64': '" TEST_LOCAL_KEK_BASE64
+            "', 'subType': '00'}}}}")),
       ctx);
 
    BSON_ASSERT (mongocrypt_ctx_state (ctx) == MONGOCRYPT_CTX_READY);

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -724,13 +724,12 @@ _test_setopt_kms_providers (_mongocrypt_tester_t *tester)
       {"{'local': {'key': 'AAAA'}}", "local key must be 96 bytes"},
       /* KMIP test cases. */
       {"{'kmip': {'endpoint': '127.0.0.1:5696' }}", NULL},
-      {"{'kmip': {}}", "expected endpoint kmip.endpoint"},
       /* localhost is a valid endpoint for KMIP.
        * Unlike Azure, GCP, and AWS, applications run their own KMIP servers. */
       {"{'kmip': {'endpoint': 'localhost' }}", NULL},
       {"{'kmip': {'endpoint': '127.0.0.1:5696', 'extra': 'invalid' }}",
        "Unexpected field: 'extra'"},
-       /* Empty documents are OK for KMS credentials */
+       /* Empty documents are OK for on-demand KMS credentials */
       {"{'aws': {}}", NULL},
       {"{'azure': {}}", NULL},
       {"{'local': {}}", NULL},

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -692,13 +692,11 @@ _test_setopt_kms_providers (_mongocrypt_tester_t *tester)
        "Invalid endpoint"},
       {"{'azure': {'tenantId': '', 'clientSecret': '' }}", "clientId"},
       {"{'aws': {'accessKeyId': 'abc', 'secretAccessKey': 'def'}}", NULL},
-      {"{'aws': {}}", NULL},
       {"{'local': {'key': {'$binary': {'base64': '" EXAMPLE_LOCAL_MATERIAL
        "', 'subType': '00'}} }}",
        NULL},
       {"{'local': {'key': '" EXAMPLE_LOCAL_MATERIAL "' }}", NULL},
       {"{'local': {'key': 'invalid base64' }}", "unable to parse base64"},
-      {"{'local': {}}", "expected UTF-8 or binary local.key"},
       /* either base64 string or binary is acceptable for privateKey */
       {"{'gcp': {'endpoint': 'oauth2.googleapis.com', 'email': 'test', "
        "'privateKey': 'AAAA' }}"},
@@ -731,7 +729,14 @@ _test_setopt_kms_providers (_mongocrypt_tester_t *tester)
        * Unlike Azure, GCP, and AWS, applications run their own KMIP servers. */
       {"{'kmip': {'endpoint': 'localhost' }}", NULL},
       {"{'kmip': {'endpoint': '127.0.0.1:5696', 'extra': 'invalid' }}",
-       "Unexpected field: 'extra'"}};
+       "Unexpected field: 'extra'"},
+       /* Empty documents are OK for KMS credentials */
+      {"{'aws': {}}", NULL},
+      {"{'azure': {}}", NULL},
+      {"{'local': {}}", NULL},
+      {"{'gcp': {}}", NULL},
+      {"{'kmip': {}}", NULL}
+       };
 
    for (i = 0; i < sizeof (tests) / sizeof (tests[0]); i++) {
       mongocrypt_t *crypt;


### PR DESCRIPTION
# Summary
Allow an empty document to be set for "azure", "gcp", "local", and "kmip" KMS providers.

# Background & Motivation

[MONGOCRYPT-382](https://jira.mongodb.org/browse/MONGOCRYPT-382) added support to passing credentials on-demand. It was later limited to only the "aws" KMS provider in https://github.com/mongodb/libmongocrypt/pull/257.

It is currently an error to pass an empty document for "azure", "gcp", "local", and "kmip" to `mongocrypt_setopt_kms_providers`.

The proposed driver implementation of on-demand KMS providers intends to permit on-demand credentials for all KMS providers. See the [conversation on this Java driver PR](https://github.com/mongodb/mongo-java-driver/pull/894#discussion_r829232804).