### PR TITLE
MONGOCRYPT-306 add "Invalid KMS response" to error.

### DIFF
--- a/src/mongocrypt-kms-ctx.c
+++ b/src/mongocrypt-kms-ctx.c
@@ -556,7 +556,8 @@ _ctx_done_oauth (mongocrypt_kms_ctx_t *kms)
 
    if (!bson_iter_init_find (&iter, bson_body, "access_token") ||
        !BSON_ITER_HOLDS_UTF8 (&iter)) {
-      CLIENT_ERR ("KMS JSON response does not include field 'access_token'. "
+      CLIENT_ERR ("Invalid KMS response. KMS JSON response does not include "
+                  "field 'access_token'. "
                   "HTTP status=%d. Response body=\n%s",
                   http_status,
                   body);
@@ -685,12 +686,11 @@ _ctx_done_gcp (mongocrypt_kms_ctx_t *kms, const char *json_field)
     */
    bson_destroy (&body_bson);
    if (!bson_init_from_json (&body_bson, body, body_len, &bson_error)) {
-      CLIENT_ERR (
-         "Invalid KMS response. Error parsing JSON in KMS response '%s'. "
-         "HTTP status=%d. Response body=\n%s",
-         bson_error.message,
-         http_status,
-         body);
+      CLIENT_ERR ("Error parsing JSON in KMS response '%s'. "
+                  "HTTP status=%d. Response body=\n%s",
+                  bson_error.message,
+                  http_status,
+                  body);
       bson_init (&body_bson);
       goto fail;
    }

--- a/src/mongocrypt-kms-ctx.c
+++ b/src/mongocrypt-kms-ctx.c
@@ -685,11 +685,12 @@ _ctx_done_gcp (mongocrypt_kms_ctx_t *kms, const char *json_field)
     */
    bson_destroy (&body_bson);
    if (!bson_init_from_json (&body_bson, body, body_len, &bson_error)) {
-      CLIENT_ERR ("Error parsing JSON in KMS response '%s'. "
-                  "HTTP status=%d. Response body=\n%s",
-                  bson_error.message,
-                  http_status,
-                  body);
+      CLIENT_ERR (
+         "Invalid KMS response. Error parsing JSON in KMS response '%s'. "
+         "HTTP status=%d. Response body=\n%s",
+         bson_error.message,
+         http_status,
+         body);
       bson_init (&body_bson);
       goto fail;
    }


### PR DESCRIPTION
# Summary
- add "Invalid KMS response" to error parsing GCP access token.

# Background & Motivation

Drivers expect the substring "Invalid KMS response" error message in the "Custom Endpoint" [prose test 9](https://github.com/mongodb/specifications/tree/b63ea83e782b1fe2081ff0ad38bd088525396f41/source/client-side-encryption/tests#test-cases). This was not considered when implementing MONGOCRYPT-306. Rather than require all drivers update tests, add the string back to the error message.

MONGOCRYPT-306 changed an [error message](https://github.com/mongodb/libmongocrypt/pull/422/files#diff-1d46e573cbccf1b7d005fcee4face95abca81c6e5c39355da793252fd1170eadL577).

