### PR TITLE
PYTHON-3269 Fix malformed mock jsonSchemas used in test suite

### DIFF
--- a/bindings/python/test/data/collection-info.json
+++ b/bindings/python/test/data/collection-info.json
@@ -19,14 +19,16 @@
                 "properties": {
                     "ssn": {
                         "encrypt": {
-                            "keyId": {
-                                "$binary": {
-                                    "base64": "YWFhYWFhYWFhYWFhYWFhYQ==",
-                                    "subType": "04"
+                            "keyId": [
+                                {
+                                    "$binary": {
+                                        "base64": "YWFhYWFhYWFhYWFhYWFhYQ==",
+                                        "subType": "04"
+                                    }
                                 }
-                            },
-                            "type": "string",
-                            "algorithm": "AEAD_AES_CBC_HMAC_SHA512-Deterministic"
+                            ],
+                            "bsonType": "string",
+                            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
                         }
                     }
                 },

--- a/bindings/python/test/data/mongocryptd-command.json
+++ b/bindings/python/test/data/mongocryptd-command.json
@@ -1,22 +1,26 @@
 {
-  "find": "test",
-  "filter": {
-    "ssn": "457-55-5462"
-  },
-  "jsonSchema": {
-    "properties": {
-      "ssn": {
-        "encrypt": {
-          "keyId": {
-            "$binary": "YWFhYWFhYWFhYWFhYWFhYQ==",
-            "$type": "04"
-          },
-          "type": "string",
-          "algorithm": "AEAD_AES_CBC_HMAC_SHA512-Deterministic"
-        }
-      }
+    "find": "test",
+    "filter": {
+        "ssn": "457-55-5462"
     },
-    "bsonType": "object"
-  },
-  "isRemoteSchema": true
+    "jsonSchema": {
+        "properties": {
+            "ssn": {
+                "encrypt": {
+                    "keyId": [
+                        {
+                            "$binary": {
+                                "base64": "YWFhYWFhYWFhYWFhYWFhYQ==",
+                                "subType": "04"
+                            }
+                        }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                }
+            }
+        },
+        "bsonType": "object"
+    },
+    "isRemoteSchema": true
 }

--- a/bindings/python/test/data/schema-map.json
+++ b/bindings/python/test/data/schema-map.json
@@ -3,14 +3,16 @@
     "properties": {
       "ssn": {
         "encrypt": {
-          "keyId": {
-            "$binary": {
-              "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
-              "subType": "04"
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
             }
-          },
-          "type": "string",
-          "algorithm": "AEAD_AES_CBC_HMAC_SHA512-Deterministic"
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
         }
       }
     },
@@ -20,14 +22,16 @@
     "properties": {
       "ssn": {
         "encrypt": {
-          "keyId": {
-            "$binary": {
-              "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
-              "subType": "04"
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
             }
-          },
-          "type": "string",
-          "algorithm": "AEAD_AES_CBC_HMAC_SHA512-Random"
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
         }
       }
     },

--- a/bindings/python/test/test_mongocrypt.py
+++ b/bindings/python/test/test_mongocrypt.py
@@ -146,6 +146,7 @@ class TestMongoCryptOptions(unittest.TestCase):
 
 
 class TestMongoCrypt(unittest.TestCase):
+    maxDiff = None
 
     def test_mongocrypt(self):
         kms_providers = {
@@ -268,6 +269,8 @@ class TestMongoCrypt(unittest.TestCase):
             self.assertEqual(ctx.state, lib.MONGOCRYPT_CTX_NEED_MONGO_MARKINGS)
 
             mongocryptd_cmd = ctx.mongo_operation()
+            self.assertEqual(bson.decode(mongocryptd_cmd, OPTS),
+                             json_data('mongocryptd-command.json'))
             self.assertEqual(mongocryptd_cmd,
                              bson_data('mongocryptd-command.json'))
 
@@ -493,7 +496,11 @@ def read(filename, **kwargs):
 OPTS = CodecOptions(uuid_representation=UuidRepresentation.UNSPECIFIED)
 
 # Use SON to preserve the order of fields while parsing json.
-JSON_OPTS = JSONOptions(document_class=SON,
+if sys.version_info[:2] < (3, 6):
+    document_class = SON
+else:
+    document_class = dict
+JSON_OPTS = JSONOptions(document_class=document_class,
                         uuid_representation=UuidRepresentation.UNSPECIFIED)
 
 

--- a/etc/generate-test-data.py
+++ b/etc/generate-test-data.py
@@ -121,15 +121,15 @@ collection_info = {
                 "properties": {
                     "ssn": {
                         "encrypt": {
-                            "keyId": key_doc["_id"],
-                            "type": "string",
+                            "keyId": [key_doc["_id"]],
+                            "bsonType": "string",
                             "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
                         }
                     },
                     "random": {
                         "encrypt": {
-                            "keyId": key_doc["_id"],
-                            "type": "string",
+                            "keyId": [key_doc["_id"]],
+                            "bsonType": "string",
                             "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
                         }
                     }

--- a/test/data/collinfo-siblings.json
+++ b/test/data/collinfo-siblings.json
@@ -19,13 +19,15 @@
                 "properties": {
                     "ssn": {
                         "encrypt": {
-                            "keyId": {
-                                "$binary": {
-                                    "base64": "YWFhYWFhYWFhYWFhYWFhYQ==", 
-                                    "subType": "04"
+                            "keyId": [
+                                {
+                                    "$binary": {
+                                        "base64": "YWFhYWFhYWFhYWFhYWFhYQ==",
+                                        "subType": "04"
+                                    }
                                 }
-                            }, 
-                            "type": "string", 
+                            ],
+                            "bsonType": "string", 
                             "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
                         }
                     }

--- a/test/data/schema-map.json
+++ b/test/data/schema-map.json
@@ -3,14 +3,16 @@
     "properties": {
       "ssn": {
         "encrypt": {
-          "keyId": {
-            "$binary": {
-              "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
-              "subType": "04"
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
             }
-          },
-          "type": "string",
-          "algorithm": "AEAD_AES_CBC_HMAC_SHA512-Deterministic"
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
         }
       }
     },
@@ -20,14 +22,16 @@
     "properties": {
       "ssn": {
         "encrypt": {
-          "keyId": {
-            "$binary": {
-              "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
-              "subType": "04"
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
             }
-          },
-          "type": "string",
-          "algorithm": "AEAD_AES_CBC_HMAC_SHA512-Random"
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
         }
       }
     },

--- a/test/data/schema.json
+++ b/test/data/schema.json
@@ -2,14 +2,16 @@
   "properties": {
     "ssn": {
       "encrypt": {
-        "keyId": {
-          "$binary": {
-            "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
-            "subType": "04"
+        "keyId": [
+          {
+            "$binary": {
+              "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+              "subType": "04"
+            }
           }
-        },
-        "type": "string",
-        "algorithm": "AEAD_AES_CBC_HMAC_SHA512-Deterministic"
+        ],
+        "bsonType": "string",
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
       }
     }
   },


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-3269

A few changes to make the mock test jsonSchemas valid according to the server's format:
- wrap "keyId" in an array
- rename "type" to "bsonType"
- rename "AEAD_AES_CBC_HMAC_SHA512" to "AEAD_AES_256_CBC_HMAC_SHA_512".

Note that this PR only changes the C and Python files, other bindings should to make similar changes on their own.