### PR TITLE
PYTHON-3287 Reenable shared library testing

### DIFF
--- a/bindings/python/.evergreen/test.sh
+++ b/bindings/python/.evergreen/test.sh
@@ -23,7 +23,7 @@ if [ "Windows_NT" = "$OS" ]; then # Magic variable in cygwin
              "C:/python/Python38/python.exe"
              "C:/python/Python39/python.exe"
              "C:/python/Python310/python.exe")
-    export CSFLE_PATH=../crypt_shared/bin/mongo_crypt_v1.dll
+    export CRYPT_SHARED_PATH=../crypt_shared/bin/mongo_crypt_v1.dll
     C:/python/Python310/python.exe drivers-evergreen-tools/.evergreen/mongodl.py --component crypt_shared \
       --version latest --out ../crypt_shared/
 elif [ "Darwin" = "$(uname -s)" ]; then
@@ -38,7 +38,7 @@ elif [ "Darwin" = "$(uname -s)" ]; then
              "/Library/Frameworks/Python.framework/Versions/3.8/bin/python3"
              "/Library/Frameworks/Python.framework/Versions/3.9/bin/python3"
              "/Library/Frameworks/Python.framework/Versions/3.10/bin/python3")
-    export CSFLE_PATH="../crypt_shared/lib/mongo_crypt_v1.dylib"
+    export CRYPT_SHARED_PATH="../crypt_shared/lib/mongo_crypt_v1.dylib"
     python3 drivers-evergreen-tools/.evergreen/mongodl.py --component crypt_shared \
       --version latest --out ../crypt_shared/
 else
@@ -49,7 +49,7 @@ else
              "/opt/python/3.6/bin/python3"
              "/opt/python/pypy/bin/pypy"
              "/opt/python/pypy3.6/bin/pypy3")
-    export CSFLE_PATH="../crypt_shared/lib/mongo_crypt_v1.so"
+    export CRYPT_SHARED_PATH="../crypt_shared/lib/mongo_crypt_v1.so"
     /opt/mongodbtoolchain/v3/bin/python3 drivers-evergreen-tools/.evergreen/mongodl.py --component \
       crypt_shared --version latest --out ../crypt_shared/ --target rhel70
 fi
@@ -62,9 +62,9 @@ for PYTHON_BINARY in "${PYTHONS[@]}"; do
     python -m pip install --prefer-binary -r test-requirements.txt
     python setup.py test
     echo "Running tests with CSFLE on dynamic library path..."
-    DYLD_FALLBACK_LIBRARY_PATH=../csfle/lib/:$DYLD_FALLBACK_LIBRARY_PATH \
-      LD_LIBRARY_PATH=../csfle/lib:$LD_LIBRARY_PATH \
-      PATH=../csfle/bin:$PATH \
+    TEST_CRYPT_SHARED=1 DYLD_FALLBACK_LIBRARY_PATH=../crypt_shared/lib/:$DYLD_FALLBACK_LIBRARY_PATH \
+      LD_LIBRARY_PATH=../crypt_shared/lib:$LD_LIBRARY_PATH \
+      PATH=../crypt_shared/bin:$PATH \
       python setup.py test
     deactivate
     rm -rf .venv


### PR DESCRIPTION
The changes in https://github.com/mongodb/libmongocrypt/pull/352 caused the shared library tests to silently be skipped. This change fixes that and makes it less likely to happen in the future by adding the TEST_CRYPT_SHARED=1 env var. When TEST_CRYPT_SHARED=1 is set the test suite fails if crypt_shared cannot be loaded.