### PR TITLE
Fix for ISO C warning

### DIFF
--- a/kms-message/src/kms_request.c
+++ b/kms-message/src/kms_request.c
@@ -284,7 +284,7 @@ kms_request_append_header_field_value (kms_request_t *request,
       KMS_ERROR (
          request,
          "Ensure the request has at least one header field before calling %s",
-         __FUNCTION__);
+         __func__);
    }
 
    v = request->header_fields->kvs[request->header_fields->len - 1].value;


### PR DESCRIPTION
We are seeing:

```
  kms/kms_request.c:240:10: warning: ISO C does not support '__FUNCTION__' predefined identifier [-Wpedantic]
```
