### PR TITLE
MONGOCRYPT-410 and MONGOCRYPT-404

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -598,7 +598,7 @@ _try_schema_from_schema_map (mongocrypt_ctx_t *ctx)
 }
 
 static bool
-_try_schema_from_encrypted_field_config_map (mongocrypt_ctx_t *ctx)
+_fle2_try_schema_from_encrypted_field_config_map (mongocrypt_ctx_t *ctx)
 {
    mongocrypt_t *crypt;
    _mongocrypt_ctx_encrypt_t *ectx;
@@ -1045,7 +1045,7 @@ mongocrypt_ctx_encrypt_init (mongocrypt_ctx_t *ctx,
    }
 
    /* Check if there is an encrypted field config in encrypted_field_config_map */
-   if (!_try_schema_from_encrypted_field_config_map (ctx)) {
+   if (!_fle2_try_schema_from_encrypted_field_config_map (ctx)) {
       return false;
    }
    if (!_mongocrypt_buffer_empty (&ectx->encrypted_field_config)) {

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -175,6 +175,31 @@ _mongo_done_collinfo (mongocrypt_ctx_t *ctx)
    return true;
 }
 
+static bool
+_fle2_mongo_op_markings (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out) {
+   _mongocrypt_ctx_encrypt_t *ectx;
+   bson_t cmd_bson, mongocryptd_cmd_bson, encrypted_field_config_bson;
+   ectx = (_mongocrypt_ctx_encrypt_t *) ctx;
+
+   if (!_mongocrypt_buffer_to_bson (&ectx->original_cmd, &cmd_bson)) {
+      return _mongocrypt_ctx_fail_w_msg (ctx, "unable to convert original_cmd to BSON");
+   }
+
+   if (!_mongocrypt_buffer_to_bson (&ectx->encrypted_field_config, &encrypted_field_config_bson)) {
+      return _mongocrypt_ctx_fail_w_msg (ctx, "unable to convert encrypted_field_config to BSON");
+   }
+
+   bson_copy_to (&cmd_bson, &mongocryptd_cmd_bson);
+   if (!_fle2_append_encryptionInformation (&mongocryptd_cmd_bson, ectx->ns, &encrypted_field_config_bson, ctx->status)) {
+      return _mongocrypt_ctx_fail (ctx);
+   }
+
+   _mongocrypt_buffer_steal_from_bson (&ectx->mongocryptd_cmd, &mongocryptd_cmd_bson);
+
+   out->data = ectx->mongocryptd_cmd.data;
+   out->len = ectx->mongocryptd_cmd.len;
+   return true;
+}
 
 static bool
 _mongo_op_markings (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
@@ -191,49 +216,36 @@ _mongo_op_markings (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
       return true;
    }
 
+   if (!_mongocrypt_buffer_empty (&ectx->encrypted_field_config)) {
+      return _fle2_mongo_op_markings (ctx, out);
+   }
+
    /* first, get the original command. */
    if (!_mongocrypt_buffer_to_bson (&ectx->original_cmd, &cmd_bson)) {
       return _mongocrypt_ctx_fail_w_msg (ctx, "invalid BSON cmd");
    }
 
-   if (!_mongocrypt_buffer_empty (&ectx->encrypted_field_config)) {
-      bson_t encrypted_field_config_bson;
-
-      /* Use FLE 2.0. */
-      if (!_mongocrypt_buffer_to_bson (&ectx->encrypted_field_config, &encrypted_field_config_bson)) {
-         return _mongocrypt_ctx_fail_w_msg (ctx, "unable to convert encrypted_field_config to BSON");
-      }
-
-      bson_copy_to (&cmd_bson, &mongocryptd_cmd_bson);
-      if (!_fle2_append_encryptionInformation (&mongocryptd_cmd_bson, ectx->ns, &encrypted_field_config_bson, ctx->status)) {
-         return _mongocrypt_ctx_fail (ctx);
-      }
-
-      _mongocrypt_buffer_steal_from_bson (&ectx->mongocryptd_cmd, &mongocryptd_cmd_bson);
-   } else {
-      /* Use FLE 1.0. */
-
-      /* Q5: Is it possible to undergo automatic encryption with a NULL schema?
-       * This _mongocrypt_buffer_empty check suggests so.
-       * A: */
-      if (_mongocrypt_buffer_empty (&ectx->schema)) {
-         bson_init (&schema_bson);
-      } else if (!_mongocrypt_buffer_to_bson (&ectx->schema, &schema_bson)) {
-         return _mongocrypt_ctx_fail_w_msg (ctx, "invalid BSON schema");
-      }
-
-      bson_copy_to (&cmd_bson, &mongocryptd_cmd_bson);
-      BSON_APPEND_DOCUMENT (&mongocryptd_cmd_bson, "jsonSchema", &schema_bson);
-
-      /* if a local schema was not set, set isRemoteSchema=true */
-      BSON_APPEND_BOOL (
-         &mongocryptd_cmd_bson, "isRemoteSchema", !ectx->used_local_schema);
-      _mongocrypt_buffer_steal_from_bson (&ectx->mongocryptd_cmd,
-                                          &mongocryptd_cmd_bson);
-
-      bson_destroy (&cmd_bson);
-      bson_destroy (&schema_bson);
+   /* Q5: Is it possible to undergo automatic encryption with a NULL schema?
+      * This _mongocrypt_buffer_empty check suggests so.
+      * A: */
+   if (_mongocrypt_buffer_empty (&ectx->schema)) {
+      bson_init (&schema_bson);
+   } else if (!_mongocrypt_buffer_to_bson (&ectx->schema, &schema_bson)) {
+      return _mongocrypt_ctx_fail_w_msg (ctx, "invalid BSON schema");
    }
+
+   bson_copy_to (&cmd_bson, &mongocryptd_cmd_bson);
+   BSON_APPEND_DOCUMENT (&mongocryptd_cmd_bson, "jsonSchema", &schema_bson);
+
+   /* if a local schema was not set, set isRemoteSchema=true */
+   BSON_APPEND_BOOL (
+      &mongocryptd_cmd_bson, "isRemoteSchema", !ectx->used_local_schema);
+   _mongocrypt_buffer_steal_from_bson (&ectx->mongocryptd_cmd,
+                                       &mongocryptd_cmd_bson);
+
+   bson_destroy (&cmd_bson);
+   bson_destroy (&schema_bson);
+
    out->data = ectx->mongocryptd_cmd.data;
    out->len = ectx->mongocryptd_cmd.len;
    return true;

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -181,6 +181,9 @@ _fle2_mongo_op_markings (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out) {
    bson_t cmd_bson, mongocryptd_cmd_bson, encrypted_field_config_bson;
    ectx = (_mongocrypt_ctx_encrypt_t *) ctx;
 
+   BSON_ASSERT (ctx->state == MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+   BSON_ASSERT (!_mongocrypt_buffer_empty (&ectx->encrypted_field_config));
+
    if (!_mongocrypt_buffer_to_bson (&ectx->original_cmd, &cmd_bson)) {
       return _mongocrypt_ctx_fail_w_msg (ctx, "unable to convert original_cmd to BSON");
    }
@@ -433,6 +436,7 @@ _fle2_finalize (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out) {
    status = ctx->status;
 
    BSON_ASSERT (!_mongocrypt_buffer_empty (&ectx->encrypted_field_config));
+   BSON_ASSERT (ctx->state == MONGOCRYPT_CTX_READY);
    
    if (ectx->explicit) {
       return _mongocrypt_ctx_fail_w_msg (ctx, "explicit encryption is not yet supported. See MONGOCRYPT-409.");

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -597,8 +597,10 @@ _try_schema_from_schema_map (mongocrypt_ctx_t *ctx)
    return true;
 }
 
+/* Check if the local encrypted field config map has an entry for this collection.
+ * If an encrypted field config is found, the context transitions to MONGOCRYPT_CTX_NEED_MONGO_MARKINGS. */
 static bool
-_fle2_try_schema_from_encrypted_field_config_map (mongocrypt_ctx_t *ctx)
+_fle2_try_encrypted_field_config_from_map (mongocrypt_ctx_t *ctx)
 {
    mongocrypt_t *crypt;
    _mongocrypt_ctx_encrypt_t *ectx;
@@ -1045,7 +1047,7 @@ mongocrypt_ctx_encrypt_init (mongocrypt_ctx_t *ctx,
    }
 
    /* Check if there is an encrypted field config in encrypted_field_config_map */
-   if (!_fle2_try_schema_from_encrypted_field_config_map (ctx)) {
+   if (!_fle2_try_encrypted_field_config_from_map (ctx)) {
       return false;
    }
    if (!_mongocrypt_buffer_empty (&ectx->encrypted_field_config)) {

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -438,11 +438,9 @@ _fle2_finalize (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
 {
    bson_t converted;
    _mongocrypt_ctx_encrypt_t *ectx;
-   mongocrypt_status_t *status;
    bson_t encrypted_field_config_bson;
 
    ectx = (_mongocrypt_ctx_encrypt_t *) ctx;
-   status = ctx->status;
 
    BSON_ASSERT (!_mongocrypt_buffer_empty (&ectx->encrypted_field_config));
    BSON_ASSERT (ctx->state == MONGOCRYPT_CTX_READY);

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -21,11 +21,17 @@
 #include "mongocrypt-marking-private.h"
 #include "mongocrypt-traverse-util-private.h"
 
-static bool _fle2_append_encryptionInformation (bson_t *dst, const char* ns, bson_t* encryptedFieldConfig, mongocrypt_status_t *status) {
+static bool
+_fle2_append_encryptionInformation (bson_t *dst,
+                                    const char *ns,
+                                    bson_t *encryptedFieldConfig,
+                                    mongocrypt_status_t *status)
+{
    bson_t encryption_information_bson;
    bson_t schema_bson;
 
-   if (!BSON_APPEND_DOCUMENT_BEGIN (dst, "encryptionInformation", &encryption_information_bson)) {
+   if (!BSON_APPEND_DOCUMENT_BEGIN (
+          dst, "encryptionInformation", &encryption_information_bson)) {
       CLIENT_ERR ("unable to begin appending 'encryptionInformation'");
       return false;
    }
@@ -33,16 +39,20 @@ static bool _fle2_append_encryptionInformation (bson_t *dst, const char* ns, bso
       CLIENT_ERR ("unable to append type to 'encryptionInformation'");
       return false;
    }
-   if (!BSON_APPEND_DOCUMENT_BEGIN (&encryption_information_bson, "schema", &schema_bson)) {
-      CLIENT_ERR ("unable to begin appending 'schema' to 'encryptionInformation'");
+   if (!BSON_APPEND_DOCUMENT_BEGIN (
+          &encryption_information_bson, "schema", &schema_bson)) {
+      CLIENT_ERR (
+         "unable to begin appending 'schema' to 'encryptionInformation'");
       return false;
    }
    if (!BSON_APPEND_DOCUMENT (&schema_bson, ns, encryptedFieldConfig)) {
-      CLIENT_ERR ("unable to append 'encryptedFieldConfig' to 'encryptionInformation'.'schema'");
+      CLIENT_ERR ("unable to append 'encryptedFieldConfig' to "
+                  "'encryptionInformation'.'schema'");
       return false;
    }
    if (!bson_append_document_end (&encryption_information_bson, &schema_bson)) {
-      CLIENT_ERR ("unable to end appending 'schema' to 'encryptionInformation'");
+      CLIENT_ERR (
+         "unable to end appending 'schema' to 'encryptionInformation'");
       return false;
    }
    if (!bson_append_document_end (dst, &encryption_information_bson)) {
@@ -176,7 +186,8 @@ _mongo_done_collinfo (mongocrypt_ctx_t *ctx)
 }
 
 static bool
-_fle2_mongo_op_markings (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out) {
+_fle2_mongo_op_markings (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
+{
    _mongocrypt_ctx_encrypt_t *ectx;
    bson_t cmd_bson, mongocryptd_cmd_bson, encrypted_field_config_bson;
    ectx = (_mongocrypt_ctx_encrypt_t *) ctx;
@@ -185,19 +196,26 @@ _fle2_mongo_op_markings (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out) {
    BSON_ASSERT (!_mongocrypt_buffer_empty (&ectx->encrypted_field_config));
 
    if (!_mongocrypt_buffer_to_bson (&ectx->original_cmd, &cmd_bson)) {
-      return _mongocrypt_ctx_fail_w_msg (ctx, "unable to convert original_cmd to BSON");
+      return _mongocrypt_ctx_fail_w_msg (
+         ctx, "unable to convert original_cmd to BSON");
    }
 
-   if (!_mongocrypt_buffer_to_bson (&ectx->encrypted_field_config, &encrypted_field_config_bson)) {
-      return _mongocrypt_ctx_fail_w_msg (ctx, "unable to convert encrypted_field_config to BSON");
+   if (!_mongocrypt_buffer_to_bson (&ectx->encrypted_field_config,
+                                    &encrypted_field_config_bson)) {
+      return _mongocrypt_ctx_fail_w_msg (
+         ctx, "unable to convert encrypted_field_config to BSON");
    }
 
    bson_copy_to (&cmd_bson, &mongocryptd_cmd_bson);
-   if (!_fle2_append_encryptionInformation (&mongocryptd_cmd_bson, ectx->ns, &encrypted_field_config_bson, ctx->status)) {
+   if (!_fle2_append_encryptionInformation (&mongocryptd_cmd_bson,
+                                            ectx->ns,
+                                            &encrypted_field_config_bson,
+                                            ctx->status)) {
       return _mongocrypt_ctx_fail (ctx);
    }
 
-   _mongocrypt_buffer_steal_from_bson (&ectx->mongocryptd_cmd, &mongocryptd_cmd_bson);
+   _mongocrypt_buffer_steal_from_bson (&ectx->mongocryptd_cmd,
+                                       &mongocryptd_cmd_bson);
 
    out->data = ectx->mongocryptd_cmd.data;
    out->len = ectx->mongocryptd_cmd.len;
@@ -211,7 +229,8 @@ _mongo_op_markings (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
    bson_t cmd_bson, schema_bson, mongocryptd_cmd_bson;
 
    ectx = (_mongocrypt_ctx_encrypt_t *) ctx;
-   if (!_mongocrypt_buffer_empty (&ectx->encrypted_field_config) && _mongocrypt_buffer_empty (&ectx->mongocryptd_cmd)) {
+   if (!_mongocrypt_buffer_empty (&ectx->encrypted_field_config) &&
+       _mongocrypt_buffer_empty (&ectx->mongocryptd_cmd)) {
       return _fle2_mongo_op_markings (ctx, out);
    } else if (_mongocrypt_buffer_empty (&ectx->mongocryptd_cmd)) {
       /* first, get the original command. */
@@ -412,9 +431,11 @@ _replace_marking_with_ciphertext (void *ctx,
    return ret;
 }
 
-/* Process a call to mongocrypt_ctx_finalize when an encryptedFieldConfig is associated with the command. */
+/* Process a call to mongocrypt_ctx_finalize when an encryptedFieldConfig is
+ * associated with the command. */
 static bool
-_fle2_finalize (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out) {
+_fle2_finalize (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
+{
    bson_t converted;
    _mongocrypt_ctx_encrypt_t *ectx;
    mongocrypt_status_t *status;
@@ -425,32 +446,41 @@ _fle2_finalize (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out) {
 
    BSON_ASSERT (!_mongocrypt_buffer_empty (&ectx->encrypted_field_config));
    BSON_ASSERT (ctx->state == MONGOCRYPT_CTX_READY);
-   
+
    if (ectx->explicit) {
-      return _mongocrypt_ctx_fail_w_msg (ctx, "explicit encryption is not yet supported. See MONGOCRYPT-409.");
+      return _mongocrypt_ctx_fail_w_msg (
+         ctx, "explicit encryption is not yet supported. See MONGOCRYPT-409.");
    }
 
-   if (!_mongocrypt_buffer_to_bson (&ectx->encrypted_field_config, &encrypted_field_config_bson)) {
-      return _mongocrypt_ctx_fail_w_msg (ctx, "malformed bson in encrypted_field_config_bson");
+   if (!_mongocrypt_buffer_to_bson (&ectx->encrypted_field_config,
+                                    &encrypted_field_config_bson)) {
+      return _mongocrypt_ctx_fail_w_msg (
+         ctx, "malformed bson in encrypted_field_config_bson");
    }
 
    /* If nothing_to_do is true, then the marked_cmd contained no markings. */
    if (ctx->nothing_to_do) {
       bson_t original_cmd_bson;
 
-      if (!_mongocrypt_buffer_to_bson (&ectx->original_cmd, &original_cmd_bson)) {
-         return _mongocrypt_ctx_fail_w_msg (ctx, "malformed bson in original_cmd");
+      if (!_mongocrypt_buffer_to_bson (&ectx->original_cmd,
+                                       &original_cmd_bson)) {
+         return _mongocrypt_ctx_fail_w_msg (ctx,
+                                            "malformed bson in original_cmd");
       }
 
       /* Append 'encryptionInformation' to the original command. */
       bson_init (&converted);
       bson_copy_to (&original_cmd_bson, &converted);
-      if (!_fle2_append_encryptionInformation (&converted, ectx->ns, &encrypted_field_config_bson, ctx->status)) {
+      if (!_fle2_append_encryptionInformation (
+             &converted, ectx->ns, &encrypted_field_config_bson, ctx->status)) {
          bson_destroy (&converted);
          return _mongocrypt_ctx_fail (ctx);
       }
    } else {
-      return _mongocrypt_ctx_fail_w_msg (ctx, "FLE 2 markings not supported yet. See: MONGOCRYPT-397, MONGOCRYPT-398, and MONGOCRYPT-399");
+      return _mongocrypt_ctx_fail_w_msg (
+         ctx,
+         "FLE 2 markings not supported yet. See: MONGOCRYPT-397, "
+         "MONGOCRYPT-398, and MONGOCRYPT-399");
    }
 
    _mongocrypt_buffer_steal_from_bson (&ectx->encrypted_cmd, &converted);
@@ -597,8 +627,10 @@ _try_schema_from_schema_map (mongocrypt_ctx_t *ctx)
    return true;
 }
 
-/* Check if the local encrypted field config map has an entry for this collection.
- * If an encrypted field config is found, the context transitions to MONGOCRYPT_CTX_NEED_MONGO_MARKINGS. */
+/* Check if the local encrypted field config map has an entry for this
+ * collection.
+ * If an encrypted field config is found, the context transitions to
+ * MONGOCRYPT_CTX_NEED_MONGO_MARKINGS. */
 static bool
 _fle2_try_encrypted_field_config_from_map (mongocrypt_ctx_t *ctx)
 {
@@ -615,13 +647,19 @@ _fle2_try_encrypted_field_config_from_map (mongocrypt_ctx_t *ctx)
       return true;
    }
 
-   if (!_mongocrypt_buffer_to_bson (&crypt->opts.encrypted_field_config_map, &encrypted_field_config_map)) {
-      return _mongocrypt_ctx_fail_w_msg (ctx, "unable to convert encrypted_field_config_map to BSON");
+   if (!_mongocrypt_buffer_to_bson (&crypt->opts.encrypted_field_config_map,
+                                    &encrypted_field_config_map)) {
+      return _mongocrypt_ctx_fail_w_msg (
+         ctx, "unable to convert encrypted_field_config_map to BSON");
    }
 
    if (bson_iter_init_find (&iter, &encrypted_field_config_map, ectx->ns)) {
-      if (!_mongocrypt_buffer_copy_from_document_iter (&ectx->encrypted_field_config, &iter)) {
-         return _mongocrypt_ctx_fail_w_msg (ctx, "unable to copy encrypted_field_config from encrypted_field_config_map");
+      if (!_mongocrypt_buffer_copy_from_document_iter (
+             &ectx->encrypted_field_config, &iter)) {
+         return _mongocrypt_ctx_fail_w_msg (
+            ctx,
+            "unable to copy encrypted_field_config from "
+            "encrypted_field_config_map");
       }
       ctx->state = MONGOCRYPT_CTX_NEED_MONGO_MARKINGS;
    }
@@ -1046,7 +1084,8 @@ mongocrypt_ctx_encrypt_init (mongocrypt_ctx_t *ctx,
       bson_free (cmd_val);
    }
 
-   /* Check if there is an encrypted field config in encrypted_field_config_map */
+   /* Check if there is an encrypted field config in encrypted_field_config_map
+    */
    if (!_fle2_try_encrypted_field_config_from_map (ctx)) {
       return false;
    }

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -415,7 +415,7 @@ _replace_marking_with_ciphertext (void *ctx,
 /* Process a call to mongocrypt_ctx_finalize when an encryptedFieldConfig is associated with the command. */
 static bool
 _fle2_finalize (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out) {
-   bson_t as_bson, converted;
+   bson_t converted;
    _mongocrypt_ctx_encrypt_t *ectx;
    mongocrypt_status_t *status;
    bson_t encrypted_field_config_bson;
@@ -428,10 +428,6 @@ _fle2_finalize (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out) {
    
    if (ectx->explicit) {
       return _mongocrypt_ctx_fail_w_msg (ctx, "explicit encryption is not yet supported. See MONGOCRYPT-409.");
-   }
-
-   if (!_mongocrypt_buffer_to_bson (&ectx->marked_cmd, &as_bson)) {
-      return _mongocrypt_ctx_fail_w_msg (ctx, "malformed bson in marked_cmd");
    }
 
    if (!_mongocrypt_buffer_to_bson (&ectx->encrypted_field_config, &encrypted_field_config_bson)) {

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -228,9 +228,6 @@ _mongo_op_markings (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
       return _mongocrypt_ctx_fail_w_msg (ctx, "invalid BSON cmd");
    }
 
-   /* Q5: Is it possible to undergo automatic encryption with a NULL schema?
-      * This _mongocrypt_buffer_empty check suggests so.
-      * A: */
    if (_mongocrypt_buffer_empty (&ectx->schema)) {
       bson_init (&schema_bson);
    } else if (!_mongocrypt_buffer_to_bson (&ectx->schema, &schema_bson)) {

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -121,7 +121,7 @@ typedef struct {
    bool collinfo_has_siblings;
    /* encrypted_field_config is set when:
     * 1. <db_name>.<coll_name> is present in an encrypted_field_config_map.
-    * 2. (TODO MONGOCRYPT-???) The collection has encryptedFields in the response to listCollections.
+    * 2. (TODO MONGOCRYPT-414) The collection has encryptedFields in the response to listCollections.
     * encrypted_field_config is true if and only if encryption is using FLE 2.0. */
    _mongocrypt_buffer_t encrypted_field_config;
 } _mongocrypt_ctx_encrypt_t;

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -119,6 +119,11 @@ typedef struct {
    /* collinfo_has_siblings is true if the schema came from a remote JSON
     * schema, and there were siblings. */
    bool collinfo_has_siblings;
+   /* encrypted_field_config is set when:
+    * 1. <db_name>.<coll_name> is present in an encrypted_field_config_map.
+    * 2. (TODO MONGOCRYPT-???) The collection has encryptedFields in the response to listCollections.
+    * encrypted_field_config is true if and only if encryption is using FLE 2.0. */
+   _mongocrypt_buffer_t encrypted_field_config;
 } _mongocrypt_ctx_encrypt_t;
 
 

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -121,8 +121,10 @@ typedef struct {
    bool collinfo_has_siblings;
    /* encrypted_field_config is set when:
     * 1. <db_name>.<coll_name> is present in an encrypted_field_config_map.
-    * 2. (TODO MONGOCRYPT-414) The collection has encryptedFields in the response to listCollections.
-    * encrypted_field_config is true if and only if encryption is using FLE 2.0. */
+    * 2. (TODO MONGOCRYPT-414) The collection has encryptedFields in the
+    * response to listCollections. encrypted_field_config is true if and only if
+    * encryption is using FLE 2.0.
+    */
    _mongocrypt_buffer_t encrypted_field_config;
 } _mongocrypt_ctx_encrypt_t;
 
@@ -183,6 +185,6 @@ _mongocrypt_ctx_state_from_key_broker (mongocrypt_ctx_t *ctx)
 /* Get the KMS providers for the current context, fall back to the ones
  * from mongocrypt_t if none are provided for the context specifically. */
 _mongocrypt_opts_kms_providers_t *
-_mongocrypt_ctx_kms_providers(mongocrypt_ctx_t *ctx);
+_mongocrypt_ctx_kms_providers (mongocrypt_ctx_t *ctx);
 
 #endif /* MONGOCRYPT_CTX_PRIVATE_H */

--- a/src/mongocrypt-opts-private.h
+++ b/src/mongocrypt-opts-private.h
@@ -68,6 +68,7 @@ typedef struct {
    mongocrypt_log_fn_t log_fn;
    void *log_ctx;
    _mongocrypt_buffer_t schema_map;
+   _mongocrypt_buffer_t encrypted_field_config_map;
 
    _mongocrypt_opts_kms_providers_t kms_providers;
    mongocrypt_hmac_fn sign_rsaes_pkcs1_v1_5;

--- a/src/mongocrypt-opts.c
+++ b/src/mongocrypt-opts.c
@@ -135,10 +135,10 @@ _mongocrypt_opts_kms_providers_validate (
    return true;
 }
 
-/* _shares_bson_fields checks haystack contains any top-level fields from
- * needle. Returns false on error and sets @status. Returns true if no error
- * occurred. Sets @found to a string if haystack contains any top-level fields
- * from needle.
+/* _shares_bson_fields checks if haystack contains any top-level fields from
+ * @needle. Returns false on error and sets @status. Returns true if no error
+ * occurred. Sets @found to the first string from @needle found in @haystack.
+ * If no strings are found, @found is set to NULL.
  */
 static bool
 _shares_bson_fields (bson_t *haystack,

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -316,10 +316,43 @@ mongocrypt_setopt_schema_map (mongocrypt_t *crypt,
 bool
 mongocrypt_setopt_encrypted_field_config_map (mongocrypt_t *crypt, mongocrypt_binary_t *efc_map) {
    mongocrypt_status_t *status;
+   bson_t as_bson;
+   bson_error_t bson_err;
 
+   if (!crypt) {
+      return false;
+   }
    status = crypt->status;
-   CLIENT_ERR ("mongocrypt_setopt_encrypted_field_config_map is not implemented");
-   return false;
+
+   if (crypt->initialized) {
+      CLIENT_ERR ("options cannot be set after initialization");
+      return false;
+   }
+
+   if (!efc_map || !mongocrypt_binary_data (efc_map)) {
+      CLIENT_ERR ("passed null encrypted_field_config_map");
+      return false;
+   }
+
+   if (!_mongocrypt_buffer_empty (&crypt->opts.encrypted_field_config_map)) {
+      CLIENT_ERR ("already set encrypted_field_config_map");
+      return false;
+   }
+
+   _mongocrypt_buffer_copy_from_binary (&crypt->opts.encrypted_field_config_map, efc_map);
+
+   /* validate bson */
+   if (!_mongocrypt_buffer_to_bson (&crypt->opts.encrypted_field_config_map, &as_bson)) {
+      CLIENT_ERR ("invalid bson");
+      return false;
+   }
+
+   if (!bson_validate_with_error (&as_bson, BSON_VALIDATE_NONE, &bson_err)) {
+      CLIENT_ERR (bson_err.message);
+      return false;
+   }
+
+   return true;
 }
 
 bool

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -313,6 +313,14 @@ mongocrypt_setopt_schema_map (mongocrypt_t *crypt,
    return true;
 }
 
+bool
+mongocrypt_setopt_encrypted_field_config_map (mongocrypt_t *crypt, mongocrypt_binary_t *efc_map) {
+   mongocrypt_status_t *status;
+
+   status = crypt->status;
+   CLIENT_ERR ("mongocrypt_setopt_encrypted_field_config_map is not implemented");
+   return false;
+}
 
 bool
 mongocrypt_setopt_kms_provider_local (mongocrypt_t *crypt,

--- a/src/mongocrypt.h.in
+++ b/src/mongocrypt.h.in
@@ -408,6 +408,22 @@ bool
 mongocrypt_setopt_schema_map (mongocrypt_t *crypt,
                               mongocrypt_binary_t *schema_map);
 
+/**
+ * Set a local EncryptedFieldConfigMap for encryption.
+ *
+ * @param[in] crypt The @ref mongocrypt_t object.
+ * @param[in] schema_map A BSON document representing the EncryptedFieldConfigMap supplied by
+ * the user. The keys are collection namespaces and values are EncryptedFieldConfigMap documents. The
+ * viewed data copied. It is valid to destroy @p efc_map with @ref
+ * mongocrypt_binary_destroy immediately after.
+ * @pre @p crypt has not been initialized.
+ * @returns A boolean indicating success. If false, an error status is set.
+ * Retrieve it with @ref mongocrypt_status
+ */
+MONGOCRYPT_EXPORT
+bool
+mongocrypt_setopt_encrypted_field_config_map (mongocrypt_t *crypt, mongocrypt_binary_t *efc_map);
+
 
 /**
  * @brief Append an additional search directory to the search path for loading

--- a/src/mongocrypt.h.in
+++ b/src/mongocrypt.h.in
@@ -412,7 +412,7 @@ mongocrypt_setopt_schema_map (mongocrypt_t *crypt,
  * Set a local EncryptedFieldConfigMap for encryption.
  *
  * @param[in] crypt The @ref mongocrypt_t object.
- * @param[in] schema_map A BSON document representing the EncryptedFieldConfigMap supplied by
+ * @param[in] efc_map A BSON document representing the EncryptedFieldConfigMap supplied by
  * the user. The keys are collection namespaces and values are EncryptedFieldConfigMap documents. The
  * viewed data copied. It is valid to destroy @p efc_map with @ref
  * mongocrypt_binary_destroy immediately after.

--- a/test/data/encrypted-field-config-map.json
+++ b/test/data/encrypted-field-config-map.json
@@ -1,0 +1,52 @@
+{
+    "test.test": {
+        "encryptedFields": {
+            "escCollection": "fle2.basic.esc",
+            "eccCollection": "fle2.basic.ecc",
+            "ecocCollection": "fle2.basic.ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "KEY1_AAAAAAAAAAAAAAAA==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": {
+                            "$numberLong": "0"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test.test2": {
+        "encryptedFields": {
+            "escCollection": "fle2.basic.esc",
+            "eccCollection": "fle2.basic.ecc",
+            "ecocCollection": "fle2.basic.ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "KEY2_AAAAAAAAAAAAAAAA==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": {
+                            "$numberLong": "0"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/test/data/encrypted-field-config-map.json
+++ b/test/data/encrypted-field-config-map.json
@@ -7,7 +7,7 @@
             {
                 "keyId": {
                     "$binary": {
-                        "base64": "KEY1_AAAAAAAAAAAAAAAA==",
+                        "base64": "KEY1+AAAAAAAAAAAAAAAAA==",
                         "subType": "04"
                     }
                 },
@@ -30,7 +30,7 @@
             {
                 "keyId": {
                     "$binary": {
-                        "base64": "KEY2_AAAAAAAAAAAAAAAA==",
+                        "base64": "KEY2+AAAAAAAAAAAAAAAAA==",
                         "subType": "04"
                     }
                 },

--- a/test/data/encrypted-field-config-map.json
+++ b/test/data/encrypted-field-config-map.json
@@ -1,52 +1,48 @@
 {
     "test.test": {
-        "encryptedFields": {
-            "escCollection": "fle2.basic.esc",
-            "eccCollection": "fle2.basic.ecc",
-            "ecocCollection": "fle2.basic.ecoc",
-            "fields": [
-                {
-                    "keyId": {
-                        "$binary": {
-                            "base64": "KEY1_AAAAAAAAAAAAAAAA==",
-                            "subType": "04"
-                        }
-                    },
-                    "path": "firstName",
-                    "bsonType": "string",
-                    "queries": {
-                        "queryType": "equality",
-                        "contention": {
-                            "$numberLong": "0"
-                        }
+        "escCollection": "fle2.basic.esc",
+        "eccCollection": "fle2.basic.ecc",
+        "ecocCollection": "fle2.basic.ecoc",
+        "fields": [
+            {
+                "keyId": {
+                    "$binary": {
+                        "base64": "KEY1_AAAAAAAAAAAAAAAA==",
+                        "subType": "04"
+                    }
+                },
+                "path": "firstName",
+                "bsonType": "string",
+                "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                        "$numberLong": "0"
                     }
                 }
-            ]
-        }
+            }
+        ]
     },
     "test.test2": {
-        "encryptedFields": {
-            "escCollection": "fle2.basic.esc",
-            "eccCollection": "fle2.basic.ecc",
-            "ecocCollection": "fle2.basic.ecoc",
-            "fields": [
-                {
-                    "keyId": {
-                        "$binary": {
-                            "base64": "KEY2_AAAAAAAAAAAAAAAA==",
-                            "subType": "04"
-                        }
-                    },
-                    "path": "firstName",
-                    "bsonType": "string",
-                    "queries": {
-                        "queryType": "equality",
-                        "contention": {
-                            "$numberLong": "0"
-                        }
+        "escCollection": "fle2.basic.esc",
+        "eccCollection": "fle2.basic.ecc",
+        "ecocCollection": "fle2.basic.ecoc",
+        "fields": [
+            {
+                "keyId": {
+                    "$binary": {
+                        "base64": "KEY2_AAAAAAAAAAAAAAAA==",
+                        "subType": "04"
+                    }
+                },
+                "path": "firstName",
+                "bsonType": "string",
+                "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                        "$numberLong": "0"
                     }
                 }
-            ]
-        }
+            }
+        ]
     }
 }

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1604,6 +1604,41 @@ _test_encrypt_caches_collinfo_without_jsonschema (_mongocrypt_tester_t *tester)
    mongocrypt_destroy (crypt);
 }
 
+static void _test_encrypt_with_encrypted_field_config_map (_mongocrypt_tester_t *tester) {
+   mongocrypt_t *crypt;
+   mongocrypt_ctx_t *ctx;
+
+   crypt = mongocrypt_new ();
+   ASSERT_OK (mongocrypt_setopt_kms_providers (crypt, TEST_BSON ("{'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'bar'}}")), crypt);
+   ASSERT_OK (mongocrypt_setopt_encrypted_field_config_map (crypt, TEST_BSON ("{'db.coll': {'foo': 'bar'}}")), crypt);
+
+   /* Test encrypting a command on a collection present in the encrypted field config map. */
+   ctx = mongocrypt_ctx_new (crypt);
+   ASSERT_OK (mongocrypt_ctx_encrypt_init (ctx, "db", -1, TEST_BSON ("{'find': 'coll'}")), ctx);
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+   {
+      mongocrypt_binary_t *cmd_to_mongocryptd;
+
+      cmd_to_mongocryptd = mongocrypt_binary_new ();
+      ASSERT_OK (mongocrypt_ctx_mongo_op (ctx, cmd_to_mongocryptd), ctx);
+      ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (cmd_to_mongocryptd, TEST_BSON("{'find': 'coll', 'encryptionInformation': { 'type': 1, 'schema': { 'db.coll': {'foo': 'bar'}}}}"));
+      ASSERT_OK (mongocrypt_ctx_mongo_feed (ctx, TEST_BSON("{'find': 'coll', 'encryptionInformation': { 'type': 1, 'schema': { 'db.coll': {'foo': 'bar'}}}, 'hasEncryptionPlaceholders': false}")), ctx);
+      mongocrypt_binary_destroy (cmd_to_mongocryptd);
+   }
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_READY);
+   {
+      mongocrypt_binary_t *cmd_to_mongod;
+
+      cmd_to_mongod = mongocrypt_binary_new ();
+      ASSERT_OK (mongocrypt_ctx_finalize (ctx, cmd_to_mongod), ctx);
+      ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (cmd_to_mongod, TEST_BSON("{'find': 'coll', 'encryptionInformation': { 'type': 1, 'schema': { 'db.coll': {'foo': 'bar'}}}}"));
+      mongocrypt_binary_destroy (cmd_to_mongod);
+   }
+
+   mongocrypt_ctx_destroy (ctx);
+   mongocrypt_destroy (crypt);
+}
+
 void
 _mongocrypt_tester_install_ctx_encrypt (_mongocrypt_tester_t *tester)
 {
@@ -1633,4 +1668,5 @@ _mongocrypt_tester_install_ctx_encrypt (_mongocrypt_tester_t *tester)
    INSTALL_TEST (_test_encrypt_caches_collinfo_without_jsonschema);
    INSTALL_TEST (_test_encrypt_per_ctx_credentials);
    INSTALL_TEST (_test_encrypt_per_ctx_credentials_local);
+   INSTALL_TEST (_test_encrypt_with_encrypted_field_config_map);
 }

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1623,8 +1623,9 @@ static void _test_encrypt_with_encrypted_field_config_map (_mongocrypt_tester_t 
       cmd_to_mongocryptd = mongocrypt_binary_new ();
       ASSERT_OK (mongocrypt_ctx_mongo_op (ctx, cmd_to_mongocryptd), ctx);
       ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (TEST_BSON("{'find': 'coll', 'encryptionInformation': { 'type': 1, 'schema': { 'db.coll': {'foo': 'bar'}}}}"), cmd_to_mongocryptd);
-      ASSERT_OK (mongocrypt_ctx_mongo_feed (ctx, TEST_BSON("{'find': 'coll', 'encryptionInformation': { 'type': 1, 'schema': { 'db.coll': {'foo': 'bar'}}}, 'hasEncryptionPlaceholders': false}")), ctx);
+      ASSERT_OK (mongocrypt_ctx_mongo_feed (ctx, TEST_BSON("{'result': {'find': 'coll', 'encryptionInformation': { 'type': 1, 'schema': { 'db.coll': {'foo': 'bar'}}}}, 'hasEncryptionPlaceholders': false}")), ctx);
       mongocrypt_binary_destroy (cmd_to_mongocryptd);
+      ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
    }
    ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_READY);
    {

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1622,7 +1622,7 @@ static void _test_encrypt_with_encrypted_field_config_map (_mongocrypt_tester_t 
 
       cmd_to_mongocryptd = mongocrypt_binary_new ();
       ASSERT_OK (mongocrypt_ctx_mongo_op (ctx, cmd_to_mongocryptd), ctx);
-      ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (cmd_to_mongocryptd, TEST_BSON("{'find': 'coll', 'encryptionInformation': { 'type': 1, 'schema': { 'db.coll': {'foo': 'bar'}}}}"));
+      ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (TEST_BSON("{'find': 'coll', 'encryptionInformation': { 'type': 1, 'schema': { 'db.coll': {'foo': 'bar'}}}}"), cmd_to_mongocryptd);
       ASSERT_OK (mongocrypt_ctx_mongo_feed (ctx, TEST_BSON("{'find': 'coll', 'encryptionInformation': { 'type': 1, 'schema': { 'db.coll': {'foo': 'bar'}}}, 'hasEncryptionPlaceholders': false}")), ctx);
       mongocrypt_binary_destroy (cmd_to_mongocryptd);
    }
@@ -1632,7 +1632,7 @@ static void _test_encrypt_with_encrypted_field_config_map (_mongocrypt_tester_t 
 
       cmd_to_mongod = mongocrypt_binary_new ();
       ASSERT_OK (mongocrypt_ctx_finalize (ctx, cmd_to_mongod), ctx);
-      ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (cmd_to_mongod, TEST_BSON("{'find': 'coll', 'encryptionInformation': { 'type': 1, 'schema': { 'db.coll': {'foo': 'bar'}}}}"));
+      ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (TEST_BSON("{'find': 'coll', 'encryptionInformation': { 'type': 1, 'schema': { 'db.coll': {'foo': 'bar'}}}}"), cmd_to_mongod);
       mongocrypt_binary_destroy (cmd_to_mongod);
    }
 

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1611,6 +1611,7 @@ static void _test_encrypt_with_encrypted_field_config_map (_mongocrypt_tester_t 
    crypt = mongocrypt_new ();
    ASSERT_OK (mongocrypt_setopt_kms_providers (crypt, TEST_BSON ("{'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'bar'}}")), crypt);
    ASSERT_OK (mongocrypt_setopt_encrypted_field_config_map (crypt, TEST_BSON ("{'db.coll': {'foo': 'bar'}}")), crypt);
+   ASSERT_OK (mongocrypt_init (crypt), crypt);
 
    /* Test encrypting a command on a collection present in the encrypted field config map. */
    ctx = mongocrypt_ctx_new (crypt);

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -662,7 +662,6 @@ _test_setopt_encrypted_field_config_map (_mongocrypt_tester_t *tester)
    mongocrypt_destroy (crypt);
 
    /* Test malformed BSON */
-   mongocrypt_destroy (crypt);
    crypt = mongocrypt_new ();
    ASSERT_FAILS (mongocrypt_setopt_encrypted_field_config_map (crypt, TEST_BIN (10)), crypt, "invalid bson");
    mongocrypt_destroy (crypt);
@@ -688,7 +687,7 @@ _test_setopt_encrypted_field_config_map (_mongocrypt_tester_t *tester)
       "{'db.coll1': {}, 'db.coll3': {}}"
    )), crypt);
    ASSERT_OK (mongocrypt_setopt_kms_providers (crypt, TEST_BSON ("{'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'bar'}}")), crypt);
-   ASSERT_FAILS (mongocrypt_init (crypt), crypt, "db.coll1 is present in both schema map and encrypted field config map");
+   ASSERT_FAILS (mongocrypt_init (crypt), crypt, "db.coll1 is present in both schema_map and encrypted_field_config_map");
    mongocrypt_destroy (crypt);
 }
 

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -881,7 +881,10 @@ main (int argc, char **argv)
    _mongocrypt_tester_install_traverse_util (&tester);
    _mongocrypt_tester_install (
       &tester, "_test_setopt_schema", _test_setopt_schema, CRYPTO_REQUIRED);
-   _mongocrypt_tester_install (&tester, "_test_setopt_encrypted_field_config_map", _test_setopt_encrypted_field_config_map, CRYPTO_OPTIONAL);
+   _mongocrypt_tester_install (&tester,
+                               "_test_setopt_encrypted_field_config_map",
+                               _test_setopt_encrypted_field_config_map,
+                               CRYPTO_REQUIRED);
    _mongocrypt_tester_install (&tester,
                                "_test_setopt_invalid_kms_providers",
                                _test_setopt_invalid_kms_providers,

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -641,53 +641,91 @@ _test_setopt_encrypted_field_config_map (_mongocrypt_tester_t *tester)
 
    /* Test success. */
    crypt = mongocrypt_new ();
-   ASSERT_OK (mongocrypt_setopt_kms_providers (crypt, TEST_BSON ("{'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'bar'}}")), crypt);
-   ASSERT_OK (mongocrypt_setopt_encrypted_field_config_map (crypt, TEST_FILE ("./test/data/encrypted-field-config-map.json")), crypt);
+   ASSERT_OK (
+      mongocrypt_setopt_kms_providers (
+         crypt,
+         TEST_BSON (
+            "{'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'bar'}}")),
+      crypt);
+   ASSERT_OK (
+      mongocrypt_setopt_encrypted_field_config_map (
+         crypt, TEST_FILE ("./test/data/encrypted-field-config-map.json")),
+      crypt);
    ASSERT_OK (mongocrypt_init (crypt), crypt);
    mongocrypt_destroy (crypt);
 
    /* Test double setting. */
    crypt = mongocrypt_new ();
-   ASSERT_OK (mongocrypt_setopt_encrypted_field_config_map (crypt, TEST_FILE ("./test/data/encrypted-field-config-map.json")), crypt);
-   ASSERT_FAILS (mongocrypt_setopt_encrypted_field_config_map (crypt, TEST_FILE ("./test/data/encrypted-field-config-map.json")), crypt, "already set encrypted_field_config_map");
+   ASSERT_OK (
+      mongocrypt_setopt_encrypted_field_config_map (
+         crypt, TEST_FILE ("./test/data/encrypted-field-config-map.json")),
+      crypt);
+   ASSERT_FAILS (
+      mongocrypt_setopt_encrypted_field_config_map (
+         crypt, TEST_FILE ("./test/data/encrypted-field-config-map.json")),
+      crypt,
+      "already set encrypted_field_config_map");
    mongocrypt_destroy (crypt);
 
    /* Test NULL/empty input */
    crypt = mongocrypt_new ();
-   ASSERT_FAILS (mongocrypt_setopt_encrypted_field_config_map (crypt, NULL), crypt, "passed null encrypted_field_config_map");
+   ASSERT_FAILS (mongocrypt_setopt_encrypted_field_config_map (crypt, NULL),
+                 crypt,
+                 "passed null encrypted_field_config_map");
    mongocrypt_destroy (crypt);
 
    crypt = mongocrypt_new ();
-   ASSERT_FAILS (mongocrypt_setopt_encrypted_field_config_map (crypt, TEST_BIN (0)), crypt, "passed null encrypted_field_config_map");
+   ASSERT_FAILS (
+      mongocrypt_setopt_encrypted_field_config_map (crypt, TEST_BIN (0)),
+      crypt,
+      "passed null encrypted_field_config_map");
    mongocrypt_destroy (crypt);
 
    /* Test malformed BSON */
    crypt = mongocrypt_new ();
-   ASSERT_FAILS (mongocrypt_setopt_encrypted_field_config_map (crypt, TEST_BIN (10)), crypt, "invalid bson");
+   ASSERT_FAILS (
+      mongocrypt_setopt_encrypted_field_config_map (crypt, TEST_BIN (10)),
+      crypt,
+      "invalid bson");
    mongocrypt_destroy (crypt);
 
-   /* Test that it is OK to set both the encrypted field config map and schema map if there are no intersecting collections. */
+   /* Test that it is OK to set both the encrypted field config map and schema
+    * map if there are no intersecting collections. */
    crypt = mongocrypt_new ();
-   ASSERT_OK (mongocrypt_setopt_schema_map (crypt, TEST_BSON (
-      "{'db.coll1': {}, 'db.coll2': {}}"
-   )), crypt);
-   ASSERT_OK (mongocrypt_setopt_encrypted_field_config_map (crypt, TEST_BSON (
-      "{'db.coll3': {}, 'db.coll3': {}}"
-   )), crypt);
-   ASSERT_OK (mongocrypt_setopt_kms_providers (crypt, TEST_BSON ("{'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'bar'}}")), crypt);
+   ASSERT_OK (mongocrypt_setopt_schema_map (
+                 crypt, TEST_BSON ("{'db.coll1': {}, 'db.coll2': {}}")),
+              crypt);
+   ASSERT_OK (mongocrypt_setopt_encrypted_field_config_map (
+                 crypt, TEST_BSON ("{'db.coll3': {}, 'db.coll3': {}}")),
+              crypt);
+   ASSERT_OK (
+      mongocrypt_setopt_kms_providers (
+         crypt,
+         TEST_BSON (
+            "{'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'bar'}}")),
+      crypt);
    ASSERT_OK (mongocrypt_init (crypt), crypt);
    mongocrypt_destroy (crypt);
 
-   /* Test that it is an error to set both the encrypted field config map and schema map referencing the same collection. */
+   /* Test that it is an error to set both the encrypted field config map and
+    * schema map referencing the same collection. */
    crypt = mongocrypt_new ();
-   ASSERT_OK (mongocrypt_setopt_schema_map (crypt, TEST_BSON (
-      "{'db.coll1': {}, 'db.coll2': {}}"
-   )), crypt);
-   ASSERT_OK (mongocrypt_setopt_encrypted_field_config_map (crypt, TEST_BSON (
-      "{'db.coll1': {}, 'db.coll3': {}}"
-   )), crypt);
-   ASSERT_OK (mongocrypt_setopt_kms_providers (crypt, TEST_BSON ("{'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'bar'}}")), crypt);
-   ASSERT_FAILS (mongocrypt_init (crypt), crypt, "db.coll1 is present in both schema_map and encrypted_field_config_map");
+   ASSERT_OK (mongocrypt_setopt_schema_map (
+                 crypt, TEST_BSON ("{'db.coll1': {}, 'db.coll2': {}}")),
+              crypt);
+   ASSERT_OK (mongocrypt_setopt_encrypted_field_config_map (
+                 crypt, TEST_BSON ("{'db.coll1': {}, 'db.coll3': {}}")),
+              crypt);
+   ASSERT_OK (
+      mongocrypt_setopt_kms_providers (
+         crypt,
+         TEST_BSON (
+            "{'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'bar'}}")),
+      crypt);
+   ASSERT_FAILS (
+      mongocrypt_init (crypt),
+      crypt,
+      "db.coll1 is present in both schema_map and encrypted_field_config_map");
    mongocrypt_destroy (crypt);
 }
 

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -241,7 +241,7 @@ _mongocrypt_tester_bin_from_json (_mongocrypt_tester_t *tester,
    va_end (ap);
    bson = &tester->test_bson[tester->bson_count++];
    if (!bson_init_from_json (bson, full_json, strlen (full_json), &error)) {
-      fprintf (stderr, "%s", error.message);
+      fprintf (stderr, "failed to parse JSON %s: %s", error.message, json);
       abort ();
    }
    bin = mongocrypt_binary_new ();


### PR DESCRIPTION
# Summary

- Support a local EncryptedFieldConfigMap (MONGOCRYPT-410)
  - Error if a collection is present in both EncryptedFieldConfigMap and SchemaMap.
- Append "encryptionInformation" to command for query analysis and to final command (MONGOCRYPT-404).

# Background
https://github.com/markbenvenuto/mongo-enterprise-modules/blob/fle2/fle_protocol.md#walkthrough-insert gives an overview of the FLE 2 interactions.