### PR TITLE
Disable ENABLE_AUTOMATIC_INIT_AND_CLEANUP by default

### DIFF
--- a/cmake/ImportBSON.cmake
+++ b/cmake/ImportBSON.cmake
@@ -134,6 +134,8 @@ function (_import_bson)
       set (ENABLE_STATIC BUILD_ONLY)
       # Disable libzstd, which isn't necessary for libmongocrypt and isn't necessarily available.
       set (ENABLE_ZSTD OFF CACHE BOOL "Toggle libzstd for the mongoc subproject (not required by libmongocrypt)")
+      # Disable deprecated automatic init and cleanup. (May be overridden by the user)
+      set (ENABLE_AUTOMATIC_INIT_AND_CLEANUP OFF CACHE BOOL "Enable automatic init and cleanup (GCC only)")
       # Disable over-alignment of bson types. (May be overridden by the user)
       set (ENABLE_EXTRA_ALIGNMENT ${_extra_alignment_default} CACHE BOOL "Toggle extra alignment of bson_t")
       # We don't want the subproject to find libmongocrypt


### PR DESCRIPTION
## Description

Currently, building the imported libmongoc library generates the following error message:

```
warning: Configure the driver with ENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF. Automatic cleanup is deprecated and will be removed in version 2.0. [-W#pragma-messages]
 ```

This PR disables `ENABLE_AUTOMATIC_INIT_AND_CLEANUP` by default when building the imported libmongoc library to silence this warning. (Note: we may also want to consider changing this default value in the C driver CMake configuration from `ON` to `OFF` if able, given how many users are having to go out of their way to explicit disable it.)