### PR TITLE
test(NODE-4343): contention factor required with indexed

### DIFF
--- a/bindings/node/test/clientEncryption.test.js
+++ b/bindings/node/test/clientEncryption.test.js
@@ -283,7 +283,8 @@ describe('ClientEncryption', function () {
         .then(dataKey => {
           const encryptOptions = {
             keyId: dataKey,
-            algorithm: 'Indexed'
+            algorithm: 'Indexed',
+            contentionFactor: 0
           };
 
           return newClientEncryption().encrypt('hello', encryptOptions);
@@ -329,7 +330,8 @@ describe('ClientEncryption', function () {
         .then(dataKey => {
           const encryptOptions = {
             keyId: dataKey,
-            algorithm: 'Indexed'
+            algorithm: 'Indexed',
+            contentionFactor: 0
           };
 
           return encryption.encrypt('hello', encryptOptions);
@@ -724,7 +726,8 @@ describe('ClientEncryption', function () {
       const findPayload = await clientEncryption.encrypt('encrypted indexed value', {
         keyId: KEY1_ID,
         algorithm: 'Indexed',
-        queryType: 'equality'
+        queryType: 'equality',
+        contentionFactor: 0
       });
       const findResult = await coll
         .find({
@@ -787,7 +790,8 @@ describe('ClientEncryption', function () {
     it('Case 4: can roundtrip encrypted indexed', async function () {
       const payload = await clientEncryption.encrypt('encrypted indexed value', {
         keyId: KEY1_ID,
-        algorithm: 'Indexed'
+        algorithm: 'Indexed',
+        contentionFactor: 10
       });
       const decrypted = await clientEncryption.decrypt(payload);
 

--- a/bindings/node/test/clientEncryption.test.js
+++ b/bindings/node/test/clientEncryption.test.js
@@ -791,7 +791,7 @@ describe('ClientEncryption', function () {
       const payload = await clientEncryption.encrypt('encrypted indexed value', {
         keyId: KEY1_ID,
         algorithm: 'Indexed',
-        contentionFactor: 10
+        contentionFactor: 0
       });
       const decrypted = await clientEncryption.decrypt(payload);
 

--- a/bindings/node/test/cryptoCallbacks.test.js
+++ b/bindings/node/test/cryptoCallbacks.test.js
@@ -225,7 +225,8 @@ describe('cryptoCallbacks', function () {
 
             const encryptOptions = {
               keyId: dataKey,
-              algorithm: 'Indexed'
+              algorithm: 'Indexed',
+              contentionFactor: 0
             };
 
             encryption.encrypt('hello', encryptOptions, (err, encryptedValue) => {


### PR DESCRIPTION
`contentionFactor` must now be provided when encrypting as indexed. This updates the prose tests and extra unit test to provide it. See https://github.com/mongodb/specifications/commit/41b335af92c12258a4cbe7e93ad4f34ef31641a7