### PR TITLE
MONGOCRYPT-469 improved and more consistent null pointer checks

### DIFF
--- a/src/crypto/cng.c
+++ b/src/crypto/cng.c
@@ -227,8 +227,8 @@ _crypto_state_destroy (cng_encrypt_state *state)
 bool
 _native_crypto_aes_256_cbc_encrypt (aes_256_args_t args)
 {
-   BSON_ASSERT_PARAM (args.in);
-   BSON_ASSERT_PARAM (args.out);
+   BSON_ASSERT (args.in);
+   BSON_ASSERT (args.out);
 
    bool ret = false;
    mongocrypt_status_t *status = args.status;
@@ -264,8 +264,8 @@ done:
 bool
 _native_crypto_aes_256_cbc_decrypt (aes_256_args_t args)
 {
-   BSON_ASSERT_PARAM (args.in);
-   BSON_ASSERT_PARAM (args.out);
+   BSON_ASSERT (args.in);
+   BSON_ASSERT (args.out);
 
    bool ret = false;
    mongocrypt_status_t *status = args.status;

--- a/src/crypto/cng.c
+++ b/src/crypto/cng.c
@@ -147,6 +147,9 @@ _crypto_state_init (const _mongocrypt_buffer_t *key,
    BCRYPT_KEY_DATA_BLOB_HEADER blobHeader;
    NTSTATUS nt_status;
 
+   BSON_ASSERT_PARAM (key);
+   BSON_ASSERT_PARAM (iv);
+
    keyBlob = NULL;
 
    state = bson_malloc0 (sizeof (*state));
@@ -224,9 +227,14 @@ _crypto_state_destroy (cng_encrypt_state *state)
 bool
 _native_crypto_aes_256_cbc_encrypt (aes_256_args_t args)
 {
+   BSON_ASSERT_PARAM (args.in);
+   BSON_ASSERT_PARAM (args.out);
+
    bool ret = false;
    mongocrypt_status_t *status = args.status;
    cng_encrypt_state *state = _crypto_state_init (args.key, args.iv, status);
+
+   BSON_ASSERT (state);
 
    NTSTATUS nt_status;
 
@@ -256,9 +264,14 @@ done:
 bool
 _native_crypto_aes_256_cbc_decrypt (aes_256_args_t args)
 {
+   BSON_ASSERT_PARAM (args.in);
+   BSON_ASSERT_PARAM (args.out);
+
    bool ret = false;
    mongocrypt_status_t *status = args.status;
    cng_encrypt_state *state = _crypto_state_init (args.key, args.iv, status);
+
+   BSON_ASSERT (state);
 
    NTSTATUS nt_status;
 
@@ -291,7 +304,7 @@ done:
  * @out is the output. @out must be allocated by the caller with
  * the expected length @expect_out_len for the output.
  * Returns false and sets @status on error. @status is required. */
-bool
+static bool
 _hmac_with_algorithm (BCRYPT_ALG_HANDLE hAlgorithm,
                       const _mongocrypt_buffer_t *key,
                       const _mongocrypt_buffer_t *in,
@@ -302,6 +315,11 @@ _hmac_with_algorithm (BCRYPT_ALG_HANDLE hAlgorithm,
    bool ret = false;
    BCRYPT_HASH_HANDLE hHash;
    NTSTATUS nt_status;
+
+   BSON_ASSERT_PARAM (key);
+   BSON_ASSERT_PARAM (in);
+   BSON_ASSERT_PARAM (out);
+   BSON_ASSERT_PARAM (status);
 
    if (out->len != expect_out_len) {
       CLIENT_ERR ("out does not contain " PRIu32 " bytes", expect_out_len);
@@ -350,6 +368,9 @@ _native_crypto_random (_mongocrypt_buffer_t *out,
                        uint32_t count,
                        mongocrypt_status_t *status)
 {
+   BSON_ASSERT_PARAM (out);
+   BSON_ASSERT_PARAM (status);
+
    NTSTATUS nt_status = BCryptGenRandom (_random, out->data, count, 0);
    if (nt_status != STATUS_SUCCESS) {
       CLIENT_ERR ("BCryptGenRandom Failed: 0x%x", (int) nt_status);
@@ -445,6 +466,10 @@ _cng_ctr_crypto_state_init (const _mongocrypt_buffer_t *key,
    unsigned char *keyBlob;
    BCRYPT_KEY_DATA_BLOB_HEADER blobHeader;
    NTSTATUS nt_status;
+
+   BSON_ASSERT_PARAM (key);
+   BSON_ASSERT_PARAM (iv);
+   BSON_ASSERT_PARAM (status);
 
    keyBlob = NULL;
 

--- a/src/crypto/commoncrypto.c
+++ b/src/crypto/commoncrypto.c
@@ -70,6 +70,11 @@ _native_crypto_init ()
 bool
 _native_crypto_aes_256_cbc_encrypt_with_mode (aes_256_args_t args, CCMode mode)
 {
+   BSON_ASSERT (args.iv);
+   BSON_ASSERT (args.key);
+   BSON_ASSERT (args.in);
+   BSON_ASSERT (args.out);
+
    bool ret = false;
    CCCryptorRef ctx = NULL;
    CCCryptorStatus cc_status;
@@ -156,6 +161,11 @@ _native_crypto_aes_256_ctr_encrypt (aes_256_args_t args)
 bool
 _native_crypto_aes_256_cbc_decrypt_with_mode (aes_256_args_t args, CCMode mode)
 {
+   BSON_ASSERT (args.iv);
+   BSON_ASSERT (args.key);
+   BSON_ASSERT (args.in);
+   BSON_ASSERT (args.out);
+
    bool ret = false;
    CCCryptorRef ctx = NULL;
    CCCryptorStatus cc_status;
@@ -242,7 +252,7 @@ _native_crypto_aes_256_ctr_decrypt (aes_256_args_t args)
  * @out is the output. @out must be allocated by the caller with
  * the expected length @expect_out_len for the output.
  * Returns false and sets @status on error. @status is required. */
-bool
+static bool
 _hmac_with_algorithm (CCHmacAlgorithm algorithm,
                       const _mongocrypt_buffer_t *key,
                       const _mongocrypt_buffer_t *in,
@@ -251,6 +261,11 @@ _hmac_with_algorithm (CCHmacAlgorithm algorithm,
                       mongocrypt_status_t *status)
 {
    CCHmacContext *ctx;
+
+   BSON_ASSERT_PARAM (key);
+   BSON_ASSERT_PARAM (in);
+   BSON_ASSERT_PARAM (out);
+   BSON_ASSERT_PARAM (status);
 
    if (out->len != expect_out_len) {
       CLIENT_ERR ("out does not contain %" PRIu32 " bytes", expect_out_len);
@@ -284,6 +299,9 @@ _native_crypto_random (_mongocrypt_buffer_t *out,
                        uint32_t count,
                        mongocrypt_status_t *status)
 {
+   BSON_ASSERT_PARAM (out);
+   BSON_ASSERT_PARAM (status);
+
    CCRNGStatus ret = CCRandomGenerateBytes (out->data, (size_t) count);
    if (ret != kCCSuccess) {
       CLIENT_ERR ("failed to generate random iv: %d", (int) ret);

--- a/src/crypto/libcrypto.c
+++ b/src/crypto/libcrypto.c
@@ -75,6 +75,9 @@ _encrypt_with_cipher (const EVP_CIPHER *cipher, aes_256_args_t args)
 
    ctx = EVP_CIPHER_CTX_new ();
 
+   BSON_ASSERT (args.key);
+   BSON_ASSERT (args.in);
+   BSON_ASSERT (args.out);
    BSON_ASSERT (ctx);
    BSON_ASSERT (cipher);
    BSON_ASSERT (NULL == args.iv ||
@@ -139,6 +142,10 @@ _decrypt_with_cipher (const EVP_CIPHER *cipher, aes_256_args_t args)
 
    ctx = EVP_CIPHER_CTX_new ();
 
+   BSON_ASSERT (args.iv);
+   BSON_ASSERT (args.key);
+   BSON_ASSERT (args.in);
+   BSON_ASSERT (args.out);
    BSON_ASSERT (EVP_CIPHER_iv_length (cipher) == args.iv->len);
    BSON_ASSERT (EVP_CIPHER_key_length (cipher) == args.key->len);
 
@@ -213,6 +220,11 @@ _hmac_with_hash (const EVP_MD *hash,
                  _mongocrypt_buffer_t *out,
                  mongocrypt_status_t *status)
 {
+   BSON_ASSERT_PARAM (key);
+   BSON_ASSERT_PARAM (in);
+   BSON_ASSERT_PARAM (out);
+   BSON_ASSERT_PARAM (status);
+
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
    if (!HMAC (hash,
               key->data,
@@ -277,6 +289,9 @@ _native_crypto_random (_mongocrypt_buffer_t *out,
                        uint32_t count,
                        mongocrypt_status_t *status)
 {
+   BSON_ASSERT_PARAM (out);
+   BSON_ASSERT_PARAM (status);
+
    int ret = RAND_bytes (out->data, count);
    /* From man page: "RAND_bytes() and RAND_priv_bytes() return 1 on success, -1
     * if not supported by the current RAND method, or 0 on other failure. The

--- a/src/crypto/libcrypto.c
+++ b/src/crypto/libcrypto.c
@@ -221,6 +221,7 @@ _hmac_with_hash (const EVP_MD *hash,
                  _mongocrypt_buffer_t *out,
                  mongocrypt_status_t *status)
 {
+   BSON_ASSERT_PARAM (hash);
    BSON_ASSERT_PARAM (key);
    BSON_ASSERT_PARAM (in);
    BSON_ASSERT_PARAM (out);

--- a/src/crypto/libcrypto.c
+++ b/src/crypto/libcrypto.c
@@ -142,6 +142,7 @@ _decrypt_with_cipher (const EVP_CIPHER *cipher, aes_256_args_t args)
 
    ctx = EVP_CIPHER_CTX_new ();
 
+   BSON_ASSERT_PARAM (cipher);
    BSON_ASSERT (args.iv);
    BSON_ASSERT (args.key);
    BSON_ASSERT (args.in);


### PR DESCRIPTION
This is mean to preview the proposed sorts of changes in a subset of the code-base.  Assuming this looks good to everyone, I will proceed with similar changes under the `src/` directory (excepting examples and tests).

Evergreen patch build: https://spruce.mongodb.com/version/6317a41030661513b86bf30a/tasks?limit=100&page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC