### PR TITLE
feat(NODE-4218): add aes256-ctr support

### DIFF
--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -252,6 +252,8 @@ module.exports = function (modules) {
       const stateMachine = new StateMachine({
         bson,
         ...options,
+        promoteValues: false,
+        promoteLongs: false,
         proxyOptions: this._proxyOptions,
         tlsOptions: this._tlsOptions
       });

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -404,7 +404,7 @@ module.exports = function (modules) {
 
       client
         .db(dbName)
-        .listCollections(filter)
+        .listCollections(filter, { promoteLongs: false, promoteValues: false })
         .toArray((err, collections) => {
           if (err) {
             callback(err, null);


### PR DESCRIPTION
##### feat(NODE-4218): add aes256-ctr support

This is required for FLE2 support. Diff best viewed with whitespace changes hidden because it moves a function to an outer scope :)

##### fix: pass promoteValues: false where encryptedFields is processed

(drive by, can be a separate PR if necessary)

This is required because `encryptedFields.fields[].queries[].contention`
must be a Long in order for the server/mongocryptd/the csfle
shared library to be able to process it.
