### PR TITLE
feat(NODE-4328): expose libmongocrypt version in bindings

### DIFF
--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -404,7 +404,7 @@ export class ClientEncryption {
     callback: ClientEncryptionCreateDataKeyCallback
   ): void;
 
-  /** 
+  /**
    * Searches the keyvault for any data keys matching the provided filter.  If there are matches, rewrapManyDataKey then attempts to re-wrap the data keys using the provided options.
    *
    * If no matches are found, then no bulk write is performed.
@@ -507,4 +507,6 @@ export class ClientEncryption {
     value: Buffer | Binary,
     callback: ClientEncryptionDecryptCallback
   ): void;
+
+  static readonly libmongocryptVersion: string;
 }

--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -332,6 +332,10 @@ module.exports = function (modules) {
     get cryptSharedLibVersionInfo() {
       return this._mongocrypt.cryptSharedLibVersionInfo;
     }
+
+    static get libmongocryptVersion() {
+      return mc.MongoCrypt.libmongocryptVersion;
+    }
   }
 
   return { AutoEncrypter };

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -687,6 +687,10 @@ module.exports = function (modules) {
     async askForKMSCredentials() {
       return this._onKmsProviderRefresh ? this._onKmsProviderRefresh() : {};
     }
+
+    static get libmongocryptVersion() {
+      return mc.MongoCrypt.libmongocryptVersion;
+    }
   }
 
   return { ClientEncryption };

--- a/bindings/node/src/mongocrypt.cc
+++ b/bindings/node/src/mongocrypt.cc
@@ -110,7 +110,8 @@ Function MongoCrypt::Init(Napi::Env env) {
                     InstanceMethod("makeDataKeyContext", &MongoCrypt::MakeDataKeyContext),
                     InstanceMethod("makeRewrapManyDataKeyContext", &MongoCrypt::MakeRewrapManyDataKeyContext),
                     InstanceAccessor("status", &MongoCrypt::Status, nullptr),
-                    InstanceAccessor("cryptSharedLibVersionInfo", &MongoCrypt::CryptSharedLibVersionInfo, nullptr)
+                    InstanceAccessor("cryptSharedLibVersionInfo", &MongoCrypt::CryptSharedLibVersionInfo, nullptr),
+                    StaticValue("libmongocryptVersion", String::New(env, mongocrypt_version(nullptr)))
                   });
 }
 

--- a/bindings/node/test/autoEncrypter.test.js
+++ b/bindings/node/test/autoEncrypter.test.js
@@ -827,4 +827,8 @@ describe('AutoEncrypter', function () {
       this.mc.teardown(true, done);
     });
   });
+
+  it('should provide the libmongocrypt version', function () {
+    expect(AutoEncrypter.libmongocryptVersion).to.be.a('string');
+  });
 });

--- a/bindings/node/test/clientEncryption.test.js
+++ b/bindings/node/test/clientEncryption.test.js
@@ -694,4 +694,8 @@ describe('ClientEncryption', function () {
         });
     });
   });
+
+  it('should provide the libmongocrypt version', function () {
+    expect(ClientEncryption.libmongocryptVersion).to.be.a('string');
+  });
 });


### PR DESCRIPTION
Decided to expose this both on `AutoEncrypter` and `ClientEncryption` for now, but happy to move it to another place altogether if there’s a strong preference.