### PR TITLE
feat(NODE-4604): add fallback to find kms credentials

### DIFF
--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -211,6 +211,12 @@ export interface ClientEncryptionOptions {
   onKmsProviderRefresh?: () => Promise<KMSProviders>;
 
   /**
+   * Optional callback to override KMS providers using the environment.
+   * @internal
+   */
+  onEmptyKmsProviders?: () => Promise<KMSProviders>;
+
+  /**
    * Options for specifying a Socks5 proxy to use for connecting to the KMS.
    */
   proxyOptions?: ProxyOptions;

--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -101,6 +101,7 @@ module.exports = function (modules) {
       this._proxyOptions = options.proxyOptions || {};
       this._tlsOptions = options.tlsOptions || {};
       this._onKmsProviderRefresh = options.onKmsProviderRefresh;
+      this._onEmptyKmsProviders = options.onEmptyKmsProviders;
 
       const mongoCryptOptions = {};
       if (options.schemaMap) {
@@ -311,17 +312,6 @@ module.exports = function (modules) {
         }
         callback(err, result);
       });
-    }
-
-    /**
-     * Ask the user for KMS credentials.
-     *
-     * This returns anything that looks like the kmsProviders original input
-     * option. It can be empty, and any provider specified here will override
-     * the original ones.
-     */
-    async askForKMSCredentials() {
-      return this._onKmsProviderRefresh ? this._onKmsProviderRefresh() : {};
     }
 
     /**

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -113,11 +113,12 @@ module.exports = function (modules) {
       // kmsProviders will be parsed by libmongocrypt, must be provided as BSON binary data
       if (options.kmsProviders && !Buffer.isBuffer(options.kmsProviders)) {
         options.kmsProviders = this._bson.serialize(options.kmsProviders);
-      } else if (!options.onKmsProviderRefresh) {
+      } else if (!options.onKmsProviderRefresh && !options.onEmptyKmsProviders) {
         throw new TypeError('Need to specify either kmsProviders ahead of time or when requested');
       }
 
       this._onKmsProviderRefresh = options.onKmsProviderRefresh;
+      this._onEmptyKmsProviders = options.onEmptyKmsProviders;
       this._keyVaultNamespace = options.keyVaultNamespace;
       this._keyVaultClient = options.keyVaultClient || client;
       this._mongoCrypt = new mc.MongoCrypt(options);
@@ -675,17 +676,6 @@ module.exports = function (modules) {
           cb(null, result.v);
         });
       });
-    }
-
-    /**
-     * Ask the user for KMS credentials.
-     *
-     * This returns anything that looks like the kmsProviders original input
-     * option. It can be empty, and any provider specified here will override
-     * the original ones.
-     */
-    async askForKMSCredentials() {
-      return this._onKmsProviderRefresh ? this._onKmsProviderRefresh() : {};
     }
   }
 

--- a/bindings/node/lib/common.js
+++ b/bindings/node/lib/common.js
@@ -104,7 +104,9 @@ async function askForKMSCredentials(encrypter) {
   // First attempt to use the user provided callback to get the credentials.
   const creds = encrypter._onKmsProviderRefresh ? await encrypter._onKmsProviderRefresh() : {};
   // If the credentials are empty and we have an additional callback provided
-  // by the driver to attempt to fetch them, attempt to use that.
+  // by the driver to attempt to fetch them, attempt to use that. We single out
+  // AWS for now since it's the only $external cloud provider auth that the driver
+  // supports.
   if (!creds.aws && encrypter._onEmptyKmsProviders) {
     return encrypter._onEmptyKmsProviders();
   }

--- a/bindings/node/lib/common.js
+++ b/bindings/node/lib/common.js
@@ -102,7 +102,7 @@ function promiseOrCallback(callback, fn) {
  */
 async function askForKMSCredentials(encrypter) {
   // First attempt to use the user provided callback to get the credentials.
-  const creds = encrypter._onKmsProviderRefresh ? encrypter._onKmsProviderRefresh() : {};
+  const creds = encrypter._onKmsProviderRefresh ? await encrypter._onKmsProviderRefresh() : {};
   // If the credentials are empty and we have an additional callback provided
   // by the driver to attempt to fetch them, attempt to use that.
   if (!creds.aws && encrypter._onEmptyKmsProviders) {

--- a/bindings/node/lib/common.js
+++ b/bindings/node/lib/common.js
@@ -91,7 +91,29 @@ function promiseOrCallback(callback, fn) {
   });
 }
 
+/**
+ * Ask for KMS credentials.
+ *
+ * This returns anything that looks like the kmsProviders original input
+ * option. It can be empty, and any provider specified here will override
+ * the original ones.
+ *
+ * @param {AutoEncrypter|ClientEncryption} encrypter The encrypter.
+ */
+async function askForKMSCredentials(encrypter) {
+  // First attempt to use the user provided callback to get the credentials.
+  const creds = encrypter._onKmsProviderRefresh ? encrypter._onKmsProviderRefresh() : {};
+  // If the credentials are empty and we have an additional callback provided
+  // by the driver to attempt to fetch them, attempt to use that.
+  if (!creds.aws && encrypter._onEmptyKmsProviders) {
+    return encrypter._onEmptyKmsProviders();
+  }
+  // Return the credentials which could be populated or empty.
+  return creds;
+}
+
 module.exports = {
+  askForKMSCredentials,
   debug,
   databaseNamespace,
   collectionNamespace,

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -12,6 +12,7 @@ module.exports = function (modules) {
     modules.mongodb.MongoNetworkTimeoutError || modules.mongodb.MongoTimeoutError;
 
   const common = require('./common');
+  const askForKMSCredentials = common.askForKMSCredentials;
   const debug = common.debug;
   const databaseNamespace = common.databaseNamespace;
   const collectionNamespace = common.collectionNamespace;
@@ -178,8 +179,7 @@ module.exports = function (modules) {
         }
 
         case MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS: {
-          autoEncrypter
-            .askForKMSCredentials()
+          askForKMSCredentials(autoEncrypter)
             .then(kmsProviders => {
               context.provideKMSProviders(
                 !Buffer.isBuffer(kmsProviders) ? bson.serialize(kmsProviders) : kmsProviders

--- a/bindings/node/test/common.test.js
+++ b/bindings/node/test/common.test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const { askForKMSCredentials } = require('../lib/common');
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('common', function () {
+  describe('#askForKMSCredentials', function () {
+    const userCreds = { aws: { accessKeyId: 'example1', secretAccessKey: 'example1' } };
+    const defaultCreds = { aws: { accessKeyId: 'example2', secretAccessKey: 'example2' } };
+    const validUserRefresh = () => {
+      return userCreds;
+    };
+    const emptyUserRefresh = () => ({});
+    const validDefaultRefresh = () => {
+      return new Promise(resolve => {
+        resolve(defaultCreds);
+      });
+    };
+    const emptyDefaultRefresh = () => {
+      return new Promise(resolve => {
+        resolve({});
+      });
+    };
+
+    context('when _onKmsProviderRefresh exists', function () {
+      context('when it returns credentials', function () {
+        const encrypter = {
+          _onKmsProviderRefresh: validUserRefresh
+        };
+
+        it('returns the user provided credentials', async function () {
+          expect(await askForKMSCredentials(encrypter)).to.deep.equal(userCreds);
+        });
+      });
+
+      context('when it does not return credentials', function () {
+        context('when _onEmptyKmsProviders exists', function () {
+          context('when it returns credentials', function () {
+            const encrypter = {
+              _onKmsProviderRefresh: emptyUserRefresh,
+              _onEmptyKmsProviders: validDefaultRefresh
+            };
+
+            it('returns the default credentials', async function () {
+              expect(await askForKMSCredentials(encrypter)).to.deep.equal(defaultCreds);
+            });
+          });
+
+          context('when it does not return credentials', function () {
+            const encrypter = {
+              _onKmsProviderRefresh: emptyUserRefresh,
+              _onEmptyKmsProviders: emptyDefaultRefresh
+            };
+
+            it('returns an empty object', async function () {
+              expect(await askForKMSCredentials(encrypter)).to.deep.equal({});
+            });
+          });
+        });
+
+        context('when _onEmptyKmsProviders does not exist', function () {
+          const encrypter = {};
+
+          it('returns an empty object', async function () {
+            expect(await askForKMSCredentials(encrypter)).to.deep.equal({});
+          });
+        });
+      });
+    });
+
+    context('when _onKmsProviderRefresh does not exist', function () {
+      context('when _onEmptyKmsProviders exists', function () {
+        context('when it returns credentials', function () {
+          const encrypter = {
+            _onEmptyKmsProviders: validDefaultRefresh
+          };
+
+          it('returns the default credentials', async function () {
+            expect(await askForKMSCredentials(encrypter)).to.deep.equal(defaultCreds);
+          });
+        });
+
+        context('when it does not return credentials', function () {
+          const encrypter = {
+            _onEmptyKmsProviders: emptyDefaultRefresh
+          };
+
+          it('returns an empty object', async function () {
+            expect(await askForKMSCredentials(encrypter)).to.deep.equal({});
+          });
+        });
+      });
+
+      context('when _onEmptyKmsProviders does not exist', function () {
+        const encrypter = {};
+
+        it('returns an empty object', async function () {
+          expect(await askForKMSCredentials(encrypter)).to.deep.equal({});
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds the ability to fallback to another callback in the Node driver if the user provided callback `onKmsProviderRefresh` does not return any credentials.

- [x] Add new option `onEmptyKmsProviders` to both `AutoEncrypter` and `ClientEncryption`
- [x] Refactor `askForKMSCredentials()` to handle the user provided callback first, then the new option.
- [x] Move duplicate `askForKMSCredentials()` into common module.
- [x] Use the common `askForKMSCredentials()` in the `StateMachine`
- [x] Add new unit tests for all possible combinations.
- [x] Mark new option as internal. 