### PR TITLE
[MONGOCRYPT-441] Accept string arguments for queryType and "index_type"

### DIFF
--- a/bindings/cs/MongoDB.Libmongocrypt/CryptClient.cs
+++ b/bindings/cs/MongoDB.Libmongocrypt/CryptClient.cs
@@ -133,7 +133,7 @@ namespace MongoDB.Libmongocrypt
         /// <param name="encryptionAlgorithm">The encryption algorithm.</param>
         /// <param name="message">The BSON message.</param>
         /// <returns>A encryption context. </returns>
-        public CryptContext StartExplicitEncryptionContext(byte[] keyId, byte[] keyAltName, int? queryType, long? contentionFactor, string encryptionAlgorithm, byte[] message)
+        public CryptContext StartExplicitEncryptionContext(byte[] keyId, byte[] keyAltName, string? queryType, long? contentionFactor, string encryptionAlgorithm, byte[] message)
         {
             var handle = Library.mongocrypt_ctx_new(_handle);
 
@@ -150,7 +150,7 @@ namespace MongoDB.Libmongocrypt
 
             if (queryType.HasValue)
             {
-                handle.Check(_status, Library.mongocrypt_ctx_setopt_query_type(handle, (Library.mongocrypt_query_type_t)queryType.Value));
+                handle.Check(_status, Library.mongocrypt_ctx_setopt_query_type(handle, queryType, -1));
             }
 
             if (contentionFactor.HasValue)

--- a/bindings/cs/MongoDB.Libmongocrypt/CryptClient.cs
+++ b/bindings/cs/MongoDB.Libmongocrypt/CryptClient.cs
@@ -146,18 +146,7 @@ namespace MongoDB.Libmongocrypt
                 PinnedBinary.RunAsPinnedBinary(handle, keyAltName, _status, (h, pb) => Library.mongocrypt_ctx_setopt_key_alt_name(h, pb));
             }
 
