### PR TITLE
Ensure we handle all enums in a switch and have a default case

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ if (ENABLE_MORE_WARNINGS_AS_ERRORS)
    mongoc_add_platform_compile_options (
       msvc:/W3 msvc:/WX msvc:/wd4996 msvc:/wd4359
       gnu-like:-Wall gnu-like:-Werror
+      gnu-like:-Wswitch-enum gnu-like:-Wswitch-default
       )
 endif ()
 

--- a/kms-message/src/kms_response_parser.c
+++ b/kms-message/src/kms_response_parser.c
@@ -70,6 +70,8 @@ kms_response_parser_wants_bytes (kms_response_parser_t *parser, int32_t max)
       KMS_ASSERT (parser->content_length != -1);
       return parser->content_length -
              ((int) parser->raw_response->len - parser->start);
+   default:
+      KMS_ASSERT (false && "Invalid kms_response_parser HTTP state");
    }
    return -1;
 }
@@ -333,6 +335,8 @@ kms_response_parser_feed (kms_response_parser_t *parser,
       case PARSING_DONE:
          KMS_ERROR (parser, "Unexpected extra HTTP content");
          return false;
+      default:
+         KMS_ASSERT (false && "Invalid kms_response_parser HTTP state");
       }
    }
 
@@ -351,7 +355,7 @@ kms_response_parser_get_response (kms_response_parser_t *parser)
    if (parser->kmip) {
       return kms_kmip_response_parser_get_response (parser->kmip);
    }
-   
+
    response = parser->response;
 
    parser->response = NULL;
@@ -367,12 +371,12 @@ kms_response_parser_status (kms_response_parser_t *parser)
    if (!parser) {
       return 0;
    }
-   
+
    if (parser->kmip) {
       KMS_ERROR (parser, "kms_response_parser_status not applicable to KMIP");
       return 0;
    }
-   
+
    if (!parser->response) {
       return 0;
    }

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -1571,6 +1571,12 @@ _fle2_finalize_explicit (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
    case MONGOCRYPT_INDEX_TYPE_NONE:
       marking.fle2.algorithm = MONGOCRYPT_FLE2_ALGORITHM_UNINDEXED;
       break;
+   default:
+      // This might be unreachable because of other validation. Better safe than
+      // sorry.
+      _mongocrypt_ctx_fail_w_msg (ctx,
+                                  "Invalid value for EncryptOpts.indexType");
+      goto fail;
    }
 
    /* Get iterator to input 'v' BSON value. */

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -1554,6 +1554,11 @@ _fle2_finalize_explicit (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
       switch (ctx->opts.query_type.value) {
       case MONGOCRYPT_QUERY_TYPE_EQUALITY:
          marking.fle2.type = MONGOCRYPT_FLE2_PLACEHOLDER_TYPE_FIND;
+         break;
+      default:
+         _mongocrypt_ctx_fail_w_msg (ctx,
+                                     "Invalid value for EncryptOpts.queryType");
+         goto fail;
       }
    } else {
       marking.fle2.type = MONGOCRYPT_FLE2_PLACEHOLDER_TYPE_INSERT;

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -967,6 +967,7 @@ _mongocrypt_ctx_state_from_key_broker (mongocrypt_ctx_t *ctx)
    /* As currently implemented, we do not expect to ever be in KB_REQUESTING
     * or KB_REQUESTING_ANY state when calling this function. */
    case KB_REQUESTING:
+   default:
       CLIENT_ERR ("key broker in unexpected state");
       new_state = MONGOCRYPT_CTX_ERROR;
       ret = false;

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -425,6 +425,10 @@ mongocrypt_ctx_mongo_op (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
       CHECK_AND_CALL (mongo_op_keys, ctx, out);
    case MONGOCRYPT_CTX_ERROR:
       return false;
+   case MONGOCRYPT_CTX_DONE:
+   case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS:
+   case MONGOCRYPT_CTX_NEED_KMS:
+   case MONGOCRYPT_CTX_READY:
    default:
       return _mongocrypt_ctx_fail_w_msg (ctx, "wrong state");
    }
@@ -467,6 +471,10 @@ mongocrypt_ctx_mongo_feed (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *in)
       CHECK_AND_CALL (mongo_feed_keys, ctx, in);
    case MONGOCRYPT_CTX_ERROR:
       return false;
+   case MONGOCRYPT_CTX_DONE:
+   case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS:
+   case MONGOCRYPT_CTX_NEED_KMS:
+   case MONGOCRYPT_CTX_READY:
    default:
       return _mongocrypt_ctx_fail_w_msg (ctx, "wrong state");
    }
@@ -492,6 +500,10 @@ mongocrypt_ctx_mongo_done (mongocrypt_ctx_t *ctx)
       CHECK_AND_CALL (mongo_done_keys, ctx);
    case MONGOCRYPT_CTX_ERROR:
       return false;
+   case MONGOCRYPT_CTX_DONE:
+   case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS:
+   case MONGOCRYPT_CTX_NEED_KMS:
+   case MONGOCRYPT_CTX_READY:
    default:
       return _mongocrypt_ctx_fail_w_msg (ctx, "wrong state");
    }
@@ -534,6 +546,12 @@ mongocrypt_ctx_next_kms_ctx (mongocrypt_ctx_t *ctx)
       return ctx->vtable.next_kms_ctx (ctx);
    case MONGOCRYPT_CTX_ERROR:
       return NULL;
