### PR TITLE
Revert "Node bindings should re-use top-level find-cmake.sh (#395)"

### DIFF
--- a/.evergreen/find-cmake.sh
+++ b/.evergreen/find-cmake.sh
@@ -3,14 +3,8 @@ set -o errexit  # Exit the script with error if any of the commands fail
 
 find_cmake ()
 {
-  # Check if on macOS with arm64. Use system cmake. See BUILD-14565.
-  local OS_NAME="$(uname -s | tr '[:upper:]' '[:lower:]')"
-  local MARCH="$(uname -m | tr '[:upper:]' '[:lower:]')"
-
   if [ ! -z "$CMAKE" ]; then
     return 0
-  elif test "$OS_NAME" = "darwin" -a "$MARCH" = "arm64"; then
-    CMAKE=cmake
   elif [ -f "/Applications/cmake-3.2.2-Darwin-x86_64/CMake.app/Contents/bin/cmake" ]; then
     CMAKE="/Applications/cmake-3.2.2-Darwin-x86_64/CMake.app/Contents/bin/cmake"
   elif [ -f "/Applications/Cmake.app/Contents/bin/cmake" ]; then

--- a/bindings/node/.evergreen/find_cmake.sh
+++ b/bindings/node/.evergreen/find_cmake.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Copied from the mongo-c-driver
+find_cmake ()
+{
+  # Check if on macOS with arm64. Use system cmake. See BUILD-14565.
+  OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
+  MARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
+  if [ "darwin" = "$OS_NAME" -a "arm64" = "$MARCH" ]; then
+      CMAKE=cmake
+      return 0
+  fi
+
+  if [ ! -z "$CMAKE" ]; then
+    return 0
+  elif [ -f "/Applications/cmake-3.2.2-Darwin-x86_64/CMake.app/Contents/bin/cmake" ]; then
+    CMAKE="/Applications/cmake-3.2.2-Darwin-x86_64/CMake.app/Contents/bin/cmake"
+  elif [ -f "/Applications/Cmake.app/Contents/bin/cmake" ]; then
+    CMAKE="/Applications/Cmake.app/Contents/bin/cmake"
+  elif [ -f "/opt/cmake/bin/cmake" ]; then
+    CMAKE="/opt/cmake/bin/cmake"
+  elif [ -z "$IGNORE_SYSTEM_CMAKE" ] && command -v cmake 2>/dev/null; then
+     CMAKE=cmake
+  elif uname -a | grep -iq 'x86_64 GNU/Linux'; then
+     curl --retry 5 https://cmake.org/files/v3.11/cmake-3.11.0-Linux-x86_64.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz
+     mkdir cmake-3.11.0
+     tar xzf cmake.tar.gz -C cmake-3.11.0 --strip-components=1
+     CMAKE=$(pwd)/cmake-3.11.0/bin/cmake
+  fi
+  if [ -z "$CMAKE" -o -z "$( $CMAKE --version 2>/dev/null )" ]; then
+     # Some images have no cmake yet, or a broken cmake (see: BUILD-8570)
+     echo "-- MAKE CMAKE --"
+     CMAKE_INSTALL_DIR=$(readlink -f cmake-install)
+     curl --retry 5 https://cmake.org/files/v3.11/cmake-3.11.0.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz
+     tar xzf cmake.tar.gz
+     cd cmake-3.11.0
+     ./bootstrap --prefix="${CMAKE_INSTALL_DIR}"
+     make -j8
+     make install
+     cd ..
+     CMAKE="${CMAKE_INSTALL_DIR}/bin/cmake"
+     echo "-- DONE MAKING CMAKE --"
+  fi
+}
+
+find_cmake
+
+export CMAKE=$CMAKE

--- a/bindings/node/.evergreen/setup_environment.sh
+++ b/bindings/node/.evergreen/setup_environment.sh
@@ -22,16 +22,14 @@ export PATH="$BIN_DIR:/opt/mongodbtoolchain/v2/bin:$PATH"
 
 # locate cmake
 if [ "$OS" == "Windows_NT" ]; then
-  : "${CMAKE:=/cygdrive/c/cmake/bin/cmake}"
+  CMAKE=/cygdrive/c/cmake/bin/cmake
   if [ "$WINDOWS_32BIT" != "ON" ]; then
       ADDITIONAL_CMAKE_FLAGS="-Thost=x64 -A x64"
   fi
 else
-  chmod u+x "$PROJECT_DIRECTORY/libmongocrypt/.evergreen/find-cmake.sh"
-  IGNORE_SYSTEM_CMAKE=1 . "$PROJECT_DIRECTORY/libmongocrypt/.evergreen/find-cmake.sh"
+  chmod u+x ./.evergreen/find_cmake.sh
+  IGNORE_SYSTEM_CMAKE=1 . ./.evergreen/find_cmake.sh
 fi
-
-export CMAKE
 
 # this needs to be explicitly exported for the nvm install below
 export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"


### PR DESCRIPTION
commit ec2403e3e1cb3e362b178acc352626d8af28ed40 updated the Node bindings CI scripts to use the shared find-cmake script, but this change unintentionally broke the Node driver's CSFLE tests.

Updating the cmake path didn't resolve all the issues, we now have build issues with our bindings (see example patch https://spruce.mongodb.com/version/62c5df0c0305b96e4b828a82/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).  Rather than investigate this issue right now, I want to revert this change until it can be made and properly tested before merging.

The Node driver also has CSFLE work in-flight that is impacted by a broken CI, so we should either fix it quickly or just revert for now.