### PR TITLE
fix(NODE-4339): remove indexKeyId

### DIFF
--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -337,9 +337,6 @@ export interface ClientEncryptionEncryptOptions {
    */
   keyAltName?: string;
 
-  /** @experimental Public Technical Preview: The id of the index key. */
-  indexKeyId?: Binary;
-
   /** @experimental Public Technical Preview: The contention factor. */
   contentionFactor?: bigint | number;
 

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -365,9 +365,6 @@ module.exports = function (modules) {
       if (options.keyId) {
         contextOptions.keyId = options.keyId.buffer;
       }
-      if (options.indexKeyId) {
-        contextOptions.indexKeyId = options.indexKeyId.buffer;
-      }
       if (options.keyAltName) {
         const keyAltName = options.keyAltName;
         if (options.keyId) {

--- a/bindings/node/src/mongocrypt.cc
+++ b/bindings/node/src/mongocrypt.cc
@@ -581,19 +581,6 @@ Value MongoCrypt::MakeExplicitEncryptionContext(const CallbackInfo& info) {
                 throw TypeError::New(Env(), errorStringFromStatus(context.get()));
             }
         }
-
-        if (options.Has("indexKeyId")) {
-            Napi::Value indexKeyId = options["indexKeyId"];
-
-            if (!indexKeyId.IsBuffer()) {
-                throw TypeError::New(Env(), "`indexKeyId` must be a Buffer");
-            }
-
-            std::unique_ptr<mongocrypt_binary_t, MongoCryptBinaryDeleter> binary(BufferToBinary(indexKeyId.As<Uint8Array>()));
-            if (!mongocrypt_ctx_setopt_index_key_id(context.get(), binary.get())) {
-                throw TypeError::New(Env(), errorStringFromStatus(context.get()));
-            }
-        }
     }
 
     std::unique_ptr<mongocrypt_binary_t, MongoCryptBinaryDeleter> binaryValue(BufferToBinary(valueBuffer.As<Uint8Array>()));

--- a/bindings/node/test/clientEncryption.test.js
+++ b/bindings/node/test/clientEncryption.test.js
@@ -560,7 +560,6 @@ describe('ClientEncryption', function () {
 
       const encryptOptions = {
         keyId: new Binary(Buffer.from('ABCDEFAB123498761234123456789012', 'hex'), 4),
-        indexKeyId: new Binary(Buffer.from('12345678123498761234123456789012', 'hex'), 4),
         algorithm: 'Unindexed'
       };
 

--- a/bindings/node/test/cryptoCallbacks.test.js
+++ b/bindings/node/test/cryptoCallbacks.test.js
@@ -225,7 +225,6 @@ describe('cryptoCallbacks', function () {
 
             const encryptOptions = {
               keyId: dataKey,
-              indexKeyId: dataKey,
               algorithm: 'Indexed'
             };
 


### PR DESCRIPTION
This PR removes the usage of indexKeyId in the Node bindings.

From DRIVERS-2348:

Queryable Encryption has two keys per field: the UserKey and IndexKey.

    The UserKey encrypts user data.
    The IndexKey is used to derive tokens for indexing.

libmongocrypt assumes IndexKeyId == UserKeyId when only the UserKeyId is specified.

IndexKeyId is must must match the "keyId" in encryptedFields for correct query results.

After discussing with Mark Benvenuto, Seny Kamara, Kenneth White, Cynthia Braund, the decision is not to add the IndexKeyId to EncryptOpts for these reasons:

    We do not need to support the use-case where IndexKeyId != UserKeyId.
    Adding IndexKeyId increases risk that a user sets an incorrect IndexKeyId.