### PR TITLE
test(NODE-4389): fix rewrap many data key test hang

### DIFF
--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -278,7 +278,7 @@ module.exports = function (modules) {
             return;
           }
 
-          if (dataKey.v.length === 0) {
+          if (!dataKey || dataKey.v.length === 0) {
             cb(null, {});
             return;
           }

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -234,6 +234,7 @@ module.exports = function (modules) {
         }
 
         case MONGOCRYPT_CTX_DONE:
+          callback();
           return;
 
         default:


### PR DESCRIPTION
When the state machine gets into a done state (code 6), the callback provided to `execute()` is never called, causing this situation to hang. This was shown to get in this state via this test:

https://evergreen.mongodb.com/task_log_raw/mongo_node_driver_next_ubuntu1804_custom_dependency_tests_run_custom_csfle_tests_patch_13158be5328c310045ea756611b18162ea2ec2b8_62c6ca4161837d149ba95830_22_07_07_11_57_54/0?type=T#L1469