### PR TITLE
MONGOCRYPT-413 always use HEAD reference for generating Debian tarball

### DIFF
--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -8,15 +8,9 @@ prebuild = bash -c "
     set -x &&
     # Use debian/changelog (not VERSION_CURRENT) to get upstream version to build
     upstream_version=$(dpkg-parsechangelog | sed -E -n 's/^Version: +(.*)-.*/\1/p') &&
-    # Determine if we are on a release branch and set the reference to use later
-    # to create the upstream tarball (when on a release branch use the most
-    # recent release tag, and when on any other branch use HEAD)
-    release_branch=$(cd $GBP_GIT_DIR/..; git symbolic-ref --short HEAD | sed -n '/^r[0-9]\./p') &&
-    if [ -n \"\${release_branch}\" ]; then archive_ref=$(cd $GBP_GIT_DIR/..; git describe --tags --abbrev=0 --match '1.*'); else archive_ref=HEAD; fi &&
     # Create upstream tarball from reference, exclude items that do not belong
     pushd $GBP_GIT_DIR/.. &&
-    ls -1 &&
-    git archive --format=tar --prefix=libmongocrypt-\${upstream_version}/ \${archive_ref} | tar -f - --delete libmongocrypt-\${upstream_version}/debian | gzip > $GBP_BUILD_DIR/../libmongocrypt_\${upstream_version}.orig.tar.gz &&
+    git archive --format=tar --prefix=libmongocrypt-\${upstream_version}/ HEAD | tar -f - --delete libmongocrypt-\${upstream_version}/debian | gzip > $GBP_BUILD_DIR/../libmongocrypt_\${upstream_version}.orig.tar.gz &&
     popd"
 
 upstream-tree = BRANCH


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/version/6244bd8ae3c3313a5f3bdaeb/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

We apparently had this issue in the C driver about a year ago and somehow I forgot about making the fix here as well.