### PR TITLE
feat(NODE-4136): adjust Node.js bindings for shared library spec

### DIFF
--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -108,6 +108,12 @@ module.exports = function (modules) {
           : this._bson.serialize(options.schemaMap);
       }
 
+      if (options.encryptedFieldsMap) {
+        mongoCryptOptions.encryptedFieldsMap = Buffer.isBuffer(options.encryptedFieldsMap)
+          ? options.encryptedFieldsMap
+          : this._bson.serialize(options.encryptedFieldsMap);
+      }
+
       if (options.kmsProviders) {
         mongoCryptOptions.kmsProviders = !Buffer.isBuffer(options.kmsProviders)
           ? this._bson.serialize(options.kmsProviders)
@@ -129,6 +135,10 @@ module.exports = function (modules) {
         mongoCryptOptions.csfleSearchPaths = options.extraOptions.csfleSearchPaths;
       } else if (!this._bypassEncryption) {
         mongoCryptOptions.csfleSearchPaths = ['$SYSTEM'];
+      }
+
+      if (options.bypassQueryAnalysis) {
+        mongoCryptOptions.bypassQueryAnalysis = options.bypassQueryAnalysis;
       }
 
       Object.assign(mongoCryptOptions, { cryptoCallbacks });


### PR DESCRIPTION
Specifically, pass a default `csfleSearchPaths` list of `['$SYSTEM']`,
and add support for `csfleRequired`.

As drive-by fixes, fix a typo that currently (unintentionally) leads to
`_mongocryptdClient` and `_mongocryptdManager` being initialized even
if `bypassAutoEncryption` was specified, and adjust the tests and the
`.teardown()` method for those cases.

Typings changes: https://github.com/mongodb/node-mongodb-native/pull/3206