### PR TITLE
MONGOCRYPT-447 require contention factor for indexed algorithm

### DIFF
--- a/bindings/python/test/test_mongocrypt.py
+++ b/bindings/python/test/test_mongocrypt.py
@@ -526,8 +526,8 @@ class TestExplicitEncryption(unittest.TestCase):
         val = {'v': 'value123'}
         encoded_val = bson.encode(val)
         for kwargs in [
-            dict(algorithm='Indexed'),
-            dict(algorithm='Indexed', query_type='equality'),
+            dict(algorithm='Indexed', contention_factor=0),
+            dict(algorithm='Indexed', query_type='equality', contention_factor=0),
             dict(algorithm='Indexed', contention_factor=100),
             dict(algorithm='Unindexed'),
         ]:

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -2365,10 +2365,10 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       ASSERT_OK (mongocrypt_ctx_setopt_index_key_id (
                     ctx, _mongocrypt_buffer_as_binary (&index_key_id)),
                  ctx);
+      ASSERT_OK (mongocrypt_ctx_setopt_contention_factor (ctx, 0), ctx);
       ASSERT_OK (mongocrypt_ctx_explicit_encrypt_init (
                     ctx, TEST_BSON ("{'v': 'value123'}")),
                  ctx);
-      ASSERT_OK (mongocrypt_ctx_setopt_contention_factor (ctx, 0), ctx);
 
       ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
                           MONGOCRYPT_CTX_NEED_MONGO_KEYS);

--- a/test/test-mongocrypt-ctx-setopt.c
+++ b/test/test-mongocrypt-ctx-setopt.c
@@ -802,6 +802,18 @@ _test_setopt_for_explicit_encrypt (_mongocrypt_tester_t *tester)
       EX_ENCRYPT_INIT_FAILS (bson, "cannot set query type with no index type");
    }
 
+   /* Contention factor is required for "Indexed" algorithm. */
+   {
+      REFRESH;
+      /* Set key ID to get past the 'either key id or key alt name required'
+       * error */
+      KEY_ID_OK (uuid);
+      ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
+                    ctx, MONGOCRYPT_ALGORITHM_INDEXED_STR, -1),
+                 ctx);
+      EX_ENCRYPT_INIT_FAILS (bson, "contention factor is required");
+   }
+
    mongocrypt_ctx_destroy (ctx);
    mongocrypt_destroy (crypt);
 }


### PR DESCRIPTION
# Summary
- Require contention factor for indexed algorithm with explicit encryption

# Background & Motivation
The server plans to support increasing the contention factor in the future. If libmongocrypt uses the fixed default value 4, that may risk the default client and server contention factors going out of sync.

This PR proposes making the contention factor a required client option for explicit encryption. The contention factor can be made optional later, if there is a way for explicit encryption to get the server default.