### PR TITLE
MONGOCRYPT-457 Use CRLF instead of LF newlines

### DIFF
--- a/bindings/java/mongocrypt/src/test/java/com/mongodb/crypt/capi/MongoCryptTest.java
+++ b/bindings/java/mongocrypt/src/test/java/com/mongodb/crypt/capi/MongoCryptTest.java
@@ -251,7 +251,7 @@ public class MongoCryptTest {
         assertEquals("kms.us-east-1.amazonaws.com:443", keyDecryptor.getHostName());
 
         ByteBuffer keyDecryptorMessage = keyDecryptor.getMessage();
-        assertEquals(781, keyDecryptorMessage.remaining());
+        assertEquals(790, keyDecryptorMessage.remaining());
 
         int bytesNeeded = keyDecryptor.bytesNeeded();
         assertEquals(1024, bytesNeeded);

--- a/bindings/python/test/test_mongocrypt.py
+++ b/bindings/python/test/test_mongocrypt.py
@@ -245,7 +245,7 @@ class TestMongoCrypt(unittest.TestCase):
         with km_contexts[0] as kms_ctx:
             self.assertEqual(kms_ctx.kms_provider, "aws")
             self.assertEqual(kms_ctx.endpoint, "kms.us-east-1.amazonaws.com:443")
-            self.assertEqual(len(kms_ctx.message), 781)
+            self.assertEqual(len(kms_ctx.message), 790)
             self.assertEqual(kms_ctx.bytes_needed, 1024)
 
             kms_ctx.feed(http_data('kms-reply.txt'))

--- a/kms-message/src/kms_request.c
+++ b/kms-message/src/kms_request.c
@@ -762,6 +762,13 @@ kms_request_validate (kms_request_t *request)
    }
 }
 
+/* append_http_endofline appends an HTTP end-of-line marker: "\r\n". */
+static void
+append_http_endofline (kms_request_str_t *str)
+{
+   kms_request_str_append_chars (str, "\r\n", 2);
+}
+
 char *
 kms_request_get_signed (kms_request_t *request)
 {
@@ -795,7 +802,7 @@ kms_request_get_signed (kms_request_t *request)
    }
 
    kms_request_str_append_chars (sreq, " HTTP/1.1", -1);
-   kms_request_str_append_newline (sreq);
+   append_http_endofline (sreq);
 
    /* headers */
    lst = kms_kv_list_dup (request->header_fields);
@@ -804,7 +811,7 @@ kms_request_get_signed (kms_request_t *request)
       kms_request_str_append (sreq, lst->kvs[i].key);
       kms_request_str_append_char (sreq, ':');
       kms_request_str_append (sreq, lst->kvs[i].value);
-      kms_request_str_append_newline (sreq);
+      append_http_endofline (sreq);
    }
 
    /* authorization header */
@@ -819,8 +826,8 @@ kms_request_get_signed (kms_request_t *request)
 
    /* body */
    if (request->payload->len) {
-      kms_request_str_append_newline (sreq);
-      kms_request_str_append_newline (sreq);
+      append_http_endofline (sreq);
+      append_http_endofline (sreq);
       kms_request_str_append (sreq, request->payload);
    }
 
@@ -867,7 +874,7 @@ kms_request_to_string (kms_request_t *request)
    }
 
    kms_request_str_append_chars (sreq, " HTTP/1.1", -1);
-   kms_request_str_append_newline (sreq);
+   append_http_endofline (sreq);
 
    /* headers */
    lst = kms_kv_list_dup (request->header_fields);
@@ -876,10 +883,10 @@ kms_request_to_string (kms_request_t *request)
       kms_request_str_append (sreq, lst->kvs[i].key);
       kms_request_str_append_char (sreq, ':');
       kms_request_str_append (sreq, lst->kvs[i].value);
-      kms_request_str_append_newline (sreq);
+      append_http_endofline (sreq);
    }
 
