### PR TITLE
MONGOCRYPT-450 Update documentation of mongocrypt_ctx_finalize

### DIFF
--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -1270,7 +1270,7 @@ mongocrypt_ctx_provide_kms_providers (
  *
  * If @p ctx was initialized with @ref mongocrypt_ctx_rewrap_many_datakey_init,
  * then this BSON has the form:
- *   { "v": [{ _id: ..., keyMaterial: ..., masterKey: ... }, ...] }
+ *   { "v": [{ "_id": ..., "keyMaterial": ..., "masterKey": ... }, ...] }
  * where each BSON document in the array contains the updated fields of a
  * rewrapped datakey to be bulk-updated into the key vault collection.
  * Note: the updateDate field should be updated using the $currentDate operator.

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -1269,9 +1269,12 @@ mongocrypt_ctx_provide_kms_providers (
  * the key vault collection.
  *
  * If @p ctx was initialized with @ref mongocrypt_ctx_rewrap_many_datakey_init,
- * then this BSON has the form { "v": [(BSON document), ...] } where each BSON
- * document in the array is a document containing a rewrapped datakey to be
- * bulk-updated into the key vault collection.
+ * then this BSON has the form:
+ *   { "v": [{ _id: ..., keyMaterial: ..., masterKey: ... }, ...] }
+ * where each BSON document in the array is a document containing the updated
+ * fields of a rewrapped datakey to be bulk-updated into the key vault
+ * collection. Note: the updateDate field should be updated using the
+ * $currentDate operator.
  *
  * @returns a bool indicating success. If false, an error status is set.
  * Retrieve it with @ref mongocrypt_ctx_status

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -1271,10 +1271,9 @@ mongocrypt_ctx_provide_kms_providers (
  * If @p ctx was initialized with @ref mongocrypt_ctx_rewrap_many_datakey_init,
  * then this BSON has the form:
  *   { "v": [{ _id: ..., keyMaterial: ..., masterKey: ... }, ...] }
- * where each BSON document in the array is a document containing the updated
- * fields of a rewrapped datakey to be bulk-updated into the key vault
- * collection. Note: the updateDate field should be updated using the
- * $currentDate operator.
+ * where each BSON document in the array contains the updated fields of a
+ * rewrapped datakey to be bulk-updated into the key vault collection.
+ * Note: the updateDate field should be updated using the $currentDate operator.
  *
  * @returns a bool indicating success. If false, an error status is set.
  * Retrieve it with @ref mongocrypt_ctx_status


### PR DESCRIPTION
## Description

Followup to MONGOCRYPT-450; improves the documentation of `mongocrypt_ctx_finalize()` to more accurately describe the structure of the resulting value.