### PR TITLE
MONGOCRYPT-411 fix URLs in windows-upload s3 cmds

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -650,7 +650,7 @@ tasks:
       params:
         aws_key: '${aws_key}'
         aws_secret: '${aws_secret}'
-        remote_file: 'libmongocrypt/windows-test/master/${libmongocrypt_s3_suffix}/libmongocrypt.tar.gz'
+        remote_file: '${project}/windows-test/${branch_name}/${libmongocrypt_s3_suffix}/libmongocrypt.tar.gz'
         bucket: mciuploads
         extract_to: libmongocrypt_download
     - command: shell.exec
@@ -674,7 +674,7 @@ tasks:
       params:
         aws_key: '${aws_key}'
         aws_secret: '${aws_secret}'
-        remote_file: '${project}/windows/latest_release/libmongocrypt${upload_suffix}.tar.gz'
+        remote_file: 'libmongocrypt/windows/latest_release/libmongocrypt${upload_suffix}.tar.gz'
         bucket: mciuploads
         permissions: public-read
         local_file: 'libmongocrypt_upload.tar.gz'


### PR DESCRIPTION
This was my mistake in #264.

The windows-upload task s3.get command was incorrectly updated.
The intended change was to update the s3.put command to make the upload URL consistent with the current upload URL.

This was discovered after doing the 1.3.2-rc1 release. The windows-upload task [failed to run the s3.get command](https://evergreen.mongodb.com/task/libmongocrypt_release_windows_uploader_windows_upload_67105e7aae76f87713debfe3bdd2b4d54702dbc9_22_03_18_21_03_28) because the `remote_file` did not exist.