### PR TITLE
MONGOCRYPT-419 Consolidate explicit and automatic decryption

### DIFF
--- a/src/mongocrypt-ctx-decrypt.c
+++ b/src/mongocrypt-ctx-decrypt.c
@@ -196,41 +196,27 @@ _finalize (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
 
    dctx = (_mongocrypt_ctx_decrypt_t *) ctx;
 
-   if (!dctx->explicit) {
-      if (ctx->nothing_to_do) {
-         _mongocrypt_buffer_to_binary (&dctx->original_doc, out);
-         ctx->state = MONGOCRYPT_CTX_DONE;
-         return true;
-      }
+   if (ctx->nothing_to_do) {
+      _mongocrypt_buffer_to_binary (&dctx->original_doc, out);
+      ctx->state = MONGOCRYPT_CTX_DONE;
+      return true;
+   }
 
-      if (!_mongocrypt_buffer_to_bson (&dctx->original_doc, &as_bson)) {
-         return _mongocrypt_ctx_fail_w_msg (ctx, "malformed bson");
-      }
+   if (!_mongocrypt_buffer_to_bson (&dctx->original_doc, &as_bson)) {
+      return _mongocrypt_ctx_fail_w_msg (ctx, "malformed bson");
+   }
 
-      bson_iter_init (&iter, &as_bson);
-      bson_init (&final_bson);
-      res = _mongocrypt_transform_binary_in_bson (
-         _replace_ciphertext_with_plaintext,
-         &ctx->kb,
-         TRAVERSE_MATCH_CIPHERTEXT,
-         &iter,
-         &final_bson,
-         ctx->status);
-      if (!res) {
-         return _mongocrypt_ctx_fail (ctx);
-      }
-   } else {
-      /* For explicit decryption, we just have a single value */
-      bson_value_t value;
-
-      if (!_replace_ciphertext_with_plaintext (
-             &ctx->kb, &dctx->unwrapped_doc, &value, ctx->status)) {
-         return _mongocrypt_ctx_fail (ctx);
-      }
-
-      bson_init (&final_bson);
-      bson_append_value (&final_bson, MONGOCRYPT_STR_AND_LEN ("v"), &value);
-      bson_value_destroy (&value);
+   bson_iter_init (&iter, &as_bson);
+   bson_init (&final_bson);
+   res = _mongocrypt_transform_binary_in_bson (
+      _replace_ciphertext_with_plaintext,
+      &ctx->kb,
+      TRAVERSE_MATCH_CIPHERTEXT,
+      &iter,
+      &final_bson,
+      ctx->status);
+   if (!res) {
+      return _mongocrypt_ctx_fail (ctx);
    }
 
    _mongocrypt_buffer_steal_from_bson (&dctx->decrypted_doc, &final_bson);
@@ -458,7 +444,7 @@ mongocrypt_ctx_explicit_decrypt_init (mongocrypt_ctx_t *ctx,
       return _mongocrypt_ctx_fail_w_msg (ctx, "invalid msg, must contain 'v'");
    }
 
-   if (!_mongocrypt_buffer_from_binary_iter (&dctx->unwrapped_doc, &iter)) {
+   if (!BSON_ITER_HOLDS_BINARY (&iter)) {
       return _mongocrypt_ctx_fail_w_msg (
          ctx, "invalid msg, 'v' must contain a binary");
    }

--- a/src/mongocrypt-ctx-decrypt.c
+++ b/src/mongocrypt-ctx-decrypt.c
@@ -397,18 +397,12 @@ bool
 mongocrypt_ctx_explicit_decrypt_init (mongocrypt_ctx_t *ctx,
                                       mongocrypt_binary_t *msg)
 {
-   _mongocrypt_ctx_decrypt_t *dctx;
    bson_iter_t iter;
    bson_t as_bson;
-   _mongocrypt_ctx_opts_spec_t opts_spec;
 
    if (!ctx) {
       return false;
    }
-   memset (&opts_spec, 0, sizeof (opts_spec));
-   // if (!_mongocrypt_ctx_init (ctx, &opts_spec)) {
-   //    return false;
-   // }
 
    if (!msg || !msg->data) {
       return _mongocrypt_ctx_fail_w_msg (ctx, "invalid msg");
@@ -427,12 +421,6 @@ mongocrypt_ctx_explicit_decrypt_init (mongocrypt_ctx_t *ctx,
       bson_free (msg_val);
    }
 
-   dctx = (_mongocrypt_ctx_decrypt_t *) ctx;
-   dctx->explicit = true;
-   ctx->type = _MONGOCRYPT_TYPE_DECRYPT;
-   ctx->vtable.finalize = _finalize;
-   ctx->vtable.cleanup = _cleanup;
-
    /* Expect msg to be the BSON a document of the form:
       { "v" : (BSON BINARY value of subtype 6) }
    */
@@ -448,23 +436,6 @@ mongocrypt_ctx_explicit_decrypt_init (mongocrypt_ctx_t *ctx,
       return _mongocrypt_ctx_fail_w_msg (
          ctx, "invalid msg, 'v' must contain a binary");
    }
-
-
-   /* We expect these to be round-tripped from explicit encrypt,
-      so they must be wrapped like { "v" : "encrypted thing" } */
-   // _mongocrypt_buffer_copy_from_binary (&dctx->original_doc, msg);
-   // if (!_mongocrypt_buffer_to_bson (&dctx->original_doc, &as_bson)) {
-   //    return _mongocrypt_ctx_fail_w_msg (ctx, "malformed bson");
-   // }
-
-   // /* Parse out our one key id */
-   // if (!_collect_key_from_ciphertext (
-   //        &ctx->kb, &dctx->unwrapped_doc, ctx->status)) {
-   //    return _mongocrypt_ctx_fail (ctx);
-   // }
-
-   // (void) _mongocrypt_key_broker_requests_done (&ctx->kb);
-   // return _mongocrypt_ctx_state_from_key_broker (ctx);
 
    if (!mongocrypt_ctx_decrypt_init (ctx, msg)) {
       return false;

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -132,7 +132,6 @@ typedef struct {
 
 typedef struct {
    mongocrypt_ctx_t parent;
-   bool explicit;
    /* TODO CDRIVER-3150: audit + rename these buffers.
     * Unlike ctx_encrypt, unwrapped_doc holds the binary value of the {v:
     * <ciphertext>} doc.

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -138,7 +138,6 @@ typedef struct {
     * <ciphertext>} doc.
     * */
    _mongocrypt_buffer_t original_doc;
-   _mongocrypt_buffer_t unwrapped_doc; /* explicit only */
    _mongocrypt_buffer_t decrypted_doc;
 } _mongocrypt_ctx_decrypt_t;
 

--- a/src/mongocrypt.h.in
+++ b/src/mongocrypt.h.in
@@ -935,7 +935,7 @@ mongocrypt_ctx_decrypt_init (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *doc);
  * Pass the binary encoding of a BSON document containing the BSON value to
  * encrypt like the following:
  *
- *   { "v" : (BSON value to encrypt) }
+ *   { "v" : (BSON BINARY value of subtype 6) }
  *
  * @param[in] ctx A @ref mongocrypt_ctx_t.
  * @param[in] msg A @ref mongocrypt_binary_t the encrypted BSON. The viewed data

--- a/src/mongocrypt.h.in
+++ b/src/mongocrypt.h.in
@@ -932,6 +932,10 @@ mongocrypt_ctx_decrypt_init (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *doc);
 /**
  * Explicit helper method to decrypt a single BSON object.
  *
+ * Pass the binary encoding of a BSON document containing the BSON value to
+ * encrypt like the following:
+ *
+ *   { "v" : (BSON value to encrypt) }
  *
  * @param[in] ctx A @ref mongocrypt_ctx_t.
  * @param[in] msg A @ref mongocrypt_binary_t the encrypted BSON. The viewed data


### PR DESCRIPTION
# Summary

- Have `mongocrypt_ctx_explicit_decrypt_init` call `mongocrypt_ctx_decrypt_init`.
- Test explicit decryption of `FLE2IndexedEqualityEncryptedValue` payload.

# Background & Motivation

This simplifies decryption with the new FLE 2 payloads. Explicit decryption support is implied by automatic decryption support.

`mongocrypt_ctx_explicit_decrypt_init` already required the input `msg` to be a BSON document like: `{ "v" : (BSON BINARY value of subtype 6) }`. Decryption would unwrap the value of "v", then rewrap it in finalize. Unwrapping and rewrapping seems unnecessary. Explicit decryption seems like an unnecessary special case as implemented.