### PR TITLE
fix(NODE-4254): allow csfle to be dynamically required

### DIFF
--- a/bindings/node/.evergreen/test.sh
+++ b/bindings/node/.evergreen/test.sh
@@ -5,6 +5,9 @@ set -o errexit  # Exit the script with error if any of the commands fail
 echo "Setting up environment"
 . ./.evergreen/setup_environment.sh
 
+# Handle the circular dependency when testing with a real client.
+export MONGODB_CLIENT_ENCRYPTION_OVERRIDE="$(pwd)"
+
 # install node dependencies
 echo "Installing package dependencies (includes a static build)"
 . ./etc/build-static.sh

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -52,7 +52,6 @@
     "jsdoc-to-markdown": "^7.1.1",
     "mocha": "^9.2.0",
     "mongodb": "^4.3.1",
-    "mongodb-client-encryption": "file:.",
     "node-gyp": "^8.4.1",
     "prebuild": "^11.0.2",
     "prettier": "^2.5.1",


### PR DESCRIPTION
Sets the `MONGODB_CLIENT_ENCRYPTION_OVERRIDE` env var when running the Node checks so we don't need to specify it as a dev dependency.