### PR TITLE
MONGOCRYPT-428 add missing MONGOCRYPT_EXPORT

### DIFF
--- a/src/mongocrypt.h.in
+++ b/src/mongocrypt.h.in
@@ -1219,6 +1219,7 @@ mongocrypt_ctx_kms_done (mongocrypt_ctx_t *ctx);
  * @returns A boolean indicating success. If false, an error status is set.
  * Retrieve it with @ref mongocrypt_ctx_status.
  */
+MONGOCRYPT_EXPORT
 bool
 mongocrypt_ctx_provide_kms_providers (
    mongocrypt_ctx_t *ctx, mongocrypt_binary_t *kms_providers_definition);


### PR DESCRIPTION
Add to `mongocrypt_ctx_provide_kms_providers`.