### PR TITLE
MONGOCRYPT-378 append empty jsonSchema as fallback

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -256,6 +256,9 @@ _create_markings_cmd_bson (mongocrypt_ctx_t *ctx, bson_t *out)
       }
       // Append the jsonSchema to the output command
       BSON_APPEND_DOCUMENT (out, "jsonSchema", &bson_view);
+   } else {
+      bson_t empty = BSON_INITIALIZER;
+      BSON_APPEND_DOCUMENT (out, "jsonSchema", &empty);
    }
 
    // if a local schema was not set, set isRemoteSchema=true


### PR DESCRIPTION
# Background & Motivation
This resolves a regression introduced in MONGOCRYPT-378. jsonSchema is not appended if there is no encryptedFieldConfig, local jsonSchema, or remote jsonSchema for the collection.

To verify this resolves the test from PYTHON-3188, I ran the test and overrode the path to libmongocrypt with the [PYMONGOCRYPT_LIB environment variable](https://github.com/mongodb/libmongocrypt/blob/master/bindings/python/README.rst#installing-from-source):
```sh
export PYMONGOCRYPT_LIB=/Users/kevin.albertson/code/libmongocrypt-pymongo-M378/cmake-build/libmongocrypt.dylib
python setup.py test --test-suite "test.test_encryption.TestEncryptedBulkWrite"
```

# Summary
- Append an empty `jsonSchema` document to the command for mongocryptd / csfle if there is no encryptedFieldConfig, local jsonSchema, or remote jsonSchema for the collection.