### PR TITLE
When executing git, we must be in a repository.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -25,12 +25,8 @@ functions:
           . libmongocrypt/.evergreen/init.sh
           bash "$EVG_DIR/print-env-info.sh"
 
-          if [ "${is_patch}" != "true" ]; then
-            # determine if we have a release tag present on HEAD
-            head_tag=$(git tag -l --points-at HEAD '[0-9].*')
-          else
-            head_tag=""
-          fi
+          # determine if we have a release tag present on HEAD
+          head_tag=$(run_chdir libmongocrypt/ git tag -l --points-at HEAD '[0-9].*' || true)
           echo "tag_upload_location: $head_tag"
 
           echo "tag_upload_location: \"$head_tag\"" > tag_expansion.yml

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -27,9 +27,12 @@ functions:
 
           # determine if we have a release tag present on HEAD
           head_tag=$(run_chdir libmongocrypt/ git tag -l --points-at HEAD '[0-9].*' || true)
-          echo "tag_upload_location: $head_tag"
-
-          echo "tag_upload_location: \"$head_tag\"" > tag_expansion.yml
+          use_tag=""
+          if test "${is_patch}" != "true"; then
+            echo "Setting tag_upload_location to '$head_tag'"
+            use_tag="$head_tag"
+          fi
+          echo "tag_upload_location: '$use_tag'" > tag_expansions.yml
     - command: expansions.update
       params:
         ignore_missing_file: true


### PR DESCRIPTION
One could also use the preferred "-C" argument, but we use older versions of Git that may not yet support that option.

This fixes main-project build breakages following merge of #453 