### PR TITLE
MONGOCRYPT-306 Return HTTP body in KMS error replies

### DIFF
--- a/src/mongocrypt-kms-ctx.c
+++ b/src/mongocrypt-kms-ctx.c
@@ -470,9 +470,11 @@ _ctx_done_aws (mongocrypt_kms_ctx_t *kms, const char *json_field)
       }
 
       /* If we couldn't parse JSON, return the body unchanged as an error. */
-      CLIENT_ERR ("Error parsing JSON in KMS response '%s'. HTTP status=%d",
-                  body,
-                  http_status);
+      CLIENT_ERR ("Error parsing JSON in KMS response '%s'. "
+                  "HTTP status=%d. Response body=\n%s",
+                  bson_error.message,
+                  http_status,
+                  body);
       goto fail;
    }
 
@@ -481,9 +483,10 @@ _ctx_done_aws (mongocrypt_kms_ctx_t *kms, const char *json_field)
    bson_destroy (&body_bson);
    if (!bson_init_from_json (&body_bson, body, body_len, &bson_error)) {
       CLIENT_ERR ("Error parsing JSON in KMS response '%s'. "
-                  "HTTP status=%d",
+                  "HTTP status=%d. Response body=\n%s",
                   bson_error.message,
-                  http_status);
+                  http_status,
+                  body);
       bson_init (&body_bson);
       goto fail;
    }
@@ -542,9 +545,11 @@ _ctx_done_oauth (mongocrypt_kms_ctx_t *kms)
    bson_body =
       bson_new_from_json ((const uint8_t *) body, body_len, &bson_error);
    if (!bson_body) {
-      CLIENT_ERR ("Invalid JSON in KMS response. HTTP status=%d. Error: %s",
+      CLIENT_ERR ("Error parsing JSON in KMS response '%s'. "
+                  "HTTP status=%d. Response body=\n%s",
+                  bson_error.message,
                   http_status,
-                  bson_error.message);
+                  body);
       goto fail;
    }
 
@@ -624,7 +629,11 @@ _ctx_done_azure_wrapkey_unwrapkey (mongocrypt_kms_ctx_t *kms)
    bson_body =
       bson_new_from_json ((const uint8_t *) body, body_len, &bson_error);
    if (!bson_body) {
-      CLIENT_ERR ("Invalid JSON in KMS response. HTTP status=%d", http_status);
+      CLIENT_ERR ("Error parsing JSON in KMS response '%s'. "
+                  "HTTP status=%d. Response body=\n%s",
+                  bson_error.message,
+                  http_status,
+                  body);
       goto fail;
    }
 
@@ -748,9 +757,10 @@ _ctx_done_gcp (mongocrypt_kms_ctx_t *kms, const char *json_field)
    bson_destroy (&body_bson);
    if (!bson_init_from_json (&body_bson, body, body_len, &bson_error)) {
       CLIENT_ERR ("Error parsing JSON in KMS response '%s'. "
-                  "HTTP status=%d",
+                  "HTTP status=%d. Response body=\n%s",
                   bson_error.message,
-                  http_status);
+                  http_status,
+                  body);
       bson_init (&body_bson);
       goto fail;
    }

--- a/src/mongocrypt-kms-ctx.c
+++ b/src/mongocrypt-kms-ctx.c
@@ -488,9 +488,11 @@ _ctx_done_aws (mongocrypt_kms_ctx_t *kms, const char *json_field)
    if (!bson_iter_init_find (&iter, &body_bson, json_field) ||
        !BSON_ITER_HOLDS_UTF8 (&iter)) {
       CLIENT_ERR (
-         "KMS JSON response does not include string '%s'. HTTP status=%d",
+         "KMS JSON response does not include field '%s'. HTTP status=%d. "
+         "Response body=\n%s",
          json_field,
-         http_status);
+         http_status,
+         body);
       goto fail;
    }
 
@@ -555,8 +557,10 @@ _ctx_done_oauth (mongocrypt_kms_ctx_t *kms)
    if (!bson_iter_init_find (&iter, bson_body, "access_token") ||
        !BSON_ITER_HOLDS_UTF8 (&iter)) {
       CLIENT_ERR (
-         "Invalid KMS response, no access_token returned. HTTP status=%d",
-         http_status);
+         "KMS JSON response does not include field 'access_token'. "
+         "HTTP status=%d. Response body=\n%s",
+         http_status,
+         body);
       goto fail;
    }
 