+   case MONGOCRYPT_CTX_DONE:
+   case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS:
+   case MONGOCRYPT_CTX_NEED_MONGO_COLLINFO:
+   case MONGOCRYPT_CTX_NEED_MONGO_KEYS:
+   case MONGOCRYPT_CTX_NEED_MONGO_MARKINGS:
+   case MONGOCRYPT_CTX_READY:
    default:
       _mongocrypt_ctx_fail_w_msg (ctx, "wrong state");
       return NULL;
@@ -609,6 +627,12 @@ mongocrypt_ctx_kms_done (mongocrypt_ctx_t *ctx)
       return ctx->vtable.kms_done (ctx);
    case MONGOCRYPT_CTX_ERROR:
       return false;
+   case MONGOCRYPT_CTX_DONE:
+   case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS:
+   case MONGOCRYPT_CTX_NEED_MONGO_COLLINFO:
+   case MONGOCRYPT_CTX_NEED_MONGO_KEYS:
+   case MONGOCRYPT_CTX_NEED_MONGO_MARKINGS:
+   case MONGOCRYPT_CTX_READY:
    default:
       return _mongocrypt_ctx_fail_w_msg (ctx, "wrong state");
    }
@@ -638,6 +662,12 @@ mongocrypt_ctx_finalize (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
       return ctx->vtable.finalize (ctx, out);
    case MONGOCRYPT_CTX_ERROR:
       return false;
+   case MONGOCRYPT_CTX_DONE:
+   case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS:
+   case MONGOCRYPT_CTX_NEED_KMS:
+   case MONGOCRYPT_CTX_NEED_MONGO_COLLINFO:
+   case MONGOCRYPT_CTX_NEED_MONGO_KEYS:
+   case MONGOCRYPT_CTX_NEED_MONGO_MARKINGS:
    default:
       return _mongocrypt_ctx_fail_w_msg (ctx, "wrong state");
    }

--- a/src/mongocrypt-log.c
+++ b/src/mongocrypt-log.c
@@ -61,6 +61,9 @@ _mongocrypt_stdout_log_fn (mongocrypt_log_level_t level,
    case MONGOCRYPT_LOG_LEVEL_TRACE:
       printf ("TRACE");
       break;
+   default:
+      printf ("UNKNOWN");
+      break;
    }
    printf (" %s\n", message);
 }

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -776,6 +776,7 @@ _mongocrypt_fle1_marking_to_ciphertext (_mongocrypt_key_broker_t *kb,
                                        &bytes_written,
                                        status);
       break;
+   case MONGOCRYPT_ENCRYPTION_ALGORITHM_NONE:
    default:
       /* Error. */
       CLIENT_ERR ("Unsupported value for encryption algorithm");

--- a/src/mongocrypt-traverse-util.c
+++ b/src/mongocrypt-traverse-util.c
@@ -50,6 +50,8 @@ _check_first_byte (uint8_t byte, traversal_match_t match)
              byte == MC_SUBTYPE_FLE2InsertUpdatePayload;
    case TRAVERSE_MATCH_SUBTYPE6:
       return true;
+   default:
+      break;
    }
    return false;
 }

--- a/test/example-state-machine.c
+++ b/test/example-state-machine.c
@@ -44,6 +44,9 @@ _log_to_stderr (mongocrypt_log_level_t level,
    case MONGOCRYPT_LOG_LEVEL_TRACE:
       fprintf (stderr, "TRACE");
       break;
+   default:
+      fprintf (stderr, "UNKNOWN");
+      break;
    }
    fprintf (stderr, " %s\n", message);
 }
@@ -220,9 +223,6 @@ _run_state_machine (mongocrypt_ctx_t *ctx, bson_t *result)
          bson_free (data);
          CHECK (mongocrypt_ctx_mongo_done (ctx));
          break;
-      case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS:
-         BSON_ASSERT (0);
-         break;
       case MONGOCRYPT_CTX_NEED_KMS:
          while ((kms = mongocrypt_ctx_next_kms_ctx (ctx))) {
             output = mongocrypt_binary_new ();
@@ -260,6 +260,12 @@ _run_state_machine (mongocrypt_ctx_t *ctx, bson_t *result)
          mongocrypt_ctx_status (ctx, status);
          printf ("\ngot error: %s\n", mongocrypt_status_message (status, NULL));
          abort ();
+         break;
+      case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS:
+         // We don't handle KMS credentials
+         // fallthrough
+      default:
+         BSON_ASSERT (0);
          break;
       }
    }

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -378,6 +378,8 @@ _mongocrypt_tester_run_ctx_to (_mongocrypt_tester_t *tester,
          ASSERT_STATE_EQUAL (state, stop_state);
          mongocrypt_status_destroy (status);
          return;
+      default:
+         BSON_UNREACHABLE ("Invalid state");
       }
       state = mongocrypt_ctx_state (ctx);
    }

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -379,7 +379,7 @@ _mongocrypt_tester_run_ctx_to (_mongocrypt_tester_t *tester,
          mongocrypt_status_destroy (status);
          return;
       default:
-         BSON_UNREACHABLE ("Invalid state");
+         BSON_ASSERT (false && "Invalid state");
       }
       state = mongocrypt_ctx_state (ctx);
    }


### PR DESCRIPTION
Fixes MONGOCRYPT-430

A bogus value for `queryType` would break invariants of the encryption context. Instead, catch that early and return an error.