### PR TITLE
[MONGOCRYPT-473] Support "accessToken" as an Azure KMS option

### DIFF
--- a/src/mongocrypt-ctx-datakey.c
+++ b/src/mongocrypt-ctx-datakey.c
@@ -218,8 +218,12 @@ _kms_start (mongocrypt_ctx_t *ctx)
 
       ctx->state = MONGOCRYPT_CTX_NEED_KMS;
    } else if (ctx->opts.kek.kms_provider == MONGOCRYPT_KMS_PROVIDER_AZURE) {
-      access_token =
-         _mongocrypt_cache_oauth_get (ctx->crypt->cache_oauth_azure);
+      if (ctx->kms_providers.azure.access_token) {
+         access_token = bson_strdup (ctx->kms_providers.azure.access_token);
+      } else {
+         access_token =
+            _mongocrypt_cache_oauth_get (ctx->crypt->cache_oauth_azure);
+      }
       if (access_token) {
          if (!_mongocrypt_kms_ctx_init_azure_wrapkey (
                 &dkctx->kms,

--- a/src/mongocrypt-key-broker.c
+++ b/src/mongocrypt-key-broker.c
@@ -539,7 +539,12 @@ _mongocrypt_key_broker_add_doc (_mongocrypt_key_broker_t *kb,
          goto done;
       }
    } else if (kek_provider == MONGOCRYPT_KMS_PROVIDER_AZURE) {
-      access_token = _mongocrypt_cache_oauth_get (kb->crypt->cache_oauth_azure);
+      if (kms_providers->azure.access_token) {
+         access_token = bson_strdup (kms_providers->azure.access_token);
+      } else {
+         access_token =
+            _mongocrypt_cache_oauth_get (kb->crypt->cache_oauth_azure);
+      }
       if (!access_token) {
          key_returned->needs_auth = true;
          /* Create an oauth request if one does not exist. */
@@ -814,8 +819,12 @@ _mongocrypt_key_broker_kms_done (
 
          if (key_returned->doc->kek.kms_provider ==
              MONGOCRYPT_KMS_PROVIDER_AZURE) {
-            access_token =
-               _mongocrypt_cache_oauth_get (kb->crypt->cache_oauth_azure);
+            if (kms_providers->azure.access_token) {
+               access_token = bson_strdup (kms_providers->azure.access_token);
+            } else {
+               access_token =
+                  _mongocrypt_cache_oauth_get (kb->crypt->cache_oauth_azure);
+            }
 
             if (!access_token) {
                return _key_broker_fail_w_msg (

--- a/src/mongocrypt-opts-private.h
+++ b/src/mongocrypt-opts-private.h
@@ -32,6 +32,7 @@ typedef struct {
    char *client_id;
    char *client_secret;
    _mongocrypt_endpoint_t *identity_platform_endpoint;
+   char *access_token;
 } _mongocrypt_opts_kms_provider_azure_t;
 
 typedef struct {

--- a/src/mongocrypt-opts.c
+++ b/src/mongocrypt-opts.c
@@ -35,6 +35,7 @@ _mongocrypt_opts_kms_provider_azure_cleanup (
    bson_free (kms_provider_azure->client_id);
    bson_free (kms_provider_azure->client_secret);
    bson_free (kms_provider_azure->tenant_id);
+   bson_free (kms_provider_azure->access_token);
    _mongocrypt_endpoint_destroy (
       kms_provider_azure->identity_platform_endpoint);
 }

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -1313,6 +1313,28 @@ _mongocrypt_parse_kms_providers (
             return false;
          }
 
+         if (!_mongocrypt_parse_optional_utf8 (
+                &as_bson,
+                "azure.accessToken",
+                &kms_providers->azure.access_token,
+                status)) {
+            return false;
+         }
+
+         if (kms_providers->azure.access_token) {
+            // Caller provides an accessToken directly
+            if (!_mongocrypt_check_allowed_fields (
+                   &as_bson, "azure", status, "accessToken")) {
+               return false;
+            }
+            kms_providers->configured_providers |=
+               MONGOCRYPT_KMS_PROVIDER_AZURE;
+            continue;
+         }
+
+         // No accessToken given, so we'll need to look one up on our own later
+         // using the Azure API
+
          if (!_mongocrypt_parse_required_utf8 (&as_bson,
                                                "azure.tenantId",
                                                &kms_providers->azure.tenant_id,

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -880,7 +880,9 @@ _test_setopt_kms_providers (_mongocrypt_tester_t *tester)
       {"{'gcp': {}}", NULL, "on-demand credentials not enabled", false},
       {"{'kmip': {}}", NULL, "on-demand credentials not enabled", false},
       {"{'gcp': {'accessToken': 'foobar', 'email': 'foo@bar.com' }}",
-       "Unexpected field: 'email'"}};
+       "Unexpected field: 'email'"},
+      {.value = "{ 'azure': { 'accessToken': 'secret' } }"},
+   };
 
    for (i = 0; i < sizeof (tests) / sizeof (tests[0]); i++) {
       mongocrypt_t *crypt;


### PR DESCRIPTION
Refer: MONGOCRYPT-473

This changeset adds support for `{ azure: { accessToken: 'abc' } }` to be specified as a KMS provider. This will bypass the logic that attempts to obtain an access token from Azure and instead uses the given token directly. This is required to support Automatic KMS for Azure, as drivers need to be able to provide the automatically-obtained access token to libmongocrypt directly.