### PR TITLE
MONGOCRYPT-427 Fix explain

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -323,7 +323,9 @@ command_needs_deleteTokens (const char *command_name)
 /* context_uses_fle2 returns true if the context uses FLE 2 behavior.
  * If a collection has an encryptedFields document, it uses FLE 2.
  */
-static bool context_uses_fle2 (mongocrypt_ctx_t *ctx) {
+static bool
+context_uses_fle2 (mongocrypt_ctx_t *ctx)
+{
    _mongocrypt_ctx_encrypt_t *ectx = (_mongocrypt_ctx_encrypt_t *) ctx;
 
    return !_mongocrypt_buffer_empty (&ectx->encrypted_field_config);
@@ -1042,14 +1044,14 @@ must_omit_encryptionInformation (const char *command_name,
       }
    }
    if (!found) {
-      return (moe_result) { .ok = true };
+      return (moe_result){.ok = true};
    }
 
    bool has_payload_requiring_encryptionInformation = false;
    bson_iter_t iter;
    if (!bson_iter_init (&iter, command)) {
       CLIENT_ERR ("unable to iterate command");
-      return (moe_result) { .ok = false };
+      return (moe_result){.ok = false};
    }
    if (!_mongocrypt_traverse_binary_in_bson (
           _check_for_payload_requiring_encryptionInformation,
@@ -1057,13 +1059,13 @@ must_omit_encryptionInformation (const char *command_name,
           TRAVERSE_MATCH_SUBTYPE6,
           &iter,
           status)) {
-      return (moe_result) { .ok = false };
+      return (moe_result){.ok = false};
    }
 
    if (!has_payload_requiring_encryptionInformation) {
-      return (moe_result) { .ok = true, .must_omit = true };
+      return (moe_result){.ok = true, .must_omit = true};
    }
-   return (moe_result) { .ok = true, .must_omit = false };
+   return (moe_result){.ok = true, .must_omit = false};
 }
 
 /* _fle2_append_compactionTokens appends compactionTokens if command_name is
@@ -1232,7 +1234,8 @@ _fle2_finalize (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
       }
    }
 
-   moe_result result = must_omit_encryptionInformation (command_name, &converted, ctx->status);
+   moe_result result =
+      must_omit_encryptionInformation (command_name, &converted, ctx->status);
    if (!result.ok) {
       return false;
    }

--- a/test/data/fle1-explain/with-csfle/cmd.json
+++ b/test/data/fle1-explain/with-csfle/cmd.json
@@ -1,0 +1,8 @@
+{
+   "explain": {
+      "find": "test",
+      "filter": {
+         "value": 123456
+      }
+   }
+}

--- a/test/data/fle1-explain/with-csfle/collinfo.json
+++ b/test/data/fle1-explain/with-csfle/collinfo.json
@@ -1,0 +1,7 @@
+{
+    "options": {
+        "validator": {
+            "$jsonSchema": {}
+        }
+    }
+}

--- a/test/data/fle1-explain/with-csfle/encrypted-payload.json
+++ b/test/data/fle1-explain/with-csfle/encrypted-payload.json
@@ -1,0 +1,8 @@
+{
+   "explain": {
+      "find": "test",
+      "filter": {
+         "value": 123456
+      }
+   }
+}

--- a/test/data/fle1-explain/with-mongocryptd/cmd-to-mongocryptd.json
+++ b/test/data/fle1-explain/with-mongocryptd/cmd-to-mongocryptd.json
@@ -1,0 +1,10 @@
+{
+    "explain": {
+        "find": "test",
+        "filter": {
+            "value": 123456
+        }
+    },
+    "jsonSchema": {},
+    "isRemoteSchema": true
+}

--- a/test/data/fle1-explain/with-mongocryptd/cmd.json
+++ b/test/data/fle1-explain/with-mongocryptd/cmd.json
@@ -1,0 +1,8 @@
+{
+   "explain": {
+      "find": "test",
+      "filter": {
+         "value": 123456
+      }
+   }
+}

--- a/test/data/fle1-explain/with-mongocryptd/collinfo.json
+++ b/test/data/fle1-explain/with-mongocryptd/collinfo.json
@@ -1,0 +1,7 @@
+{
+    "options": {
+        "validator": {
+            "$jsonSchema": {}
+        }
+    }
+}

--- a/test/data/fle1-explain/with-mongocryptd/encrypted-payload.json
+++ b/test/data/fle1-explain/with-mongocryptd/encrypted-payload.json
@@ -1,0 +1,8 @@
+{
+   "explain": {
+      "find": "test",
+      "filter": {
+         "value": 123456
+      }
+   }
+}

--- a/test/data/fle1-explain/with-mongocryptd/mongocryptd-reply.json
+++ b/test/data/fle1-explain/with-mongocryptd/mongocryptd-reply.json
@@ -1,0 +1,14 @@
+{
+    "ok": {
+        "$numberInt": "1"
+    },
+    "result": {
+        "explain": {
+            "find": "test",
+            "filter": {
+                "value": 123456
+            }
+        }
+    },
+    "hasEncryptedPlaceholders": false
+}

--- a/test/data/fle2-explain/with-csfle/cmd.json
+++ b/test/data/fle2-explain/with-csfle/cmd.json
@@ -1,0 +1,8 @@
+{
+   "explain": {
+      "find": "test",
+      "filter": {
+         "value": 123456
+      }
+   }
+}

--- a/test/data/fle2-explain/with-csfle/collinfo.json
+++ b/test/data/fle2-explain/with-csfle/collinfo.json
@@ -1,0 +1,27 @@
+{
+    "options": {
+        "encryptedFields": {
+            "escCollection": "esc",
+            "eccCollection": "ecc",
+            "ecocCollection": "ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "value",
+                    "bsonType": "int",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": {
+                            "$numberLong": "0"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/test/data/fle2-explain/with-csfle/encrypted-payload.json
+++ b/test/data/fle2-explain/with-csfle/encrypted-payload.json
@@ -1,0 +1,46 @@
+{
+   "explain": {
+      "find": "test",
+      "filter": {
+         "value": {
+            "$eq": {
+               "$binary": {
+                  "base64": "BYkAAAAFZAAgAAAAAE8KGPgq7h3n9nH5lfHcia8wtOTLwGkZNLBesb6PULqbBXMAIAAAAACq0558QyD3c3jkR5k0Zc9UpQK8ByhXhtn2d1xVQnuJ3AVjACAAAAAA1003zUWGwD4zVZ0KeihnZOthS3V6CEHUfnJZcIYHefISY20AAAAAAAAAAAAA",
+                  "subType": "06"
+               }
+            }
+         }
+      },
+      "encryptionInformation": {
+         "type": {
+            "$numberInt": "1"
+         },
+         "schema": {
+            "db.test": {
+               "escCollection": "esc",
+               "eccCollection": "ecc",
+               "ecocCollection": "ecoc",
+               "fields": [
+                  {
+                     "keyId": {
+                        "$binary": {
+                           "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                           "subType": "04"
+                        }
+                     },
+                     "path": "value",
+                     "bsonType": "int",
+                     "queries": {
+                        "queryType": "equality",
+                        "contention": {
+                           "$numberLong": "0"
+                        }
+                     }
+                  }
+               ]
+            }
+         }
+      }
+   },
+   "verbosity": "allPlansExecution"
+}

--- a/test/data/fle2-explain/with-mongocryptd/cmd-to-mongocryptd.json
+++ b/test/data/fle2-explain/with-mongocryptd/cmd-to-mongocryptd.json
@@ -1,0 +1,36 @@
+{
+    "explain": {
+        "find": "test",
+        "filter": {
+            "value": 123456
+        }
+    },
+    "encryptionInformation": {
+        "type": 1,
+        "schema": {
+            "db.test": {
+                "escCollection": "esc",
+                "eccCollection": "ecc",
+                "ecocCollection": "ecoc",
+                "fields": [
+                    {
+                        "keyId": {
+                            "$binary": {
+                                "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                                "subType": "04"
+                            }
+                        },
+                        "path": "value",
+                        "bsonType": "int",
+                        "queries": {
+                            "queryType": "equality",
+                            "contention": {
+                                "$numberLong": "0"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/test/data/fle2-explain/with-mongocryptd/cmd.json
+++ b/test/data/fle2-explain/with-mongocryptd/cmd.json
@@ -1,0 +1,8 @@
+{
+   "explain": {
+      "find": "test",
+      "filter": {
+         "value": 123456
+      }
+   }
+}

--- a/test/data/fle2-explain/with-mongocryptd/collinfo.json
+++ b/test/data/fle2-explain/with-mongocryptd/collinfo.json
@@ -1,0 +1,27 @@
+{
+    "options": {
+        "encryptedFields": {
+            "escCollection": "esc",
+            "eccCollection": "ecc",
+            "ecocCollection": "ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "value",
+                    "bsonType": "int",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": {
+                            "$numberLong": "0"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/test/data/fle2-explain/with-mongocryptd/encrypted-payload.json
+++ b/test/data/fle2-explain/with-mongocryptd/encrypted-payload.json
@@ -1,0 +1,41 @@
+{
+   "explain": {
+      "find": "test",
+      "filter": {
+         "value": {
+            "$binary": {
+               "base64": "BYkAAAAFZAAgAAAAAE8KGPgq7h3n9nH5lfHcia8wtOTLwGkZNLBesb6PULqbBXMAIAAAAACq0558QyD3c3jkR5k0Zc9UpQK8ByhXhtn2d1xVQnuJ3AVjACAAAAAA1003zUWGwD4zVZ0KeihnZOthS3V6CEHUfnJZcIYHefISY20AAAAAAAAAAAAA",
+               "subType": "06"
+            }
+         }
+      },
+      "encryptionInformation": {
+         "type": 1,
+         "schema": {
+            "db.test": {
+               "escCollection": "esc",
+               "eccCollection": "ecc",
+               "ecocCollection": "ecoc",
+               "fields": [
+                  {
+                     "keyId": {
+                        "$binary": {
+                           "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                           "subType": "04"
+                        }
+                     },
+                     "path": "value",
+                     "bsonType": "int",
+                     "queries": {
+                        "queryType": "equality",
+                        "contention": {
+                           "$numberLong": "0"
+                        }
+                     }
+                  }
+               ]
+            }
+         }
+      }
+   }
+}

--- a/test/data/fle2-explain/with-mongocryptd/mongocryptd-reply.json
+++ b/test/data/fle2-explain/with-mongocryptd/mongocryptd-reply.json
@@ -1,0 +1,47 @@
+{
+   "ok": {
+      "$numberInt": "1"
+   },
+   "result": {
+      "explain": {
+         "find": "test",
+         "filter": {
+            "value": {
+               "$binary": {
+                  "base64": "A1gAAAAQdAACAAAAEGEAAgAAAAVraQAQAAAABBI0VngSNJh2EjQSNFZ4kBIFa3UAEAAAAASrze+rEjSYdhI0EjRWeJASEHYAQOIBABJjbQAAAAAAAAAAAAA=",
+                  "subType": "06"
+               }
+            }
+         },
+         "encryptionInformation": {
+            "type": 1,
+            "schema": {
+               "db.test": {
+                  "escCollection": "esc",
+                  "eccCollection": "ecc",
+                  "ecocCollection": "ecoc",
+                  "fields": [
+                     {
+                        "keyId": {
+                           "$binary": {
+                              "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                              "subType": "04"
+                           }
+                        },
+                        "path": "value",
+                        "bsonType": "int",
+                        "queries": {
+                           "queryType": "equality",
+                           "contention": {
+                              "$numberLong": "0"
+                           }
+                        }
+                     }
+                  ]
+               }
+            }
+         }
+      }
+   },
+   "hasEncryptedPlaceholders": true
+}

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -2379,8 +2379,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
 
          ASSERT_OK (mongocrypt_ctx_finalize (ctx, got), ctx);
          ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (
-            TEST_FILE ("./test/data/fle2-explicit/insert-indexed.json"),
-            got);
+            TEST_FILE ("./test/data/fle2-explicit/insert-indexed.json"), got);
          mongocrypt_binary_destroy (got);
       }
 
@@ -2395,10 +2394,10 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
  * Third 16 bytes are IV for 'v' field in FLE2InsertUpdatePayload
  */
 #define RNG_DATA                                                      \
-   "\x00\x00\x00\x00\x00\x00\x00\x00" \
+   "\x00\x00\x00\x00\x00\x00\x00\x00"                                 \
    "\xc7\x43\xd6\x75\x76\x9e\xa7\x88\xd5\xe5\xc4\x40\xdb\x24\x0d\xf9" \
-   "\x4c\xd9\x64\x10\x43\x81\xe6\x61\xfa\x1f\xa0\x5c\x49\x8e\xad\x21" \
-   
+   "\x4c\xd9\x64\x10\x43\x81\xe6\x61\xfa\x1f\xa0\x5c\x49\x8e\xad\x21"
+
       _test_rng_data_source source = {
          .buf = {.data = (uint8_t *) RNG_DATA, .len = sizeof (RNG_DATA) - 1}};
 #undef RNG_DATA
@@ -2443,8 +2442,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
 
          ASSERT_OK (mongocrypt_ctx_finalize (ctx, got), ctx);
          ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (
-            TEST_FILE ("./test/data/fle2-explicit/insert-indexed.json"),
-            got);
+            TEST_FILE ("./test/data/fle2-explicit/insert-indexed.json"), got);
          mongocrypt_binary_destroy (got);
       }
 
