### PR TITLE
MONGOCRYPT-461 Support `accessToken` for `gcp` KMS provider

### DIFF
--- a/src/mongocrypt-ctx-datakey.c
+++ b/src/mongocrypt-ctx-datakey.c
@@ -65,8 +65,8 @@ _kms_kmip_start (mongocrypt_ctx_t *ctx)
 
    if (ctx->opts.kek.provider.kmip.endpoint) {
       endpoint = ctx->opts.kek.provider.kmip.endpoint;
-   } else if (_mongocrypt_ctx_kms_providers(ctx)->kmip.endpoint) {
-      endpoint = _mongocrypt_ctx_kms_providers(ctx)->kmip.endpoint;
+   } else if (_mongocrypt_ctx_kms_providers (ctx)->kmip.endpoint) {
+      endpoint = _mongocrypt_ctx_kms_providers (ctx)->kmip.endpoint;
    } else {
       CLIENT_ERR ("endpoint not set for KMIP request");
       goto fail;
@@ -182,7 +182,7 @@ _kms_start (mongocrypt_ctx_t *ctx)
    _mongocrypt_ctx_datakey_t *dkctx;
    char *access_token = NULL;
    _mongocrypt_opts_kms_providers_t *const kms_providers =
-      _mongocrypt_ctx_kms_providers(ctx);
+      _mongocrypt_ctx_kms_providers (ctx);
 
    dkctx = (_mongocrypt_ctx_datakey_t *) ctx;
 
@@ -245,7 +245,13 @@ _kms_start (mongocrypt_ctx_t *ctx)
       }
       ctx->state = MONGOCRYPT_CTX_NEED_KMS;
    } else if (ctx->opts.kek.kms_provider == MONGOCRYPT_KMS_PROVIDER_GCP) {
-      access_token = _mongocrypt_cache_oauth_get (ctx->crypt->cache_oauth_gcp);
+      if (!_mongocrypt_buffer_empty (&ctx->kms_providers.gcp.access_token)) {
+         access_token = bson_strdup (
+            (const char *) ctx->kms_providers.gcp.access_token.data);
+      } else {
+         access_token =
+            _mongocrypt_cache_oauth_get (ctx->crypt->cache_oauth_gcp);
+      }
       if (access_token) {
          if (!_mongocrypt_kms_ctx_init_gcp_encrypt (
                 &dkctx->kms,

--- a/src/mongocrypt-ctx-datakey.c
+++ b/src/mongocrypt-ctx-datakey.c
@@ -245,9 +245,9 @@ _kms_start (mongocrypt_ctx_t *ctx)
       }
       ctx->state = MONGOCRYPT_CTX_NEED_KMS;
    } else if (ctx->opts.kek.kms_provider == MONGOCRYPT_KMS_PROVIDER_GCP) {
-      if (!_mongocrypt_buffer_empty (&ctx->kms_providers.gcp.access_token)) {
-         access_token = bson_strdup (
-            (const char *) ctx->kms_providers.gcp.access_token.data);
+      if (NULL != ctx->kms_providers.gcp.access_token) {
+         access_token =
+            bson_strdup ((const char *) ctx->kms_providers.gcp.access_token);
       } else {
          access_token =
             _mongocrypt_cache_oauth_get (ctx->crypt->cache_oauth_gcp);

--- a/src/mongocrypt-key-broker.c
+++ b/src/mongocrypt-key-broker.c
@@ -569,7 +569,13 @@ _mongocrypt_key_broker_add_doc (_mongocrypt_key_broker_t *kb,
          }
       }
    } else if (kek_provider == MONGOCRYPT_KMS_PROVIDER_GCP) {
-      access_token = _mongocrypt_cache_oauth_get (kb->crypt->cache_oauth_gcp);
+      if (!_mongocrypt_buffer_empty (&kms_providers->gcp.access_token)) {
+         access_token =
+            bson_strdup ((const char *) kms_providers->gcp.access_token.data);
+      } else {
+         access_token =
+            _mongocrypt_cache_oauth_get (kb->crypt->cache_oauth_gcp);
+      }
       if (!access_token) {
          key_returned->needs_auth = true;
          /* Create an oauth request if one does not exist. */
@@ -831,8 +837,13 @@ _mongocrypt_key_broker_kms_done (
             bson_free (access_token);
          } else if (key_returned->doc->kek.kms_provider ==
                     MONGOCRYPT_KMS_PROVIDER_GCP) {
-            access_token =
-               _mongocrypt_cache_oauth_get (kb->crypt->cache_oauth_gcp);
+            if (!_mongocrypt_buffer_empty (&kms_providers->gcp.access_token)) {
+               access_token = bson_strdup (
+                  (const char *) kms_providers->gcp.access_token.data);
+            } else {
+               access_token =
+                  _mongocrypt_cache_oauth_get (kb->crypt->cache_oauth_gcp);
+            }
 
             if (!access_token) {
                return _key_broker_fail_w_msg (

--- a/src/mongocrypt-key-broker.c
+++ b/src/mongocrypt-key-broker.c
@@ -569,9 +569,8 @@ _mongocrypt_key_broker_add_doc (_mongocrypt_key_broker_t *kb,
          }
       }
    } else if (kek_provider == MONGOCRYPT_KMS_PROVIDER_GCP) {
-      if (!_mongocrypt_buffer_empty (&kms_providers->gcp.access_token)) {
-         access_token =
-            bson_strdup ((const char *) kms_providers->gcp.access_token.data);
+      if (NULL != kms_providers->gcp.access_token) {
+         access_token = bson_strdup (kms_providers->gcp.access_token);
       } else {
          access_token =
             _mongocrypt_cache_oauth_get (kb->crypt->cache_oauth_gcp);
@@ -837,9 +836,8 @@ _mongocrypt_key_broker_kms_done (
             bson_free (access_token);
          } else if (key_returned->doc->kek.kms_provider ==
                     MONGOCRYPT_KMS_PROVIDER_GCP) {
-            if (!_mongocrypt_buffer_empty (&kms_providers->gcp.access_token)) {
-               access_token = bson_strdup (
-                  (const char *) kms_providers->gcp.access_token.data);
+            if (NULL != kms_providers->gcp.access_token) {
+               access_token = bson_strdup (kms_providers->gcp.access_token);
             } else {
                access_token =
                   _mongocrypt_cache_oauth_get (kb->crypt->cache_oauth_gcp);

--- a/src/mongocrypt-opts-private.h
+++ b/src/mongocrypt-opts-private.h
@@ -38,7 +38,7 @@ typedef struct {
    char *email;
    _mongocrypt_buffer_t private_key;
    _mongocrypt_endpoint_t *endpoint;
-   _mongocrypt_buffer_t access_token;
+   char *access_token;
 } _mongocrypt_opts_kms_provider_gcp_t;
 
 typedef struct {

--- a/src/mongocrypt-opts-private.h
+++ b/src/mongocrypt-opts-private.h
@@ -38,6 +38,7 @@ typedef struct {
    char *email;
    _mongocrypt_buffer_t private_key;
    _mongocrypt_endpoint_t *endpoint;
+   _mongocrypt_buffer_t access_token;
 } _mongocrypt_opts_kms_provider_gcp_t;
 
 typedef struct {

--- a/src/mongocrypt-opts.c
+++ b/src/mongocrypt-opts.c
@@ -46,7 +46,7 @@ _mongocrypt_opts_kms_provider_gcp_cleanup (
    bson_free (kms_provider_gcp->email);
    _mongocrypt_endpoint_destroy (kms_provider_gcp->endpoint);
    _mongocrypt_buffer_cleanup (&kms_provider_gcp->private_key);
-   _mongocrypt_buffer_cleanup (&kms_provider_gcp->access_token);
+   bson_free (kms_provider_gcp->access_token);
 }
 
 void

--- a/src/mongocrypt-opts.c
+++ b/src/mongocrypt-opts.c
@@ -46,6 +46,7 @@ _mongocrypt_opts_kms_provider_gcp_cleanup (
    bson_free (kms_provider_gcp->email);
    _mongocrypt_endpoint_destroy (kms_provider_gcp->endpoint);
    _mongocrypt_buffer_cleanup (&kms_provider_gcp->private_key);
+   _mongocrypt_buffer_cleanup (&kms_provider_gcp->access_token);
 }
 
 void

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -1363,6 +1363,34 @@ _mongocrypt_parse_kms_providers (
             return false;
          }
 
+         if (!_mongocrypt_parse_optional_binary (
+                &as_bson,
+                "gcp.accessToken",
+                &kms_providers->gcp.access_token,
+                status)) {
+            return false;
+         }
+
+         if (!_mongocrypt_buffer_empty (&kms_providers->gcp.access_token)) {
+            /* "gcp" document has form:
+             * {
+             *    "accessToken": <required UTF-8 or Binary>
+             * }
+             */
+            if (!_mongocrypt_check_allowed_fields (
+                   &as_bson, "gcp", status, "accessToken")) {
+               return false;
+            }
+            kms_providers->configured_providers |= MONGOCRYPT_KMS_PROVIDER_GCP;
+            continue;
+         }
+
+         /* "gcp" document has form:
+          * {
+          *    "email": <required UTF-8>
+          *    "privateKey": <required UTF-8 or Binary>
+          * }
+          */
          if (!_mongocrypt_parse_required_utf8 (
                 &as_bson, "gcp.email", &kms_providers->gcp.email, status)) {
             return false;

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -1363,18 +1363,17 @@ _mongocrypt_parse_kms_providers (
             return false;
          }
 
-         if (!_mongocrypt_parse_optional_binary (
-                &as_bson,
-                "gcp.accessToken",
-                &kms_providers->gcp.access_token,
-                status)) {
+         if (!_mongocrypt_parse_optional_utf8 (&as_bson,
+                                               "gcp.accessToken",
+                                               &kms_providers->gcp.access_token,
+                                               status)) {
             return false;
          }
 
-         if (!_mongocrypt_buffer_empty (&kms_providers->gcp.access_token)) {
+         if (NULL != kms_providers->gcp.access_token) {
             /* "gcp" document has form:
              * {
-             *    "accessToken": <required UTF-8 or Binary>
+             *    "accessToken": <required UTF-8>
              * }
              */
             if (!_mongocrypt_check_allowed_fields (

--- a/test/test-gcp-auth.c
+++ b/test/test-gcp-auth.c
@@ -196,11 +196,10 @@ _test_createdatakey_with_accesstoken (_mongocrypt_tester_t *tester)
    ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
                        MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
    {
-      ASSERT_OK (mongocrypt_ctx_provide_kms_providers (
-                    ctx,
-                    TEST_BSON ("{'gcp': { 'accessToken': { '$binary': { "
-                               "'base64': 'AAAA', 'subType': '00' } } } }")),
-                 ctx);
+      ASSERT_OK (
+         mongocrypt_ctx_provide_kms_providers (
+            ctx, TEST_BSON ("{'gcp': { 'accessToken': { 'foobar' } } }")),
+         ctx);
    }
 
    /* Assert first CTX_NEED_KMS state requests encryption. */
@@ -259,11 +258,10 @@ _test_encrypt_with_accesstoken (_mongocrypt_tester_t *tester)
    ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
                        MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
    {
-      ASSERT_OK (mongocrypt_ctx_provide_kms_providers (
-                    ctx,
-                    TEST_BSON ("{'gcp': { 'accessToken': { '$binary': { "
-                               "'base64': 'AAAA', 'subType': '00' } } } }")),
-                 ctx);
+      ASSERT_OK (
+         mongocrypt_ctx_provide_kms_providers (
+            ctx, TEST_BSON ("{'gcp': { 'accessToken': { 'foobar' } } }")),
+         ctx);
    }
 
    ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -878,7 +878,11 @@ _test_setopt_kms_providers (_mongocrypt_tester_t *tester)
       {"{'azure': {}}", NULL, "on-demand credentials not enabled", false},
       {"{'local': {}}", NULL, "on-demand credentials not enabled", false},
       {"{'gcp': {}}", NULL, "on-demand credentials not enabled", false},
-      {"{'kmip': {}}", NULL, "on-demand credentials not enabled", false}};
+      {"{'kmip': {}}", NULL, "on-demand credentials not enabled", false},
+      {"{'gcp': {'accessToken': { '$binary': {'base64': 'AAAA', 'subType': "
+       "'00' }}, 'email': 'foo@bar.com' }}",
+       "Unexpected field: 'email'"}
+   };
 
    for (i = 0; i < sizeof (tests) / sizeof (tests[0]); i++) {
       mongocrypt_t *crypt;

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -879,8 +879,7 @@ _test_setopt_kms_providers (_mongocrypt_tester_t *tester)
       {"{'local': {}}", NULL, "on-demand credentials not enabled", false},
       {"{'gcp': {}}", NULL, "on-demand credentials not enabled", false},
       {"{'kmip': {}}", NULL, "on-demand credentials not enabled", false},
-      {"{'gcp': {'accessToken': { '$binary': {'base64': 'AAAA', 'subType': "
-       "'00' }}, 'email': 'foo@bar.com' }}",
+      {"{'gcp': {'accessToken': 'foobar', 'email': 'foo@bar.com' }}",
        "Unexpected field: 'email'"}
    };
 


### PR DESCRIPTION
# Summary
- Support `accessToken` for `gcp` KMS provider.

# Background & Motivation

This change is intended to enable drivers to pass an `accessToken` for `gcp` on-demand.

The expected behavior is:
- User configures `kmsProviders` with `gcp: {}` to have the driver fetch `gcp` credentials.
- When in the state `MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS`, the driver obtains an `accessToken` and passes to libmongocrypt with `mongocrypt_provide_kms_providers`.
- The driver obtains an `accessToken` by sending an HTTP request to the GCP Metadata Server, noted in [AIP-4115](https://google.aip.dev/auth/4115).

The `accessToken` passed in `mongocrypt_provide_kms_providers` is not cached in `crypt->cache_oauth_gcp`. The `MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS` state is always entered before `mongocrypt_ctx_t` may reach out to KMS. The expectation is that a driver will always attempt to fetch a new `accessToken`.