### PR TITLE
MONGOCRYPT-463 check the `collMod` command for `validator.$jsonSchema`

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -1935,8 +1935,9 @@ _try_empty_schema_for_create (mongocrypt_ctx_t *ctx)
    return true;
 }
 
-/* _try_schema_from_create_cmd tries to find a JSON schema included in a create
- * command by checking for "validator.$jsonSchema". Example:
+/* _try_schema_from_create_or_collMod_cmd tries to find a JSON schema included
+ * in a create or collMod command by checking for "validator.$jsonSchema".
+ * Example:
  * {
  *     "create" : "coll",
  *     "validator" : {
@@ -1946,19 +1947,23 @@ _try_empty_schema_for_create (mongocrypt_ctx_t *ctx)
  *     }
  * }
  * If the "create" command does not include a JSON schema, an empty JSON schema
- * is returned. This is to avoid an unnecessary 'listCollections' command for
- * create. */
+ * is later. This is to avoid an unnecessary 'listCollections' command for
+ * create.
+ *
+ * If the "collMod" command does not include a JSON schema, a schema is later
+ * requested from other sources. This is because a "collMod" command may have
+ * sensitive data in the "validator" field.
+ */
 static bool
-_try_schema_from_create_cmd (mongocrypt_ctx_t *ctx)
+_try_schema_from_create_or_collMod_cmd (mongocrypt_ctx_t *ctx)
 {
    _mongocrypt_ctx_encrypt_t *ectx;
    mongocrypt_status_t *status = ctx->status;
 
    ectx = (_mongocrypt_ctx_encrypt_t *) ctx;
-   /* As a special case, use an empty schema for the 'create' command. */
    const char *cmd_name = ectx->cmd_name;
 
-   if (0 != strcmp (cmd_name, "create")) {
+   if (0 != strcmp (cmd_name, "create") && 0 != strcmp (cmd_name, "collMod")) {
       return true;
    }
 
@@ -2524,7 +2529,7 @@ mongocrypt_ctx_encrypt_ismaster_done (mongocrypt_ctx_t *ctx)
       return false;
    }
    if (_mongocrypt_buffer_empty (&ectx->encrypted_field_config)) {
-      if (!_try_schema_from_create_cmd (ctx)) {
+      if (!_try_schema_from_create_or_collMod_cmd (ctx)) {
          return false;
       }
 

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -1947,7 +1947,7 @@ _try_empty_schema_for_create (mongocrypt_ctx_t *ctx)
  *     }
  * }
  * If the "create" command does not include a JSON schema, an empty JSON schema
- * is later. This is to avoid an unnecessary 'listCollections' command for
+ * is returned. This is to avoid an unnecessary 'listCollections' command for
  * create.
  *
  * If the "collMod" command does not include a JSON schema, a schema is later

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -1951,8 +1951,9 @@ _try_empty_schema_for_create (mongocrypt_ctx_t *ctx)
  * create.
  *
  * If the "collMod" command does not include a JSON schema, a schema is later
- * requested from other sources. This is because a "collMod" command may have
- * sensitive data in the "validator" field.
+ * requested by entering the MONGOCRYPT_CTX_NEED_MONGO_COLLINFO state.
+ * This is because a "collMod" command may have sensitive data in the
+ * "validator" field.
  */
 static bool
 _try_schema_from_create_or_collMod_cmd (mongocrypt_ctx_t *ctx)

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -2138,7 +2138,8 @@ mongocrypt_ctx_explicit_encrypt_init (mongocrypt_ctx_t *ctx,
    if (ctx->opts.index_type.set &&
        ctx->opts.index_type.value == MONGOCRYPT_INDEX_TYPE_EQUALITY &&
        !ctx->opts.contention_factor.set) {
-      return _mongocrypt_ctx_fail_w_msg (ctx, "contention factor is required for indexed algorithm");
+      return _mongocrypt_ctx_fail_w_msg (
+         ctx, "contention factor is required for indexed algorithm");
    }
 
    ectx = (_mongocrypt_ctx_encrypt_t *) ctx;

--- a/test/data/fle1-collMod/cmd-to-mongocryptd.json
+++ b/test/data/fle1-collMod/cmd-to-mongocryptd.json
@@ -1,0 +1,12 @@
+{
+    "collMod": "encryptedCollection",
+    "validator": {
+        "$jsonSchema": {
+            "bsonType": "object"
+        }
+    },
+    "jsonSchema": {
+        "bsonType": "object"
+    },
+    "isRemoteSchema": true
+}

--- a/test/data/fle1-collMod/cmd.json
+++ b/test/data/fle1-collMod/cmd.json
@@ -1,0 +1,8 @@
+{
+    "collMod": "encryptedCollection",
+    "validator": {
+        "$jsonSchema": {
+            "bsonType": "object"
+        }
+    }
+}

--- a/test/data/fle1-collMod/insert/cmd.json
+++ b/test/data/fle1-collMod/insert/cmd.json
@@ -1,0 +1,8 @@
+{
+    "insert": "encryptedCollection",
+    "documents": [
+        {
+            "x": 1
+        }
+    ]
+}

--- a/test/data/fle1-collMod/insert/collinfo.json
+++ b/test/data/fle1-collMod/insert/collinfo.json
@@ -1,0 +1,9 @@
+{
+    "options": {
+        "validator": {
+            "$jsonSchema": {
+                "bsonType": "object"
+            }
+        }
+    }
+}

--- a/test/data/fle1-collMod/mongocryptd-reply.json
+++ b/test/data/fle1-collMod/mongocryptd-reply.json
@@ -1,0 +1,14 @@
+{
+    "ok": {
+        "$numberInt": "1"
+    },
+    "result": {
+        "collMod": "encryptedCollection",
+        "validator": {
+            "$jsonSchema": {
+                "bsonType": "object"
+            }
+        }
+    },
+    "hasEncryptedPlaceholders": false
+}


### PR DESCRIPTION
# Summary
- Check the `collMod` command for `validator.$jsonSchema` and send it to query analysis.

# Background & Motivation

## Checking collMod for `validator.$jsonSchema`
Since MONGOCRYPT-429, automatic encryption has supported the `collMod` command. Prior to MONGOCRYPT-429, it was always an error to automatically encrypt a `collMod` command. A `collMod` command is not bypassed because it may include sensitive plaintext in a `validator` field:
```json
{
    "collMod": "encryptedCollection",
    "validator": {
        "encryptedField": "plaintext",
    }
}
```

A `collMod` command may also include a `validator.$jsonSchema`:
```json
{
    "collMod": "encryptedCollection",
    "validator": {
        "$jsonSchema": {
            "encryptedField": {
                "encrypt": {
                    "bsonType": "string",
                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
                    "keyId": {
                        "$binary": {
                            "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
                            "subType": "04"
                        }
                    }
                }
            }
        }
    }
}
```

If a `collMod` includes a `validator.$jsonSchema`, Query Analysis (mongocryptd or the mongo_crypt shared library) expects the `jsonSchema` field added by libmongocrypt to match. See MONGOCRYPT-463 for an example of this error.

A regression specification test is tested with the Go driver [here](https://spruce.mongodb.com/version/62f67ca80305b9451042e293/changes?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)


