### PR TITLE
MONGOCRYPT-449 Reject empty KMS providers if NEED_KMS_CREDENTIALS is not supported

### DIFF
--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -586,7 +586,8 @@ mongocrypt_ctx_provide_kms_providers (
       return false;
    }
 
-   if (!_mongocrypt_opts_kms_providers_validate (&ctx->per_ctx_kms_providers,
+   if (!_mongocrypt_opts_kms_providers_validate (&ctx->crypt->opts,
+                                                 &ctx->per_ctx_kms_providers,
                                                  ctx->status)) {
       /* Remove the parsed KMS providers if they are invalid */
       _mongocrypt_opts_kms_providers_cleanup (&ctx->per_ctx_kms_providers);

--- a/src/mongocrypt-opts-private.h
+++ b/src/mongocrypt-opts-private.h
@@ -117,6 +117,7 @@ _mongocrypt_opts_validate (_mongocrypt_opts_t *opts,
 
 bool
 _mongocrypt_opts_kms_providers_validate (
+   _mongocrypt_opts_t *opts,
    _mongocrypt_opts_kms_providers_t *kms_providers,
    mongocrypt_status_t *status) MONGOCRYPT_WARN_UNUSED_RESULT;
 

--- a/src/mongocrypt-opts.c
+++ b/src/mongocrypt-opts.c
@@ -109,7 +109,9 @@ _mongocrypt_opts_cleanup (_mongocrypt_opts_t *opts)
 
 bool
 _mongocrypt_opts_kms_providers_validate (
-   _mongocrypt_opts_kms_providers_t *kms_providers, mongocrypt_status_t *status)
+   _mongocrypt_opts_t *opts,
+   _mongocrypt_opts_kms_providers_t *kms_providers,
+   mongocrypt_status_t *status)
 {
    if (!kms_providers->configured_providers &&
        !kms_providers->need_credentials) {
@@ -130,6 +132,12 @@ _mongocrypt_opts_kms_providers_validate (
          CLIENT_ERR ("local data key unset");
          return false;
       }
+   }
+
+   if (kms_providers->need_credentials &&
+         !opts->use_need_kms_credentials_state) {
+      CLIENT_ERR ("on-demand credentials not supported");
+      return false;
    }
 
    return true;
@@ -224,7 +232,8 @@ _mongocrypt_opts_validate (_mongocrypt_opts_t *opts,
           &opts->encrypted_field_config_map, &opts->schema_map, status)) {
       return false;
    }
-   return _mongocrypt_opts_kms_providers_validate (&opts->kms_providers,
+   return _mongocrypt_opts_kms_providers_validate (opts,
+                                                   &opts->kms_providers,
                                                    status);
 }
 

--- a/test/test-mongocrypt-ctx-rewrap-many-datakey.c
+++ b/test/test-mongocrypt-ctx-rewrap-many-datakey.c
@@ -1026,29 +1026,6 @@ _test_rewrap_many_datakey_kms_credentials (_mongocrypt_tester_t *tester)
       mongocrypt_destroy (crypt);
    }
 
-   /* Should not enter NEED_KMS_CREDENTIALS state if use need KMS credentials
-    * option is not set. If required credentials are not provided, should fail
-    * on decryption. */
-   crypt = mongocrypt_new ();
-   ASSERT_OK (
-      mongocrypt_setopt_kms_providers (crypt, TEST_BSON ("{'aws': {}}")),
-      crypt);
-   ASSERT_OK (mongocrypt_init (crypt), crypt);
-   ctx = mongocrypt_ctx_new (crypt);
-   ASSERT_OK (ctx, crypt);
-   ASSERT_OK (mongocrypt_ctx_rewrap_many_datakey_init (ctx, TEST_BSON ("{}")),
-              ctx);
-   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
-                       MONGOCRYPT_CTX_NEED_MONGO_KEYS);
-   ASSERT_FAILS (
-      mongocrypt_ctx_mongo_feed (
-         ctx, TEST_FILE ("./test/data/rmd/key-document-a.json")),
-      ctx,
-      "client not configured with KMS provider necessary to decrypt");
-   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_ERROR);
-   mongocrypt_ctx_destroy (ctx);
-   mongocrypt_destroy (crypt);
-
    /* Should not enter NEED_KMS_CREDENTIALS state if credentials already
     * provided. */
    crypt = mongocrypt_new ();

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -799,7 +799,12 @@ _test_setopt_invalid_kms_providers (_mongocrypt_tester_t *tester)
 
 typedef struct {
    char *value;
+   /* errmsg is the expected error message from mongocrypt_setopt_kms_providers
+   */
    char *errmsg;
+   /* errmsg_init is the expected error message from mongocrypt_init */
+   char *errmsg_init;
+   bool use_need_kms_credentials_state;
 } setopt_kms_providers_testcase_t;
 
 #define EXAMPLE_LOCAL_MATERIAL                                                 \
