### PR TITLE
Make mongocrypt.h a non-generated header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ include (CTest)
 
 set (MONGOCRYPT_PUBLIC_HEADERS
    src/mongocrypt-compat.h
+   src/mongocrypt.h
 )
 
 set (MONGOCRYPT_SOURCES
@@ -165,6 +166,24 @@ if (ENABLE_TRACE)
    message (WARNING "Building with trace logging. This is highly insecure. Do not use in a production environment")
    set (MONGOCRYPT_ENABLE_TRACE 1)
 endif ()
+
+set (BUILD_VERSION "0.0.0" CACHE STRING "Library version")
+if (BUILD_VERSION STREQUAL "0.0.0")
+   if (EXISTS ${PROJECT_SOURCE_DIR}/VERSION_CURRENT)
+      file (STRINGS ${PROJECT_SOURCE_DIR}/VERSION_CURRENT BUILD_VERSION)
+      message (STATUS "File VERSION_CURRENT contained BUILD_VERSION ${BUILD_VERSION}")
+   else ()
+      include (GetVersion)
+      GetVersion (BUILD_VERSION)
+      message (STATUS "Storing BUILD_VERSION ${BUILD_VERSION} in file VERSION_CURRENT for later use")
+      file (WRITE ${PROJECT_SOURCE_DIR}/VERSION_CURRENT ${BUILD_VERSION})
+   endif ()
+else ()
+   message (STATUS "Storing BUILD_VERSION ${BUILD_VERSION} in file VERSION_CURRENT for later use")
+   file (WRITE ${PROJECT_SOURCE_DIR}/VERSION_CURRENT ${BUILD_VERSION})
+endif ()
+
+set (MONGOCRYPT_BUILD_VERSION ${BUILD_VERSION})
 
 configure_file (
    "${PROJECT_SOURCE_DIR}/src/mongocrypt-config.h.in"
@@ -485,33 +504,11 @@ export (EXPORT _exports_for_export)
 install (
    FILES
       ${MONGOCRYPT_PUBLIC_HEADERS}
-      ${CMAKE_CURRENT_BINARY_DIR}/src/mongocrypt.h
       ${CMAKE_CURRENT_BINARY_DIR}/src/mongocrypt-config.h
       ${CMAKE_CURRENT_BINARY_DIR}/src/mongocrypt-export.h
    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mongocrypt
    COMPONENT Devel
 )
-
-set (BUILD_VERSION "0.0.0" CACHE STRING "Library version")
-
-if (BUILD_VERSION STREQUAL "0.0.0")
-   if (EXISTS ${PROJECT_SOURCE_DIR}/VERSION_CURRENT)
-      file (STRINGS ${PROJECT_SOURCE_DIR}/VERSION_CURRENT BUILD_VERSION)
-      message ("file VERSION_CURRENT contained BUILD_VERSION ${BUILD_VERSION}")
-   else ()
-      include (GetVersion)
-      GetVersion (BUILD_VERSION)
-      message ("storing BUILD_VERSION ${BUILD_VERSION} in file VERSION_CURRENT for later use")
-      file (WRITE ${PROJECT_SOURCE_DIR}/VERSION_CURRENT ${BUILD_VERSION})
-   endif ()
-else ()
-   message ("storing BUILD_VERSION ${BUILD_VERSION} in file VERSION_CURRENT for later use")
-   file (WRITE ${PROJECT_SOURCE_DIR}/VERSION_CURRENT ${BUILD_VERSION})
-endif ()
-
-message ("Configuring libmongocrypt version ${BUILD_VERSION}")
-set (MONGOCRYPT_BUILD_VERSION ${BUILD_VERSION})
-configure_file (src/mongocrypt.h.in src/mongocrypt.h)
 
 set (PROJECT_VERSION "${BUILD_VERSION}")
 set (PROJECT_DESCRIPTION "The libmongocrypt client-side field level encryption library.")

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you have encountered a bug, or would like to see a new feature in libmongocry
 ## Documentation ##
 See [The Integration Guide](integrating.md) to integrate with your driver.
 
-See [mongocrypt.h.in](src/mongocrypt.h.in) for the public API reference.
+See [mongocrypt.h](src/mongocrypt.h) for the public API reference.
 The documentation can be rendered into HTML with doxygen. Run `doxygen ./doc/Doxygen`, then open `./doc/html/index.html`.
 
 ## Building libmongocrypt ##
@@ -28,7 +28,7 @@ First build the following dependencies:
    make -j8 install
    ```
    This installs the library and includes into /path/to/bson-install. The prefix can be omitted if you prefer installing in /usr/local.
-   
+
 2. OpenSSL (if on Linux).
 
 Then build libmongocrypt:
@@ -101,7 +101,7 @@ libmongocrypt is [continuously built and published on evergreen](https://evergre
 The latest tarball containing libmongocrypt built on all supported variants is [published here](https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz).
 
 ### Troubleshooting ###
-If OpenSSL is installed in a non-default directory, pass `-DOPENSSL_ROOT_DIR=/path/to/openssl` to the cmake command for libmongocrypt. 
+If OpenSSL is installed in a non-default directory, pass `-DOPENSSL_ROOT_DIR=/path/to/openssl` to the cmake command for libmongocrypt.
 
 If there are errors with cmake configuration, send the set of steps you performed to the maintainers of this project.
 

--- a/bindings/python/pymongocrypt/binding.py
+++ b/bindings/python/pymongocrypt/binding.py
@@ -57,11 +57,8 @@ ffi.cdef("""
  * See all public API documentation in: @ref mongocrypt.h
  */
 
-/**
- * @def MONGOCRYPT_VERSION
- * The version string describing libmongocrypt.
- * Has the form x.y.z-<pre>+<date>+git<sha>.
- */
+/* clang-format off */
+/* clang-format on */
 
 /**
  * Returns the version string for libmongocrypt.

--- a/bindings/python/strip_header.py
+++ b/bindings/python/strip_header.py
@@ -20,7 +20,7 @@ Usage (on macOS):: python strip_header.py ../../src/mongocrypt.h.in | pbcopy
 import re
 import sys
 
-HEADER_RE = re.compile(r'^(#|MONGOCRYPT_EXPORT)')
+HEADER_RE = re.compile(r'^\s*(#|MONGOCRYPT_EXPORT)')
 BLANK_RE = re.compile(r'^\s*$')
 
 

--- a/bindings/python/strip_header.py
+++ b/bindings/python/strip_header.py
@@ -14,7 +14,7 @@
 
 """Generate a CFFI.cdef() string from a C header file
 
-Usage (on macOS):: python strip_header.py ../../src/mongocrypt.h.in | pbcopy
+Usage (on macOS):: python strip_header.py ../../src/mongocrypt.h | pbcopy
 """
 
 import re

--- a/src/mongocrypt-config.h.in
+++ b/src/mongocrypt-config.h.in
@@ -17,6 +17,15 @@
 #ifndef MONGOCRYPT_CONFIG_H
 #define MONGOCRYPT_CONFIG_H
 
+/* clang-format off */
+
+/**
+ * @def MONGOCRYPT_VERSION
+ * @brief The version string describing libmongocrypt.
+ * Has the form x.y.z-<pre>+<date>+git<sha>.
+ */
+#define MONGOCRYPT_VERSION "@MONGOCRYPT_VERSION@"
+
 /*
  * MONGOCRYPT_ENABLE_CRYPTO_CNG is set from configure to determine if we are
  * compiled with Native Crypto support on Windows
@@ -72,5 +81,7 @@
 #if MONGOCRYPT_ENABLE_TRACE != 1
 #  undef MONGOCRYPT_ENABLE_TRACE
 #endif
+
+/* clang-format on */
 
 #endif /* MONGOCRYPT_CONFIG_H */

--- a/src/mongocrypt-config.h.in
+++ b/src/mongocrypt-config.h.in
@@ -24,7 +24,7 @@
  * @brief The version string describing libmongocrypt.
  * Has the form x.y.z-<pre>+<date>+git<sha>.
  */
-#define MONGOCRYPT_VERSION "@MONGOCRYPT_VERSION@"
+#define MONGOCRYPT_VERSION "@MONGOCRYPT_BUILD_VERSION@"
 
 /*
  * MONGOCRYPT_ENABLE_CRYPTO_CNG is set from configure to determine if we are

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -26,22 +26,15 @@
 #include "mongocrypt-export.h"
 #include "mongocrypt-compat.h"
 
-/**
- * @macro MONGOCRYPT_VERSION
- * @brief The version string describing libmongocrypt.
- * Has the form x.y.z-<pre>+<date>+git<sha>.
- */
-
-// clang-format off
+/* clang-format off */
 #ifndef __has_include
    #include "mongocrypt-config.h"
 #elif __has_include("mongocrypt-config.h")
    #include "mongocrypt-config.h"
 #else
-   #error "No 'mongocrypt-config.h' header is available. " \
-          "This must be generated in order to use libmongocrypt"
+   #error "No 'mongocrypt-config.h' header is available. This must be generated in order to use libmongocrypt"
 #endif
-// clang-format on
+/* clang-format on */
 
 /**
  * Returns the version string for libmongocrypt.

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -33,7 +33,8 @@
    #if __has_include("mongocrypt-config.h")
       #include "mongocrypt-config.h"
    #else
-      #error "No 'mongocrypt-config.h' header is available. This must be generated in order to use libmongocrypt"
+      #error No "mongocrypt-config.h" header is available. That file must \
+             be generated in order to use libmongocrypt.
    #endif
 #endif
 /* clang-format on */

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -25,14 +25,23 @@
 
 #include "mongocrypt-export.h"
 #include "mongocrypt-compat.h"
-#include "mongocrypt-config.h"
 
 /**
- * @def MONGOCRYPT_VERSION
- * The version string describing libmongocrypt.
+ * @macro MONGOCRYPT_VERSION
+ * @brief The version string describing libmongocrypt.
  * Has the form x.y.z-<pre>+<date>+git<sha>.
  */
-#define MONGOCRYPT_VERSION "@MONGOCRYPT_BUILD_VERSION@"
+
+// clang-format off
+#ifndef __has_include
+   #include "mongocrypt-config.h"
+#elif __has_include("mongocrypt-config.h")
+   #include "mongocrypt-config.h"
+#else
+   #error "No 'mongocrypt-config.h' header is available. " \
+          "This must be generated in order to use libmongocrypt"
+#endif
+// clang-format on
 
 /**
  * Returns the version string for libmongocrypt.

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -29,10 +29,12 @@
 /* clang-format off */
 #ifndef __has_include
    #include "mongocrypt-config.h"
-#elif __has_include("mongocrypt-config.h")
-   #include "mongocrypt-config.h"
 #else
-   #error "No 'mongocrypt-config.h' header is available. This must be generated in order to use libmongocrypt"
+   #if __has_include("mongocrypt-config.h")
+      #include "mongocrypt-config.h"
+   #else
+      #error "No 'mongocrypt-config.h' header is available. This must be generated in order to use libmongocrypt"
+   #endif
 #endif
 /* clang-format on */
 


### PR DESCRIPTION
The only reason we generate `mongocrypt.h` at configure-time is to generate the `MONGOCRYPT_VERSION` macro string. Since we are already doing configure-time generation of `mongocrypt-config.h`, it is easier to just move the version macro into that file, which is already `#include`d by `mongocrypt.h`.