### PR TITLE
Remove unnecessary fields in result of rewrapManyDataKey

### DIFF
--- a/test/test-mongocrypt-ctx-rewrap-many-datakey.c
+++ b/test/test-mongocrypt-ctx-rewrap-many-datakey.c
@@ -892,43 +892,6 @@ _test_rewrap_many_datakey_finalize (_mongocrypt_tester_t *tester)
          ASSERT (iter.raw != b_iter.raw || iter.off != b_iter.off);
       }
 
-      /* Both keys should have same creation date as prior to rewrap. */
-      iter = a_iter;
-      ASSERT (bson_iter_find_descendant (&iter, "creationDate", &iter));
-      ASSERT (fields_a->creation_date == bson_iter_date_time (&iter));
-      iter = b_iter;
-      ASSERT (bson_iter_find_descendant (&iter, "creationDate", &iter));
-      ASSERT (fields_b->creation_date == bson_iter_date_time (&iter));
-
-      /* Both keys should have same alt names as prior to rewrap. */
-      {
-         _mongocrypt_key_alt_name_t *key_alt_names;
-
-         iter = a_iter;
-         ASSERT (bson_iter_find_descendant (&iter, "keyAltNames", &iter));
-         ASSERT (
-            _mongocrypt_key_alt_name_from_iter (&iter, &key_alt_names, NULL));
-         ASSERT (_mongocrypt_key_alt_name_unique_list_equal (
-            fields_a->key_alt_names, key_alt_names));
-         _mongocrypt_key_alt_name_destroy_all (key_alt_names);
-
-         iter = b_iter;
-         ASSERT (bson_iter_find_descendant (&iter, "keyAltNames", &iter));
-         ASSERT (
-            _mongocrypt_key_alt_name_from_iter (&iter, &key_alt_names, NULL));
-         ASSERT (_mongocrypt_key_alt_name_unique_list_equal (
-            fields_b->key_alt_names, key_alt_names));
-         _mongocrypt_key_alt_name_destroy_all (key_alt_names);
-      }
-
-      /* Both keys should have a new update date. */
-      iter = a_iter;
-      ASSERT (bson_iter_find_descendant (&iter, "updateDate", &iter));
-      ASSERT (fields_a->update_date < bson_iter_date_time (&iter));
-      iter = b_iter;
-      ASSERT (bson_iter_find_descendant (&iter, "updateDate", &iter));
-      ASSERT (fields_b->update_date < bson_iter_date_time (&iter));
-
       /* Both keys should be rewrapped with new masterKey. */
       iter = a_iter;
       ASSERT (bson_iter_find_descendant (&iter, "masterKey.key", &iter));


### PR DESCRIPTION
## Description

Long during initial implementation of `rewrapManyDataKey()`, the arbitrary decision was made to preserve as many fields of the key document(s) being rewrapped as possible. This turns out to be unnecessary: the bulk write operation(s) constructed by Drivers to `updateOne` the rewrapped key in the key vault collection only require:

- `_id`: the ID of the key to update.
- `keyMaterial`: the (possibly) new and rewrapped data key material.
- `masterKey`: the (possibly) new master key.

The `updateDate` field is updated by the `updateOne` command's `$currentDate` operator. All other fields are unnecessary and may give the incorrect impression that a `replaceOne` with the resulting document(s) may suffice to update the key vault collection.