@@ -860,22 +865,38 @@ _test_setopt_kms_providers (_mongocrypt_tester_t *tester)
       {"{'kmip': {'endpoint': 'localhost' }}", NULL},
       {"{'kmip': {'endpoint': '127.0.0.1:5696', 'extra': 'invalid' }}",
        "Unexpected field: 'extra'"},
-      /* Empty documents are OK for on-demand KMS credentials */
-      {"{'aws': {}}", NULL},
-      {"{'azure': {}}", NULL},
-      {"{'local': {}}", NULL},
-      {"{'gcp': {}}", NULL},
-      {"{'kmip': {}}", NULL}};
+      /* Empty documents are OK if on-demand KMS credentials are opted-in with
+       * a call to mongocrypt_setopt_use_need_kms_credentials_state. */
+      {"{'aws': {}}", NULL, NULL, true},
+      {"{'azure': {}}", NULL, NULL, true},
+      {"{'local': {}}", NULL, NULL, true},
+      {"{'gcp': {}}", NULL, NULL, true},
+      {"{'kmip': {}}", NULL, NULL, true},
+      /* Empty documents are not OK if on-demand KMS credentials are not opted-in. */
+      {"{'aws': {}}", NULL, "on-demand credentials not supported", false},
+      {"{'azure': {}}", NULL, "on-demand credentials not supported", false},
+      {"{'local': {}}", NULL, "on-demand credentials not supported", false},
+      {"{'gcp': {}}", NULL, "on-demand credentials not supported", false},
+      {"{'kmip': {}}", NULL, "on-demand credentials not supported", false}
+      };
 
    for (i = 0; i < sizeof (tests) / sizeof (tests[0]); i++) {
       mongocrypt_t *crypt;
 
       test = tests + i;
       crypt = mongocrypt_new ();
+      if (test->use_need_kms_credentials_state) {
+         mongocrypt_setopt_use_need_kms_credentials_state (crypt);
+      }
       if (!test->errmsg) {
          ASSERT_OK (
             mongocrypt_setopt_kms_providers (crypt, TEST_BSON (test->value)),
             crypt);
+         if (!test->errmsg_init) {
+            ASSERT_OK (mongocrypt_init (crypt), crypt);
+         } else {
+            ASSERT_FAILS (mongocrypt_init (crypt), crypt, test->errmsg_init);
+         }
       } else {
          ASSERT_FAILS (
             mongocrypt_setopt_kms_providers (crypt, TEST_BSON (test->value)),


### PR DESCRIPTION
# Summary
- Reject empty KMS providers if consumer does not support `MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS` state.

# Background & Motivation.

libmongocrypt supports setting KMS providers with an empty document (example: `{ "gcp": {} }`) in `mongocrypt_setopt_kms_providers`. That tells libmongocrypt to enter the `MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS` before KMS credentials are needed.

Drivers must opt-in to supporting on-demand credentials by calling `mongocrypt_setopt_use_need_kms_credentials_state`. This signals the driver is prepared to handle the `MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS` state.

If `mongocrypt_setopt_use_need_kms_credentials_state` is not called, there is no use-case for setting an empty document.

I do not expect this change to require driver changes. There are no unified specification tests using an empty document for a KMS provider configured after https://github.com/mongodb/specifications/pull/1267.