### PR TITLE
fix(NODE-4516): dont require a connected client

### DIFF
--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -6,6 +6,7 @@ module.exports = function (modules) {
   const fs = require('fs');
   const { once } = require('events');
   const { SocksClient } = require('socks');
+  const bson = require('bson');
 
   // Try first to import 4.x name, fallback to 3.x name
   const MongoNetworkTimeoutError =
@@ -89,7 +90,6 @@ module.exports = function (modules) {
   class StateMachine {
     constructor(options) {
       this.options = options || {};
-      this.bson = options.bson;
     }
 
     /**
@@ -101,7 +101,6 @@ module.exports = function (modules) {
      * @returns {void}
      */
     execute(autoEncrypter, context, callback) {
-      const bson = this.bson;
       const keyVaultNamespace = autoEncrypter._keyVaultNamespace;
       const keyVaultClient = autoEncrypter._keyVaultClient;
       const metaDataClient = autoEncrypter._metaDataClient;
@@ -400,7 +399,6 @@ module.exports = function (modules) {
      * @param {StateMachine~fetchCollectionInfoCallback} callback Invoked with the info of the requested collection, or with an error
      */
     fetchCollectionInfo(client, ns, filter, callback) {
-      const bson = this.bson;
       const dbName = databaseNamespace(ns);
 
       client
@@ -432,7 +430,6 @@ module.exports = function (modules) {
      * @returns {void}
      */
     markCommand(client, ns, command, callback) {
-      const bson = this.bson;
       const options = { promoteLongs: false, promoteValues: false };
       const dbName = databaseNamespace(ns);
       const rawCommand = bson.deserialize(command, options);
@@ -457,7 +454,6 @@ module.exports = function (modules) {
      * @returns {void}
      */
     fetchKeys(client, keyVaultNamespace, filter, callback) {
-      const bson = this.bson;
       const dbName = databaseNamespace(keyVaultNamespace);
       const collectionName = collectionNamespace(keyVaultNamespace);
       filter = bson.deserialize(filter);

--- a/bindings/node/test/autoEncrypter.test.js
+++ b/bindings/node/test/autoEncrypter.test.js
@@ -60,9 +60,7 @@ const MOCK_KMS_DECRYPT_REPLY = readHttpResponse(`${__dirname}/data/kms-decrypt-r
 
 class MockClient {
   constructor() {
-    this.topology = {
-      bson: BSON
-    };
+    this.topology = {};
   }
 }
 

--- a/bindings/node/test/clientEncryption.test.js
+++ b/bindings/node/test/clientEncryption.test.js
@@ -23,9 +23,7 @@ const ClientEncryption = require('../lib/clientEncryption')({
 
 class MockClient {
   constructor() {
-    this.topology = {
-      bson: BSON
-    };
+    this.topology = {};
   }
 }
 

--- a/bindings/node/test/stateMachine.test.js
+++ b/bindings/node/test/stateMachine.test.js
@@ -59,7 +59,7 @@ describe('StateMachine', function () {
     };
     const options = { promoteLongs: false, promoteValues: false };
     const serializedCommand = BSON.serialize(command);
-    const stateMachine = new StateMachine({ bson: BSON });
+    const stateMachine = new StateMachine({});
     const callback = () => {};
 
     context('when executing the command', function () {
@@ -97,7 +97,7 @@ describe('StateMachine', function () {
       });
 
       it('should only resolve once bytesNeeded drops to zero', function (done) {
-        const stateMachine = new StateMachine({ bson: BSON });
+        const stateMachine = new StateMachine({});
         const request = new MockRequest(Buffer.from('foobar'), 500);
         let status = 'pending';
         stateMachine
@@ -139,7 +139,6 @@ describe('StateMachine', function () {
         ].forEach(function (option) {
           context(`when the option is ${option}`, function () {
             const stateMachine = new StateMachine({
-              bson: BSON,
               tlsOptions: { aws: { [option]: true } }
             });
             const request = new MockRequest(Buffer.from('foobar'), 500);
@@ -157,7 +156,6 @@ describe('StateMachine', function () {
       context('when the options are secure', function () {
         context('when providing tlsCertificateKeyFile', function () {
           const stateMachine = new StateMachine({
-            bson: BSON,
             tlsOptions: { aws: { tlsCertificateKeyFile: 'test.pem' } }
           });
           const request = new MockRequest(Buffer.from('foobar'), -1);
@@ -185,7 +183,6 @@ describe('StateMachine', function () {
 
         context('when providing tlsCAFile', function () {
           const stateMachine = new StateMachine({
-            bson: BSON,
             tlsOptions: { aws: { tlsCAFile: 'test.pem' } }
           });
           const request = new MockRequest(Buffer.from('foobar'), -1);
@@ -212,7 +209,6 @@ describe('StateMachine', function () {
 
         context('when providing tlsCertificateKeyFilePassword', function () {
           const stateMachine = new StateMachine({
-            bson: BSON,
             tlsOptions: { aws: { tlsCertificateKeyFilePassword: 'test' } }
           });
           const request = new MockRequest(Buffer.from('foobar'), -1);
@@ -285,7 +281,6 @@ describe('StateMachine', function () {
 
     it('should create HTTPS connections through a Socks5 proxy (no proxy auth)', async function () {
       const stateMachine = new StateMachine({
-        bson: BSON,
         proxyOptions: {
           proxyHost: 'localhost',
           proxyPort: socks5srv.address().port
@@ -307,7 +302,6 @@ describe('StateMachine', function () {
     it('should create HTTPS connections through a Socks5 proxy (username/password auth)', async function () {
       withUsernamePassword = true;
       const stateMachine = new StateMachine({
-        bson: BSON,
         proxyOptions: {
           proxyHost: 'localhost',
           proxyPort: socks5srv.address().port,


### PR DESCRIPTION
This removes the need to pass the bson module as an option to the auto encrypter or the state machine as it is now required directly.