### PR TITLE
MONGOCRYPT-395 Implement crypto callback for AES with CTR mode

### DIFF
--- a/src/mongocrypt-crypto-private.h
+++ b/src/mongocrypt-crypto-private.h
@@ -34,6 +34,8 @@ typedef struct {
    int hooks_enabled;
    mongocrypt_crypto_fn aes_256_cbc_encrypt;
    mongocrypt_crypto_fn aes_256_cbc_decrypt;
+   mongocrypt_crypto_fn aes_256_ctr_encrypt;
+   mongocrypt_crypto_fn aes_256_ctr_decrypt;
    mongocrypt_random_fn random;
    mongocrypt_hmac_fn hmac_sha_512;
    mongocrypt_hmac_fn hmac_sha_256;

--- a/src/mongocrypt.h.in
+++ b/src/mongocrypt.h.in
@@ -1376,7 +1376,7 @@ mongocrypt_setopt_crypto_hooks (mongocrypt_t *crypt,
  * operation.
  * @param[in] aes_256_ctr_decrypt The crypto callback function for decrypt
  * operation.
- * @param[in] sign_ctx A context passed as an argument to the crypto callback
+ * @param[in] ctx A context passed as an argument to the crypto callback
  * every invocation.
  * @pre @ref mongocrypt_init has not been called on @p crypt.
  * @returns A boolean indicating success. If false, an error status is set.

--- a/src/mongocrypt.h.in
+++ b/src/mongocrypt.h.in
@@ -381,8 +381,8 @@ mongocrypt_setopt_kms_provider_local (mongocrypt_t *crypt,
  *
  * @param[in] crypt The @ref mongocrypt_t object.
  * @param[in] kms_providers A BSON document mapping the KMS provider names
- * to credentials. Set a KMS provider value to an empty document to supply credentials
- * on-demand with @ref mongocrypt_ctx_provide_kms_providers.
+ * to credentials. Set a KMS provider value to an empty document to supply
+ * credentials on-demand with @ref mongocrypt_ctx_provide_kms_providers.
  * @pre @ref mongocrypt_init has not been called on @p crypt.
  * @returns A boolean indicating success. If false, an error status is set.
  * Retrieve it with @ref mongocrypt_ctx_status
@@ -413,17 +413,18 @@ mongocrypt_setopt_schema_map (mongocrypt_t *crypt,
  * Set a local EncryptedFieldConfigMap for encryption.
  *
  * @param[in] crypt The @ref mongocrypt_t object.
- * @param[in] efc_map A BSON document representing the EncryptedFieldConfigMap supplied by
- * the user. The keys are collection namespaces and values are EncryptedFieldConfigMap documents. The
- * viewed data copied. It is valid to destroy @p efc_map with @ref
- * mongocrypt_binary_destroy immediately after.
+ * @param[in] efc_map A BSON document representing the EncryptedFieldConfigMap
+ * supplied by the user. The keys are collection namespaces and values are
+ * EncryptedFieldConfigMap documents. The viewed data copied. It is valid to
+ * destroy @p efc_map with @ref mongocrypt_binary_destroy immediately after.
  * @pre @p crypt has not been initialized.
  * @returns A boolean indicating success. If false, an error status is set.
  * Retrieve it with @ref mongocrypt_status
  */
 MONGOCRYPT_EXPORT
 bool
-mongocrypt_setopt_encrypted_field_config_map (mongocrypt_t *crypt, mongocrypt_binary_t *efc_map);
+mongocrypt_setopt_encrypted_field_config_map (mongocrypt_t *crypt,
+                                              mongocrypt_binary_t *efc_map);
 
 
 /**
@@ -1366,6 +1367,28 @@ mongocrypt_setopt_crypto_hooks (mongocrypt_t *crypt,
                                 mongocrypt_hmac_fn hmac_sha_256,
                                 mongocrypt_hash_fn sha_256,
                                 void *ctx);
+
+/**
+ * Set a crypto hook for the AES256-CTR operations.
+ *
+ * @param[in] crypt The @ref mongocrypt_t object.
+ * @param[in] aes_256_ctr_encrypt The crypto callback function for encrypt
+ * operation.
+ * @param[in] aes_256_ctr_encrypt The crypto callback function for decrypt
+ * operation.
+ * @param[in] sign_ctx A context passed as an argument to the crypto callback
+ * every invocation.
+ * @pre @ref mongocrypt_init has not been called on @p crypt.
+ * @returns A boolean indicating success. If false, an error status is set.
+ * Retrieve it with @ref mongocrypt_status
+ *
+ */
+MONGOCRYPT_EXPORT
+bool
+mongocrypt_setopt_aes_256_ctr (mongocrypt_t *crypt,
+                               mongocrypt_crypto_fn aes_256_ctr_encrypt,
+                               mongocrypt_crypto_fn aes_256_ctr_decrypt,
+                               void *ctx);
 
 /**
  * Set a crypto hook for the RSASSA-PKCS1-v1_5 algorithm with a SHA-256 hash.

--- a/src/mongocrypt.h.in
+++ b/src/mongocrypt.h.in
@@ -1374,7 +1374,7 @@ mongocrypt_setopt_crypto_hooks (mongocrypt_t *crypt,
  * @param[in] crypt The @ref mongocrypt_t object.
  * @param[in] aes_256_ctr_encrypt The crypto callback function for encrypt
  * operation.
- * @param[in] aes_256_ctr_encrypt The crypto callback function for decrypt
+ * @param[in] aes_256_ctr_decrypt The crypto callback function for decrypt
  * operation.
  * @param[in] sign_ctx A context passed as an argument to the crypto callback
  * every invocation.

--- a/test/test-mongocrypt-crypto-hooks.c
+++ b/test/test-mongocrypt-crypto-hooks.c
@@ -274,7 +274,7 @@ _create_mongocrypt (_mongocrypt_tester_t *tester, const char *error_on)
    ASSERT_OK (ret, crypt);
    ret = mongocrypt_setopt_aes_256_ctr (crypt,
                                         _mock_aes_256_xxx_encrypt,
-                                        _mock_aes_256_xxx_encrypt,
+                                        _mock_aes_256_xxx_decrypt,
                                         (void *) error_on);
    ASSERT_OK (ret, crypt);
    ASSERT_OK (mongocrypt_init (crypt), crypt);

--- a/test/test-mongocrypt-crypto-hooks.c
+++ b/test/test-mongocrypt-crypto-hooks.c
@@ -59,15 +59,14 @@ _append_bin (const char *name, mongocrypt_binary_t *bin)
    _mongocrypt_buffer_cleanup (&tmp);
 }
 
-
 static bool
-_aes_256_cbc_encrypt (void *ctx,
-                      mongocrypt_binary_t *key,
-                      mongocrypt_binary_t *iv,
-                      mongocrypt_binary_t *in,
-                      mongocrypt_binary_t *out,
-                      uint32_t *bytes_written,
-                      mongocrypt_status_t *status)
+_mock_aes_256_xxx_encrypt (void *ctx,
+                           mongocrypt_binary_t *key,
+                           mongocrypt_binary_t *iv,
+                           mongocrypt_binary_t *in,
+                           mongocrypt_binary_t *out,
+                           uint32_t *bytes_written,
+                           mongocrypt_status_t *status)
 {
    BSON_ASSERT (0 == strncmp ("error_on:", (char *) ctx, strlen ("error_on:")));
    bson_string_append_printf (call_history, "call:%s\n", BSON_FUNC);
@@ -78,7 +77,8 @@ _aes_256_cbc_encrypt (void *ctx,
    memcpy (out->data + *bytes_written, in->data, in->len);
    *bytes_written += in->len;
    bson_string_append_printf (call_history, "ret:%s\n", BSON_FUNC);
-   if (0 == strcmp ((char *) ctx, "error_on:aes_256_cbc_encrypt")) {
+   if (0 == strcmp ((char *) ctx, "error_on:aes_256_cbc_encrypt") ||
+       0 == strcmp ((char *) ctx, "error_on:aes_256_ctr_encrypt")) {
       mongocrypt_status_set (
          status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char *) ctx, -1);
       return false;
@@ -87,13 +87,13 @@ _aes_256_cbc_encrypt (void *ctx,
 }
 
 static bool
-_aes_256_cbc_decrypt (void *ctx,
-                      mongocrypt_binary_t *key,
-                      mongocrypt_binary_t *iv,
-                      mongocrypt_binary_t *in,
-                      mongocrypt_binary_t *out,
-                      uint32_t *bytes_written,
-                      mongocrypt_status_t *status)
+_mock_aes_256_xxx_decrypt (void *ctx,
+                           mongocrypt_binary_t *key,
+                           mongocrypt_binary_t *iv,
+                           mongocrypt_binary_t *in,
+                           mongocrypt_binary_t *out,
+                           uint32_t *bytes_written,
+                           mongocrypt_status_t *status)
 {
    BSON_ASSERT (0 == strncmp ("error_on:", (char *) ctx, strlen ("error_on:")));
    bson_string_append_printf (call_history, "call:%s\n", BSON_FUNC);
@@ -104,7 +104,8 @@ _aes_256_cbc_decrypt (void *ctx,
    memcpy (out->data + *bytes_written, in->data, in->len);
    *bytes_written += in->len;
    bson_string_append_printf (call_history, "ret:%s\n", BSON_FUNC);
-   if (0 == strcmp ((char *) ctx, "error_on:aes_256_cbc_decrypt")) {
+   if (0 == strcmp ((char *) ctx, "error_on:aes_256_cbc_decrypt") ||
+       0 == strcmp ((char *) ctx, "error_on:aes_256_ctr_decrypt")) {
       mongocrypt_status_set (
          status, MONGOCRYPT_STATUS_ERROR_CLIENT, 1, (char *) ctx, -1);
       return false;
@@ -260,8 +261,8 @@ _create_mongocrypt (_mongocrypt_tester_t *tester, const char *error_on)
          TEST_BSON ("{'gcp': { 'email': 'test', 'privateKey': 'AAAA'}}")),
       crypt);
    ret = mongocrypt_setopt_crypto_hooks (crypt,
-                                         _aes_256_cbc_encrypt,
-                                         _aes_256_cbc_decrypt,
+                                         _mock_aes_256_xxx_encrypt,
+                                         _mock_aes_256_xxx_decrypt,
                                          _random,
                                          _hmac_sha_512,
                                          _hmac_sha_256,
@@ -270,6 +271,11 @@ _create_mongocrypt (_mongocrypt_tester_t *tester, const char *error_on)
    ASSERT_OK (ret, crypt);
    ret = mongocrypt_setopt_crypto_hook_sign_rsaes_pkcs1_v1_5 (
       crypt, _sign_rsaes_pkcs1_v1_5, (void *) error_on);
+   ASSERT_OK (ret, crypt);
+   ret = mongocrypt_setopt_aes_256_ctr (crypt,
+                                        _mock_aes_256_xxx_encrypt,
+                                        _mock_aes_256_xxx_encrypt,
+                                        (void *) error_on);
    ASSERT_OK (ret, crypt);
    ASSERT_OK (mongocrypt_init (crypt), crypt);
    return crypt;
@@ -286,11 +292,11 @@ _test_crypto_hooks_encryption_helper (_mongocrypt_tester_t *tester,
    mongocrypt_status_t *status;
    _mongocrypt_buffer_t iv, associated_data, key, plaintext, ciphertext;
    const char *expected_call_history =
-      "call:_aes_256_cbc_encrypt\n"
+      "call:_mock_aes_256_xxx_encrypt\n"
       "key:" ENCRYPTION_KEY_HEX "\n"
       "iv:" IV_HEX "\n"
       "in:BBBB0E0E0E0E0E0E0E0E0E0E0E0E0E0E\n"
-      "ret:_aes_256_cbc_encrypt\n"
+      "ret:_mock_aes_256_xxx_encrypt\n"
       "call:_hmac_sha_512\n"
       "key:CCD3836C8F24AC5FAAFAAA630C5C6C5D210FD03934EA1440CD67E0DCDE3F8EA6\n"
       "in:AAAA" IV_HEX "BBBB0E0E0E0E0E0E0E0E0E0E0E0E0E0E0000000000000010\n"
@@ -357,6 +363,8 @@ _test_crypto_hooks_encryption (_mongocrypt_tester_t *tester)
    _test_crypto_hooks_encryption_helper (tester, "error_on:none");
    _test_crypto_hooks_encryption_helper (tester,
                                          "error_on:aes_256_cbc_encrypt");
+   _test_crypto_hooks_encryption_helper (tester,
+                                         "error_on:aes_256_ctr_encrypt");
    _test_crypto_hooks_encryption_helper (tester, "error_on:hmac_sha512");
 }
 
@@ -375,11 +383,11 @@ _test_crypto_hooks_decryption_helper (_mongocrypt_tester_t *tester,
       "key:" HMAC_KEY_HEX "\n"
       "in:AAAA" IV_HEX "BBBB0E0E0E0E0E0E0E0E0E0E0E0E0E0E0000000000000010\n"
       "ret:_hmac_sha_512\n"
-      "call:_aes_256_cbc_decrypt\n"
+      "call:_mock_aes_256_xxx_decrypt\n"
       "key:" ENCRYPTION_KEY_HEX "\n"
       "iv:" IV_HEX "\n"
       "in:BBBB0E0E0E0E0E0E0E0E0E0E0E0E0E0E\n"
-      "ret:_aes_256_cbc_decrypt\n";
+      "ret:_mock_aes_256_xxx_decrypt\n";
 
    status = mongocrypt_status_new ();
    crypt = _create_mongocrypt (tester, error_on);
@@ -431,6 +439,8 @@ _test_crypto_hooks_decryption (_mongocrypt_tester_t *tester)
    _test_crypto_hooks_decryption_helper (tester, "error_on:none");
    _test_crypto_hooks_decryption_helper (tester,
                                          "error_on:aes_256_cbc_decrypt");
+   _test_crypto_hooks_decryption_helper (tester,
+                                         "error_on:aes_256_ctr_decrypt");
    _test_crypto_hooks_decryption_helper (tester, "error_on:hmac_sha512");
 }
 


### PR DESCRIPTION
This implements `mongocrypt_setopt_aes_256_ctr` function to supply user AES-CTR crypto functions

Some changes are generated by clang-format

