### PR TITLE
fix(NODE-4356): update rewrapManyDataKey to use UpdateOne bulk ops

### DIFF
--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -310,7 +310,8 @@ export interface ClientEncryptionRewrapManyDataKeyProviderOptions {
 
 /** @experimental */
 export interface ClientEncryptionRewrapManyDataKeyResult {
-  bulkWriteResult: BulkWriteResult;
+  /** The result of rewrapping data keys. If unset, no keys matched the filter. */
+  bulkWriteResult?: BulkWriteResult;
 }
 
 /** @experimental */

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -282,6 +282,10 @@ module.exports = function (modules) {
             return;
           }
 
+          if (dataKey.v.length === 0) {
+            return process.nextTick(cb, null, {});
+          }
+
           const dbName = databaseNamespace(this._keyVaultNamespace);
           const collectionName = collectionNamespace(this._keyVaultNamespace);
           const replacements = dataKey.v.map(key => ({

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -285,9 +285,17 @@ module.exports = function (modules) {
           const dbName = databaseNamespace(this._keyVaultNamespace);
           const collectionName = collectionNamespace(this._keyVaultNamespace);
           const replacements = dataKey.v.map(key => ({
-            replaceOne: {
+            updateOne: {
               filter: { _id: key._id },
-              replacement: key
+              update: {
+                $set: {
+                  masterKey: key.masterKey,
+                  keyMaterial: key.keyMaterial
+                },
+                $currentDate: {
+                  updateDate: true
+                }
+              }
             }
           }));
 

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -283,7 +283,8 @@ module.exports = function (modules) {
           }
 
           if (dataKey.v.length === 0) {
-            return process.nextTick(cb, null, {});
+            cb(null, {});
+            return;
           }
 
           const dbName = databaseNamespace(this._keyVaultNamespace);

--- a/bindings/node/test/clientEncryption.test.js
+++ b/bindings/node/test/clientEncryption.test.js
@@ -305,6 +305,17 @@ describe('ClientEncryption', function () {
         });
     });
 
+    it('should not perform updates if no keys match', function () {
+      const clientEncryption = new ClientEncryption(client, {
+        keyVaultNamespace: 'client.encryption',
+        kmsProviders: { local: { key: 'A'.repeat(128) } }
+      });
+
+      return clientEncryption.rewrapManyDataKey({ _id: 12345 }).then(rewrapManyDataKeyResult => {
+        expect(rewrapManyDataKeyResult.bulkWriteResult).to.equal(undefined);
+      });
+    });
+
     it('should explicitly encrypt and decrypt with a re-wrapped local key (explicit session/transaction)', function () {
       const encryption = new ClientEncryption(client, {
         keyVaultNamespace: 'client.encryption',


### PR DESCRIPTION
##### fix(NODE-4356): update rewrapManyDataKey to use UpdateOne bulk ops

See the ticket description. Since edb12c6b54602f68abe has already
been merged, this is required in order for rewrapManyDatakey
(as it would otherwise inadvertently destroy key information when run).

##### fix(NODE-4332): leave out bulk write in rewrapManyDataKey if unnecessary

Do not perform a bulk write if no keys are being updated.
