### PR TITLE
test: loosen test error assertion for fails to autospawn

### DIFF
--- a/bindings/node/test/autoEncrypter.test.js
+++ b/bindings/node/test/autoEncrypter.test.js
@@ -8,6 +8,7 @@ const sinon = require('sinon');
 const mongodb = require('mongodb');
 const requirements = require('./requirements.helper');
 const MongoNetworkTimeoutError = mongodb.MongoNetworkTimeoutError || mongodb.MongoTimeoutError;
+const MongoError = mongodb.MongoError;
 const stateMachine = require('../lib/stateMachine')({ mongodb });
 const StateMachine = stateMachine.StateMachine;
 const MongocryptdManager = require('../lib/mongocryptdManager').MongocryptdManager;
@@ -539,7 +540,7 @@ describe('AutoEncrypter', function () {
 
       this.mc.init(err => {
         expect(err).to.exist;
-        expect(err).to.match(/Unable to connect to `mongocryptd`/);
+        expect(err).to.be.instanceOf(MongoError);
         done();
       });
     });


### PR DESCRIPTION
### Description

#### What is changing?

Loosening the test error message checking to instead assert we raise a subclass of our own error classes. The test is failing due to DNS configuration of the system. We don't want to add the DNS case to the filter that generates the "helpful" message the test refers to since it wouldn't be helpful to be told to ensure mongocryptd is in the path when the real issue is an incorrect mongocryptdURI.

#### What is the motivation for this change?

It is blocking the adoption of new nodejs versions in the CI for the driver.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket