### PR TITLE
Make all shell scripts nounset-clean, enable "strict mode"

### DIFF
--- a/.evergreen/build_all.sh
+++ b/.evergreen/build_all.sh
@@ -9,8 +9,7 @@
 # Set extra cflags for libmongocrypt variables by setting LIBMONGOCRYPT_EXTRA_CFLAGS.
 #
 
-set -o xtrace
-set -o errexit
+set -euxo pipefail
 
 echo "Begin compile process"
 
@@ -72,7 +71,7 @@ ADDITIONAL_CMAKE_FLAGS="$ADDITIONAL_CMAKE_FLAGS -DENABLE_MORE_WARNINGS_AS_ERRORS
 
 $CMAKE -DCMAKE_BUILD_TYPE=RelWithDebInfo $ADDITIONAL_CMAKE_FLAGS "${LIBMONGOCRYPT_EXTRA_CMAKE_FLAGS}" -DCMAKE_C_FLAGS="${LIBMONGOCRYPT_EXTRA_CFLAGS}" -DCMAKE_CXX_FLAGS="${LIBMONGOCRYPT_EXTRA_CFLAGS} $_cxxflags" "-DCMAKE_INSTALL_PREFIX=${MONGOCRYPT_INSTALL_PREFIX}" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../
 
-if [ "$CONFIGURE_ONLY" ]; then
+if [ "${CONFIGURE_ONLY-}" ]; then
     echo "Only running cmake";
     exit 0;
 fi

--- a/.evergreen/clang-tidy.sh
+++ b/.evergreen/clang-tidy.sh
@@ -3,8 +3,7 @@
 # static analyzer.
 #
 
-set -o xtrace
-set -o errexit
+set -euxo pipefail
 
 echo "Begin compile process"
 

--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -10,8 +10,7 @@
 # NOTE: This script is not meant to be invoked for Evergreen builds.  It is a
 # convenience script for users of libmongocrypt
 
-set -o xtrace
-set -o errexit
+set -euxo pipefail
 
 save_pwd="$(pwd)"
 

--- a/.evergreen/compile_cs.sh
+++ b/.evergreen/compile_cs.sh
@@ -3,8 +3,7 @@
 # Set extra cflags for libmongocrypt variables by setting LIBMONGOCRYPT_EXTRA_CFLAGS.
 #
 
-set -o xtrace
-set -o errexit
+set -euxo pipefail
 
 echo "Begin compile process"
 
@@ -16,7 +15,7 @@ cd $evergreen_root
 
 if [ "$OS" == "Windows_NT" ]; then
     # Make sure libbson.dll is in the path on Windows
-    export PATH=${INSTALL_PREFIX}/mongo-c-driver/bin:$PATH
+    export PATH=${MONGOCRYPT_INSTALL_PREFIX}/mongo-c-driver/bin:$PATH
 
     for var in TMP TEMP NUGET_PACKAGES NUGET_HTTP_CACHE_PATH APPDATA; do export $var=z:\\data\\tmp; done
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -652,7 +652,7 @@ tasks:
           set -o errexit
           set -o xtrace
           export IS_PATCH="${is_patch}"
-          sh .evergreen/debian_package_build.sh
+          bash .evergreen/debian_package_build.sh
     - command: s3.put
       params:
         aws_key: ${aws_key}

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -79,61 +79,14 @@ functions:
     - command: "shell.exec"
       shell: bash
       params:
