### PR TITLE
feat(NODE-4517): add official support for the key management API

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -374,7 +374,7 @@ const dataKeyId = await clientEncryption.createDataKey('aws', {
 | options.provider | [<code>KmsProvider</code>](#KmsProvider) | The KMS provider to use when re-wrapping the data keys. |
 | [options.masterKey] | [<code>AWSEncryptionKeyOptions</code>](#AWSEncryptionKeyOptions) \| [<code>AzureEncryptionKeyOptions</code>](#AzureEncryptionKeyOptions) \| [<code>GCPEncryptionKeyOptions</code>](#GCPEncryptionKeyOptions) |  |
 
-Searches the keyvault for any data keys matching the provided filter.  If there are matches, the attempts to re-wrap the data keys using the provided options.
+Searches the keyvault for any data keys matching the provided filter.  If there are matches, rewrapManyDataKey then attempts to re-wrap the data keys using the provided options.
 
 If no matches are found, then no bulk write is performed.
 
@@ -442,7 +442,7 @@ const keys = await clientEncryption.getKeys().toArray();
 
 Finds a key in the keyvault with the specified _id.
 
-**Returns**: [<code>Promise.&lt;DataKey&gt;</code>](#DataKey) - IReturns a promise that either resolves to a [DataKey](#DataKey) if a document matches the key or null if no documents
+**Returns**: [<code>Promise.&lt;DataKey&gt;</code>](#DataKey) - Returns a promise that either resolves to a [DataKey](#DataKey) if a document matches the key or null if no documents
 match the id.  The promise rejects with an error if an error is thrown.  
 **Example**  
 ```js
@@ -464,7 +464,7 @@ if (!key) {
 Finds a key in the keyvault which has the specified keyAltName.
 
 **Returns**: <code>Promise.&lt;(DataKey\|null)&gt;</code> - Returns a promise that either resolves to a [DataKey](#DataKey) if a document matches the key or null if no documents
-match the id.  The promise rejects with an error if an error is thrown.  
+match the keyAltName.  The promise rejects with an error if an error is thrown.  
 **Example**  
 ```js
 // get a key by alt name
@@ -540,7 +540,7 @@ if (!oldKey) {
 | [options.algorithm] |  | The algorithm to use for encryption. Must be either `'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'`, `'AEAD_AES_256_CBC_HMAC_SHA_512-Random'`, `'Indexed'` or `'Unindexed'` |
 | [callback] | [<code>ClientEncryptionEncryptCallback</code>](#ClientEncryptionEncryptCallback) | Optional callback to invoke when value is encrypted |
 
-Explicitly encrypt a provided value. Noe that either `options.keyId` or `options.keyAltName` must
+Explicitly encrypt a provided value. Note that either `options.keyId` or `options.keyAltName` must
 be specified. Specifying both `options.keyId` and `options.keyAltName` is considered an error.
 
 **Returns**: <code>Promise</code> \| <code>void</code> - If no callback is provided, returns a Promise that either resolves with the encrypted value, or rejects with an error. If a callback is provided, returns nothing.  

--- a/bindings/node/etc/README.hbs
+++ b/bindings/node/etc/README.hbs
@@ -30,11 +30,8 @@ server running with the following conditions:
 |-----------|-----------|
 | host      | localhost |
 | port      | 27017     |
-| username  | bob       |
-| password  | pwd123    |
 
-Note: this is the same setup as the default from the `cluster_setup.sh` script for standalone servers in the Node driver.
-
+This is the standard setup for a standalone server with no authentication.
 
 Run the test suite using:
 

--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -405,7 +405,7 @@ export class ClientEncryption {
   ): void;
 
   /** 
-   * Searches the keyvault for any data keys matching the provided filter.  If there are matches, the attempts to re-wrap the data keys using the provided options.
+   * Searches the keyvault for any data keys matching the provided filter.  If there are matches, rewrapManyDataKey then attempts to re-wrap the data keys using the provided options.
    *
    * If no matches are found, then no bulk write is performed.
    */

--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -404,14 +404,17 @@ export class ClientEncryption {
     callback: ClientEncryptionCreateDataKeyCallback
   ): void;
 
-  /** @experimental */
+  /** 
+   * Searches the keyvault for any data keys matching the provided filter.  If there are matches, the attempts to re-wrap the data keys using the provided options.
+   *
+   * If no matches are found, then no bulk write is performed.
+   */
   rewrapManyDataKey(
     filter: Document,
     options?: ClientEncryptionRewrapManyDataKeyProviderOptions
   ): Promise<ClientEncryptionRewrapManyDataKeyResult>;
 
   /**
-   * @experimental
    * Deletes the key with the provided id from the keyvault, if it exists.
    *
    * @param id - the id of the document to delete.
@@ -419,15 +422,13 @@ export class ClientEncryption {
   deleteKey(id: Binary): Promise<DeleteResult>;
 
   /**
-   * @experimental
    * Finds all the keys currently stored in the keyvault.
    *
    * This method will not throw.
    */
-  getKeys(): FindCursor<DataKey>; 
+  getKeys(): FindCursor<DataKey>;
 
   /**
-   * @experimental
    * Finds a key in the keyvault with the specified key.
    *
    * @param id - the id of the document to delete.
@@ -435,7 +436,6 @@ export class ClientEncryption {
   getKey(id: Binary): Promise<DataKey | null>;
 
   /**
-   * @experimental
    * Finds a key in the keyvault which has the specified keyAltNames as a keyAltName.
    *
    * @param keyAltName - a potential keyAltName to search for in the keyAltNames array
@@ -443,7 +443,6 @@ export class ClientEncryption {
   getKeyByAltName(keyAltName: string): Promise<DataKey | null>;
 
   /**
-   * @experimental
    * Adds a keyAltName to a key identified by the provided `id`.
    *
    * This method resolves to/returns the *old* key value (prior to adding the new altKeyName).
@@ -454,7 +453,6 @@ export class ClientEncryption {
   addKeyAltName(id: Binary, keyAltName: string): Promise<DataKey | null>;
 
   /**
-   * @experimental
    * Adds a keyAltName to a key identified by the provided `id`.
    *
    * This method resolves to/returns the *old* key value (prior to removing the new altKeyName).

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -280,7 +280,7 @@ module.exports = function (modules) {
      */
 
     /**
-     * Searches the keyvault for any data keys matching the provided filter.  If there are matches, the attempts to re-wrap the data keys using the provided options.
+     * Searches the keyvault for any data keys matching the provided filter.  If there are matches, rewrapManyDataKey then attempts to re-wrap the data keys using the provided options.
      *
      * If no matches are found, then no bulk write is performed.
      *


### PR DESCRIPTION
NODE-4517 (part of NODE-4443)

This PR removes experimental tags from the key management API in preparation for the release of mongodb-client-encryption@2.2.0.

It also adds a doc comment for rewrapManyDataKey.