### PR TITLE
Runtime UB and csfle analysis fixes

### DIFF
--- a/src/mongocrypt-buffer.c
+++ b/src/mongocrypt-buffer.c
@@ -498,7 +498,9 @@ _mongocrypt_buffer_concat (_mongocrypt_buffer_t *dst,
    _mongocrypt_buffer_resize (dst, total);
    offset = 0;
    for (i = 0; i < num_srcs; i++) {
-      memcpy (dst->data + offset, srcs[i].data, srcs[i].len);
+      if (srcs[i].len) {
+         memcpy (dst->data + offset, srcs[i].data, srcs[i].len);
+      }
       offset += srcs[i].len;
    }
    return true;


### PR DESCRIPTION
This fixes a few issues encountered during csfle integration in mongo-c-driver:

- Failing to create the command will destroy an invalid `cslfe_status` object.
- UBSan catches a memcpy(d, NULL, 0)`, which is "benign" in most cases but still warns and is UB.
- The `$db` property should only be inserted if it isn't already a part of the command document. (Otherwise `csfle` errors because of a duplicate `$db`.)
- `csfle` doesn't report any errors on destruction, so attempting to check for errors will just log the most-recent error, which is irrelevant to the destruction process.