@@ -2460,14 +2458,14 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
  */
 #ifdef MONGOCRYPT_LITTLE_ENDIAN
 #define RNG_DATA                                                      \
-   "\x01\x00\x00\x00\x00\x00\x00\x00" \
+   "\x01\x00\x00\x00\x00\x00\x00\x00"                                 \
    "\xc7\x43\xd6\x75\x76\x9e\xa7\x88\xd5\xe5\xc4\x40\xdb\x24\x0d\xf9" \
-   "\x4c\xd9\x64\x10\x43\x81\xe6\x61\xfa\x1f\xa0\x5c\x49\x8e\xad\x21" 
+   "\x4c\xd9\x64\x10\x43\x81\xe6\x61\xfa\x1f\xa0\x5c\x49\x8e\xad\x21"
 #else
 #define RNG_DATA                                                      \
-   "\x00\x00\x00\x00\x00\x00\x00\x01" \
+   "\x00\x00\x00\x00\x00\x00\x00\x01"                                 \
    "\xc7\x43\xd6\x75\x76\x9e\xa7\x88\xd5\xe5\xc4\x40\xdb\x24\x0d\xf9" \
-   "\x4c\xd9\x64\x10\x43\x81\xe6\x61\xfa\x1f\xa0\x5c\x49\x8e\xad\x21" 
+   "\x4c\xd9\x64\x10\x43\x81\xe6\x61\xfa\x1f\xa0\x5c\x49\x8e\xad\x21"
 #endif /* MONGOCRYPT_LITTLE_ENDIAN */
 
       _test_rng_data_source source = {
@@ -2514,7 +2512,8 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
 
          ASSERT_OK (mongocrypt_ctx_finalize (ctx, got), ctx);
          ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (
-            TEST_FILE ("./test/data/fle2-explicit/insert-indexed-contentionFactor1.json"),
+            TEST_FILE ("./test/data/fle2-explicit/"
+                       "insert-indexed-contentionFactor1.json"),
             got);
          mongocrypt_binary_destroy (got);
       }