-            switch (encryptionAlgorithm)
-            {
-                case "Indexed":
-                    handle.Check(_status, Library.mongocrypt_ctx_setopt_index_type(handle, Library.mongocrypt_index_type_t.MONGOCRYPT_INDEX_TYPE_EQUALITY));
-                    break;
-                case "Unindexed":
-                    handle.Check(_status, Library.mongocrypt_ctx_setopt_index_type(handle, Library.mongocrypt_index_type_t.MONGOCRYPT_INDEX_TYPE_NONE));
-                    break;
-                default:
-                    handle.Check(_status, Library.mongocrypt_ctx_setopt_algorithm(handle, encryptionAlgorithm, -1));
-                    break;
-            }
+            handle.Check(_status, Library.mongocrypt_ctx_setopt_algorithm(handle, encryptionAlgorithm, -1));
 
             if (queryType.HasValue)
             {

--- a/bindings/cs/MongoDB.Libmongocrypt/CryptClient.cs
+++ b/bindings/cs/MongoDB.Libmongocrypt/CryptClient.cs
@@ -133,7 +133,7 @@ namespace MongoDB.Libmongocrypt
         /// <param name="encryptionAlgorithm">The encryption algorithm.</param>
         /// <param name="message">The BSON message.</param>
         /// <returns>A encryption context. </returns>
-        public CryptContext StartExplicitEncryptionContext(byte[] keyId, byte[] keyAltName, string? queryType, long? contentionFactor, string encryptionAlgorithm, byte[] message)
+        public CryptContext StartExplicitEncryptionContext(byte[] keyId, byte[] keyAltName, string queryType, long? contentionFactor, string encryptionAlgorithm, byte[] message)
         {
             var handle = Library.mongocrypt_ctx_new(_handle);
 
@@ -148,7 +148,7 @@ namespace MongoDB.Libmongocrypt
 
             handle.Check(_status, Library.mongocrypt_ctx_setopt_algorithm(handle, encryptionAlgorithm, -1));
 
-            if (queryType.HasValue)
+            if (queryType != null)
             {
                 handle.Check(_status, Library.mongocrypt_ctx_setopt_query_type(handle, queryType, -1));
             }

--- a/bindings/cs/MongoDB.Libmongocrypt/Library.cs
+++ b/bindings/cs/MongoDB.Libmongocrypt/Library.cs
@@ -363,17 +363,6 @@ namespace MongoDB.Libmongocrypt
             MONGOCRYPT_STATUS_ERROR_KMS
         }
 
-        internal enum mongocrypt_index_type_t
-        {
-            MONGOCRYPT_INDEX_TYPE_NONE = 1,
-            MONGOCRYPT_INDEX_TYPE_EQUALITY = 2
-        }
-
-        internal enum mongocrypt_query_type_t
-        {
-            MONGOCRYPT_QUERY_TYPE_EQUALITY = 1
-        }
-
         internal class Delegates
         {
             // NOTE: Bool is expected to be 4 bytes during marshalling so we need to overwite it
@@ -579,10 +568,10 @@ namespace MongoDB.Libmongocrypt
             [return: MarshalAs(UnmanagedType.I1)]
             public delegate bool mongocrypt_ctx_setopt_contention_factor(ContextSafeHandle ctx, long contention_factor);
             /// <summary>
-            /// bool mongocrypt_ctx_setopt_query_type(mongocrypt_ctx_t* ctx, mongocrypt_query_type_t query_type)
+            /// bool mongocrypt_ctx_setopt_query_type(mongocrypt_ctx_t* ctx, const char* query_type, int len)
             /// </summary>
             [return: MarshalAs(UnmanagedType.I1)]
-            public delegate bool mongocrypt_ctx_setopt_query_type(ContextSafeHandle ctx, mongocrypt_query_type_t query_type);
+            public delegate bool mongocrypt_ctx_setopt_query_type(ContextSafeHandle ctx [MarshalAs(UnmanagedType.LPStr)] string query_type, int length);
 
             public delegate CryptContext.StateCode mongocrypt_ctx_state(ContextSafeHandle handle);
 

--- a/bindings/cs/MongoDB.Libmongocrypt/Library.cs
+++ b/bindings/cs/MongoDB.Libmongocrypt/Library.cs
@@ -571,7 +571,7 @@ namespace MongoDB.Libmongocrypt
             /// bool mongocrypt_ctx_setopt_query_type(mongocrypt_ctx_t* ctx, const char* query_type, int len)
             /// </summary>
             [return: MarshalAs(UnmanagedType.I1)]
-            public delegate bool mongocrypt_ctx_setopt_query_type(ContextSafeHandle ctx [MarshalAs(UnmanagedType.LPStr)] string query_type, int length);
+            public delegate bool mongocrypt_ctx_setopt_query_type(ContextSafeHandle ctx, [MarshalAs(UnmanagedType.LPStr)] string query_type, int length);
 
             public delegate CryptContext.StateCode mongocrypt_ctx_state(ContextSafeHandle handle);
 

--- a/bindings/cs/MongoDB.Libmongocrypt/Library.cs
+++ b/bindings/cs/MongoDB.Libmongocrypt/Library.cs
@@ -131,9 +131,6 @@ namespace MongoDB.Libmongocrypt
             _mongocrypt_ctx_setopt_contention_factor = new Lazy<Delegates.mongocrypt_ctx_setopt_contention_factor>(
                 () => __loader.Value.GetFunction<Delegates.mongocrypt_ctx_setopt_contention_factor>(
                     ("mongocrypt_ctx_setopt_contention_factor")), true);
-            _mongocrypt_ctx_setopt_index_type = new Lazy<Delegates.mongocrypt_ctx_setopt_index_type>(
-                () => __loader.Value.GetFunction<Delegates.mongocrypt_ctx_setopt_index_type>(
-                    ("mongocrypt_ctx_setopt_index_type")), true);
             _mongocrypt_ctx_setopt_query_type = new Lazy<Delegates.mongocrypt_ctx_setopt_query_type>(
                 () => __loader.Value.GetFunction<Delegates.mongocrypt_ctx_setopt_query_type>(
                     ("mongocrypt_ctx_setopt_query_type")), true);
@@ -261,7 +258,6 @@ namespace MongoDB.Libmongocrypt
         internal static Delegates.mongocrypt_ctx_setopt_key_alt_name mongocrypt_ctx_setopt_key_alt_name => _mongocrypt_ctx_setopt_key_alt_name.Value;
         internal static Delegates.mongocrypt_ctx_setopt_algorithm mongocrypt_ctx_setopt_algorithm => _mongocrypt_ctx_setopt_algorithm.Value;
         internal static Delegates.mongocrypt_ctx_setopt_contention_factor mongocrypt_ctx_setopt_contention_factor => _mongocrypt_ctx_setopt_contention_factor.Value;
-        internal static Delegates.mongocrypt_ctx_setopt_index_type mongocrypt_ctx_setopt_index_type => _mongocrypt_ctx_setopt_index_type.Value;
         internal static Delegates.mongocrypt_ctx_setopt_query_type mongocrypt_ctx_setopt_query_type => _mongocrypt_ctx_setopt_query_type.Value;
 
         internal static Delegates.mongocrypt_ctx_state mongocrypt_ctx_state => _mongocrypt_ctx_state.Value;
@@ -341,7 +337,6 @@ namespace MongoDB.Libmongocrypt
         private static readonly Lazy<Delegates.mongocrypt_ctx_setopt_key_alt_name> _mongocrypt_ctx_setopt_key_alt_name;
         private static readonly Lazy<Delegates.mongocrypt_ctx_setopt_algorithm> _mongocrypt_ctx_setopt_algorithm;
         private static readonly Lazy<Delegates.mongocrypt_ctx_setopt_contention_factor> _mongocrypt_ctx_setopt_contention_factor;
-        private static readonly Lazy<Delegates.mongocrypt_ctx_setopt_index_type> _mongocrypt_ctx_setopt_index_type;
         private static readonly Lazy<Delegates.mongocrypt_ctx_setopt_query_type> _mongocrypt_ctx_setopt_query_type;
 
         private static readonly Lazy<Delegates.mongocrypt_ctx_state> _mongocrypt_ctx_state;
@@ -583,11 +578,6 @@ namespace MongoDB.Libmongocrypt
             /// </summary>
             [return: MarshalAs(UnmanagedType.I1)]
             public delegate bool mongocrypt_ctx_setopt_contention_factor(ContextSafeHandle ctx, long contention_factor);
-            /// <summary>
-            /// bool mongocrypt_ctx_setopt_index_type(mongocrypt_ctx_t* ctx, mongocrypt_index_type_t index_type)
-            /// </summary>
-            [return: MarshalAs(UnmanagedType.I1)]
-            public delegate bool mongocrypt_ctx_setopt_index_type(ContextSafeHandle ctx, mongocrypt_index_type_t index_type);
             /// <summary>
             /// bool mongocrypt_ctx_setopt_query_type(mongocrypt_ctx_t* ctx, mongocrypt_query_type_t query_type)
             /// </summary>

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
@@ -462,19 +462,6 @@ public class CAPI {
     mongocrypt_setopt_bypass_query_analysis (mongocrypt_t crypt);
 
     /**
-     * Set the index type used for explicit encryption.
-     * The index type is only used for Queryable Encryption.
-     *
-     * @param ctx The @ref mongocrypt_ctx_t object.
-     * @param index_type the index type
-     * @return A boolean indicating success. If false, an error status is set.
-     * Retrieve it with @ref mongocrypt_ctx_status.
-     * @since 1.5
-     */
-    public static native boolean
-    mongocrypt_ctx_setopt_index_type (mongocrypt_ctx_t ctx, int index_type);
-
-    /**
      * Set the contention factor used for explicit encryption.
      * The contention factor is only used for indexed Queryable Encryption.
      *

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
@@ -554,7 +554,7 @@ public class CAPI {
      * Retrieve it with @ref mongocrypt_ctx_status
      */
     public static native boolean
-    mongocrypt_ctx_setopt_query_type (mongocrypt_ctx_t ctx, int query_type);
+    mongocrypt_ctx_setopt_query_type (mongocrypt_ctx_t ctx, cstring query_type, int len);
 
     /**
      * Initialize new @ref mongocrypt_t object.

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoCryptImpl.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoCryptImpl.java
@@ -283,7 +283,7 @@ class MongoCryptImpl implements MongoCrypt {
 
         configure(() -> mongocrypt_ctx_setopt_algorithm(context, new cstring(options.getAlgorithm()), -1), context);
         if (options.getQueryType() != null) {
-            configure(() -> mongocrypt_ctx_setopt_query_type(context, options.getQueryType().getQueryType()), context);
+            configure(() -> mongocrypt_ctx_setopt_query_type(context, new cstring(options.getQueryType()), -1), context);
         }
         if (options.getContentionFactor() != null) {
             configure(() -> mongocrypt_ctx_setopt_contention_factor(context, options.getContentionFactor()), context);

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoCryptImpl.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoCryptImpl.java
@@ -48,7 +48,6 @@ import static com.mongodb.crypt.capi.CAPI.mongocrypt_ctx_explicit_encrypt_init;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_ctx_new;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_ctx_setopt_algorithm;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_ctx_setopt_contention_factor;
-import static com.mongodb.crypt.capi.CAPI.mongocrypt_ctx_setopt_index_type;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_ctx_setopt_key_alt_name;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_ctx_setopt_key_encryption_key;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_ctx_setopt_key_id;
@@ -282,18 +281,12 @@ class MongoCryptImpl implements MongoCrypt {
             }
         }
 
-        if (INDEXED.equalsIgnoreCase(options.getAlgorithm())) {
-            configure(() -> mongocrypt_ctx_setopt_index_type(context, MONGOCRYPT_INDEX_TYPE_EQUALITY), context);
-            if (options.getQueryType() != null) {
-                configure(() -> mongocrypt_ctx_setopt_query_type(context, options.getQueryType().getQueryType()), context);
-            }
-            if (options.getContentionFactor() != null) {
-                configure(() -> mongocrypt_ctx_setopt_contention_factor(context, options.getContentionFactor()), context);
-            }
-        } else if (options.getAlgorithm().equalsIgnoreCase(UNINDEXED)) {
-            configure(() -> mongocrypt_ctx_setopt_index_type(context, MONGOCRYPT_INDEX_TYPE_NONE), context);
-        } else {
-            configure(() -> mongocrypt_ctx_setopt_algorithm(context, new cstring(options.getAlgorithm()), -1), context);
+        configure(() -> mongocrypt_ctx_setopt_algorithm(context, new cstring(options.getAlgorithm()), -1), context);
+        if (options.getQueryType() != null) {
+            configure(() -> mongocrypt_ctx_setopt_query_type(context, options.getQueryType().getQueryType()), context);
+        }
+        if (options.getContentionFactor() != null) {
+            configure(() -> mongocrypt_ctx_setopt_contention_factor(context, options.getContentionFactor()), context);
         }
 
         try (BinaryHolder documentBinaryHolder = toBinary(document)) {

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoExplicitEncryptOptions.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoExplicitEncryptOptions.java
@@ -29,34 +29,7 @@ public class MongoExplicitEncryptOptions {
     private final String keyAltName;
     private final String algorithm;
     private final Long contentionFactor;
-    private final QueryType queryType;
-
-    /**
-     * The QueryType to use for "Indexed" queries
-     *
-     * @since 1.5
-     */
-    public enum QueryType {
-        EQUALITY(CAPI.MONGOCRYPT_QUERY_TYPE_EQUALITY);
-
-        private final int queryType;
-        QueryType(final int queryType) {
-            this.queryType = queryType;
-        }
-
-        public int getQueryType() {
-            return queryType;
-        }
-
-        public static QueryType fromInteger(final int queryType) {
-            for (QueryType value : QueryType.values()) {
-                if (value.queryType == queryType) {
-                    return value;
-                }
-            }
-            throw new MongoCryptException("Unknown context queryType " + queryType);
-        }
-    }
+    private final String queryType;
 
     /**
      * The builder for the options
@@ -130,7 +103,7 @@ public class MongoExplicitEncryptOptions {
          * @return this
          * @since 1.5
          */
-        public Builder queryType(final QueryType queryType) {
+        public Builder queryType(final String queryType) {
             this.queryType = queryType;
             return this;
         }
@@ -192,7 +165,7 @@ public class MongoExplicitEncryptOptions {
      * @return the query type
      * @since 1.5
      */
-    public QueryType getQueryType() {
+    public String getQueryType() {
         return queryType;
     }
 

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoExplicitEncryptOptions.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoExplicitEncryptOptions.java
@@ -39,7 +39,7 @@ public class MongoExplicitEncryptOptions {
         private String keyAltName;
         private String algorithm;
         private Long contentionFactor;
-        private QueryType queryType;
+        private String queryType;
 
         private Builder() {
         }

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -382,14 +382,6 @@ module.exports = function (modules) {
 
         contextOptions.keyAltName = bson.serialize({ keyAltName });
       }
-      if (options.algorithm === 'Indexed') {
-        delete contextOptions.algorithm;
-        contextOptions.indexType = 'Equality';
-      }
-      if (options.algorithm === 'Unindexed') {
-        delete contextOptions.algorithm;
-        contextOptions.indexType = 'None';
-      }
 
       const stateMachine = new StateMachine({
         bson,

--- a/bindings/node/src/mongocrypt.cc
+++ b/bindings/node/src/mongocrypt.cc
@@ -577,10 +577,7 @@ Value MongoCrypt::MakeExplicitEncryptionContext(const CallbackInfo& info) {
 
         if (options.Has("queryType")) {
             std::string query_type_str = options.Get("queryType").ToString();
-            mongocrypt_query_type_t query_type = strToEnumValue<mongocrypt_query_type_t>(
-                Env(), query_type_str, "queryType",
-                {{"Equality", MONGOCRYPT_QUERY_TYPE_EQUALITY}});
-            if (!mongocrypt_ctx_setopt_query_type(context.get(), query_type)) {
+            if (!mongocrypt_ctx_setopt_query_type(context.get(), query_type_str.data(), -1)) {
                 throw TypeError::New(Env(), errorStringFromStatus(context.get()));
             }
         }

--- a/bindings/node/src/mongocrypt.cc
+++ b/bindings/node/src/mongocrypt.cc
@@ -560,19 +560,7 @@ Value MongoCrypt::MakeExplicitEncryptionContext(const CallbackInfo& info) {
         if (options.Has("algorithm")) {
             std::string algorithm = options.Get("algorithm").ToString();
             if (!mongocrypt_ctx_setopt_algorithm(
-                    context.get(), const_cast<char*>(algorithm.c_str()), algorithm.size())) {
-
-                throw TypeError::New(Env(), errorStringFromStatus(context.get()));
-            }
-        }
-
-        if (options.Has("indexType")) {
-            std::string index_type_str = options.Get("indexType").ToString();
-            mongocrypt_index_type_t index_type = strToEnumValue<mongocrypt_index_type_t>(
-                Env(), index_type_str, "indexType",
-                {{"None", MONGOCRYPT_INDEX_TYPE_NONE},
-                 {"Equality", MONGOCRYPT_INDEX_TYPE_EQUALITY}});
-            if (!mongocrypt_ctx_setopt_index_type(context.get(), index_type)) {
+                    context.get(), algorithm.c_str(), algorithm.size())) {
                 throw TypeError::New(Env(), errorStringFromStatus(context.get()));
             }
         }

--- a/bindings/python/pymongocrypt/binding.py
+++ b/bindings/python/pymongocrypt/binding.py
@@ -33,8 +33,7 @@ except ImportError:
 ffi = cffi.FFI()
 
 # Generated with strip_header.py
-ffi.cdef("""
-/*
+ffi.cdef("""/*
  * Copyright 2019-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -163,7 +162,6 @@ typedef enum {
    MONGOCRYPT_STATUS_ERROR_CLIENT = 1,
    MONGOCRYPT_STATUS_ERROR_KMS = 2,
    MONGOCRYPT_STATUS_ERROR_CRYPT_SHARED = 3,
-   MONGOCRYPT_STATUS_ERROR_CSFLE = MONGOCRYPT_STATUS_ERROR_CRYPT_SHARED,
 } mongocrypt_status_type_t;
 
 /**
@@ -687,6 +685,11 @@ bool
 mongocrypt_ctx_setopt_algorithm (mongocrypt_ctx_t *ctx,
                                  const char *algorithm,
                                  int len);
+
+/// String constant for setopt_algorithm "Deterministic" encryption
+/// String constant for setopt_algorithm "Random" encryption
+/// String constant for setopt_algorithm "Indexed" explicit encryption
+/// String constant for setopt_algorithm "Unindexed" explicit encryption
 
 /**
  * Identify the AWS KMS master key to use for creating a data key.
@@ -1394,22 +1397,23 @@ bool
 mongocrypt_ctx_setopt_index_key_id (mongocrypt_ctx_t *ctx,
                                     mongocrypt_binary_t *key_id);
 
-typedef enum { MONGOCRYPT_QUERY_TYPE_EQUALITY = 1 } mongocrypt_query_type_t;
-
 /**
  * Set the query type to use for explicit Queryable Encryption.
  *
  * @param[in] ctx The @ref mongocrypt_ctx_t object.
- * @param[in] query_type
+ * @param[in] query_type The query type string
+ * @param[in] len The length of query_type, or -1 for automatic
  * @pre @p ctx has not been initialized.
  * @returns A boolean indicating success. If false, an error status is set.
  * Retrieve it with @ref mongocrypt_ctx_status
  */
 bool
 mongocrypt_ctx_setopt_query_type (mongocrypt_ctx_t *ctx,
-                                  mongocrypt_query_type_t query_type);
-""")
+                                  const char *query_type,
+                                  int len);
 
+/// String constant for setopt_query_type_v2, "equality" query type
+""")
 
 if PY3:
     def _to_string(cdata):

--- a/bindings/python/pymongocrypt/binding.py
+++ b/bindings/python/pymongocrypt/binding.py
@@ -856,7 +856,6 @@ mongocrypt_ctx_encrypt_init (mongocrypt_ctx_t *ctx,
  * - @ref mongocrypt_ctx_setopt_algorithm
  *
  * Associated options for Queryable Encryption:
- * - @ref mongocrypt_ctx_setopt_index_type
  * - @ref mongocrypt_ctx_setopt_key_id
  * - @ref mongocrypt_ctx_setopt_index_key_id
  * - @ref mongocrypt_ctx_setopt_contention_factor
@@ -1361,25 +1360,6 @@ mongocrypt_setopt_crypto_hook_sign_rsaes_pkcs1_v1_5 (
  */
 void
 mongocrypt_setopt_bypass_query_analysis (mongocrypt_t *crypt);
-
-typedef enum {
-   MONGOCRYPT_INDEX_TYPE_NONE = 1,
-   MONGOCRYPT_INDEX_TYPE_EQUALITY = 2
-} mongocrypt_index_type_t;
-
-/**
- * Set the index type used for explicit encryption.
- * The index type is only used for Queryable Encryption.
- *
- * @param[in] ctx The @ref mongocrypt_ctx_t object.
- * @param[in] index_type
- * @pre @p ctx has not been initialized.
- * @returns A boolean indicating success. If false, an error status is set.
- * Retrieve it with @ref mongocrypt_ctx_status.
- */
-bool
-mongocrypt_ctx_setopt_index_type (mongocrypt_ctx_t *ctx,
-                                  mongocrypt_index_type_t index_type);
 
 /**
  * Set the contention factor used for explicit encryption.

--- a/bindings/python/pymongocrypt/explicit_encrypter.py
+++ b/bindings/python/pymongocrypt/explicit_encrypter.py
@@ -28,7 +28,7 @@ class ExplicitEncryptOpts(object):
             'keyAltName'. Must be BSON encoded document in the form:
             { "keyAltName" : (BSON UTF8 value) }
           - `index_key_id` (bytes): the index key id to use for Queryable Encryption.
-          - `query_type` (int): The query type to execute.
+          - `query_type` (str): The query type to execute.
           - `contention_factor` (int): The contention factor to use
             when the algorithm is "Indexed".
 
@@ -40,9 +40,9 @@ class ExplicitEncryptOpts(object):
         self.key_alt_name = key_alt_name
         self.index_key_id = index_key_id
         if query_type is not None:
-            if not isinstance(query_type, int):
+            if not isinstance(query_type, str):
                 raise TypeError(
-                    'query_type must be an int or None, not: %r' % (type(query_type),))
+                    'query_type must be str or None, not: %r' % (type(query_type),))
         self.query_type = query_type
         if contention_factor is not None and not isinstance(contention_factor, int):
             raise TypeError(
@@ -168,7 +168,7 @@ class ExplicitEncrypter(object):
           - `key_alt_name` (string): Identifies a key vault document by
             'keyAltName'.
           - `index_key_id` (bytes): the index key id to use for Queryable Encryption.
-          - `query_type` (int): The query type to execute.
+          - `query_type` (str): The query type to execute.
           - `contention_factor` (int): The contention factor to use
             when the algorithm is "Indexed".
 

--- a/bindings/python/pymongocrypt/mongocrypt.py
+++ b/bindings/python/pymongocrypt/mongocrypt.py
@@ -510,7 +510,8 @@ class ExplicitEncryptionContext(MongoCryptContext):
                         self._raise_from_status()
 
             if opts.query_type is not None:
-                if not lib.mongocrypt_ctx_setopt_query_type(ctx, opts.query_type):
+                qt = str_to_bytes(opts.query_type)
+                if not lib.mongocrypt_ctx_setopt_query_type(ctx, qt, -1):
                     self._raise_from_status()
 
             if opts.contention_factor is not None:

--- a/bindings/python/pymongocrypt/mongocrypt.py
+++ b/bindings/python/pymongocrypt/mongocrypt.py
@@ -490,17 +490,9 @@ class ExplicitEncryptionContext(MongoCryptContext):
         """
         super(ExplicitEncryptionContext, self).__init__(ctx)
         try:
-            if opts.algorithm == 'Indexed':
-                if not lib.mongocrypt_ctx_setopt_index_type(
-                        ctx, lib.MONGOCRYPT_INDEX_TYPE_EQUALITY):
-                    self._raise_from_status()
-            elif opts.algorithm == 'Unindexed':
-                if not lib.mongocrypt_ctx_setopt_index_type(ctx, lib.MONGOCRYPT_INDEX_TYPE_NONE):
-                    self._raise_from_status()
-            else:
-                algorithm = str_to_bytes(opts.algorithm)
-                if not lib.mongocrypt_ctx_setopt_algorithm(ctx, algorithm, -1):
-                    self._raise_from_status()
+            algorithm = str_to_bytes(opts.algorithm)
+            if not lib.mongocrypt_ctx_setopt_algorithm(ctx, algorithm, -1):
+                self._raise_from_status()
 
             if opts.key_id is not None:
                 with MongoCryptBinaryIn(opts.key_id) as binary:

--- a/bindings/python/test/test_mongocrypt.py
+++ b/bindings/python/test/test_mongocrypt.py
@@ -497,7 +497,10 @@ class TestExplicitEncryption(unittest.TestCase):
             encrypter.encrypt(encoded_val, "Indexed", key_id, index_key_id=b'1234')
         # Invalid query_type type.
         with self.assertRaisesRegex(TypeError, "query_type"):
-            encrypter.encrypt(encoded_val, "Indexed", key_id, query_type='not an int')
+            encrypter.encrypt(encoded_val, "Indexed", key_id, query_type=42)
+        # Invalid query_type string.
+        with self.assertRaisesRegex(MongoCryptError, "query_type"):
+            encrypter.encrypt(encoded_val, "Indexed", key_id, query_type='invalid query type string')
         # Invalid contention_factor type.
         with self.assertRaisesRegex(TypeError, "contention_factor"):
             encrypter.encrypt(encoded_val, "Indexed", key_id, contention_factor='not an int')
@@ -505,7 +508,7 @@ class TestExplicitEncryption(unittest.TestCase):
             encrypter.encrypt(encoded_val, "Indexed", key_id, contention_factor=-1)
         # Invalid: Unindexed + query_type is an error.
         with self.assertRaisesRegex(MongoCryptError, "query"):
-            encrypter.encrypt(encoded_val, "Unindexed", key_id, query_type=1)
+            encrypter.encrypt(encoded_val, "Unindexed", key_id, query_type='equality')
         # Invalid: Unindexed + contention_factor is an error.
         with self.assertRaisesRegex(MongoCryptError, "contention"):
             encrypter.encrypt(encoded_val, "Unindexed", key_id, contention_factor=1)
@@ -524,7 +527,7 @@ class TestExplicitEncryption(unittest.TestCase):
         encoded_val = bson.encode(val)
         for kwargs in [
             dict(algorithm='Indexed'),
-            dict(algorithm='Indexed', query_type=1),
+            dict(algorithm='Indexed', query_type='equality'),
             dict(algorithm='Indexed', contention_factor=100),
             dict(algorithm='Unindexed'),
         ]:

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -2092,10 +2092,6 @@ mongocrypt_ctx_explicit_encrypt_init (mongocrypt_ctx_t *ctx,
       }
       /* algorithm is FLE 1 only. */
       if (ctx->opts.algorithm != MONGOCRYPT_ENCRYPTION_ALGORITHM_NONE) {
-         // This condition is guarded in setopt_algorithm:
-         BSON_ASSERT (
-            !ctx->opts.index_type.set &&
-            "Both an encryption algorithm and an index_type were set.");
          if (!_mongocrypt_buffer_empty (&ctx->opts.index_key_id)) {
             return _mongocrypt_ctx_fail_w_msg (
                ctx, "cannot set both algorithm and index key id");

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -2092,10 +2092,10 @@ mongocrypt_ctx_explicit_encrypt_init (mongocrypt_ctx_t *ctx,
       }
       /* algorithm is FLE 1 only. */
       if (ctx->opts.algorithm != MONGOCRYPT_ENCRYPTION_ALGORITHM_NONE) {
-         if (ctx->opts.index_type.set) {
-            return _mongocrypt_ctx_fail_w_msg (
-               ctx, "cannot set both algorithm and index type");
-         }
+         // This condition is guarded in setopt_algorithm:
+         BSON_ASSERT (
+            !ctx->opts.index_type.set &&
+            "Both an encryption algorithm and an index_type were set.");
          if (!_mongocrypt_buffer_empty (&ctx->opts.index_key_id)) {
             return _mongocrypt_ctx_fail_w_msg (
                ctx, "cannot set both algorithm and index key id");

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -39,6 +39,8 @@ typedef enum {
    MONGOCRYPT_INDEX_TYPE_EQUALITY = 2
 } mongocrypt_index_type_t;
 
+typedef enum { MONGOCRYPT_QUERY_TYPE_EQUALITY = 1 } mongocrypt_query_type_t;
+
 /* Option values are validated when set.
  * Different contexts accept/require different options,
  * validated when a context is initialized.

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -34,6 +34,11 @@ typedef enum {
    _MONGOCRYPT_TYPE_COMPACT,
 } _mongocrypt_ctx_type_t;
 
+typedef enum {
+   MONGOCRYPT_INDEX_TYPE_NONE = 1,
+   MONGOCRYPT_INDEX_TYPE_EQUALITY = 2
+} mongocrypt_index_type_t;
+
 /* Option values are validated when set.
  * Different contexts accept/require different options,
  * validated when a context is initialized.

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -19,11 +19,6 @@
 #include "mongocrypt-ctx-private.h"
 #include "mongocrypt-key-broker-private.h"
 
-#define ALGORITHM_DETERMINISTIC "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
-#define ALGORITHM_DETERMINISTIC_LEN 43
-#define ALGORITHM_RANDOM "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
-#define ALGORITHM_RANDOM_LEN 36
-
 bool
 _mongocrypt_ctx_fail_w_msg (mongocrypt_ctx_t *ctx, const char *msg)
 {
@@ -288,14 +283,16 @@ mongocrypt_ctx_setopt_algorithm (mongocrypt_ctx_t *ctx,
    }
 
    mstr_view algo_str = mstrv_view_data (algorithm, calculated_len);
-   if (mstr_eq (algo_str, mstrv_lit (ALGORITHM_DETERMINISTIC))) {
+   if (mstr_eq (algo_str, mstrv_lit (MONGOCRYPT_ALGORITHM_DETERMINISTIC_STR))) {
       ctx->opts.algorithm = MONGOCRYPT_ENCRYPTION_ALGORITHM_DETERMINISTIC;
-   } else if (mstr_eq (algo_str, mstrv_lit (ALGORITHM_RANDOM))) {
+   } else if (mstr_eq (algo_str, mstrv_lit (MONGOCRYPT_ALGORITHM_RANDOM_STR))) {
       ctx->opts.algorithm = MONGOCRYPT_ENCRYPTION_ALGORITHM_RANDOM;
-   } else if (mstr_eq (algo_str, mstrv_lit ("Indexed"))) {
+   } else if (mstr_eq (algo_str,
+                       mstrv_lit (MONGOCRYPT_ALGORITHM_INDEXED_STR))) {
       ctx->opts.index_type.value = MONGOCRYPT_INDEX_TYPE_EQUALITY;
       ctx->opts.index_type.set = true;
-   } else if (mstr_eq (algo_str, mstrv_lit ("Unindexed"))) {
+   } else if (mstr_eq (algo_str,
+                       mstrv_lit (MONGOCRYPT_ALGORITHM_UNINDEXED_STR))) {
       ctx->opts.index_type.value = MONGOCRYPT_INDEX_TYPE_NONE;
       ctx->opts.index_type.set = true;
    } else {
@@ -1137,7 +1134,7 @@ mongocrypt_ctx_setopt_query_type_v2 (mongocrypt_ctx_t *ctx,
 
    const size_t calc_len = len == -1 ? strlen (query_type) : (size_t) len;
    mstr_view qt_str = mstrv_view_data (query_type, calc_len);
-   if (mstr_eq (qt_str, mstrv_lit ("equality"))) {
+   if (mstr_eq (qt_str, mstrv_lit (MONGOCRYPT_QUERY_TYPE_EQUALITY_STR))) {
       ctx->opts.query_type.value = MONGOCRYPT_QUERY_TYPE_EQUALITY;
       ctx->opts.query_type.set = true;
    } else {

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -825,6 +825,12 @@ _mongocrypt_ctx_init (mongocrypt_ctx_t *ctx,
 {
    bool has_id = false, has_alt_name = false, has_multiple_alt_names = false;
 
+   // This condition is guarded in setopt_algorithm:
+   BSON_ASSERT (
+      !(ctx->opts.index_type.set &&
+        ctx->opts.algorithm != MONGOCRYPT_ENCRYPTION_ALGORITHM_NONE) &&
+      "Both an encryption algorithm and an index_type were set.");
+
    if (ctx->initialized) {
       return _mongocrypt_ctx_fail_w_msg (ctx, "cannot double initialize");
    }

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -1099,20 +1099,8 @@ mongocrypt_ctx_setopt_index_key_id (mongocrypt_ctx_t *ctx,
 
 bool
 mongocrypt_ctx_setopt_query_type (mongocrypt_ctx_t *ctx,
-                                  mongocrypt_query_type_t query_type)
-{
-   if (!ctx) {
-      return false;
-   }
-   ctx->opts.query_type.value = query_type;
-   ctx->opts.query_type.set = true;
-   return true;
-}
-
-bool
-mongocrypt_ctx_setopt_query_type_v2 (mongocrypt_ctx_t *ctx,
-                                     const char *query_type,
-                                     int len)
+                                  const char *query_type,
+                                  int len)
 {
    if (!ctx) {
       return false;

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -263,7 +263,8 @@ mongocrypt_ctx_setopt_algorithm (mongocrypt_ctx_t *ctx,
       return false;
    }
 
-   if (ctx->opts.algorithm != MONGOCRYPT_ENCRYPTION_ALGORITHM_NONE) {
+   if (ctx->opts.algorithm != MONGOCRYPT_ENCRYPTION_ALGORITHM_NONE ||
+       ctx->opts.index_type.set) {
       return _mongocrypt_ctx_fail_w_msg (ctx, "already set algorithm");
    }
 
@@ -1073,18 +1074,6 @@ _mongocrypt_ctx_kms_providers (mongocrypt_ctx_t *ctx)
    return ctx->kms_providers.configured_providers
              ? &ctx->kms_providers
              : &ctx->crypt->opts.kms_providers;
-}
-
-bool
-mongocrypt_ctx_setopt_index_type (mongocrypt_ctx_t *ctx,
-                                  mongocrypt_index_type_t index_type)
-{
-   if (!ctx) {
-      return false;
-   }
-   ctx->opts.index_type.value = index_type;
-   ctx->opts.index_type.set = true;
-   return true;
 }
 
 bool

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -1501,21 +1501,6 @@ bool
 mongocrypt_ctx_setopt_index_key_id (mongocrypt_ctx_t *ctx,
                                     mongocrypt_binary_t *key_id);
 
-typedef enum { MONGOCRYPT_QUERY_TYPE_EQUALITY = 1 } mongocrypt_query_type_t;
-
-/**
- * Set the query type to use for explicit Queryable Encryption.
- *
- * @param[in] ctx The @ref mongocrypt_ctx_t object.
- * @param[in] query_type
- * @pre @p ctx has not been initialized.
- * @returns A boolean indicating success. If false, an error status is set.
- * Retrieve it with @ref mongocrypt_ctx_status
- */
-MONGOCRYPT_EXPORT
-bool
-mongocrypt_ctx_setopt_query_type (mongocrypt_ctx_t *ctx,
-                                  mongocrypt_query_type_t query_type);
 
 /**
  * Set the query type to use for explicit Queryable Encryption.
@@ -1529,9 +1514,9 @@ mongocrypt_ctx_setopt_query_type (mongocrypt_ctx_t *ctx,
  */
 MONGOCRYPT_EXPORT
 bool
-mongocrypt_ctx_setopt_query_type_v2 (mongocrypt_ctx_t *ctx,
-                                     const char *query_type,
-                                     int len);
+mongocrypt_ctx_setopt_query_type (mongocrypt_ctx_t *ctx,
+                                  const char *query_type,
+                                  int len);
 
 /// String constant for setopt_query_type_v2, "equality" query type
 #define MONGOCRYPT_QUERY_TYPE_EQUALITY_STR "equality"

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -731,6 +731,16 @@ mongocrypt_ctx_setopt_algorithm (mongocrypt_ctx_t *ctx,
                                  const char *algorithm,
                                  int len);
 
+/// String constant for setopt_algorithm "Deterministic" encryption
+#define MONGOCRYPT_ALGORITHM_DETERMINISTIC_STR \
+   "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+/// String constant for setopt_algorithm "Random" encryption
+#define MONGOCRYPT_ALGORITHM_RANDOM_STR "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+/// String constant for setopt_algorithm "Indexed" explicit encryption
+#define MONGOCRYPT_ALGORITHM_INDEXED_STR "Indexed"
+/// String constant for setopt_algorithm "Unindexed" explicit encryption
+#define MONGOCRYPT_ALGORITHM_UNINDEXED_STR "Unindexed"
+
 
 /**
  * Identify the AWS KMS master key to use for creating a data key.
@@ -1522,5 +1532,8 @@ bool
 mongocrypt_ctx_setopt_query_type_v2 (mongocrypt_ctx_t *ctx,
                                      const char *query_type,
                                      int len);
+
+/// String constant for setopt_query_type_v2, "equality" query type
+#define MONGOCRYPT_QUERY_TYPE_EQUALITY_STR "equality"
 
 #endif /* MONGOCRYPT_H */

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -1507,4 +1507,20 @@ bool
 mongocrypt_ctx_setopt_query_type (mongocrypt_ctx_t *ctx,
                                   mongocrypt_query_type_t query_type);
 
+/**
+ * Set the query type to use for explicit Queryable Encryption.
+ *
+ * @param[in] ctx The @ref mongocrypt_ctx_t object.
+ * @param[in] query_type The query type string
+ * @param[in] len The length of query_type, or -1 for automatic
+ * @pre @p ctx has not been initialized.
+ * @returns A boolean indicating success. If false, an error status is set.
+ * Retrieve it with @ref mongocrypt_ctx_status
+ */
+MONGOCRYPT_EXPORT
+bool
+mongocrypt_ctx_setopt_query_type_v2 (mongocrypt_ctx_t *ctx,
+                                     const char *query_type,
+                                     int len);
+
 #endif /* MONGOCRYPT_H */

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -908,7 +908,6 @@ mongocrypt_ctx_encrypt_init (mongocrypt_ctx_t *ctx,
  * - @ref mongocrypt_ctx_setopt_algorithm
  *
  * Associated options for Queryable Encryption:
- * - @ref mongocrypt_ctx_setopt_index_type
  * - @ref mongocrypt_ctx_setopt_key_id
  * - @ref mongocrypt_ctx_setopt_index_key_id
  * - @ref mongocrypt_ctx_setopt_contention_factor
@@ -1456,26 +1455,6 @@ mongocrypt_setopt_crypto_hook_sign_rsaes_pkcs1_v1_5 (
 MONGOCRYPT_EXPORT
 void
 mongocrypt_setopt_bypass_query_analysis (mongocrypt_t *crypt);
-
-typedef enum {
-   MONGOCRYPT_INDEX_TYPE_NONE = 1,
-   MONGOCRYPT_INDEX_TYPE_EQUALITY = 2
-} mongocrypt_index_type_t;
-
-/**
- * Set the index type used for explicit encryption.
- * The index type is only used for Queryable Encryption.
- *
- * @param[in] ctx The @ref mongocrypt_ctx_t object.
- * @param[in] index_type
- * @pre @p ctx has not been initialized.
- * @returns A boolean indicating success. If false, an error status is set.
- * Retrieve it with @ref mongocrypt_ctx_status.
- */
-MONGOCRYPT_EXPORT
-bool
-mongocrypt_ctx_setopt_index_type (mongocrypt_ctx_t *ctx,
-                                  mongocrypt_index_type_t index_type);
 
 /**
  * Set the contention factor used for explicit encryption.

--- a/test/example-state-machine.c
+++ b/test/example-state-machine.c
@@ -338,8 +338,7 @@ main ()
    key_id = _iter_to_binary (&iter);
    mongocrypt_ctx_setopt_key_id (ctx, key_id);
    bson_destroy (&key_doc);
-   mongocrypt_ctx_setopt_algorithm (
-      ctx, "AEAD_AES_256_CBC_HMAC_SHA_512-Random", -1);
+   mongocrypt_ctx_setopt_algorithm (ctx, MONGOCRYPT_ALGORITHM_RANDOM_STR, -1);
 
    wrapped = BCON_NEW ("v", "hello");
    msg = mongocrypt_binary_new_from_data ((uint8_t *) bson_get_data (wrapped),

--- a/test/test-mongocrypt-crypto-hooks.c
+++ b/test/test-mongocrypt-crypto-hooks.c
@@ -669,7 +669,7 @@ _test_crypto_hooks_explicit_err (_mongocrypt_tester_t *tester)
    mongocrypt_t *crypt;
    mongocrypt_ctx_t *ctx;
    mongocrypt_binary_t *bin, *key_id;
-   char *deterministic = "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic";
+   const char *deterministic = MONGOCRYPT_ALGORITHM_DETERMINISTIC_STR;
 
    call_history = bson_string_new (NULL);
 

--- a/test/test-mongocrypt-ctx-decrypt.c
+++ b/test/test-mongocrypt-ctx-decrypt.c
@@ -179,7 +179,7 @@ _test_decrypt_empty_binary (_mongocrypt_tester_t *tester)
    mongocrypt_ctx_setopt_key_alt_name (
       ctx, TEST_BSON ("{'keyAltName': 'keyDocumentName'}"));
    mongocrypt_ctx_setopt_algorithm (
-      ctx, "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic", -1);
+      ctx, MONGOCRYPT_ALGORITHM_DETERMINISTIC_STR, -1);
    mongocrypt_ctx_explicit_encrypt_init (
       ctx,
       TEST_BSON ("{'v': { '$binary': { 'base64': '', 'subType': '00' } } }"));
@@ -221,7 +221,7 @@ _test_decrypt_per_ctx_credentials (_mongocrypt_tester_t *tester)
    mongocrypt_ctx_setopt_key_alt_name (
       ctx, TEST_BSON ("{'keyAltName': 'keyDocumentName'}"));
    mongocrypt_ctx_setopt_algorithm (
-      ctx, "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic", -1);
+      ctx, MONGOCRYPT_ALGORITHM_DETERMINISTIC_STR, -1);
    mongocrypt_ctx_explicit_encrypt_init (
       ctx,
       TEST_BSON ("{'v': { '$binary': { 'base64': '', 'subType': '00' } } }"));
@@ -280,7 +280,7 @@ _test_decrypt_per_ctx_credentials_local (_mongocrypt_tester_t *tester)
    mongocrypt_ctx_setopt_key_id (
       ctx, _mongocrypt_buffer_as_binary (&local_uuid_buf));
    mongocrypt_ctx_setopt_algorithm (
-      ctx, "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic", -1);
+      ctx, MONGOCRYPT_ALGORITHM_DETERMINISTIC_STR, -1);
    mongocrypt_ctx_explicit_encrypt_init (
       ctx,
       TEST_BSON ("{'v': { '$binary': { 'base64': '', 'subType': '00' } } }"));

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -2596,9 +2596,9 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
                     ctx, MONGOCRYPT_ALGORITHM_INDEXED_STR, -1),
                  ctx);
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_query_type (ctx, MONGOCRYPT_QUERY_TYPE_EQUALITY),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_query_type (
+                    ctx, MONGOCRYPT_QUERY_TYPE_EQUALITY_STR, -1),
+                 ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&user_key_id)),
                  ctx);
@@ -2650,9 +2650,9 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
                     ctx, MONGOCRYPT_ALGORITHM_INDEXED_STR, -1),
                  ctx);
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_query_type (ctx, MONGOCRYPT_QUERY_TYPE_EQUALITY),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_query_type (
+                    ctx, MONGOCRYPT_QUERY_TYPE_EQUALITY_STR, -1),
+                 ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_contention_factor (ctx, 1), ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&user_key_id)),

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -2292,9 +2292,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       mongocrypt_t *crypt = _crypt_with_rng (&source);
       mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
 
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_index_type (ctx, MONGOCRYPT_INDEX_TYPE_NONE),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Unindexed", -1), ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&user_key_id)),
                  ctx);
@@ -2355,9 +2353,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       mongocrypt_t *crypt = _crypt_with_rng (&source);
       mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
 
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_index_type (ctx, MONGOCRYPT_INDEX_TYPE_EQUALITY),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Indexed", -1), ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&user_key_id)),
                  ctx);
@@ -2417,9 +2413,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       mongocrypt_t *crypt = _crypt_with_rng (&source);
       mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
 
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_index_type (ctx, MONGOCRYPT_INDEX_TYPE_EQUALITY),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Indexed", -1), ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&user_key_id)),
                  ctx);
@@ -2487,9 +2481,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       mongocrypt_t *crypt = _crypt_with_rng (&source);
       mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
 
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_index_type (ctx, MONGOCRYPT_INDEX_TYPE_EQUALITY),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Indexed", -1), ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&user_key_id)),
                  ctx);
@@ -2549,9 +2541,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       mongocrypt_t *crypt = _crypt_with_rng (&source);
       mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
 
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_index_type (ctx, MONGOCRYPT_INDEX_TYPE_EQUALITY),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Indexed", -1), ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&user_key_id)),
                  ctx);
@@ -2593,9 +2583,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       mongocrypt_t *crypt = _crypt_with_rng (&source);
       mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
 
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_index_type (ctx, MONGOCRYPT_INDEX_TYPE_EQUALITY),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Indexed", -1), ctx);
       ASSERT_OK (
          mongocrypt_ctx_setopt_query_type (ctx, MONGOCRYPT_QUERY_TYPE_EQUALITY),
          ctx);
@@ -2647,9 +2635,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       mongocrypt_t *crypt = _crypt_with_rng (&source);
       mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
 
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_index_type (ctx, MONGOCRYPT_INDEX_TYPE_EQUALITY),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Indexed", -1), ctx);
       ASSERT_OK (
          mongocrypt_ctx_setopt_query_type (ctx, MONGOCRYPT_QUERY_TYPE_EQUALITY),
          ctx);
@@ -2704,9 +2690,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       mongocrypt_t *crypt = _crypt_with_rng (&source);
       mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
 
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_index_type (ctx, MONGOCRYPT_INDEX_TYPE_EQUALITY),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Indexed", -1), ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_contention_factor (ctx, -1), ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&user_key_id)),
@@ -2726,9 +2710,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       mongocrypt_t *crypt = _crypt_with_rng (&source);
       mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
 
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_index_type (ctx, MONGOCRYPT_INDEX_TYPE_EQUALITY),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Indexed", -1), ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_contention_factor (ctx, INT64_MAX), ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&user_key_id)),

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -38,8 +38,8 @@ _test_explicit_encrypt_init (_mongocrypt_tester_t *tester)
    bson_t *bson_name;
    bson_t *bson_bad_name;
 
-   char *random = "AEAD_AES_256_CBC_HMAC_SHA_512-Random";
-   char *deterministic = "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic";
+   char *random = MONGOCRYPT_ALGORITHM_RANDOM_STR;
+   char *deterministic = MONGOCRYPT_ALGORITHM_DETERMINISTIC_STR;
 
    bson_msg = BCON_NEW ("v", "hello");
    msg = mongocrypt_binary_new_from_data ((uint8_t *) bson_get_data (bson_msg),
@@ -1354,7 +1354,7 @@ _test_explicit_encryption (_mongocrypt_tester_t *tester)
    mongocrypt_ctx_t *ctx;
    _mongocrypt_buffer_t from_key_id, from_key_altname;
    mongocrypt_binary_t *bin, *key_id;
-   char *deterministic = "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic";
+   char *deterministic = MONGOCRYPT_ALGORITHM_DETERMINISTIC_STR;
 
    crypt = _mongocrypt_tester_mongocrypt (TESTER_MONGOCRYPT_DEFAULT);
 
@@ -2292,7 +2292,9 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       mongocrypt_t *crypt = _crypt_with_rng (&source);
       mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
 
-      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Unindexed", -1), ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
+                    ctx, MONGOCRYPT_ALGORITHM_UNINDEXED_STR, -1),
+                 ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&user_key_id)),
                  ctx);
@@ -2353,7 +2355,9 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       mongocrypt_t *crypt = _crypt_with_rng (&source);
       mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
 
-      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Indexed", -1), ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
+                    ctx, MONGOCRYPT_ALGORITHM_INDEXED_STR, -1),
+                 ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&user_key_id)),
                  ctx);
@@ -2413,7 +2417,9 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       mongocrypt_t *crypt = _crypt_with_rng (&source);
       mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
 
-      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Indexed", -1), ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
+                    ctx, MONGOCRYPT_ALGORITHM_INDEXED_STR, -1),
+                 ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&user_key_id)),
                  ctx);
@@ -2481,7 +2487,9 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       mongocrypt_t *crypt = _crypt_with_rng (&source);
       mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
 
-      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Indexed", -1), ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
+                    ctx, MONGOCRYPT_ALGORITHM_INDEXED_STR, -1),
+                 ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&user_key_id)),
                  ctx);
@@ -2541,7 +2549,9 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       mongocrypt_t *crypt = _crypt_with_rng (&source);
       mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
 
-      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Indexed", -1), ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
+                    ctx, MONGOCRYPT_ALGORITHM_INDEXED_STR, -1),
+                 ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&user_key_id)),
                  ctx);
@@ -2583,7 +2593,9 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       mongocrypt_t *crypt = _crypt_with_rng (&source);
       mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
 
-      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Indexed", -1), ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
+                    ctx, MONGOCRYPT_ALGORITHM_INDEXED_STR, -1),
+                 ctx);
       ASSERT_OK (
          mongocrypt_ctx_setopt_query_type (ctx, MONGOCRYPT_QUERY_TYPE_EQUALITY),
          ctx);
@@ -2635,7 +2647,9 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       mongocrypt_t *crypt = _crypt_with_rng (&source);
       mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
 
-      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Indexed", -1), ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
+                    ctx, MONGOCRYPT_ALGORITHM_INDEXED_STR, -1),
+                 ctx);
       ASSERT_OK (
          mongocrypt_ctx_setopt_query_type (ctx, MONGOCRYPT_QUERY_TYPE_EQUALITY),
          ctx);
@@ -2690,7 +2704,9 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       mongocrypt_t *crypt = _crypt_with_rng (&source);
       mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
 
-      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Indexed", -1), ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
+                    ctx, MONGOCRYPT_ALGORITHM_INDEXED_STR, -1),
+                 ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_contention_factor (ctx, -1), ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&user_key_id)),
@@ -2710,7 +2726,9 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       mongocrypt_t *crypt = _crypt_with_rng (&source);
       mongocrypt_ctx_t *ctx = mongocrypt_ctx_new (crypt);
 
-      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Indexed", -1), ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
+                    ctx, MONGOCRYPT_ALGORITHM_INDEXED_STR, -1),
+                 ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_contention_factor (ctx, INT64_MAX), ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&user_key_id)),

--- a/test/test-mongocrypt-ctx-setopt.c
+++ b/test/test-mongocrypt-ctx-setopt.c
@@ -724,9 +724,9 @@ _test_setopt_for_explicit_encrypt (_mongocrypt_tester_t *tester)
 
       REFRESH;
       KEY_ALT_NAME_OK (TEST_BSON ("{'keyAltName': 'abc'}"));
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_query_type (ctx, MONGOCRYPT_QUERY_TYPE_EQUALITY),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_query_type (
+                    ctx, MONGOCRYPT_QUERY_TYPE_EQUALITY_STR, -1),
+                 ctx);
       EX_ENCRYPT_INIT_FAILS (bson,
                              "cannot set both key alt name and query type");
    }
@@ -756,9 +756,9 @@ _test_setopt_for_explicit_encrypt (_mongocrypt_tester_t *tester)
        * error */
       KEY_ID_OK (uuid);
       ALGORITHM_OK (RAND, -1);
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_query_type (ctx, MONGOCRYPT_QUERY_TYPE_EQUALITY),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_query_type (
+                    ctx, MONGOCRYPT_QUERY_TYPE_EQUALITY_STR, -1),
+                 ctx);
       EX_ENCRYPT_INIT_FAILS (bson, "cannot set both algorithm and query type");
    }
 
@@ -793,9 +793,9 @@ _test_setopt_for_explicit_encrypt (_mongocrypt_tester_t *tester)
       /* Set key ID to get past the 'either key id or key alt name required'
        * error */
       KEY_ID_OK (uuid);
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_query_type (ctx, MONGOCRYPT_QUERY_TYPE_EQUALITY),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_query_type (
+                    ctx, MONGOCRYPT_QUERY_TYPE_EQUALITY_STR, -1),
+                 ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
                     ctx, MONGOCRYPT_ALGORITHM_UNINDEXED_STR, -1),
                  ctx);

--- a/test/test-mongocrypt-ctx-setopt.c
+++ b/test/test-mongocrypt-ctx-setopt.c
@@ -704,9 +704,7 @@ _test_setopt_for_explicit_encrypt (_mongocrypt_tester_t *tester)
    {
       REFRESH;
       KEY_ALT_NAME_OK (TEST_BSON ("{'keyAltName': 'abc'}"));
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_index_type (ctx, MONGOCRYPT_INDEX_TYPE_NONE),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Unindexed", -1), ctx);
       EX_ENCRYPT_INIT_FAILS (bson,
                              "cannot set both key alt name and index type");
 
@@ -734,16 +732,6 @@ _test_setopt_for_explicit_encrypt (_mongocrypt_tester_t *tester)
    /* It is an error to set the FLE 1 algorithm option with any of the FLE 2
     * options (index_type, index_key_id, contention_factor, or query_type). */
    {
-      REFRESH;
-      /* Set key ID to get past the 'either key id or key alt name required'
-       * error */
-      KEY_ID_OK (uuid);
-      ALGORITHM_OK (RAND, -1);
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_index_type (ctx, MONGOCRYPT_INDEX_TYPE_NONE),
-         ctx);
-      EX_ENCRYPT_INIT_FAILS (bson, "cannot set both algorithm and index type");
-
       REFRESH;
       /* Set key ID to get past the 'either key id or key alt name required'
        * error */
@@ -789,9 +777,7 @@ _test_setopt_for_explicit_encrypt (_mongocrypt_tester_t *tester)
        * error */
       KEY_ID_OK (uuid);
       ASSERT_OK (mongocrypt_ctx_setopt_contention_factor (ctx, 0), ctx);
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_index_type (ctx, MONGOCRYPT_INDEX_TYPE_NONE),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Unindexed", -1), ctx);
       EX_ENCRYPT_INIT_FAILS (bson,
                              "cannot set contention factor with no index type");
    }
@@ -806,9 +792,7 @@ _test_setopt_for_explicit_encrypt (_mongocrypt_tester_t *tester)
       ASSERT_OK (
          mongocrypt_ctx_setopt_query_type (ctx, MONGOCRYPT_QUERY_TYPE_EQUALITY),
          ctx);
-      ASSERT_OK (
-         mongocrypt_ctx_setopt_index_type (ctx, MONGOCRYPT_INDEX_TYPE_NONE),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Unindexed", -1), ctx);
       EX_ENCRYPT_INIT_FAILS (bson, "cannot set query type with no index type");
    }
 

--- a/test/test-mongocrypt-ctx-setopt.c
+++ b/test/test-mongocrypt-ctx-setopt.c
@@ -108,8 +108,8 @@ static char invalid_utf8[] = {(char) 0x80, (char) 0x00};
       ctx = mongocrypt_ctx_new (crypt); \
    } while (0)
 
-#define DET "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
-#define RAND "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+#define DET MONGOCRYPT_ALGORITHM_DETERMINISTIC_STR
+#define RAND MONGOCRYPT_ALGORITHM_RANDOM_STR
 
 /* Test valid and invalid options */
 static void
@@ -509,7 +509,7 @@ _test_setopt_for_datakey (_mongocrypt_tester_t *tester)
 
    REFRESH;
    MASTERKEY_AWS_OK ("region", -1, "cmk", -1);
-   ALGORITHM_OK ("AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic", -1);
+   ALGORITHM_OK (MONGOCRYPT_ALGORITHM_DETERMINISTIC_STR, -1);
    DATAKEY_INIT_FAILS ("algorithm prohibited");
 
    /* Test setting options after init. */
@@ -704,7 +704,9 @@ _test_setopt_for_explicit_encrypt (_mongocrypt_tester_t *tester)
    {
       REFRESH;
       KEY_ALT_NAME_OK (TEST_BSON ("{'keyAltName': 'abc'}"));
-      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Unindexed", -1), ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
+                    ctx, MONGOCRYPT_ALGORITHM_UNINDEXED_STR, -1),
+                 ctx);
       EX_ENCRYPT_INIT_FAILS (bson,
                              "cannot set both key alt name and index type");
 
@@ -777,7 +779,9 @@ _test_setopt_for_explicit_encrypt (_mongocrypt_tester_t *tester)
        * error */
       KEY_ID_OK (uuid);
       ASSERT_OK (mongocrypt_ctx_setopt_contention_factor (ctx, 0), ctx);
-      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Unindexed", -1), ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
+                    ctx, MONGOCRYPT_ALGORITHM_UNINDEXED_STR, -1),
+                 ctx);
       EX_ENCRYPT_INIT_FAILS (bson,
                              "cannot set contention factor with no index type");
    }
@@ -792,7 +796,9 @@ _test_setopt_for_explicit_encrypt (_mongocrypt_tester_t *tester)
       ASSERT_OK (
          mongocrypt_ctx_setopt_query_type (ctx, MONGOCRYPT_QUERY_TYPE_EQUALITY),
          ctx);
-      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (ctx, "Unindexed", -1), ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
+                    ctx, MONGOCRYPT_ALGORITHM_UNINDEXED_STR, -1),
+                 ctx);
       EX_ENCRYPT_INIT_FAILS (bson, "cannot set query type with no index type");
    }
 


### PR DESCRIPTION
There are several commits in this changeset, and each can be read alone.

This change has two important facets:

- Allow passing `"Indexed"` and `"Unindexed"` as the algorithm string to `setopt_algorithm`. This mimics the user-facing API and allows drivers to be forwards-compatible in the face of new "index types."
- Change `setopt_query_type` to accepta a string for the `query_type` instead of an enumerator. (Implements [DRIVERS-2352](https://jira.mongodb.org/browse/DRIVERS-2352))