### PR TITLE
fix(NODE-4279): handle decrypted nested documents well with devtools decoration

### DIFF
--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -365,6 +365,9 @@ function decorateDecryptionResult(decrypted, original, bson, isTopLevelDecorateC
         });
       }
       decrypted[decryptedKeys].push(k);
+      // Do not recurse into this decrypted value. It could be a subdocument/array,
+      // in which case there is no original value associated with its subfields.
+      continue;
     }
 
     decorateDecryptionResult(decrypted[k], originalValue, bson, false);

--- a/bindings/node/test/data/encrypted-document-nested.json
+++ b/bindings/node/test/data/encrypted-document-nested.json
@@ -1,0 +1,8 @@
+{
+  "nested": {
+    "$binary": {
+        "base64": "AmFhYWFhYWFhYWFhYWFhYWEDW89+etsVGIufAfsiEwR62ce6+lry79sJJBUyJ6hH89wBkhpRkzFLz26Nu6jXQRe8ESYAF5cAa5wg9rsq95IBHuaIaLEQLW2jLjGo1fp69jg=",
+        "subType": "06"
+    }
+  }
+}


### PR DESCRIPTION
Handle cases in which the decrypted values are documents/arrays
in the devtools-specific decrypted-reponse marking.

This was previously untested because it’s quite a bit of effort
to generate new mock data (like the one added in this commit)
for the current test setup, but obviously that was a mistake.