-   kms_request_str_append_newline (sreq);
+   append_http_endofline (sreq);
 
    /* body */
    if (request->payload->len) {

--- a/kms-message/test/test_kms_request.c
+++ b/kms-message/test/test_kms_request.c
@@ -278,9 +278,10 @@ read_req (const char *path)
          /* end of header */
          break;
       } else if (line_len > 2) {
-         /* continuing a multiline header from previous line */
-         /* TODO: is this a test quirk or HTTP specified behavior? */
-         kms_request_append_header_field_value (request, "\n", 1);
+         /* continuing a multiline header value from previous line */
+         /* Header line folding is deprecated by RFC 7230 section 3.2. */
+         /* get-header-value-multiline tests this behavior. */
+         kms_request_append_header_field_value (request, "\r\n", 2);
          /* omit this line's newline */
          kms_request_append_header_field_value (
             request, line, (size_t) (line_len - 1));

--- a/kms-message/test/test_kms_request.c
+++ b/kms-message/test/test_kms_request.c
@@ -1279,6 +1279,7 @@ main (int argc, char *argv[])
    RUN_TEST (kms_kmip_response_parser_excess_test);
    RUN_TEST (kms_kmip_response_parser_notenough_test);
    RUN_TEST (test_request_newlines);
+   RUN_TEST (test_kms_util);
 
 
    if (!ran_tests) {

--- a/kms-message/test/test_kms_request.c
+++ b/kms-message/test/test_kms_request.c
@@ -313,6 +313,13 @@ test_compare (kms_request_t *request,
    char *actual;
 
    expect = read_test (dir_path, suffix);
+   if (0 == strcmp (suffix, "sreq")) {
+      /* The final signed request is an HTTP request.
+       * The expected output must contain \r\n, not \n. */
+      char* tmp = replace_all (expect, "\n", "\r\n");
+      free (expect);
+      expect = tmp;
+   }
    actual = func (request);
    ASSERT_CMPSTR (expect, actual);
    free (actual);

--- a/kms-message/test/test_kms_util.c
+++ b/kms-message/test/test_kms_util.c
@@ -70,7 +70,7 @@ replace_all (const char *input, const char *match, const char *replacement)
    while (iter != NULL) {
       kms_request_str_append_chars (replaced, start, (ssize_t) (iter - start));
       kms_request_str_append_chars (
-         replaced, replacement, strlen (replacement));
+         replaced, replacement, (ssize_t) strlen (replacement));
       iter += strlen (match);
       start = iter;
       iter = strstr (iter, match);

--- a/kms-message/test/test_kms_util.c
+++ b/kms-message/test/test_kms_util.c
@@ -16,6 +16,7 @@
 
 #include "test_kms_util.h"
 
+#include "test_kms_assert.h"
 #include "hexlify.h"
 
 #include <ctype.h> /* tolower */
@@ -58,4 +59,31 @@ hex_to_data (const char *unfiltered_hex, size_t *outlen)
 char *
 data_to_hex (const uint8_t *buf, size_t len) {
    return hexlify (buf, len);
+}
+
+char *
+replace_all (const char *input, const char *match, const char *replacement)
+{
+   kms_request_str_t *replaced = kms_request_str_new ();
+   const char *start = input;
+   const char *iter = strstr (input, match);
+   while (iter != NULL) {
+      kms_request_str_append_chars (replaced, start, (ssize_t) (iter - start));
+      kms_request_str_append_chars (
+         replaced, replacement, strlen (replacement));
+      iter += strlen (match);
+      start = iter;
+      iter = strstr (iter, match);
+   }
+   // Append the remainder of input.
+   kms_request_str_append_chars (replaced, start, -1);
+   return kms_request_str_detach (replaced);
+}
+
+void
+test_kms_util (void)
+{
+   char *got = replace_all ("foo bar baz", "bar", "baz");
+   ASSERT_CMPSTR (got, "foo baz baz");
+   free (got);
 }

--- a/kms-message/test/test_kms_util.c
+++ b/kms-message/test/test_kms_util.c
@@ -64,6 +64,9 @@ data_to_hex (const uint8_t *buf, size_t len) {
 char *
 replace_all (const char *input, const char *match, const char *replacement)
 {
+   ASSERT (input);
+   ASSERT (match);
+   ASSERT (replacement);
    kms_request_str_t *replaced = kms_request_str_new ();
    const char *start = input;
    const char *iter = strstr (input, match);

--- a/kms-message/test/test_kms_util.h
+++ b/kms-message/test/test_kms_util.h
@@ -33,4 +33,13 @@ hex_to_data (const char *unfiltered_hex, size_t *outlen);
 char *
 data_to_hex (const uint8_t *data, size_t len);
 
+/* replace_all returns a copy of @input with all occurrences of @match replaced
+ * with @replacement. */
+char *
+replace_all (const char *input, const char *match, const char *replacement);
+
+/* test_kms_util tests utility functions. */
+void
+test_kms_util (void);
+
 #endif /* TEST_KMS_UTIL_H */


### PR DESCRIPTION
# Summary
- Use `\r\n`, not `\n`, as the end-of-line delimitter in HTTP requests.

The Go driver integration tests were run with this branch in a [patch build](https://spruce.mongodb.com/version/62e16a0c3e8e8618242ec912/) to test sending KMS requests to live services.