@@ -620,8 +624,11 @@ _ctx_done_azure_wrapkey_unwrapkey (mongocrypt_kms_ctx_t *kms)
 
    if (!bson_iter_init_find (&iter, bson_body, "value") ||
        !BSON_ITER_HOLDS_UTF8 (&iter)) {
-      CLIENT_ERR ("Invalid KMS response, no value returned. HTTP status=%d",
-                  http_status);
+      CLIENT_ERR (
+         "KMS JSON response does not include field 'value'. HTTP status=%d. "
+         "Response body=\n%s",
+         http_status,
+         body);
       goto fail;
    }
 
@@ -691,9 +698,11 @@ _ctx_done_gcp (mongocrypt_kms_ctx_t *kms, const char *json_field)
    if (!bson_iter_init_find (&iter, &body_bson, json_field) ||
        !BSON_ITER_HOLDS_UTF8 (&iter)) {
       CLIENT_ERR (
-         "KMS JSON response does not include string '%s'. HTTP status=%d",
+         "KMS JSON response does not include field '%s'. HTTP status=%d. "
+         "Response body=\n%s",
          json_field,
-         http_status);
+         http_status,
+         body);
       goto fail;
    }
 

--- a/test/data/kms-tests.json
+++ b/test/data/kms-tests.json
@@ -86,7 +86,7 @@
       "HTTP/1.1 100 Continue\r\n",
       "\r\n"
     ],
-    "expect": "Unsupported HTTP code in KMS response"
+    "expect": "Unsupported HTTP code in KMS response. HTTP status=100. Response body=\n"
   },
   {
     "description": "Bad JSON in response",

--- a/test/data/kms-tests.json
+++ b/test/data/kms-tests.json
@@ -252,5 +252,32 @@
       "  }\n",
       "}\n"
     ]
+  },
+  {
+    "description": "JSON in response missing needed field",
+    "ctx": [
+      "datakey",
+      "decrypt",
+      "azure_oauth_datakey",
+      "azure_oauth_decrypt",
+      "azure_datakey",
+      "azure_decrypt",
+      "gcp_oauth_datakey",
+      "gcp_oauth_decrypt",
+      "gcp_datakey",
+      "gcp_decrypt"
+    ],
+    "http_reply": [
+      "HTTP/1.1 200 OK\r\n",
+      "x-amzn-RequestId: deeb35e5-4ecb-4bf1-9af5-84a54ff0af0e\r\n",
+      "Content-Type: application/x-amz-json-1.1\r\n",
+      "Content-Length: 8\r\n",
+      "\r\n",
+      "{\"x\": 1}"
+    ],
+    "expect": [
+      "HTTP status=200. Response body=\n",
+      "{\"x\": 1}"
+    ]
   }
 ]

--- a/test/data/kms-tests.json
+++ b/test/data/kms-tests.json
@@ -90,16 +90,30 @@
   },
   {
     "description": "Bad JSON in response",
-    "ctx": ["decrypt"],
+    "ctx": [
+      "datakey",
+      "decrypt",
+      "azure_oauth_datakey",
+      "azure_oauth_decrypt",
+      "azure_datakey",
+      "azure_decrypt",
+      "gcp_oauth_datakey",
+      "gcp_oauth_decrypt",
+      "gcp_datakey",
+      "gcp_decrypt"
+    ],
     "http_reply": [
       "HTTP/1.1 200 OK\r\n",
       "x-amzn-RequestId: deeb35e5-4ecb-4bf1-9af5-84a54ff0af0e\r\n",
       "Content-Type: application/x-amz-json-1.1\r\n",
-      "Content-Length: 233\r\n",
+      "Content-Length: 7\r\n",
       "\r\n",
-      "BADJSON\": \"arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0\", \"Plaintext\": \"TqhXy3tKckECjy4/ZNykMWG8amBF46isVPzeOgeusKrwheBmYaU8TMG5AHR/NeUDKukqo8hBGgogiQOVpLPkqBQHD8YkLsNbDmHoGOill5QAHnniF/Lz405bGucB5TfR\"}"
+      "BADJSON"
     ],
-    "expect": "Error parsing JSON in KMS response"
+    "expect": [
+      "Error parsing JSON in KMS response 'Got parse error at \"B\", position 0: \"SPECIAL_EXPECTED\"'. HTTP status=200. Response body=\n",
+      "BADJSON"
+    ]
   },
   {
     "description": "Non-numeric status in response",

--- a/test/data/kms-tests.json
+++ b/test/data/kms-tests.json
@@ -198,5 +198,45 @@
       "\r\n"
     ],
     "expect": "Invalid JWT Signature"