-        script: |-
-          set -o xtrace
-          set -o errexit
-
-          # Find cmake.
-          if [ "$OS" == "Windows_NT" ]; then
-             CMAKE=/cygdrive/c/cmake/bin/cmake
-          else
-             # Amazon Linux 2 (arm64) has a very old system CMake we want to ignore
-             IGNORE_SYSTEM_CMAKE=1 . ./libmongocrypt/.evergreen/find-cmake.sh
-             set +u
-          fi
-          # Get current version of libmongocrypt.
-          cd libmongocrypt
-          mongocrypt_version="$($CMAKE -DRELEASE_BRANCH_REF=origin/r1.5 -P ./cmake/GetVersion.cmake 2>&1)"
-          cd ..
-
-          if [ "${has_packages|}" != "true" ] ; then
-            echo "'has_packages' is not 'true', skipping package build"
-            exit 0
-          fi
-
-          # check if virtualenv is set up
-          if [ -d "${workdir}/venv" ]; then
-            if [ "Windows_NT" = "$OS" ]; then
-              # Need to quote the path on Windows to preserve the separator.
-              . "${workdir}/venv/Scripts/activate" 2> /tmp/activate_error.log
-            else
-              . ${workdir}/venv/bin/activate 2> /tmp/activate_error.log
-            fi
-            if [ $? -ne 0 ]; then
-              echo "Failed to activate virtualenv: $(cat /tmp/activate_error.log)"
-            fi
-            python=python
-          else
-            python=${python|/opt/mongodbtoolchain/v3/bin/python3}
-          fi
-
-          if [ "Windows_NT" = "$OS" ]; then
-            export PYTHONPATH="$PYTHONPATH;$(cygpath -w ${workdir}/src)"
-          else
-            export PYTHONPATH="$PYTHONPATH:${workdir}/src"
-          fi
-
-          PPA_BUILD_ONLY=1 ${compile_env|} ./libmongocrypt/.evergreen/build_all.sh
-          pkg_version=$mongocrypt_version
-          tar -zcv -C install --transform="s|^libmongocrypt/|libmongocrypt-$pkg_version/|" --exclude=nocrypto --exclude=sharedbson -f libmongocrypt-$pkg_version.tar.gz libmongocrypt
-          cd libmongocrypt/etc/
-          # The files from libmongocrypt/debian/ are the official maintainer scripts,
-          # but libmongocrypt/etc/debian/ contains a few custom scripts that are
-          # meant to support the packager.py workflow.  This step "fills in" around
-          # those custom scripts.
-          cp -nr ../debian/* debian/
-          $python ./packager.py --prefix `pwd`/.. --distros ${packager_distro} --tarball `pwd`/../../libmongocrypt-$pkg_version.tar.gz --library-version $pkg_version --metadata-gitspec HEAD --arches ${packager_arch}
-          cd ../..
+        script: |
+          env "WORKDIR=${workdir}" \
+              "PYTHON=${python|}" \
+              "HAS_PACKAGES=${has_packages|false}" \
+              "PACKAGER_DISTRO=${packager_distro}" \
+              "PACKAGER_ARCH=${packager_arch}" \
+              ${compile_env|} \
+            bash libmongocrypt/.evergreen/create-packages-and-repos.sh
     - command: archive.targz_pack
       params:
         target: libmongocrypt-distro-packages.tar.gz
@@ -242,6 +195,7 @@ functions:
     - command: shell.exec
       params:
         silent: true
+        shell: bash
         script: |
           set -o errexit
           if [ "${is_patch}" = "true" ]; then
@@ -274,8 +228,8 @@ functions:
     - command: "shell.exec"
       params:
         script: |-
-          ${compile_env|} ./libmongocrypt/.evergreen/build_all.sh
-          ${compile_env|} ./libmongocrypt/.evergreen/compile_cs.sh
+          env ${compile_env|} bash ./libmongocrypt/.evergreen/build_all.sh
+          env ${compile_env|} bash ./libmongocrypt/.evergreen/compile_cs.sh
 
 tasks:
 - name: build-and-test-and-upload
@@ -576,6 +530,7 @@ tasks:
     - command: shell.exec
       params:
         working_dir: libmongocrypt
+        shell: bash
         script: |-
           [ -f ~/.notary_env.sh ] && . ~/.notary_env.sh
           set -o xtrace

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -77,6 +77,7 @@ functions:
 
   "create packages and repos":
     - command: "shell.exec"
+      shell: bash
       params:
         script: |-
           set -o xtrace
@@ -88,6 +89,7 @@ functions:
           else
              # Amazon Linux 2 (arm64) has a very old system CMake we want to ignore
              IGNORE_SYSTEM_CMAKE=1 . ./libmongocrypt/.evergreen/find-cmake.sh
+             set +u
           fi
           # Get current version of libmongocrypt.
           cd libmongocrypt

--- a/.evergreen/create-packages-and-repos.sh
+++ b/.evergreen/create-packages-and-repos.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+: "${WORKDIR:="$PWD"}"
+
+# Generate an error if these are unset:
+: "$PACKAGER_DISTRO" "$PACKAGER_ARCH"
+
+. "$WORKDIR/libmongocrypt/.evergreen/setup-env.sh"
+
+
+if [ "$OS" = "Windows_NT" ]; then
+  CMAKE="/cygdrive/c/cmake/bin/cmake"
+else
+  IGNORE_SYSTEM_CMAKE=1 . "$WORKDIR/libmongocrypt/.evergreen/find-cmake.sh"
+fi
+
+# Get current version of libmongocrypt.
+pushd "$WORKDIR/libmongocrypt"
+  mongocrypt_version="$("$CMAKE" -DRELEASE_BRANCH_REF=origin/r1.5 -P ./cmake/GetVersion.cmake 2>&1)"
+popd
+
+if ! "${HAS_PACKAGES:-false}"; then
+  echo "'HAS_PACKAGES' is not 'true': Skipping package build"
+  exit 0
+fi
+
+if test -d "$WORKDIR/venv"; then
+  if test "$OS" = "Windows_NT"; then
+    # Need to quote the path on Windows to preserve the separator.
+    . "$WORKDIR/venv/Scripts/activate" 2> /tmp/activate_error.log
+  else
+    . "$WORKDIR/venv/bin/activate" 2> /tmp/activate_error.log
+  fi
+  if test $? -ne 0; then
+    echo "Failed to activate virtualenv: $(cat /tmp/activate_error.log)"
+  fi
+  python=python
+else
+  python="${PYTHON:-/opt/mongodbtoolchain/v3/bin/python3}"
+fi
+
+export PYTHONPATH
+: "${PYTHONPATH:=}"
+if test "$OS" = "Windows_NT"; then
+  PYTHONPATH="$PYTHONPATH;$(cygpath -w "$WORKDIR/src")"
+else
+  PYTHONPATH="$PYTHONPATH:$WORKDIR/src"
+fi
+
+PPA_BUILD_ONLY=1 ./libmongocrypt/.evergreen/build_all.sh
+pkg_version=$mongocrypt_version
+tar -zcv -C install \
+  --transform="s|^libmongocrypt/|libmongocrypt-$pkg_version/|" \
+  --exclude=nocrypto \
+  --exclude=sharedbson \
+  -f "libmongocrypt-$pkg_version.tar.gz" \
+  libmongocrypt
+pushd libmongocrypt/etc/
+  # The files from libmongocrypt/debian/ are the official maintainer scripts,
+  # but libmongocrypt/etc/debian/ contains a few custom scripts that are
+  # meant to support the packager.py workflow.  This step "fills in" around
+  # those custom scripts.
+  cp -nr ../debian/* debian/
+  command "$python" ./packager.py \
+    --prefix "$WORKDIR/libmongocrypt" \
+    --distros "$PACKAGER_DISTRO" \
+    --tarball "$WORKDIR/libmongocrypt-$pkg_version.tar.gz" \
+    --library-version "$pkg_version" \
+    --metadata-gitspec HEAD \
+    --arches "$PACKAGER_ARCH"
+popd

--- a/.evergreen/debian_package_build.sh
+++ b/.evergreen/debian_package_build.sh
@@ -6,8 +6,7 @@
 # Supported/used environment variables:
 #   IS_PATCH    If "true", this is an Evergreen patch build.
 
-set -o xtrace
-set -o errexit
+set -euxo pipefail
 
 on_exit () {
   if [ -e ./unstable-chroot/debootstrap/debootstrap.log ]; then

--- a/.evergreen/find-cmake.sh
+++ b/.evergreen/find-cmake.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euxo pipefail
 

--- a/.evergreen/find-cmake.sh
+++ b/.evergreen/find-cmake.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
-set -o errexit  # Exit the script with error if any of the commands fail
+
+set -euxo pipefail
 
 find_cmake ()
 {
-  if [ ! -z "$CMAKE" ]; then
+  if [ ! -z "${CMAKE-}" ]; then
     return 0
   elif [ -f "/Applications/cmake-3.2.2-Darwin-x86_64/CMake.app/Contents/bin/cmake" ]; then
     CMAKE="/Applications/cmake-3.2.2-Darwin-x86_64/CMake.app/Contents/bin/cmake"
@@ -11,7 +12,7 @@ find_cmake ()
     CMAKE="/Applications/Cmake.app/Contents/bin/cmake"
   elif [ -f "/opt/cmake/bin/cmake" ]; then
     CMAKE="/opt/cmake/bin/cmake"
-  elif [ -z "$IGNORE_SYSTEM_CMAKE" ] && command -v cmake 2>/dev/null; then
+  elif [ -z "${IGNORE_SYSTEM_CMAKE-}" ] && command -v cmake 2>/dev/null; then
     CMAKE=cmake
   elif uname -a | grep -iq 'GNU/Linux'; then
     version="3.19.4"  # First version that ships arm64 binaries

--- a/.evergreen/linker-tests.sh
+++ b/.evergreen/linker-tests.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-set -o xtrace
-set -o errexit
+
+set -euxo pipefail
 
 system_path () {
-    if [ "$OS" == "Windows_NT" ]; then
+    if [ "${OS-}" == "Windows_NT" ]; then
         cygpath -a "$1" -w
     else
         echo $1

--- a/.evergreen/pkgconfig-tests.sh
+++ b/.evergreen/pkgconfig-tests.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-set -o xtrace
-set -o errexit
+
+set -euxo pipefail
 
 system_path () {
-    if [ "$OS" == "Windows_NT" ]; then
+    if [ "${OS-}" == "Windows_NT" ]; then
         cygpath -a "$1" -w
     else
         echo $1

--- a/.evergreen/prep_c_driver_source.sh
+++ b/.evergreen/prep_c_driver_source.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-set -o xtrace
-set -o errexit
+set -euxo pipefail
 
 # Clone mongo-c-driver and check out to a tagged version.
 MONGO_C_DRIVER_VERSION=1.17.0

--- a/.evergreen/setup-env.sh
+++ b/.evergreen/setup-env.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
+
+set -euxo pipefail
+
 evergreen_root="$(pwd)"
+
+: "${ADDITIONAL_CMAKE_FLAGS:=}"
+: "${LIBMONGOCRYPT_EXTRA_CMAKE_FLAGS:=}"
+: "${LIBMONGOCRYPT_EXTRA_CFLAGS:=}"
+: "${PPA_BUILD_ONLY:=}"
+: "${MACOS_UNIVERSAL:=}"
+: "${WINDOWS_32BIT:=}"
+: "${OS:=unspecified}"
 
 [ -d "${MONGOCRYPT_INSTALL_PREFIX:=${evergreen_root}/install/libmongocrypt}" ] || mkdir -p "${MONGOCRYPT_INSTALL_PREFIX}"
 

--- a/.evergreen/setup-env.sh
+++ b/.evergreen/setup-env.sh
@@ -15,7 +15,7 @@ evergreen_root="$(pwd)"
 [ -d "${MONGOCRYPT_INSTALL_PREFIX:=${evergreen_root}/install/libmongocrypt}" ] || mkdir -p "${MONGOCRYPT_INSTALL_PREFIX}"
 
 if [ "$OS" == "Windows_NT" ]; then
-	MONGOCRYPT_INSTALL_PREFIX=$(cygpath -w $MONGOCRYPT_INSTALL_PREFIX)
+	MONGOCRYPT_INSTALL_PREFIX=$(cygpath -w "$MONGOCRYPT_INSTALL_PREFIX")
 fi
 
 if test -f /proc/cpuinfo; then

--- a/README.md
+++ b/README.md
@@ -116,7 +116,12 @@ Do the following when releasing:
 - Update CHANGELOG.md with any new changes and update the `[Unreleased]` text to the version being released.
 - If this is a new minor release (e.g. `x.y.0`):
    - Update the Linux distribution package installation instructions in the below sections to refer to the new version x.y.
-   - Update the release branch references (i.e., `-DRELEASE_BRANCH_REF=origin/rx.y`) in the invocations of `GetVersion.cmake` (currently located in `CMakeLists.txt`, `.evergreen/debian_package_build.sh`, and `.evergreen/config.yml`) so that they refer to the new branch you are about to create
+   - Update the release branch references (i.e.,
+     `-DRELEASE_BRANCH_REF=origin/rx.y`) in the invocations of
+     `GetVersion.cmake` (currently located in `CMakeLists.txt`,
+     `.evergreen/debian_package_build.sh`,
+     `.evergreen/create-packages-and-repos.sh`, and `.evergreen/config.yml`) so
+     that they refer to the new branch you are about to create
    - Commit these changes (on `master`) so that both the `master` branch and the new branch you are about to create refer to the new branch (note that this means you will commit changes to this file, `CHANGELOG.md`, and the files which contain invocations of `GetVersion.cmake`)
    - Create a branch named `rx.y`.
    - Update the [libmongocrypt-release](https://evergreen.mongodb.com/projects##libmongocrypt-release) Evergreen project to set `Branch Name` to `rx.y`.


### PR DESCRIPTION
This changeset ensures most of the build shell scripts execute cleanly in Bash with "strict mode." Several environment variables used by the scripts are given default empty values in `setup-env.sh`. The "create packages" script was moved out-of-line from `config.yml` and placed in a dedicated file to allow for braced shell substitutions without EVG expansions interfering. The behavior of the scripts is otherwise unchanged.