### PR TITLE
fix(NODE-4260): mongocrypterror has name getter

### DIFF
--- a/bindings/node/lib/common.js
+++ b/bindings/node/lib/common.js
@@ -38,8 +38,11 @@ function collectionNamespace(ns) {
 class MongoCryptError extends Error {
   constructor(message) {
     super(message);
-    this.name = 'MongoCryptError';
     Error.captureStackTrace(this, this.constructor);
+  }
+
+  get name() {
+    return 'MongoCryptError';
   }
 }
 


### PR DESCRIPTION
Switch the `name` property of `MongoCryptError` to a getter in order to avoid the property setting errors caused by bulk write errors in the Node driver.