+  },
+  {
+    "description": "GCP invalid ciphertext",
+    "ctx": ["gcp_datakey", "gcp_decrypt"],
+    "http_reply": [
+      "HTTP/1.1 400 Bad Request\r\n",
+      "Alt-Svc: h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"\r\n",
+      "Cache-Control: private\r\n",
+      "Content-Encoding: gzip\r\n",
+      "Content-Type: application/json; charset=UTF-8\r\n",
+      "Date: Wed, 20 Jul 2022 17:36:54 GMT\r\n",
+      "Server: ESF\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "Vary: Origin, X-Origin, Referer\r\n",
+      "X-Content-Type-Options: nosniff\r\n",
+      "X-Frame-Options: SAMEORIGIN\r\n",
+      "X-XSS-Protection: 0\r\n",
+      "\r\n",
+      "87\r\n",
+      "{\n",
+      "  \"error\": {\n",
+      "    \"code\": 400,\n",
+      "    \"message\": \"Decryption failed: the ciphertext is invalid.\",\n",
+      "    \"status\": \"INVALID_ARGUMENT\"\n",
+      "  }\n",
+      "}\n",
+      "\r\n",
+      "0\r\n",
+      "\r\n"      
+    ],
+    "expect": [
+      "Error in KMS response. HTTP status=400. Response body=\n",
+      "{\n",
+      "  \"error\": {\n",
+      "    \"code\": 400,\n",
+      "    \"message\": \"Decryption failed: the ciphertext is invalid.\",\n",
+      "    \"status\": \"INVALID_ARGUMENT\"\n",
+      "  }\n",
+      "}\n"
+    ]
   }
 ]

--- a/test/test-mongocrypt-kms-responses.c
+++ b/test/test-mongocrypt-kms-responses.c
@@ -32,6 +32,22 @@
 */
 
 static void
