### PR TITLE
Support multiple rounds of KMS encryption requests for rewrapManyDataKey

### DIFF
--- a/src/mongocrypt-ctx-rewrap-many-datakey.c
+++ b/src/mongocrypt-ctx-rewrap-many-datakey.c
@@ -104,6 +104,21 @@ _kms_done_encrypt (mongocrypt_ctx_t *ctx)
       }
    }
 
+   /* Some providers may require multiple rounds of KMS requests. Reiterate
+    * through datakey contexts to verify if more work needs to be done. */
+   rmdctx->datakeys_iter = rmdctx->datakeys;
+
+   while (rmdctx->datakeys_iter &&
+          rmdctx->datakeys_iter->dkctx->state != MONGOCRYPT_CTX_NEED_KMS) {
+      rmdctx->datakeys_iter = rmdctx->datakeys_iter->next;
+   }
+
+   if (rmdctx->datakeys_iter) {
+      /* More work to be done, remain in MONGOCRYPT_CTX_NEED_KMS state. */
+      return true;
+   }
+
+   /* All datakeys have been encrypted and are ready to be finalized. */
    ctx->state = MONGOCRYPT_CTX_READY;
    ctx->vtable.finalize = _finalize;
 


### PR DESCRIPTION
This PR fixes the incorrect assumption that every KMS provider requires only a _single_ round of KMS requests for encryption during rewrapManyDataKey, which is not the case for Azure or GCP providers. This PR introduces a check that reiterates over the list of datakey contexts after a call to `mongocrypt_ctx_kms_done` during encryption and remains in the `MONGOCRYPT_CTX_NEED_KMS` state if any datakey contexts still require KMS requests for encryption.