### PR TITLE
Fix missing vtable entry for MONGOCRYPT_CTX_READY state during rewrapManyDataKey

### DIFF
--- a/src/mongocrypt-ctx-rewrap-many-datakey.c
+++ b/src/mongocrypt-ctx-rewrap-many-datakey.c
@@ -237,6 +237,7 @@ _start_kms_encrypt (mongocrypt_ctx_t *ctx)
    /* Skip to READY state if no KMS requests are required. */
    if (!rmdctx->datakeys_iter) {
       ctx->state = MONGOCRYPT_CTX_READY;
+      ctx->vtable.finalize = _finalize;
       return true;
    }
 


### PR DESCRIPTION
This PR fixes a missing vtable entry on transition directly to the `MONGOCRYPT_CTX_READY` state during rewrapManyDataKey when the set of KEKs to rewrap do not require KMS for KEK encryption (all already use, or are rewrapped to use, a local provider). The state machine indicates the client should invoke `mongocrypt_ctx_finalize` but does not set the appropriate `finalize` vtable function, leading to an unexpected "not applicable to context" error.