### PR TITLE
libmongocrypt 1.4.0 Debian packaging

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libmongocrypt (1.4.0-1) UNRELEASED; urgency=medium
+
+  * New upstream release.
+
+ -- Roberto C. Sanchez <roberto@connexer.com>  Mon, 18 Apr 2022 18:46:10 -0400
+
 libmongocrypt (1.3.1-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-libmongocrypt (1.4.0-1) UNRELEASED; urgency=medium
+libmongocrypt (1.4.0-1) unstable; urgency=medium
 
   * New upstream release.
 


### PR DESCRIPTION
This PR cherry-picks onto master the commits for the 1.4.0 Debian packaging.