### PR TITLE
chore: revert change to uri in node binding tests

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -30,11 +30,8 @@ server running with the following conditions:
 |-----------|-----------|
 | host      | localhost |
 | port      | 27017     |
-| username  | bob       |
-| password  | pwd123    |
 
-Note: this is the same setup as the default from the `cluster_setup.sh` script for standalone servers in the Node driver.
-
+This is the standard setup for a standalone server with no authentication.
 
 Run the test suite using:
 

--- a/bindings/node/test/clientEncryption.test.js
+++ b/bindings/node/test/clientEncryption.test.js
@@ -42,7 +42,7 @@ describe('ClientEncryption', function () {
   }
 
   async function setup() {
-    client = new MongoClient('mongodb://bob:pwd123@localhost:27017', {
+    client = new MongoClient('mongodb://localhost:27017/test', {
       useNewUrlParser: true,
       useUnifiedTopology: true
     });


### PR DESCRIPTION
In https://github.com/mongodb/libmongocrypt/pull/414, I updated the URI in the clientEncryption tests to use authentication because I saw errors locally.  This causes CI in the driver to fail.  Upon investigation, my initial changes weren't necessary.  I mistakenly tested locally with a standalone server with auth enabled, but the tests connect to a standalone without auth.  The connection succeeds, but the `drop` command fails because auth is enabled on the standalone.  I mistakenly interpreted the error "command 'drop' requires authentication" to mean authentication was required to run any drop command, and updated the URI.

This PR reverts that change to fix the driver tests.