### PR TITLE
PYTHON-3241 FLE 2.0 support for pymongocrypt

### DIFF
--- a/bindings/python/pymongocrypt/mongocrypt.py
+++ b/bindings/python/pymongocrypt/mongocrypt.py
@@ -25,6 +25,8 @@ from pymongocrypt.state_machine import MongoCryptCallback
 
 from pymongocrypt.crypto import (aes_256_cbc_encrypt,
                                  aes_256_cbc_decrypt,
+                                 aes_256_ctr_decrypt,
+                                 aes_256_ctr_encrypt,
                                  hmac_sha_256,
                                  hmac_sha_512,
                                  sha_256,
@@ -200,6 +202,10 @@ class MongoCrypt(object):
 
         if not lib.mongocrypt_setopt_crypto_hook_sign_rsaes_pkcs1_v1_5(
                 self.__crypt, sign_rsaes_pkcs1_v1_5, ffi.NULL):
+            self.__raise_from_status()
+
+        if not lib.mongocrypt_setopt_aes_256_ctr(
+                self.__crypt, aes_256_ctr_encrypt, aes_256_ctr_decrypt, ffi.NULL):
             self.__raise_from_status()
 
         if not lib.mongocrypt_init(self.__crypt):

--- a/bindings/python/pymongocrypt/mongocrypt.py
+++ b/bindings/python/pymongocrypt/mongocrypt.py
@@ -35,7 +35,8 @@ from pymongocrypt.crypto import (aes_256_cbc_encrypt,
 
 
 class MongoCryptOptions(object):
-    def __init__(self, kms_providers, schema_map=None):
+    def __init__(self, kms_providers, schema_map=None, encrypted_fields_map=None,
+                 bypass_query_analysis=False):
         """Options for :class:`MongoCrypt`.
 
         :Parameters:
@@ -65,6 +66,11 @@ class MongoCryptOptions(object):
             automatic encryption for client side encryption. Other validation
             rules in the JSON schema will not be enforced by the driver and
             will result in an error.
+          - `encrypted_fields_map`: Optional map encoded to BSON `bytes`.
+          - `bypass_query_analysis`: If ``True``, disable automatic analysis of
+            outgoing commands. Set `bypass_query_analysis` to use explicit
+            encryption on indexed fields without the MongoDB Enterprise Advanced
+            licensed csfle shared library.
 
         .. versionadded:: 1.1
            Support for "azure" and "gcp" kms_providers.
@@ -135,8 +141,13 @@ class MongoCryptOptions(object):
         if schema_map is not None and not isinstance(schema_map, bytes):
             raise TypeError("schema_map must be bytes or None")
 
+        if encrypted_fields_map is not None and not isinstance(encrypted_fields_map, bytes):
+            raise TypeError("encrypted_fields_map must be bytes or None")
+
         self.kms_providers = kms_providers
         self.schema_map = schema_map
+        self.encrypted_fields_map = encrypted_fields_map
+        self.bypass_query_analysis = bypass_query_analysis
 
 
 class MongoCrypt(object):
@@ -194,6 +205,17 @@ class MongoCrypt(object):
                 if not lib.mongocrypt_setopt_schema_map(
                         self.__crypt, binary_schema_map.bin):
                     self.__raise_from_status()
+
+        encrypted_fields_map = self.__opts.encrypted_fields_map
+        if encrypted_fields_map is not None:
+            with MongoCryptBinaryIn(encrypted_fields_map) as binary_encrypted_fields_map:
+                if not lib.mongocrypt_setopt_encrypted_field_config_map(
+                        self.__crypt, binary_encrypted_fields_map.bin):
+                    self.__raise_from_status()
+
+        if self.__opts.bypass_query_analysis:
+            if not lib.mongocrypt_setopt_bypass_query_analysis(self.__crypt):
+                self.__raise_from_status()
 
         if not lib.mongocrypt_setopt_crypto_hooks(
                 self.__crypt, aes_256_cbc_encrypt, aes_256_cbc_decrypt,

--- a/bindings/python/pymongocrypt/version.py
+++ b/bindings/python/pymongocrypt/version.py
@@ -14,4 +14,4 @@
 
 __version__ = '1.3.0.dev0'
 
-_MIN_LIBMONGOCRYPT_VERSION = '1.3.0'
+_MIN_LIBMONGOCRYPT_VERSION = '1.5.0a1'

--- a/bindings/python/test/data/compact/success/cmd.json
+++ b/bindings/python/test/data/compact/success/cmd.json
@@ -1,0 +1,1 @@
+{ "compactStructuredEncryptionData": "test" }

--- a/bindings/python/test/data/compact/success/encrypted-field-config-map.json
+++ b/bindings/python/test/data/compact/success/encrypted-field-config-map.json
@@ -1,0 +1,47 @@
+{
+    "db.test": {
+        "escCollection": "esc",
+        "eccCollection": "ecc",
+        "ecocCollection": "ecoc",
+        "fields": [
+            {
+                "keyId": {
+                    "$binary": {
+                        "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                        "subType": "04"
+                    }
+                },
+                "path": "encrypted",
+                "bsonType": "string",
+                "queries": {
+                    "queryType": "equality",
+                    "contention": 0
+                }
+            },
+            {
+                "keyId": {
+                    "$binary": {
+                        "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                        "subType": "04"
+                    }
+                },
+                "path": "nested.encrypted",
+                "bsonType": "string",
+                "queries": {
+                    "queryType": "equality",
+                    "contention": 0
+                }
+            },
+            {
+                "keyId": {
+                    "$binary": {
+                        "base64": "EjRWeBI0mHYSNBI0VniQEw==",
+                        "subType": "04"
+                    }
+                },
+                "path": "nested.notindexed",
+                "bsonType": "string"
+            }
+        ]
+    }
+}

--- a/bindings/python/test/data/compact/success/encrypted-payload.json
+++ b/bindings/python/test/data/compact/success/encrypted-payload.json
@@ -1,0 +1,23 @@
+{
+   "compactStructuredEncryptionData": "test",
+   "compactionTokens": {
+      "nested.notindexed": {
+         "$binary": {
+            "base64": "27J6DZqcjkRzZ3lWEsxH7CsQHr4CZirrGmuPS8ZkRO0=",
+            "subType": "00"
+         }
+      },
+      "nested.encrypted": {
+         "$binary": {
+            "base64": "SWO8WEoZ2r2Kx/muQKb7+COizy85nIIUFiHh4K9kcvA=",
+            "subType": "00"
+         }
+      },
+      "encrypted": {
+         "$binary": {
+            "base64": "noN+05JsuO1oDg59yypIGj45i+eFH6HOTXOPpeZ//Mk=",
+            "subType": "00"
+         }
+      }
+   }
+}

--- a/bindings/python/test/data/encrypted-field-config-map.json
+++ b/bindings/python/test/data/encrypted-field-config-map.json
@@ -1,0 +1,48 @@
+{
+    "test.test": {
+        "escCollection": "fle2.basic.esc",
+        "eccCollection": "fle2.basic.ecc",
+        "ecocCollection": "fle2.basic.ecoc",
+        "fields": [
+            {
+                "keyId": {
+                    "$binary": {
+                        "base64": "KEY1+AAAAAAAAAAAAAAAAA==",
+                        "subType": "04"
+                    }
+                },
+                "path": "firstName",
+                "bsonType": "string",
+                "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                        "$numberLong": "0"
+                    }
+                }
+            }
+        ]
+    },
+    "test.test2": {
+        "escCollection": "fle2.basic.esc",
+        "eccCollection": "fle2.basic.ecc",
+        "ecocCollection": "fle2.basic.ecoc",
+        "fields": [
+            {
+                "keyId": {
+                    "$binary": {
+                        "base64": "KEY2+AAAAAAAAAAAAAAAAA==",
+                        "subType": "04"
+                    }
+                },
+                "path": "firstName",
+                "bsonType": "string",
+                "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                        "$numberLong": "0"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/bindings/python/test/data/keys/12345678123498761234123456789012-local-document.json
+++ b/bindings/python/test/data/keys/12345678123498761234123456789012-local-document.json
@@ -1,0 +1,30 @@
+{
+    "_id": {
+        "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+        }
+    },
+    "keyMaterial": {
+        "$binary": {
+            "base64": "1ZbBTB1i/z4LcmBKi9+nnWqkVB4Wl6P4G7/TFQvXATRF2fX0lhBLIM6rT1U547FX2YgMtaP7sid+jpd4Vhz5kS+UlgtmCFfjeO4qOnJ78KEXRzeIebzKWKQz1pMhYZ3OURDL4wCtNqt3tbSr11kfTADmCMuzgp8U8P8T21RWWBU0f2XDcxiIShYncOS3poKu7GJaPCTav4r3h5h2xRklDA==",
+            "subType": "00"
+        }
+    },
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1648914851981"
+        }
+    },
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1648914851981"
+        }
+    },
+    "status": {
+        "$numberInt": "0"
+    },
+    "masterKey": {
+        "provider": "local"
+    }
+}

--- a/bindings/python/test/data/keys/12345678123498761234123456789013-local-document.json
+++ b/bindings/python/test/data/keys/12345678123498761234123456789013-local-document.json
@@ -1,0 +1,30 @@
+{
+    "_id": {
+        "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEw==",
+            "subType": "04"
+        }
+    },
+    "keyMaterial": {
+        "$binary": {
+            "base64": "YQXu48YyDbXvVQ1OhPsodQQNA1gLVWZSV0udYVmCTpVrgyAZePHQmsWWnQzNZj+ZsTxRm02soje/FJCqWGLeth3gKdvIsRg15CDEUOqLdDEpHl46hadosXyJIfo0umZ/LVTkvxRhmDCDxAkd0+Dg4/vWSiG0FgNzGrlvOUsTLGbqWtNMuOdZ8pKAdnFRrqce5cwBGQmd2VVBA2OQ0/IMxQ==",
+            "subType": "00"
+        }
+    },
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1650631142512"
+        }
+    },
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1650631142512"
+        }
+    },
+    "status": {
+        "$numberInt": "0"
+    },
+    "masterKey": {
+        "provider": "local"
+    }
+}

--- a/bindings/python/test/data/keys/ABCDEFAB123498761234123456789012-local-document.json
+++ b/bindings/python/test/data/keys/ABCDEFAB123498761234123456789012-local-document.json
@@ -1,0 +1,30 @@
+{
+    "_id": {
+        "$binary": {
+            "base64": "q83vqxI0mHYSNBI0VniQEg==",
+            "subType": "04"
+        }
+    },
+    "keyMaterial": {
+        "$binary": {
+            "base64": "27OBvUqHAuYFy60nwCdvq2xmZ4kFzVySphXzBGq+HEot13comCoydEfnltBzLTuXLbV9cnREFJIO5f0jMqrlkxIuvAV8yO84p5VJTEa8j/xSNe7iA594rx7UeKT0fOt4VqM47fht8h+8PZYc5JVezvEMvwk115IBCwENxDjLtT0g+y8Hf+aTUEGtxrYToH8zf1/Y7S16mHiIc4jK3/vxHw==",
+            "subType": "00"
+        }
+    },
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1648915408923"
+        }
+    },
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1648915408923"
+        }
+    },
+    "status": {
+        "$numberInt": "0"
+    },
+    "masterKey": {
+        "provider": "local"
+    }
+}


### PR DESCRIPTION
3 changes:
- Bump _MIN_LIBMONGOCRYPT_VERSION to 1.5.0a1 and update binding header.
- [PYTHON-3241](https://jira.mongodb.org/browse/PYTHON-3241) Add mongocrypt_setopt_aes_256_ctr crypto callbacks
- [PYTHON-3241](https://jira.mongodb.org/browse/PYTHON-3241) Add support for encrypted_fields_map and bypass_query_analysis

I believe this is everything needed for FLE 2.0 support in pymongocrypt itself.