@@ -2621,8 +2620,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
 
          ASSERT_OK (mongocrypt_ctx_finalize (ctx, got), ctx);
          ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (
-            TEST_FILE ("./test/data/fle2-explicit/find-indexed.json"),
-            got);
+            TEST_FILE ("./test/data/fle2-explicit/find-indexed.json"), got);
          mongocrypt_binary_destroy (got);
       }
 
@@ -2642,8 +2640,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       ASSERT_OK (
          mongocrypt_ctx_setopt_query_type (ctx, MONGOCRYPT_QUERY_TYPE_EQUALITY),
          ctx);
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_contention_factor (ctx, 1), ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_contention_factor (ctx, 1), ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&user_key_id)),
                  ctx);
@@ -3256,8 +3253,9 @@ _test_encrypt_fle2_omits_encryptionInformation (_mongocrypt_tester_t *tester)
                           MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
       {
          ASSERT_OK (mongocrypt_ctx_mongo_feed (
-                       ctx, TEST_BSON ("{'name': 'coll', 'options': "
-                                       "{'encryptedFields': {'fields': []}}}")),
+                       ctx,
+                       TEST_BSON ("{'name': 'coll', 'options': "
+                                  "{'encryptedFields': {'fields': []}}}")),
                     ctx);
          ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
       }
