### PR TITLE
Set MAKEFLAGS to provide compilation parallelism

### DIFF
--- a/.evergreen/build_all.sh
+++ b/.evergreen/build_all.sh
@@ -18,19 +18,6 @@ evergreen_root="$(pwd)"
 
 . ${evergreen_root}/libmongocrypt/.evergreen/setup-env.sh
 
-if test -f /proc/cpuinfo; then
-    # Count the number of lines beginning with "processor" in the cpuinfo
-    jobs="$(grep -c '^processor' /proc/cpuinfo)"
-    if command -v bc; then
-        # Add two (hueristic to compensate for I/O latency)
-        jobs="$(echo "$jobs+2" | bc)"
-    fi
-    export MAKEFLAGS="-j$jobs ${MAKEFLAGS-}"
-else
-    # Cannot tell the best number of jobs. Provide a reasonable default.
-    export MAKEFLAGS="-j8 ${MAKEFLAGS-}"
-fi
-
 # We may need some more C++ flags
 _cxxflags=""
 

--- a/.evergreen/build_all.sh
+++ b/.evergreen/build_all.sh
@@ -18,6 +18,19 @@ evergreen_root="$(pwd)"
 
 . ${evergreen_root}/libmongocrypt/.evergreen/setup-env.sh
 
+if test -f /proc/cpuinfo; then
+    # Count the number of lines beginning with "processor" in the cpuinfo
+    jobs="$(grep -c '^processor' /proc/cpuinfo)"
+    if command -v bc; then
+        # Add two (hueristic to compensate for I/O latency)
+        jobs="$(echo "$jobs+2" | bc)"
+    fi
+    export MAKEFLAGS="-j$jobs ${MAKEFLAGS-}"
+else
+    # Cannot tell the best number of jobs. Provide a reasonable default.
+    export MAKEFLAGS="-j8 ${MAKEFLAGS-}"
+fi
+
 # We may need some more C++ flags
 _cxxflags=""
 

--- a/.evergreen/linker-tests.sh
+++ b/.evergreen/linker-tests.sh
@@ -36,6 +36,8 @@ libmongocrypt_root=$(pwd)
 linker_tests_root=${libmongocrypt_root}/linker_tests
 linker_tests_deps_root=${libmongocrypt_root}/.evergreen/linker_tests_deps
 
+. ${libmongocrypt_root}/.evergreen/setup-env.sh
+
 rm -rf linker_tests
 mkdir -p linker_tests/{install,libmongocrypt-cmake-build,app-cmake-build}
 cd linker_tests

--- a/.evergreen/pkgconfig-tests.sh
+++ b/.evergreen/pkgconfig-tests.sh
@@ -23,6 +23,8 @@ fi
 libmongocrypt_root=$(pwd)
 pkgconfig_tests_root=${libmongocrypt_root}/pkgconfig_tests
 
+. ${libmongocrypt_root}/.evergreen/setup-env.sh
+
 rm -rf pkgconfig_tests
 mkdir -p pkgconfig_tests/{install,libmongocrypt-cmake-build}
 cd pkgconfig_tests

--- a/.evergreen/setup-env.sh
+++ b/.evergreen/setup-env.sh
@@ -7,4 +7,15 @@ if [ "$OS" == "Windows_NT" ]; then
 	MONGOCRYPT_INSTALL_PREFIX=$(cygpath -w $MONGOCRYPT_INSTALL_PREFIX)
 fi
 
-
+if test -f /proc/cpuinfo; then
+    # Count the number of lines beginning with "processor" in the cpuinfo
+    jobs="$(grep -c '^processor' /proc/cpuinfo)"
+    if command -v bc; then
+        # Add two (hueristic to compensate for I/O latency)
+        jobs="$(echo "$jobs+2" | bc)"
+    fi
+    export MAKEFLAGS="-j$jobs ${MAKEFLAGS-}"
+else
+    # Cannot tell the best number of jobs. Provide a reasonable default.
+    export MAKEFLAGS="-j8 ${MAKEFLAGS-}"
+fi


### PR DESCRIPTION
Make respects a `MAKEFLAGS` environment variable to specify additional command-line flags. It's possible to specify flags to the build executor to `cmake --build`, but we don't have a guarantee that `cmake --build` will actually be running Make. Setting `MAKEFLAGS` will give arguments to Make if it happens to be the build executor.

This change shaves off several minutes for most Linux and macOS tasks.