### PR TITLE
fix Java bindings version

### DIFF
--- a/bindings/java/mongocrypt/build.gradle.kts
+++ b/bindings/java/mongocrypt/build.gradle.kts
@@ -43,7 +43,7 @@ repositories {
 }
 
 group = "org.mongodb"
-version = "1.6.0-SNAPSHOT"
+version = "1.5.1-SNAPSHOT"
 description = "MongoDB client-side crypto support"
 
 java {


### PR DESCRIPTION
This fixes the Java bindings version on the `r1.5` branch in anticipation of a fix to the way that build versions are generated for the project.