### PR TITLE
MONGOCRYPT-315 upload tagged releases to a URL containing the tag name

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -21,8 +21,23 @@ functions:
       params:
         script: |-
           set -o errexit
-          chmod u+x libmongocrypt/.evergreen/*.sh
-          ./libmongocrypt/.evergreen/print-env-info.sh
+          cd libmongocrypt
+          chmod u+x .evergreen/*.sh
+          ./.evergreen/print-env-info.sh
+
+          if [ "${is_patch}" != "true" ]; then
+            # determine if we have a release tag present on HEAD
+            head_tag=$(git tag -l --points-at HEAD '[0-9].*' | tail -1)
+          fi
+          echo "tag_upload_location: $head_tag"
+
+          cat <<EOT > ../tag_expansion.yml
+          tag_upload_location: "$head_tag"
+          EOT
+    - command: expansions.update
+      params:
+        ignore_missing_file: true
+        file: tag_expansion.yml
 
   "tar and upload libmongocrypt libraries":
     - command: archive.targz_pack
@@ -469,9 +484,13 @@ tasks:
     - variant: macos
       name: build-and-test-and-upload
   commands:
+    - func: "fetch source"
     - command: shell.exec
       params:
-        script: mkdir all
+        script: |-
+          # this directory was created in "fetch source", but it isn't needed here
+          rm -rf libmongocrypt
+          mkdir all
     - func: "download tarball"
       vars: { variant_name: ubuntu1604 }
     - func: "download tarball"
@@ -521,6 +540,15 @@ tasks:
         target: libmongocrypt-all.tar.gz
         source_dir: all
         include: [./**]
+    - command: shell.exec
+      params:
+        script: |-
+          set -o errexit
+          if [ -n "${tag_upload_location}" ]; then
+            # the "fetch source" step detected a release tag on HEAD, so we
+            # prepare a local file for upload to a location based on the tag
+            cp -a libmongocrypt-all.tar.gz libmongocrypt-all-${tag_upload_location}.tar.gz
+          fi
     - command: s3.put
       params:
         aws_key: '${aws_key}'
@@ -538,6 +566,17 @@ tasks:
         bucket: mciuploads
         permissions: public-read
         local_file: 'libmongocrypt-all.tar.gz'
+        content_type: '${content_type|application/x-gzip}'
+    - command: s3.put
+      params:
+        aws_key: '${aws_key}'
+        aws_secret: '${aws_secret}'
+        remote_file: 'libmongocrypt-feature/all/${tag_upload_location}/libmongocrypt-all.tar.gz'
+        bucket: mciuploads
+        permissions: public-read
+        optional: true
+        display_name: 'libmongocrypt-all-${tag_upload_location}.tar.gz'
+        local_file: 'libmongocrypt-all-${tag_upload_location}.tar.gz'
         content_type: '${content_type|application/x-gzip}'
 
 - name: publish-packages

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -27,13 +27,11 @@ functions:
 
           if [ "${is_patch}" != "true" ]; then
             # determine if we have a release tag present on HEAD
-            head_tag=$(git tag -l --points-at HEAD '[0-9].*' | tail -1)
+            head_tag=$(git tag -l --points-at HEAD '[0-9].*')
           fi
           echo "tag_upload_location: $head_tag"
 
-          cat <<EOT > ../tag_expansion.yml
-          tag_upload_location: "$head_tag"
-          EOT
+          echo "tag_upload_location: \"$head_tag\"" > ../tag_expansion.yml
     - command: expansions.update
       params:
         ignore_missing_file: true
@@ -487,10 +485,7 @@ tasks:
     - func: "fetch source"
     - command: shell.exec
       params:
-        script: |-
-          # this directory was created in "fetch source", but it isn't needed here
-          rm -rf libmongocrypt
-          mkdir all
+        script: mkdir all
     - func: "download tarball"
       vars: { variant_name: ubuntu1604 }
     - func: "download tarball"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -566,7 +566,7 @@ tasks:
       params:
         aws_key: '${aws_key}'
         aws_secret: '${aws_secret}'
-        remote_file: 'libmongocrypt-feature/all/${tag_upload_location}/libmongocrypt-all.tar.gz'
+        remote_file: 'libmongocrypt/all/${tag_upload_location}/libmongocrypt-all.tar.gz'
         bucket: mciuploads
         permissions: public-read
         optional: true

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ Do the following when releasing:
    - Update the [libmongocrypt-release](https://evergreen.mongodb.com/projects##libmongocrypt-release) Evergreen project to set `Branch Name` to `rx.y`.
 - In the Java binding build.gradle.kts, replace `version = "1.0.0-SNAPSHOT"` with `version = "1.0.0-rc123"`.
 - Commit, create a new git tag, like `1.0.0-rc123`, and push.
+   - Push both the branch ref and tag ref in the same command: `git push origin master 1.0.0-rc123` or `git push origin r1.0 1.0.0`
+   - Pushing the branch ref and the tag ref in the same command eliminates the possibility of a race condition in Evergreen (for building resources based on the presence of a release tag)
+   - Note that in the future (e.g., if we move to a PR-based workflow for releases, or if we simply want to take better advantage of advanced Evergreen features), it is possible to use Evergreen's "Trigger Versions With Git Tags" feature by updating both `config.yml` and the project's settings in Evergreen
 - In the Java binding build.gradle.kts, replace `version = "1.0.0-rc123"` with `version = "1.0.0-SNAPSHOT"` (i.e. undo the change). For an example of this, see [this commit](https://github.com/mongodb/libmongocrypt/commit/2336123fbc1f4f5894f49df5e6320040987bb0d3) and its parent commit.
 - Commit and push.
 - Ensure the version on Evergreen with the tagged commit is scheduled. The upload-all task must run to complete the release. ([Example](https://evergreen.mongodb.com/task/libmongocrypt_publish_snapshot_upload_all_77eec777c14171956c69b60aaaa4f85931c957ba_22_03_02_13_51_38)).


### PR DESCRIPTION
The main goal with this change, as the PR title suggests, is to upload to a URL based on the tag name for release tags.  Note that this is in addition to the normal uploads based on the commit hash and that existing uploads and upload locations were deliberately left undisturbed.  A separate ticket (MONGOCRYPT-437) will deal with necessary adjustments to the existing upload locations.

These changes cannot be effectively observed in a patch build, so you will have to consult the `upload-all` task in the last two builds on the waterfall of the special Evergreen project:

https://evergreen.mongodb.com/waterfall/libmongocrypt-feature

The only difference between the aggregate changes on the feature branch used for the special Evergreen project and this PR is that the line

```
head_tag=$(git tag -l --points-at HEAD 'MONGOCRYPT-315/[0-9].*' | tail -1 | sed 's/MONGOCRYPT-315\///')
```

is replaced with

```
head_tag=$(git tag -l --points-at HEAD '[0-9].*' | tail -1)
```

as the `MONGOCRYPT-315/` tag prefix was used only for development purposes and real release tags will have the form `1.x.y`.

Once this PR is approved by everyone, I will do the following:

- delete the `MONGOCRYPT-315/*` tags and `MONGOCRYPT-315` branch in the base repo
- announce to the team that the remote can be pruned to remove the cruft
- merge this PR