### PR TITLE
MONGOCRYPT-437 remove hard-coded branch names in Evergreen s3.put targets

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -539,7 +539,7 @@ tasks:
       params:
         aws_key: '${aws_key}'
         aws_secret: '${aws_secret}'
-        remote_file: 'libmongocrypt/all/master/${libmongocrypt_s3_suffix}/libmongocrypt-all.tar.gz'
+        remote_file: 'libmongocrypt/all/${branch_name}/${libmongocrypt_s3_suffix}/libmongocrypt-all.tar.gz'
         bucket: mciuploads
         permissions: public-read
         local_file: 'libmongocrypt-all.tar.gz'
@@ -548,7 +548,7 @@ tasks:
       params:
         aws_key: '${aws_key}'
         aws_secret: '${aws_secret}'
-        remote_file: 'libmongocrypt/all/master/${libmongocrypt_s3_suffix_copy}/libmongocrypt-all.tar.gz'
+        remote_file: 'libmongocrypt/all/${branch_name}/${libmongocrypt_s3_suffix_copy}/libmongocrypt-all.tar.gz'
         bucket: mciuploads
         permissions: public-read
         local_file: 'libmongocrypt-all.tar.gz'


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/version/62d09cffd1fe075d969e38e6/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Before/after comparison of file artifacts associated with the `upload-all` task:

Before: https://mciuploads.s3.amazonaws.com/libmongocrypt/all/master/b14d06000535e55be0c619e936972805cac24d37/libmongocrypt-all.tar.gz
After: https://mciuploads.s3.amazonaws.com/libmongocrypt/all/master/4ac9be9c8cca65d2a0a0e7c069f4701db981cdf1/62d09cffd1fe075d969e38e6/libmongocrypt-all.tar.gz

Before: https://mciuploads.s3.amazonaws.com/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz
After: https://mciuploads.s3.amazonaws.com/libmongocrypt/all/master/latest/62d09cffd1fe075d969e38e6/libmongocrypt-all.tar.gz

(note that the 'After' URLs are from the patch build, so they also have a component for the patch build ID that the 'Before' URLs lack as they are from a waterfall build)

The before/after comparison demonstrates that the URLs are not materially changed for builds from the `master` branch, which is what is expected in the context of this change.