### PR TITLE
MONGOCRYPT-316 bypass hello, buildInfo, getCmdLineOpts, and getLog

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -2192,6 +2192,14 @@ _check_cmd_for_auto_encrypt (mongocrypt_binary_t *cmd,
       *bypass = true;
    } else if (0 == strcmp (cmd_name, "compactStructuredEncryptionData")) {
       eligible = true;
+   } else if (0 == strcmp (cmd_name, "hello")) {
+      *bypass = true;
+   } else if (0 == strcmp (cmd_name, "buildInfo")) {
+      *bypass = true;
+   } else if (0 == strcmp (cmd_name, "getCmdLineOpts")) {
+      *bypass = true;
+   } else if (0 == strcmp (cmd_name, "getLog")) {
+      *bypass = true;
    }
 
    /* database/client commands are ineligible. */

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1237,6 +1237,10 @@ _test_encrypt_init_each_cmd (_mongocrypt_tester_t *tester)
    _init_bypass (tester, "{'killAllSessionsByPattern': 1}");
    _init_bypass (tester, "{'refreshSessions': 1}");
    _init_ok (tester, "{'compactStructuredEncryptionData': 'coll'}");
+   _init_bypass (tester, "{'hello': 1}");
+   _init_bypass (tester, "{'buildInfo': 1}");
+   _init_bypass (tester, "{'getCmdLineOpts': 1}");
+   _init_bypass (tester, "{'getLog': 1}");
 }
 
 


### PR DESCRIPTION
# Summary

Resolves MONGOCRYPT-316 and MONGOCRYPT-308.

- Bypass auto encryption for the commands: `hello`, `buildInfo`, `getCmdLineOpts` and `getLog`.

# Background & Motivation

`mongocrypt_ctx_encrypt_init` uses an allow-list to determine how to handle commands in automatic encryption.
- Commands expected to contain no sensitive information may be bypassed. Bypassed commands are sent as-is.
- Eligible commands are sent to query analysis.
- Commands not listed result in an error.