### PR TITLE
fix: add missing import in Node.js bindings TS definitions

### DIFF
--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -1,4 +1,4 @@
-import type { Binary } from 'bson';
+import type { Document, Binary } from 'bson';
 import type { MongoClient, BulkWriteResult, ClientSession } from 'mongodb';
 
 export type ClientEncryptionDataKeyProvider = 'aws' | 'azure' | 'gcp' | 'local' | 'kmip';


### PR DESCRIPTION
Otherwise this was picking up `Document` from the HTML spec (if that was enabled in the relevant TS config).