### PR TITLE
MONGOCRYPT-437 remove hard-coded branch names in Evergreen s3.put targets

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -548,7 +548,7 @@ tasks:
       params:
         aws_key: '${aws_key}'
         aws_secret: '${aws_secret}'
-        remote_file: 'libmongocrypt/all/master/${libmongocrypt_s3_suffix}/libmongocrypt-all.tar.gz'
+        remote_file: 'libmongocrypt/all/${branch_name}/${libmongocrypt_s3_suffix}/libmongocrypt-all.tar.gz'
         bucket: mciuploads
         permissions: public-read
         local_file: 'libmongocrypt-all.tar.gz'
@@ -557,7 +557,7 @@ tasks:
       params:
         aws_key: '${aws_key}'
         aws_secret: '${aws_secret}'
-        remote_file: 'libmongocrypt/all/master/${libmongocrypt_s3_suffix_copy}/libmongocrypt-all.tar.gz'
+        remote_file: 'libmongocrypt/all/${branch_name}/${libmongocrypt_s3_suffix_copy}/libmongocrypt-all.tar.gz'
         bucket: mciuploads
         permissions: public-read
         local_file: 'libmongocrypt-all.tar.gz'


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/version/62d0a10c3627e00b7c7a3434/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Before/after comparison of file artifacts associated with the `upload-all` task:

Before: https://mciuploads.s3.amazonaws.com/libmongocrypt/all/master/118e5f6701a02966bc199892fcd111b832ac8c3d/libmongocrypt-all.tar.gz
After: https://mciuploads.s3.amazonaws.com/libmongocrypt/all/r1.5/c19f9fb794b923b0b1884c3fa582e17aa459f06e/62d0a10c3627e00b7c7a3434/libmongocrypt-all.tar.gz

Before: https://mciuploads.s3.amazonaws.com/libmongocrypt/all/master/latest-r1.5/libmongocrypt-all.tar.gz
After: https://mciuploads.s3.amazonaws.com/libmongocrypt/all/r1.5/latest/62d0a10c3627e00b7c7a3434/libmongocrypt-all.tar.gz

(note that the 'After' URLs are from the patch build, so they also have a component for the patch build ID that the 'Before' URLs lack as they are from a waterfall build)

The before/after comparison demonstrates that the URLs are changed in the way expected for builds from the `r1.5` branch, which is the branch currently tracked by the `libmongocrypt-release` Evergreen project.  This change makes the origin of the artifacts more clear (including `master` in the URL when the artifacts were built from a different branch was a bit confusing).