+_satisfy_oauth_request (mongocrypt_kms_ctx_t *kms_ctx)
+{
+   const char *valid_reply =
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Length: 85\r\n"
+      "\r\n"
+      "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_"
+      "in\":3599,\"access_token\":\"AAAA\"}";
+
+   mongocrypt_binary_t *bin = mongocrypt_binary_new_from_data (
+      (uint8_t *) valid_reply, (uint32_t) strlen (valid_reply));
+   ASSERT_OK (mongocrypt_kms_ctx_feed (kms_ctx, bin), kms_ctx);
+   mongocrypt_binary_destroy (bin);
+}
+
+static void
 _test_one_kms_response (_mongocrypt_tester_t *tester, bson_t *test)
 {
    mongocrypt_t *crypt;
@@ -66,23 +82,27 @@ _test_one_kms_response (_mongocrypt_tester_t *tester, bson_t *test)
          bin = _mongocrypt_tester_encrypted_doc (tester);
          tester->paths.key_file = "./test/example/key-document.json";
          ASSERT_OK (mongocrypt_ctx_decrypt_init (ctx, bin), ctx);
-      } else if (0 == strcmp ("azure_oauth_datakey", ctx_type)) {
+      } else if (0 == strcmp ("azure_oauth_datakey", ctx_type) ||
+                 0 == strcmp ("azure_datakey", ctx_type)) {
          mongocrypt_ctx_setopt_key_encryption_key (
             ctx,
             TEST_BSON ("{'provider': 'azure', 'keyVaultEndpoint': "
                        "'example.vault.azure.net', 'keyName': 'test'}"));
          ASSERT_OK (mongocrypt_ctx_datakey_init (ctx), ctx);
-      } else if (0 == strcmp ("azure_oauth_decrypt", ctx_type)) {
+      } else if (0 == strcmp ("azure_oauth_decrypt", ctx_type)
+                 || 0 == strcmp ("azure_decrypt", ctx_type)) {
          bin = _mongocrypt_tester_encrypted_doc (tester);
          tester->paths.key_file = "./test/data/key-document-azure.json";
          ASSERT_OK (mongocrypt_ctx_decrypt_init (ctx, bin), ctx);
-      } else if (0 == strcmp ("gcp_oauth_datakey", ctx_type)) {
+      } else if (0 == strcmp ("gcp_oauth_datakey", ctx_type) ||
+                 0 == strcmp ("gcp_datakey", ctx_type)) {
          mongocrypt_ctx_setopt_key_encryption_key (
             ctx,
             TEST_BSON ("{'provider': 'gcp', 'projectId': 'test', 'location': "
                        "'global', 'keyRing': 'test', 'keyName': 'test'}"));
          ASSERT_OK (mongocrypt_ctx_datakey_init (ctx), ctx);
-      } else if (0 == strcmp ("gcp_oauth_decrypt", ctx_type)) {
+      } else if (0 == strcmp ("gcp_oauth_decrypt", ctx_type) ||
+                 0 == strcmp ("gcp_decrypt", ctx_type)) {
          bin = _mongocrypt_tester_encrypted_doc (tester);
          tester->paths.key_file = "./test/data/key-document-gcp.json";
          ASSERT_OK (mongocrypt_ctx_decrypt_init (ctx, bin), ctx);
@@ -95,6 +115,20 @@ _test_one_kms_response (_mongocrypt_tester_t *tester, bson_t *test)
       kms_ctx = mongocrypt_ctx_next_kms_ctx (ctx);
       BSON_ASSERT (kms_ctx);
       BSON_ASSERT (mongocrypt_kms_ctx_bytes_needed (kms_ctx) > 0);
+
+      if (0 == strcmp ("gcp_datakey", ctx_type) ||
+          0 == strcmp ("gcp_decrypt", ctx_type) ||
+          0 == strcmp ("azure_datakey", ctx_type) ||
+          0 == strcmp ("azure_decrypt", ctx_type)) {
+         /* The targeted request is after the oauth request.
+          * Satisfy the oauth request with a valid response */
+         _satisfy_oauth_request (kms_ctx);
+         ASSERT_OK (mongocrypt_ctx_kms_done (ctx), ctx);
+         ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_NEED_KMS);
+         kms_ctx = mongocrypt_ctx_next_kms_ctx (ctx);
+         BSON_ASSERT (kms_ctx);
+         BSON_ASSERT (mongocrypt_kms_ctx_bytes_needed (kms_ctx) > 0);
+      }
 
       /* Feed until failure or completion. */
       BSON_ASSERT (bson_iter_init_find (&iter, test, "http_reply"));


### PR DESCRIPTION
# Summary
- Return HTTP body in KMS error replies.
- Update `kms-tests.json` test runner
    - Test non-oauth GCP and Azure requests.
    - Support array of strings for "expect".

# Background & Motivation

When parsing an HTTP reply from a KMS, libmongocrypt makes incorrect assumptions about the returned JSON body.

For example: creating a data key for the "gcp" KMS provider with an incorrect `masterKey.location` results in a `mongocrypt_status_t` with the message: `Error in KMS response '', code: '0'. HTTP status=404`.

The full reply body is:
```json
{
    "error": {
        "code": 404,
        "message": "The request concerns location 'foobar' but was sent to location 'global'. Either Cloud KMS is not available in 'invalid' or the request was misrouted. gRPC clients must ensure that 'x-goog-request-params' is specified in request metadata. See https://cloud.google.com/kms/docs/grpc for more information.",
        "status": "NOT_FOUND"
    }
}
```

A similar HTTP reply can be observed with a command like the following:
```
gcloud --log-http kms encrypt --plaintext-file KEVINALBS-README.md --ciphertext-file KEVINALBS-README.encrypted --key quickstart --keyring test --location foobar --project csfle-poc
```

libmongocrypt incorrectly checks for field `message` instead of `error.message`.

CSHARP-3360 describes another case where libmongocrypt returns an unhelpful error message from the HTTP reply when using KMS.

The message in `mongocrypt_status_t` is not structured. This PR proposes including the full HTTP reply, rather than attempt to parse the JSON for specific error fields.

This is also motivated by recent work on DRIVERS-2377. Using a GCP service account with insufficient permissions gives a truncated error that is difficult to diagnose.