### PR TITLE
Do not skip NEED_MONGO_COLLINFO state with bypass_query_analysis

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -197,6 +197,11 @@ _mongo_done_collinfo (mongocrypt_ctx_t *ctx)
       bson_destroy (&empty_collinfo);
    }
 
+   if (ctx->crypt->opts.bypass_query_analysis) {
+      ctx->nothing_to_do = true;
+      ctx->state = MONGOCRYPT_CTX_READY;
+      return true;
+   }
    ectx->parent.state = MONGOCRYPT_CTX_NEED_MONGO_MARKINGS;
    return _try_run_csfle_marking (ctx);
 }
@@ -1309,13 +1314,12 @@ mongocrypt_ctx_encrypt_init (mongocrypt_ctx_t *ctx,
       }
    }
 
-   if (ctx->crypt->opts.bypass_query_analysis) {
-      ctx->nothing_to_do = true;
-      ctx->state = MONGOCRYPT_CTX_READY;
-      return true;
-   }
-
    if (ctx->state == MONGOCRYPT_CTX_NEED_MONGO_MARKINGS) {
+      if (ctx->crypt->opts.bypass_query_analysis) {
+         ctx->nothing_to_do = true;
+         ctx->state = MONGOCRYPT_CTX_READY;
+         return true;
+      }
       // We're ready for markings. Try to generate them ourself.
       return _try_run_csfle_marking (ctx);
    } else {

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1921,39 +1921,86 @@ _test_encrypt_with_bypassqueryanalysis (_mongocrypt_tester_t *tester)
    mongocrypt_t *crypt;
    mongocrypt_ctx_t *ctx;
 
-   crypt = mongocrypt_new ();
-   ASSERT_OK (
-      mongocrypt_setopt_kms_providers (
-         crypt,
-         TEST_BSON (
-            "{'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'bar'}}")),
-      crypt);
-   ASSERT_OK (mongocrypt_setopt_encrypted_field_config_map (
-                 crypt, TEST_BSON ("{'db.coll': {'foo': 'bar'}}")),
-              crypt);
-   mongocrypt_setopt_bypass_query_analysis (crypt);
-   ASSERT_OK (mongocrypt_init (crypt), crypt);
-
-   ctx = mongocrypt_ctx_new (crypt);
-   ASSERT_OK (mongocrypt_ctx_encrypt_init (
-                 ctx, "db", -1, TEST_BSON ("{'find': 'coll'}")),
-              ctx);
-
-   /* Should transition directly to ready. */
-   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_READY);
+   /* Test with EncryptedFieldConfig from map. */
    {
-      mongocrypt_binary_t *cmd_to_mongod = mongocrypt_binary_new ();
-      ASSERT_OK (mongocrypt_ctx_finalize (ctx, cmd_to_mongod), ctx);
-      /* "encryptionInformation" must be present. */
-      ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (
-         TEST_BSON ("{'find': 'coll', 'encryptionInformation': { 'type': 1, "
-                    "'schema': { 'db.coll': {'foo': 'bar'}}}}"),
-         cmd_to_mongod);
-      mongocrypt_binary_destroy (cmd_to_mongod);
+      crypt = mongocrypt_new ();
+      ASSERT_OK (
+         mongocrypt_setopt_kms_providers (
+            crypt,
+            TEST_BSON (
+               "{'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'bar'}}")),
+         crypt);
+      ASSERT_OK (mongocrypt_setopt_encrypted_field_config_map (
+                    crypt, TEST_BSON ("{'db.coll': {'foo': 'bar'}}")),
+                 crypt);
+      mongocrypt_setopt_bypass_query_analysis (crypt);
+      ASSERT_OK (mongocrypt_init (crypt), crypt);
+
+      ctx = mongocrypt_ctx_new (crypt);
+      ASSERT_OK (mongocrypt_ctx_encrypt_init (
+                    ctx, "db", -1, TEST_BSON ("{'find': 'coll'}")),
+                 ctx);
+
+      /* Should transition directly to ready. */
+      ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_READY);
+      {
+         mongocrypt_binary_t *cmd_to_mongod = mongocrypt_binary_new ();
+         ASSERT_OK (mongocrypt_ctx_finalize (ctx, cmd_to_mongod), ctx);
+         /* "encryptionInformation" must be present. */
+         ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (
+            TEST_BSON ("{'find': 'coll', 'encryptionInformation': { 'type': 1, "
+                       "'schema': { 'db.coll': {'foo': 'bar'}}}}"),
+            cmd_to_mongod);
+         mongocrypt_binary_destroy (cmd_to_mongod);
+      }
+
+      mongocrypt_ctx_destroy (ctx);
+      mongocrypt_destroy (crypt);
    }
 
-   mongocrypt_ctx_destroy (ctx);
-   mongocrypt_destroy (crypt);
+   /* Test with EncryptedFieldConfig from listCollections. */
+   {
+      crypt = mongocrypt_new ();
+      ASSERT_OK (
+         mongocrypt_setopt_kms_providers (
+            crypt,
+            TEST_BSON (
+               "{'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'bar'}}")),
+         crypt);
+      mongocrypt_setopt_bypass_query_analysis (crypt);
+      ASSERT_OK (mongocrypt_init (crypt), crypt);
+
+      ctx = mongocrypt_ctx_new (crypt);
+      ASSERT_OK (mongocrypt_ctx_encrypt_init (
+                    ctx, "db", -1, TEST_BSON ("{'find': 'coll'}")),
+                 ctx);
+
+      ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
+                          MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+      {
+         ASSERT_OK (
+            mongocrypt_ctx_mongo_feed (
+               ctx,
+               TEST_BSON ("{'options': {'encryptedFields': {'foo': 'bar'}}}")),
+            ctx);
+         ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
+      }
+
+      ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_READY);
+      {
+         mongocrypt_binary_t *cmd_to_mongod = mongocrypt_binary_new ();
+         ASSERT_OK (mongocrypt_ctx_finalize (ctx, cmd_to_mongod), ctx);
+         /* "encryptionInformation" must be present. */
+         ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (
+            TEST_BSON ("{'find': 'coll', 'encryptionInformation': { 'type': 1, "
+                       "'schema': { 'db.coll': {'foo': 'bar'}}}}"),
+            cmd_to_mongod);
+         mongocrypt_binary_destroy (cmd_to_mongod);
+      }
+
+      mongocrypt_ctx_destroy (ctx);
+      mongocrypt_destroy (crypt);
+   }
 }
 
 


### PR DESCRIPTION
# Summary

- Do not skip the `MONGOCRYPT_CTX_NEED_MONGO_COLLINFO` state when the `bypass_query_analysis` option is true.

# Background & Motivation

If the target collection has an associated `encrypted_field_config`, it must be appended to the outgoing command with `_fle2_append_encryptionInformation`. The server uses the `encrypted_field_config` to process FLE 2 payloads.

The `MONGOCRYPT_CTX_NEED_MONGO_COLLINFO` state requests the driver to run `listCollections`. It is used to obtain a server-side `$jsonSchema` (for FLE 1 `schema`) or a server-side `encryptedFields` (for FLE 2 `encrypted_field_config`).
