### PR TITLE
Fix compact context terminal state and bypass

### DIFF
--- a/src/mongocrypt-ctx-compact.c
+++ b/src/mongocrypt-ctx-compact.c
@@ -62,7 +62,8 @@ _finalize (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
                                              &key,
                                              key.len - MONGOCRYPT_TOKEN_KEY_LEN,
                                              MONGOCRYPT_TOKEN_KEY_LEN)) {
-         _mongocrypt_ctx_fail_w_msg (ctx, "unable to get TokenKey from Data Encryption Key");
+         _mongocrypt_ctx_fail_w_msg (
+            ctx, "unable to get TokenKey from Data Encryption Key");
          goto ecoc_fail;
       }
       cl1t =

--- a/src/mongocrypt-ctx-compact.c
+++ b/src/mongocrypt-ctx-compact.c
@@ -53,6 +53,8 @@ _finalize (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
 
       if (!_mongocrypt_key_broker_decrypted_key_by_id (
              &ctx->kb, &ptr->keyId, &key)) {
+         _mongocrypt_key_broker_status (&ctx->kb, ctx->status);
+         _mongocrypt_ctx_fail (ctx);
          goto ecoc_fail;
       }
       /* The last 32 bytes of the user key are the token key. */
@@ -60,17 +62,19 @@ _finalize (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
                                              &key,
                                              key.len - MONGOCRYPT_TOKEN_KEY_LEN,
                                              MONGOCRYPT_TOKEN_KEY_LEN)) {
-         CLIENT_ERR ("unable to get TokenKey from Data Encryption Key");
+         _mongocrypt_ctx_fail_w_msg (ctx, "unable to get TokenKey from Data Encryption Key");
          goto ecoc_fail;
       }
       cl1t =
          mc_CollectionsLevel1Token_new (ctx->crypt->crypto, &tokenkey, status);
       if (!cl1t) {
+         _mongocrypt_ctx_fail (ctx);
          goto ecoc_fail;
       }
 
       ecoct = mc_ECOCToken_new (ctx->crypt->crypto, cl1t, status);
       if (!ecoct) {
+         _mongocrypt_ctx_fail (ctx);
          goto ecoc_fail;
       }
 
@@ -97,6 +101,7 @@ _finalize (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
    _mongocrypt_buffer_steal_from_bson (&cctx->result, &result_bson);
    _mongocrypt_buffer_to_binary (&cctx->result, out);
    ret = true;
+   ctx->state = MONGOCRYPT_CTX_DONE;
 fail:
    if (!ret) {
       bson_destroy (&result_bson);

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -1760,6 +1760,8 @@ _check_cmd_for_auto_encrypt (mongocrypt_binary_t *cmd,
       *bypass = true;
    } else if (0 == strcmp (cmd_name, "refreshSessions")) {
       *bypass = true;
+   } else if (0 == strcmp (cmd_name, "compactStructuredEncryptionData")) {
+      *bypass = true;
    }
 
    /* database/client commands are ineligible. */

--- a/test/test-mongocrypt-ctx-compact.c
+++ b/test/test-mongocrypt-ctx-compact.c
@@ -55,6 +55,8 @@ _test_compact_success (_mongocrypt_tester_t *tester)
       mongocrypt_binary_destroy (out);
    }
 
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_DONE);
+
    mongocrypt_ctx_destroy (ctx);
    mongocrypt_destroy (crypt);
 }
@@ -111,6 +113,8 @@ _test_compact_nonlocal_kms (_mongocrypt_tester_t *tester)
       mongocrypt_binary_destroy (out);
    }
 
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_DONE);
+
    mongocrypt_ctx_destroy (ctx);
    mongocrypt_destroy (crypt);
 }
@@ -143,6 +147,7 @@ _test_compact_init (_mongocrypt_tester_t *tester)
             ctx, TEST_FILE ("./test/data/efc/efc-missingKeyId.json")),
          ctx,
          "unable to find 'keyId' in 'field' document");
+      ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_ERROR);
       mongocrypt_ctx_destroy (ctx);
    }
 
@@ -157,6 +162,7 @@ _test_compact_init (_mongocrypt_tester_t *tester)
             ctx, TEST_FILE ("./test/data/efc/efc-missingKeyId.json")),
          ctx,
          "algorithm prohibited");
+      ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_ERROR);
       mongocrypt_ctx_destroy (ctx);
    }
 
@@ -180,6 +186,7 @@ _test_compact_key_not_provided (_mongocrypt_tester_t *tester)
    ASSERT_FAILS (mongocrypt_ctx_mongo_done (ctx),
                  ctx,
                  "not all keys requested were satisfied");
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_ERROR);
 
    mongocrypt_ctx_destroy (ctx);
    mongocrypt_destroy (crypt);
@@ -255,6 +262,7 @@ _test_compact_need_kms_credentials (_mongocrypt_tester_t *tester)
       mongocrypt_binary_destroy (out);
    }
 
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_DONE);
 
    mongocrypt_ctx_destroy (ctx);
    mongocrypt_destroy (crypt);
@@ -284,6 +292,8 @@ _test_compact_no_fields (_mongocrypt_tester_t *tester)
       _assert_match_bson (&out_bson, TMP_BSON ("{'compactionTokens': {}}"));
       mongocrypt_binary_destroy (out);
    }
+
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_DONE);
 
    mongocrypt_ctx_destroy (ctx);
    mongocrypt_destroy (crypt);

--- a/test/test-mongocrypt-ctx-compact.c
+++ b/test/test-mongocrypt-ctx-compact.c
@@ -130,10 +130,9 @@ _test_compact_init (_mongocrypt_tester_t *tester)
    /* Test success. */
    {
       ctx = mongocrypt_ctx_new (crypt);
-      ASSERT_OK (
-         mongocrypt_ctx_compact_init (
-            ctx, TEST_FILE ("./test/data/efc/efc-oneField.json")),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_compact_init (
+                    ctx, TEST_FILE ("./test/data/efc/efc-oneField.json")),
+                 ctx);
       ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
                           MONGOCRYPT_CTX_NEED_MONGO_KEYS);
       mongocrypt_ctx_destroy (ctx);

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1236,6 +1236,7 @@ _test_encrypt_init_each_cmd (_mongocrypt_tester_t *tester)
    _init_bypass (tester, "{'killSessions': 1}");
    _init_bypass (tester, "{'killAllSessionsByPattern': 1}");
    _init_bypass (tester, "{'refreshSessions': 1}");
+   _init_bypass (tester, "{'compactStructuredEncryptionData': 'coll'}");
 }
 
 


### PR DESCRIPTION
# Summary
- Set final compact context state to `MONGOCRYPT_CTX_DONE` or `MONGOCRYPT_CTX_ERROR`.
- Bypass the `compactStructuredEncryptionData` command from automatic encryption.

# Background & Motivation

Both bugs were caught in integration testing.