### PR TITLE
test(NODE-4089): test with or without shared lib

### DIFF
--- a/bindings/node/test/data/collection-info.json
+++ b/bindings/node/test/data/collection-info.json
@@ -19,13 +19,15 @@
                 "properties": {
                     "ssn": {
                         "encrypt": {
-                            "keyId": {
-                                "$binary": {
-                                    "base64": "YWFhYWFhYWFhYWFhYWFhYQ==",
-                                    "subType": "04"
+                            "keyId": [
+                                {
+                                    "$binary": {
+                                        "base64": "YWFhYWFhYWFhYWFhYWFhYQ==",
+                                        "subType": "04"
+                                    }
                                 }
-                            },
-                            "type": "string",
+                            ],
+                            "bsonType": "string",
                             "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
                         }
                     }


### PR DESCRIPTION
TODO:

[ ] - Filter with client metadata instead of if blocks checking for `process.env.CRYPT_SHARED_LIBRARY`?
[ ] - NODE-4383 download the shared library for the requested mongodb version
[ ] - Evergreen setup to set `CRYPT_SHARED_LIBRARY` as the path to the shared library.