### PR TITLE
chore(NODE-4304): accept string value for queryType

### DIFF
--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -344,7 +344,7 @@ export interface ClientEncryptionEncryptOptions {
   contentionFactor?: bigint | number;
 
   /** @experimental */
-  queryType?: 'Equality';
+  queryType?: 'equality';
 }
 
 /**

--- a/bindings/node/test/clientEncryption.test.js
+++ b/bindings/node/test/clientEncryption.test.js
@@ -684,7 +684,7 @@ describe('ClientEncryption', function () {
       const findPayload = await clientEncryption.encrypt('encrypted indexed value', {
         keyId: KEY1_ID,
         algorithm: 'Indexed',
-        queryType: 'Equality'
+        queryType: 'equality'
       });
       const findResult = await coll
         .find({
@@ -714,7 +714,7 @@ describe('ClientEncryption', function () {
       const findPayload = await clientEncryption.encrypt('encrypted indexed value', {
         keyId: KEY1_ID,
         algorithm: 'Indexed',
-        queryType: 'Equality'
+        queryType: 'equality'
       });
       const findResult = await coll
         .find({
@@ -733,7 +733,7 @@ describe('ClientEncryption', function () {
       const findPayload2 = await clientEncryption.encrypt('encrypted indexed value', {
         keyId: KEY1_ID,
         algorithm: 'Indexed',
-        queryType: 'Equality',
+        queryType: 'equality',
         contentionFactor: 10
       });
       const findResult2 = await coll


### PR DESCRIPTION
MONGOCRYPT-441 has no impact besides updating `equality` to
be spelled lowercase.