### PR TITLE
MONGOCRYPT-447 set default contention factor to 4

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -1643,6 +1643,11 @@ _fle2_finalize_explicit (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
 
    if (ctx->opts.contention_factor.set) {
       marking.fle2.maxContentionCounter = ctx->opts.contention_factor.value;
+   } else {
+      // DEFAULT_CONTENTION_FACTOR must match the default on the server.
+      // See https://github.com/mongodb/mongo/blob/ddff02d34d8a9b2a999267e5c94dcc405eb7fc42/src/mongo/crypto/encryption_fields.idl#L66
+      #define DEFAULT_CONTENTION_FACTOR 4
+      marking.fle2.maxContentionCounter = DEFAULT_CONTENTION_FACTOR;
    }
 
    /* Convert marking to ciphertext. */

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -2304,6 +2304,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       ASSERT_OK (mongocrypt_ctx_explicit_encrypt_init (
                     ctx, TEST_BSON ("{'v': 'value123'}")),
                  ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_contention_factor (ctx, 0), ctx);
 
       ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
                           MONGOCRYPT_CTX_NEED_MONGO_KEYS);
@@ -2367,6 +2368,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       ASSERT_OK (mongocrypt_ctx_explicit_encrypt_init (
                     ctx, TEST_BSON ("{'v': 'value123'}")),
                  ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_contention_factor (ctx, 0), ctx);
 
       ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
                           MONGOCRYPT_CTX_NEED_MONGO_KEYS);
@@ -2555,6 +2557,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       ASSERT_OK (mongocrypt_ctx_setopt_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&user_key_id)),
                  ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_contention_factor (ctx, 0), ctx);
       ASSERT_OK (mongocrypt_ctx_explicit_encrypt_init (
                     ctx, TEST_BSON ("{'v': 'value123'}")),
                  ctx);
@@ -2605,6 +2608,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       ASSERT_OK (mongocrypt_ctx_setopt_index_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&index_key_id)),
                  ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_contention_factor (ctx, 0), ctx);
       ASSERT_OK (mongocrypt_ctx_explicit_encrypt_init (
                     ctx, TEST_BSON ("{'v': 123456}")),
                  ctx);


### PR DESCRIPTION
# Summary
- Set default contention factor to 4 for explicit encryption.

# Background & Motivation
This is to account for https://jira.mongodb.org/browse/SERVER-66663.

This is planned to be tested in drivers with this [integration test](https://github.com/mongodb/specifications/pull/1262/files#diff-c57f446f49351e6f7432a2d3028c880a728f1a33031510a7c376aed157d6de00R1798)