### PR TITLE
MONGOCRYPT-431 Preserve $db

### DIFF
--- a/test/data/dollardb/omitted/cmd-to-mongocryptd.json
+++ b/test/data/dollardb/omitted/cmd-to-mongocryptd.json
@@ -1,0 +1,34 @@
+{
+    "find": "test",
+    "filter": {
+        "value": 123456
+    },
+    "encryptionInformation": {
+        "type": 1,
+        "schema": {
+            "db.test": {
+                "escCollection": "esc",
+                "eccCollection": "ecc",
+                "ecocCollection": "ecoc",
+                "fields": [
+                    {
+                        "keyId": {
+                            "$binary": {
+                                "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                                "subType": "04"
+                            }
+                        },
+                        "path": "value",
+                        "bsonType": "int",
+                        "queries": {
+                            "queryType": "equality",
+                            "contention": {
+                                "$numberLong": "0"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/test/data/dollardb/omitted/cmd.json
+++ b/test/data/dollardb/omitted/cmd.json
@@ -1,0 +1,6 @@
+{
+   "find": "test",
+   "filter": {
+      "value": 123456
+   }
+}

--- a/test/data/dollardb/omitted/collinfo.json
+++ b/test/data/dollardb/omitted/collinfo.json
@@ -1,0 +1,27 @@
+{
+    "options": {
+        "encryptedFields": {
+            "escCollection": "esc",
+            "eccCollection": "ecc",
+            "ecocCollection": "ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "value",
+                    "bsonType": "int",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": {
+                            "$numberLong": "0"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/test/data/dollardb/omitted/encrypted-payload.json
+++ b/test/data/dollardb/omitted/encrypted-payload.json
@@ -1,0 +1,39 @@
+{
+   "find": "test",
+   "filter": {
+      "value": {
+         "$binary": {
+            "base64": "BYkAAAAFZAAgAAAAAE8KGPgq7h3n9nH5lfHcia8wtOTLwGkZNLBesb6PULqbBXMAIAAAAACq0558QyD3c3jkR5k0Zc9UpQK8ByhXhtn2d1xVQnuJ3AVjACAAAAAA1003zUWGwD4zVZ0KeihnZOthS3V6CEHUfnJZcIYHefISY20AAAAAAAAAAAAA",
+            "subType": "06"
+         }
+      }
+   },
+   "encryptionInformation": {
+      "type": 1,
+      "schema": {
+         "db.test": {
+            "escCollection": "esc",
+            "eccCollection": "ecc",
+            "ecocCollection": "ecoc",
+            "fields": [
+               {
+                  "keyId": {
+                     "$binary": {
+                        "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                        "subType": "04"
+                     }
+                  },
+                  "path": "value",
+                  "bsonType": "int",
+                  "queries": {
+                     "queryType": "equality",
+                     "contention": {
+                        "$numberLong": "0"
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   }
+}

--- a/test/data/dollardb/omitted/mongocryptd-reply.json
+++ b/test/data/dollardb/omitted/mongocryptd-reply.json
@@ -1,0 +1,45 @@
+{
+   "ok": {
+      "$numberInt": "1"
+   },
+   "result": {
+      "find": "test",
+      "filter": {
+         "value": {
+            "$binary": {
+               "base64": "A1gAAAAQdAACAAAAEGEAAgAAAAVraQAQAAAABBI0VngSNJh2EjQSNFZ4kBIFa3UAEAAAAASrze+rEjSYdhI0EjRWeJASEHYAQOIBABJjbQAAAAAAAAAAAAA=",
+               "subType": "06"
+            }
+         }
+      },
+      "encryptionInformation": {
+         "type": 1,
+         "schema": {
+            "db.test": {
+               "escCollection": "esc",
+               "eccCollection": "ecc",
+               "ecocCollection": "ecoc",
+               "fields": [
+                  {
+                     "keyId": {
+                        "$binary": {
+                           "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                           "subType": "04"
+                        }
+                     },
+                     "path": "value",
+                     "bsonType": "int",
+                     "queries": {
+                        "queryType": "equality",
+                        "contention": {
+                           "$numberLong": "0"
+                        }
+                     }
+                  }
+               ]
+            }
+         }
+      }
+   },
+   "hasEncryptedPlaceholders": true
+}

--- a/test/data/dollardb/preserved/cmd-to-mongocryptd.json
+++ b/test/data/dollardb/preserved/cmd-to-mongocryptd.json
@@ -1,0 +1,34 @@
+{
+    "find": "test",
+    "filter": {
+        "value": 123456
+    },
+    "encryptionInformation": {
+        "type": 1,
+        "schema": {
+            "db.test": {
+                "escCollection": "esc",
+                "eccCollection": "ecc",
+                "ecocCollection": "ecoc",
+                "fields": [
+                    {
+                        "keyId": {
+                            "$binary": {
+                                "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                                "subType": "04"
+                            }
+                        },
+                        "path": "value",
+                        "bsonType": "int",
+                        "queries": {
+                            "queryType": "equality",
+                            "contention": {
+                                "$numberLong": "0"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/test/data/dollardb/preserved/cmd.json
+++ b/test/data/dollardb/preserved/cmd.json
@@ -1,0 +1,7 @@
+{
+   "find": "test",
+   "filter": {
+      "value": 123456
+   },
+   "$db": "db"
+}

--- a/test/data/dollardb/preserved/collinfo.json
+++ b/test/data/dollardb/preserved/collinfo.json
@@ -1,0 +1,27 @@
+{
+    "options": {
+        "encryptedFields": {
+            "escCollection": "esc",
+            "eccCollection": "ecc",
+            "ecocCollection": "ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "value",
+                    "bsonType": "int",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": {
+                            "$numberLong": "0"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/test/data/dollardb/preserved/encrypted-payload.json
+++ b/test/data/dollardb/preserved/encrypted-payload.json
@@ -1,0 +1,40 @@
+{
+   "find": "test",
+   "filter": {
+      "value": {
+         "$binary": {
+            "base64": "BYkAAAAFZAAgAAAAAE8KGPgq7h3n9nH5lfHcia8wtOTLwGkZNLBesb6PULqbBXMAIAAAAACq0558QyD3c3jkR5k0Zc9UpQK8ByhXhtn2d1xVQnuJ3AVjACAAAAAA1003zUWGwD4zVZ0KeihnZOthS3V6CEHUfnJZcIYHefISY20AAAAAAAAAAAAA",
+            "subType": "06"
+         }
+      }
+   },
+   "encryptionInformation": {
+      "type": 1,
+      "schema": {
+         "db.test": {
+            "escCollection": "esc",
+            "eccCollection": "ecc",
+            "ecocCollection": "ecoc",
+            "fields": [
+               {
+                  "keyId": {
+                     "$binary": {
+                        "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                        "subType": "04"
+                     }
+                  },
+                  "path": "value",
+                  "bsonType": "int",
+                  "queries": {
+                     "queryType": "equality",
+                     "contention": {
+                        "$numberLong": "0"
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   },
+   "$db": "db"
+}

--- a/test/data/dollardb/preserved/mongocryptd-reply.json
+++ b/test/data/dollardb/preserved/mongocryptd-reply.json
@@ -1,0 +1,45 @@
+{
+   "ok": {
+      "$numberInt": "1"
+   },
+   "result": {
+      "find": "test",
+      "filter": {
+         "value": {
+            "$binary": {
+               "base64": "A1gAAAAQdAACAAAAEGEAAgAAAAVraQAQAAAABBI0VngSNJh2EjQSNFZ4kBIFa3UAEAAAAASrze+rEjSYdhI0EjRWeJASEHYAQOIBABJjbQAAAAAAAAAAAAA=",
+               "subType": "06"
+            }
+         }
+      },
+      "encryptionInformation": {
+         "type": 1,
+         "schema": {
+            "db.test": {
+               "escCollection": "esc",
+               "eccCollection": "ecc",
+               "ecocCollection": "ecoc",
+               "fields": [
+                  {
+                     "keyId": {
+                        "$binary": {
+                           "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                           "subType": "04"
+                        }
+                     },
+                     "path": "value",
+                     "bsonType": "int",
+                     "queries": {
+                        "queryType": "equality",
+                        "contention": {
+                           "$numberLong": "0"
+                        }
+                     }
+                  }
+               ]
+            }
+         }
+      }
+   },
+   "hasEncryptedPlaceholders": true
+}

--- a/test/data/dollardb/preserved_empty/cmd-to-mongocryptd.json
+++ b/test/data/dollardb/preserved_empty/cmd-to-mongocryptd.json
@@ -1,0 +1,17 @@
+{
+    "find": "test",
+    "filter": {
+        "value": 123456
+    },
+    "encryptionInformation": {
+        "type": 1,
+        "schema": {
+            "db.test": {
+                "escCollection": "esc",
+                "eccCollection": "ecc",
+                "ecocCollection": "ecoc",
+                "fields": []
+            }
+        }
+    }
+}

--- a/test/data/dollardb/preserved_empty/cmd.json
+++ b/test/data/dollardb/preserved_empty/cmd.json
@@ -1,0 +1,7 @@
+{
+   "find": "test",
+   "filter": {
+      "value": 123456
+   },
+   "$db": "db"
+}

--- a/test/data/dollardb/preserved_empty/collinfo.json
+++ b/test/data/dollardb/preserved_empty/collinfo.json
@@ -1,0 +1,10 @@
+{
+    "options": {
+        "encryptedFields": {
+            "escCollection": "esc",
+            "eccCollection": "ecc",
+            "ecocCollection": "ecoc",
+            "fields": []
+        }
+    }
+}

--- a/test/data/dollardb/preserved_empty/encrypted-payload.json
+++ b/test/data/dollardb/preserved_empty/encrypted-payload.json
@@ -1,0 +1,7 @@
+{
+   "find": "test",
+   "filter": {
+      "value": 123456
+   },
+   "$db": "db"
+}

--- a/test/data/dollardb/preserved_empty/mongocryptd-reply.json
+++ b/test/data/dollardb/preserved_empty/mongocryptd-reply.json
@@ -1,0 +1,23 @@
+{
+   "ok": {
+      "$numberInt": "1"
+   },
+   "result": {
+      "find": "test",
+      "filter": {
+         "value": 123456
+      },
+      "encryptionInformation": {
+         "type": 1,
+         "schema": {
+            "db.test": {
+               "escCollection": "esc",
+               "eccCollection": "ecc",
+               "ecocCollection": "ecoc",
+               "fields": []
+            }
+         }
+      }
+   },
+   "hasEncryptedPlaceholders": false
+}

--- a/test/data/dollardb/preserved_fle1/cmd-to-mongocryptd.json
+++ b/test/data/dollardb/preserved_fle1/cmd-to-mongocryptd.json
@@ -1,0 +1,26 @@
+{
+    "find": "test",
+    "filter": {
+        "value": 123456
+    },
+    "jsonSchema": {
+        "properties": {
+            "value": {
+                "encrypt": {
+                    "keyId": [
+                        {
+                            "$binary": {
+                                "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                                "subType": "04"
+                            }
+                        }
+                    ],
+                    "bsonType": "int",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                }
+            }
+        },
+        "bsonType": "object"
+    },
+    "isRemoteSchema": true
+}

--- a/test/data/dollardb/preserved_fle1/cmd.json
+++ b/test/data/dollardb/preserved_fle1/cmd.json
@@ -1,0 +1,7 @@
+{
+   "find": "test",
+   "filter": {
+      "value": 123456
+   },
+   "$db": "db"
+}

--- a/test/data/dollardb/preserved_fle1/collinfo.json
+++ b/test/data/dollardb/preserved_fle1/collinfo.json
@@ -1,0 +1,25 @@
+{
+    "options": {
+        "validator": {
+            "$jsonSchema": {
+                "properties": {
+                    "value": {
+                        "encrypt": {
+                            "keyId": [
+                                {
+                                    "$binary": {
+                                        "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                                        "subType": "04"
+                                    }
+                                }
+                            ],
+                            "bsonType": "int",
+                            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                        }
+                    }
+                },
+                "bsonType": "object"
+            }
+        }
+    }
+}

--- a/test/data/dollardb/preserved_fle1/encrypted-payload.json
+++ b/test/data/dollardb/preserved_fle1/encrypted-payload.json
@@ -1,0 +1,14 @@
+{
+   "find": "test",
+   "filter": {
+      "value": {
+         "$eq": {
+            "$binary": {
+               "base64": "ARI0VngSNJh2EjQSNFZ4kBIQl2bQhMRGH/FbUJH1jGuUSHGQS6UYOSv5kqZrzd4hKx1erD8rDjS/c50CQ6nQb1S2WKlgWL3SeoyT23g//BNWfA==",
+               "subType": "06"
+            }
+         }
+      }
+   },
+   "$db": "db"
+}

--- a/test/data/dollardb/preserved_fle1/mongocryptd-reply.json
+++ b/test/data/dollardb/preserved_fle1/mongocryptd-reply.json
@@ -1,0 +1,15 @@
+{
+    "hasEncryptionPlaceholders": true,
+    "schemaRequiresEncryption": true,
+    "result": {
+        "find": "test",
+        "filter": {
+            "value": {
+                "$eq": {
+                    "$binary": "ACwAAAAQYQABAAAABWtpABAAAAAEEjRWeBI0mHYSNBI0VniQEhB2AEDiAQAA",
+                    "$type": "06"
+                }
+            }
+        }
+    }
+}

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -3609,6 +3609,295 @@ _test_encrypt_fle1_explain_with_csfle (_mongocrypt_tester_t *tester)
    }
 }
 
+// Test that an input command with $db preserves $db in the output.
+static void
+_test_dollardb_preserved (_mongocrypt_tester_t *tester)
+{
+   /* Test with an encrypted value. */
+
+   mongocrypt_t *crypt =
+      _mongocrypt_tester_mongocrypt (TESTER_MONGOCRYPT_DEFAULT);
+   mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
+
+   ASSERT_OK (
+      mongocrypt_ctx_encrypt_init (
+         ctx, "db", -1, TEST_FILE ("./test/data/dollardb/preserved/cmd.json")),
+      ctx);
+
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
+                       MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+   {
+      ASSERT_OK (
+         mongocrypt_ctx_mongo_feed (
+            ctx, TEST_FILE ("./test/data/dollardb/preserved/collinfo.json")),
+         ctx);
+      ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
+   }
+
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
+                       MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+   {
+      mongocrypt_binary_t *cmd_to_mongocryptd = mongocrypt_binary_new ();
+
+      ASSERT_OK (mongocrypt_ctx_mongo_op (ctx, cmd_to_mongocryptd), ctx);
+      ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (
+         TEST_FILE ("./test/data/dollardb/preserved/"
+                    "cmd-to-mongocryptd.json"),
+         cmd_to_mongocryptd);
+      mongocrypt_binary_destroy (cmd_to_mongocryptd);
+
+      ASSERT_OK (
+         mongocrypt_ctx_mongo_feed (ctx,
+                                    TEST_FILE ("./test/data/dollardb/preserved/"
+                                               "mongocryptd-reply.json")),
+         ctx);
+      ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
+   }
+
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
+                       MONGOCRYPT_CTX_NEED_MONGO_KEYS);
+   {
+      ASSERT_OK (
+         mongocrypt_ctx_mongo_feed (
+            ctx,
+            TEST_FILE ("./test/data/keys/"
+                       "ABCDEFAB123498761234123456789012-local-document.json")),
+         ctx);
+      ASSERT_OK (
+         mongocrypt_ctx_mongo_feed (
+            ctx,
+            TEST_FILE ("./test/data/keys/"
+                       "12345678123498761234123456789012-local-document.json")),
+         ctx);
+      ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
+   }
+
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_READY);
+   {
+      mongocrypt_binary_t *out = mongocrypt_binary_new ();
+      ASSERT_OK (mongocrypt_ctx_finalize (ctx, out), ctx);
+      ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (
+         TEST_FILE ("./test/data/dollardb/preserved/"
+                    "encrypted-payload.json"),
+         out);
+      mongocrypt_binary_destroy (out);
+   }
+
+   mongocrypt_ctx_destroy (ctx);
+   mongocrypt_destroy (crypt);
+}
+
+// Test that an input command with $db preserves $db in the output, when no
+// values are encrypted.
+static void
+_test_dollardb_preserved_empty (_mongocrypt_tester_t *tester)
+{
+   mongocrypt_t *crypt =
+      _mongocrypt_tester_mongocrypt (TESTER_MONGOCRYPT_DEFAULT);
+   mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
+
+   ASSERT_OK (mongocrypt_ctx_encrypt_init (
+                 ctx,
+                 "db",
+                 -1,
+                 TEST_FILE ("./test/data/dollardb/preserved_empty/cmd.json")),
+              ctx);
+
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
+                       MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+   {
+      ASSERT_OK (
+         mongocrypt_ctx_mongo_feed (
+            ctx,
+            TEST_FILE ("./test/data/dollardb/preserved_empty/collinfo.json")),
+         ctx);
+      ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
+   }
+
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
+                       MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+   {
+      mongocrypt_binary_t *cmd_to_mongocryptd = mongocrypt_binary_new ();
+
+      ASSERT_OK (mongocrypt_ctx_mongo_op (ctx, cmd_to_mongocryptd), ctx);
+      ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (
+         TEST_FILE ("./test/data/dollardb/preserved_empty/"
+                    "cmd-to-mongocryptd.json"),
+         cmd_to_mongocryptd);
+      mongocrypt_binary_destroy (cmd_to_mongocryptd);
+
+      ASSERT_OK (mongocrypt_ctx_mongo_feed (
+                    ctx,
+                    TEST_FILE ("./test/data/dollardb/preserved_empty/"
+                               "mongocryptd-reply.json")),
+                 ctx);
+      ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
+   }
+
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_READY);
+   {
+      mongocrypt_binary_t *out = mongocrypt_binary_new ();
+      ASSERT_OK (mongocrypt_ctx_finalize (ctx, out), ctx);
+      ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (
+         TEST_FILE ("./test/data/dollardb/preserved_empty/"
+                    "encrypted-payload.json"),
+         out);
+      mongocrypt_binary_destroy (out);
+   }
+
+   mongocrypt_ctx_destroy (ctx);
+   mongocrypt_destroy (crypt);
+}
+
+// Test that an input command with no $db does not include $db in the output.
+static void
+_test_dollardb_omitted (_mongocrypt_tester_t *tester)
+{
+   mongocrypt_t *crypt =
+      _mongocrypt_tester_mongocrypt (TESTER_MONGOCRYPT_DEFAULT);
+   mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
+
+   ASSERT_OK (
+      mongocrypt_ctx_encrypt_init (
+         ctx, "db", -1, TEST_FILE ("./test/data/dollardb/omitted/cmd.json")),
+      ctx);
+
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
+                       MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+   {
+      ASSERT_OK (
+         mongocrypt_ctx_mongo_feed (
+            ctx, TEST_FILE ("./test/data/dollardb/omitted/collinfo.json")),
+         ctx);
+      ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
+   }
+
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
+                       MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+   {
+      mongocrypt_binary_t *cmd_to_mongocryptd = mongocrypt_binary_new ();
+
+      ASSERT_OK (mongocrypt_ctx_mongo_op (ctx, cmd_to_mongocryptd), ctx);
+      ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (
+         TEST_FILE ("./test/data/dollardb/omitted/"
+                    "cmd-to-mongocryptd.json"),
+         cmd_to_mongocryptd);
+      mongocrypt_binary_destroy (cmd_to_mongocryptd);
+
+      ASSERT_OK (
+         mongocrypt_ctx_mongo_feed (ctx,
+                                    TEST_FILE ("./test/data/dollardb/omitted/"
+                                               "mongocryptd-reply.json")),
+         ctx);
+      ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
+   }
+
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
+                       MONGOCRYPT_CTX_NEED_MONGO_KEYS);
+   {
+      ASSERT_OK (
+         mongocrypt_ctx_mongo_feed (
+            ctx,
+            TEST_FILE ("./test/data/keys/"
+                       "ABCDEFAB123498761234123456789012-local-document.json")),
+         ctx);
+      ASSERT_OK (
+         mongocrypt_ctx_mongo_feed (
+            ctx,
+            TEST_FILE ("./test/data/keys/"
+                       "12345678123498761234123456789012-local-document.json")),
+         ctx);
+      ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
+   }
+
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_READY);
+   {
+      mongocrypt_binary_t *out = mongocrypt_binary_new ();
+      ASSERT_OK (mongocrypt_ctx_finalize (ctx, out), ctx);
+      ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (
+         TEST_FILE ("./test/data/dollardb/omitted/"
+                    "encrypted-payload.json"),
+         out);
+      mongocrypt_binary_destroy (out);
+   }
+
+   mongocrypt_ctx_destroy (ctx);
+   mongocrypt_destroy (crypt);
+}
+
+// Test that an input command with $db does includes $db in the output for FLE1.
+static void
+_test_dollardb_preserved_fle1 (_mongocrypt_tester_t *tester)
+{
+   mongocrypt_t *crypt =
+      _mongocrypt_tester_mongocrypt (TESTER_MONGOCRYPT_DEFAULT);
+   mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
+
+   ASSERT_OK (mongocrypt_ctx_encrypt_init (
+                 ctx,
+                 "db",
+                 -1,
+                 TEST_FILE ("./test/data/dollardb/preserved_fle1/cmd.json")),
+              ctx);
+
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
+                       MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+   {
+      ASSERT_OK (
+         mongocrypt_ctx_mongo_feed (
+            ctx,
+            TEST_FILE ("./test/data/dollardb/preserved_fle1/collinfo.json")),
+         ctx);
+      ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
+   }
+
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
+                       MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+   {
+      mongocrypt_binary_t *cmd_to_mongocryptd = mongocrypt_binary_new ();
+
+      ASSERT_OK (mongocrypt_ctx_mongo_op (ctx, cmd_to_mongocryptd), ctx);
+      ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (
+         TEST_FILE ("./test/data/dollardb/preserved_fle1/"
+                    "cmd-to-mongocryptd.json"),
+         cmd_to_mongocryptd);
+      mongocrypt_binary_destroy (cmd_to_mongocryptd);
+
+      ASSERT_OK (mongocrypt_ctx_mongo_feed (
+                    ctx,
+                    TEST_FILE ("./test/data/dollardb/preserved_fle1/"
+                               "mongocryptd-reply.json")),
+                 ctx);
+      ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
+   }
+
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
+                       MONGOCRYPT_CTX_NEED_MONGO_KEYS);
+   {
+      ASSERT_OK (
+         mongocrypt_ctx_mongo_feed (
+            ctx,
+            TEST_FILE ("./test/data/keys/"
+                       "12345678123498761234123456789012-local-document.json")),
+         ctx);
+      ASSERT_OK (mongocrypt_ctx_mongo_done (ctx), ctx);
+   }
+
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_READY);
+   {
+      mongocrypt_binary_t *out = mongocrypt_binary_new ();
+      ASSERT_OK (mongocrypt_ctx_finalize (ctx, out), ctx);
+      ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (
+         TEST_FILE ("./test/data/dollardb/preserved_fle1/"
+                    "encrypted-payload.json"),
+         out);
+      mongocrypt_binary_destroy (out);
+   }
+
+   mongocrypt_ctx_destroy (ctx);
+   mongocrypt_destroy (crypt);
+}
+
 void
 _mongocrypt_tester_install_ctx_encrypt (_mongocrypt_tester_t *tester)
 {
@@ -3656,4 +3945,8 @@ _mongocrypt_tester_install_ctx_encrypt (_mongocrypt_tester_t *tester)
    INSTALL_TEST (_test_encrypt_fle2_explain_with_csfle);
    INSTALL_TEST (_test_encrypt_fle1_explain_with_mongocryptd);
    INSTALL_TEST (_test_encrypt_fle1_explain_with_csfle);
+   INSTALL_TEST (_test_dollardb_preserved);
+   INSTALL_TEST (_test_dollardb_preserved_empty);
+   INSTALL_TEST (_test_dollardb_omitted);
+   INSTALL_TEST (_test_dollardb_preserved_fle1);
 }

--- a/test/test-mongocrypt.h
+++ b/test/test-mongocrypt.h
@@ -41,9 +41,9 @@ typedef enum tester_mongocrypt_flags {
    TESTER_MONGOCRYPT_WITH_CSFLE_LIB = 1 << 0,
 } tester_mongocrypt_flags;
 
-/* Arbitrary max of 1024 instances of temporary test data. Increase as needed.
+/* Arbitrary max of 2048 instances of temporary test data. Increase as needed.
  */
-#define TEST_DATA_COUNT 1024
+#define TEST_DATA_COUNT 2048
 typedef struct __mongocrypt_tester_t {
    int test_count;
    char *test_names[TEST_DATA_COUNT];


### PR DESCRIPTION
# Summary

- If $db is included in the input command, preserve it in the output command.
- If $db is not included in the input command, do not add it to the output command.
- Always omit the $db to the command for mongocryptd.

# Background & Motivation

C# expects $db to be on the command after encryption. This was done by [injecting $db into the response from mongocryptd](https://github.com/mongodb/mongo-csharp-driver/blob/master/src/MongoDB.Driver/Encryption/AutoEncryptionLibMongoController.cs#L268-L278). That is no longer possible when using the `csfle` shared library. The `MONGOCRYPT_CTX_NEED_MONGO_MARKINGS` state is not entered for `csfle`.

Other drivers append $db to the command after encryption. See [Do drivers append $db before or after encryption](https://docs.google.com/spreadsheets/d/18O6cfAQKC3OIUMW4_prWnpaLBMDh-lmv1F1RNUn0Sa0/edit#gid=0).