@@ -3309,8 +3307,9 @@ _test_encrypt_fle2_omits_encryptionInformation (_mongocrypt_tester_t *tester)
                           MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
       {
          ASSERT_OK (mongocrypt_ctx_mongo_feed (
-                       ctx, TEST_BSON ("{'name': 'coll', 'options': "
-                                       "{'encryptedFields': {'fields': []}}}")),
+                       ctx,
+                       TEST_BSON ("{'name': 'coll', 'options': "
+                                  "{'encryptedFields': {'fields': []}}}")),
                     ctx);
          ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
       }


### PR DESCRIPTION
# Summary

- Fix handling of the `explain` command for FLE 2.
   - Append "encryptionInformation" in correct location.
   - Strip "encryptionInformation" nested inside `explain`.
- Fix handling of the `explain` command for FLE 1 with `csfle`
  - Use command database name for value of "$db".
  - Append "$db" nested inside `explain`.

Integration tests were run in the C driver locally with both mongocryptd and csfle, and [on Evergreen here](https://spruce.mongodb.com/version/627ff0030ae6067da396c836/changes?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

# Background & Motivation

These are the expectations of "explain" for csfle and mongocryptd found through experimenting.

## FLE1 explain expectations

mongocryptd and csfle expect "jsonSchema" as a sibling of "explain". Example:

```js
{
    "explain": {
        "find": "foo",
        "$db": "db" // Required by csfle. Prohibited by mongocryptd.
    },
    "jsonSchema": { },
    "isRemoteSchema": false,
    "$db": "db" // Appended by driver for mongocryptd. Appended by libmongocrypt for csfle.
}
```

csfle requires a "$db" field be nested in the "explain" document matching the top-level "$db".

Neither csfle or mongocryptd return "jsonSchema" or "$db" in the reply.

## FLE2 explain expectations

mongocryptd expects "encryptionInformation" as a sibling of "explain":

```js
{
    "explain": {
        "find": "foo"
    },
    "encryptionInformation": { "fields": [] },
    "$db": "db" // Appended by driver.
}
```

csfle expects "encryptionInformation" nested in "explain":

```js
{
    "explain": {
        "find": "foo",
        "encryptionInformation": { "fields": [] },
        "$db": "db"
    },
    "$db": "db"
}
```

mongocryptd and csfle return "encryptionInformation" nested in "explain". Neither csfle nor mongocryptd return "$db" in the reply.

csfle requires a "$db" field be nested in the "explain" document matching the top-level "$db".

mongod and mongos expect "encryptionInformation" nested in "explain".

