### PR TITLE
MONGOCRYPT-435 do not run ismaster check if bypassing query analysis

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -2304,11 +2304,12 @@ static bool
 needs_ismaster_check (mongocrypt_ctx_t *ctx)
 {
    _mongocrypt_ctx_encrypt_t *ectx = (_mongocrypt_ctx_encrypt_t *) ctx;
+   bool using_mongocryptd =
+      !ectx->bypass_query_analysis && !ctx->crypt->csfle.okay;
    // The "create" and "createIndexes" command require an isMaster check when
    // using mongocryptd. See MONGOCRYPT-429.
-   return !ctx->crypt->csfle.okay &&
-          (0 == strcmp (ectx->cmd_name, "create") ||
-           0 == strcmp (ectx->cmd_name, "createIndexes"));
+   return using_mongocryptd && (0 == strcmp (ectx->cmd_name, "create") ||
+                                0 == strcmp (ectx->cmd_name, "createIndexes"));
 }
 
 bool

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -4211,7 +4211,7 @@ _test_fle2_create (_mongocrypt_tester_t *tester)
    mongocrypt_destroy (crypt);
 }
 
-/* Regression test for MONGOCRYPT-??? */
+/* Regression test for MONGOCRYPT-435 */
 static void
 _test_fle2_create_bypass_query_analysis (_mongocrypt_tester_t *tester)
 {


### PR DESCRIPTION
# Summary

- Do not run ismaster check of mongocryptd if bypassing query analysis

# Background & Motivation

MONGOCRYPT-429 added logic to run an `isMaster` command on mongocryptd when automatically encrypting the `create` and `createIndexes` command. The `create` and `createIndexes` commands are only supported on mongocryptd >= 6.0.0-rc5. The `isMaster` check is used to determine if mongocryptd supports `create` and `createIndexes`.

If query analysis is bypassed is set, a context expected not to enter the `MONGOCRYPT_CTX_NEED_MONGO_MARKINGS` state.

This change is validated with a C driver specification test here: https://github.com/mongodb/mongo-c-driver/pull/1023