### PR TITLE
Fix CMake GUI config errors due to external working directory

### DIFF
--- a/cmake/GetVersion.cmake
+++ b/cmake/GetVersion.cmake
@@ -26,6 +26,7 @@
 function (GetVersion OUTVAR)
     execute_process (
         COMMAND git describe --tags --match "1.*"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
         OUTPUT_VARIABLE VERSION_WITH_SUFFIX
         RESULT_VARIABLE GIT_STATUS
         ERROR_VARIABLE GIT_ERROR
@@ -38,6 +39,7 @@ function (GetVersion OUTVAR)
 
     execute_process (
         COMMAND git describe --tags --abbrev=0 --match "1.*"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
         OUTPUT_VARIABLE VERSION
         RESULT_VARIABLE GIT_STATUS
         ERROR_VARIABLE GIT_ERROR
@@ -88,6 +90,7 @@ function (GetVersion OUTVAR)
     # Append our custom suffix +<date>git<short hash>
     execute_process (
         COMMAND git rev-parse --revs-only --short=10 HEAD
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
         OUTPUT_VARIABLE SUFFIX_SHA
         RESULT_VARIABLE GIT_STATUS
         ERROR_VARIABLE GIT_ERROR


### PR DESCRIPTION
When initially configuring CMake using [CMake GUI](https://cmake.org/cmake/help/latest/manual/cmake-gui.1.html) where `VERSION_CURRENT` is not yet set or generated, configuration fails due to the following error:

```
CMake Error at cmake/GetVersion.cmake:36 (message):
  Unable to determine version: 'git describe' failed: 'fatal: not a git
  repository (or any of the parent directories): .git

  '
Call Stack (most recent call first):
  CMakeLists.txt:153 (GetVersion)
```

This issue can be replicated by running `cmake` from outside the source directory:

```
$ git clone https://github.com/mongodb/libmongocrypt
$ cmake -S libmongocrypt -B libmongocrypt/build
```

This PR ensures the `git` commands being run in `GetVersion.cmake` use the working directory of the CMake source file invoking the `GetVersion` function, which (as far as this repo is concerned) should only be the root CMake source file.

Note, `${CMAKE_CURRENT_SOURCE_DIR}` is used instead of `${CMAKE_SOURCE_DIR}` to ensure the working directory is not computed to be the directory of a "higher" CMake source file that may be `add_subdirectory()`-ing this repo.