### PR TITLE
MONGOCRYPT-478 update payloads and terms

### DIFF
--- a/src/mc-fle2-encryption-placeholder-private.h
+++ b/src/mc-fle2-encryption-placeholder-private.h
@@ -25,7 +25,11 @@
 /** FLE2RangeFindSpec represents the range find specification that is encoded
  * inside of a FLE2EncryptionPlaceholder. See
  * https://github.com/mongodb/mongo/blob/master/src/mongo/crypto/fle_field_schema.idl#L346
- * for the representation in the MongoDB server. */
+ * for the representation in the MongoDB server.
+ *
+ * Bounds on range queries are referred to as lowerBound or lb, and upperBound
+ * or ub. Bounds on an underlying range index are referred to as min and max.
+ */
 typedef struct {
    // lowerBound is the lower bound for an encrypted range query.
    bson_iter_t lowerBound;

--- a/src/mc-fle2-encryption-placeholder-private.h
+++ b/src/mc-fle2-encryption-placeholder-private.h
@@ -22,37 +22,43 @@
 #include "mongocrypt.h"
 #include "mongocrypt-private.h"
 
-/** FLE2RangeSpec represents the range find specification that is encoded inside
- * of a FLE2EncryptionPlaceholder. See
- * https://github.com/mongodb/mongo/blob/d870dda33fb75983f628636ff8f849c7f1c90b09/src/mongo/crypto/fle_field_schema.idl#L346
+/** FLE2RangeFindSpec represents the range find specification that is encoded
+ * inside of a FLE2EncryptionPlaceholder. See
+ * https://github.com/mongodb/mongo/blob/master/src/mongo/crypto/fle_field_schema.idl#L346
  * for the representation in the MongoDB server. */
 typedef struct {
-   // min is the minimum value for an encrypted range query.
-   bson_iter_t min;
-   // minIncluded indicates if the lower bound should be included in the range.
-   bool minIncluded;
-   // max is the maximum value for an encrypted range query.
-   bson_iter_t max;
-   // maxIncluded indicates if the upper bound should be included in the range.
-   bool maxIncluded;
-} mc_FLE2RangeSpec_t;
+   // lowerBound is the lower bound for an encrypted range query.
+   bson_iter_t lowerBound;
+   // lbIncluded indicates if the lower bound should be included in the range.
+   bool lbIncluded;
+   // upperBound is the upperBound for an encrypted range query.
+   bson_iter_t upperBound;
+   // ubIncluded indicates if the upper bound should be included in the range.
+   bool ubIncluded;
+   // indexMin is the minimum value for the encrypted index that this query is
+   // using.
+   bson_iter_t indexMin;
+   // indexMax is the maximum value for the encrypted index that this query is
+   // using.
+   bson_iter_t indexMax;
+} mc_FLE2RangeFindSpec_t;
 
 bool
-mc_FLE2RangeSpec_parse (mc_FLE2RangeSpec_t *out,
-                        const bson_iter_t *in,
-                        mongocrypt_status_t *status);
+mc_FLE2RangeFindSpec_parse (mc_FLE2RangeFindSpec_t *out,
+                            const bson_iter_t *in,
+                            mongocrypt_status_t *status);
 
 /** mc_FLE2RangeInsertSpec_t represents the range insert specification that is
  * encoded inside of a FLE2EncryptionPlaceholder. See
- * https://github.com/mongodb/mongo/blob/d870dda33fb75983f628636ff8f849c7f1c90b09/src/mongo/crypto/fle_field_schema.idl#L364
+ * https://github.com/mongodb/mongo/blob/master/src/mongo/crypto/fle_field_schema.idl#L364
  * for the representation in the MongoDB server. */
 typedef struct {
    // v is the value to encrypt.
    bson_iter_t v;
-   // lb is the Queryable Encryption lower bound for range.
-   bson_iter_t lb;
-   // ub is the Queryable Encryption upper bound for range.
-   bson_iter_t ub;
+   // min is the Queryable Encryption min bound for range.
+   bson_iter_t min;
+   // max is the Queryable Encryption max bound for range.
+   bson_iter_t max;
 } mc_FLE2RangeInsertSpec_t;
 
 bool
@@ -84,7 +90,7 @@ typedef struct {
    _mongocrypt_buffer_t user_key_id;
    int64_t maxContentionCounter;
    // sparsity is the Queryable Encryption range hypergraph sparsity factor
-   int32_t sparsity;
+   int64_t sparsity;
 } mc_FLE2EncryptionPlaceholder_t;
 
 void
@@ -108,6 +114,6 @@ mc_validate_contention (int64_t contention, mongocrypt_status_t *status);
 /* mc_validate_sparsity is used to check that sparsity is a valid
  * value. */
 bool
-mc_validate_sparsity (int32_t sparsity, mongocrypt_status_t *status);
+mc_validate_sparsity (int64_t sparsity, mongocrypt_status_t *status);
 
 #endif /* MC_FLE2_ENCRYPTION_PLACEHOLDER_PRIVATE_H */

--- a/src/mc-fle2-encryption-placeholder.c
+++ b/src/mc-fle2-encryption-placeholder.c
@@ -16,6 +16,8 @@
 
 #include <bson/bson.h>
 
+#include <limits.h> // SIZE_MAX
+
 #include "mc-fle2-encryption-placeholder-private.h"
 #include "mongocrypt.h"
 #include "mongocrypt-buffer-private.h"
@@ -197,6 +199,11 @@ mc_validate_sparsity (int64_t sparsity, mongocrypt_status_t *status)
 {
    if (sparsity < 0) {
       CLIENT_ERR ("sparsity must be non-negative, got: %" PRId64, sparsity);
+      return false;
+   }
+   // mc_getEdgesInt expects a size_t sparsity.
+   if (sparsity >= SIZE_MAX) {
+      CLIENT_ERR ("sparsity must be < %zu, got: %" PRId64, SIZE_MAX, sparsity);
       return false;
    }
    return true;

--- a/src/mc-fle2-insert-update-payload-private.h
+++ b/src/mc-fle2-insert-update-payload-private.h
@@ -32,7 +32,7 @@
  *
  * struct {
  *   uint8_t fle_blob_subtype = 4;
- *   uint8_t bson[16];
+ *   uint8_t bson[];
  * } FLE2InsertUpdatePayload;
  *
  * bson is a BSON document of this form:

--- a/src/mc-range-mincover-private.h
+++ b/src/mc-range-mincover-private.h
@@ -39,8 +39,8 @@ void
 mc_mincover_destroy (mc_mincover_t *mincover);
 
 typedef struct {
-   int32_t range_min;
-   int32_t range_max;
+   int32_t lowerBound;
+   int32_t upperBound;
    mc_optional_int32_t min;
    mc_optional_int32_t max;
    size_t sparsity;
@@ -53,8 +53,8 @@ mc_getMincoverInt32 (mc_getMincoverInt32_args_t args,
                      mongocrypt_status_t *status) MONGOCRYPT_WARN_UNUSED_RESULT;
 
 typedef struct {
-   int64_t range_min;
-   int64_t range_max;
+   int64_t lowerBound;
+   int64_t upperBound;
    mc_optional_int64_t min;
    mc_optional_int64_t max;
    size_t sparsity;

--- a/src/mc-range-mincover.c
+++ b/src/mc-range-mincover.c
@@ -82,14 +82,14 @@ mc_getMincoverInt32 (mc_getMincoverInt32_args_t args,
    mc_OSTType_Int32 a, b;
    if (!mc_getTypeInfo32 ((mc_getTypeInfo32_args_t){.min = args.min,
                                                     .max = args.max,
-                                                    .value = args.range_min},
+                                                    .value = args.lowerBound},
                           &a,
                           status)) {
       return NULL;
    }
    if (!mc_getTypeInfo32 ((mc_getTypeInfo32_args_t){.min = args.min,
                                                     .max = args.max,
-                                                    .value = args.range_max},
+                                                    .value = args.upperBound},
                           &b,
                           status)) {
       return NULL;
@@ -120,14 +120,14 @@ mc_getMincoverInt64 (mc_getMincoverInt64_args_t args,
    mc_OSTType_Int64 a, b;
    if (!mc_getTypeInfo64 ((mc_getTypeInfo64_args_t){.min = args.min,
                                                     .max = args.max,
-                                                    .value = args.range_min},
+                                                    .value = args.lowerBound},
                           &a,
                           status)) {
       return NULL;
    }
    if (!mc_getTypeInfo64 ((mc_getTypeInfo64_args_t){.min = args.min,
                                                     .max = args.max,
-                                                    .value = args.range_max},
+                                                    .value = args.upperBound},
                           &b,
                           status)) {
       return NULL;

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -742,7 +742,7 @@ _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange (
 
    // g:= array<EdgeTokenSet>
    {
-      edges = get_edges (&insertSpec, placeholder->sparsity, status);
+      edges = get_edges (&insertSpec, (size_t) placeholder->sparsity, status);
       if (!edges) {
          goto fail;
       }

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -643,7 +643,7 @@ _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange (
    _mongocrypt_ciphertext_init (ciphertext);
    mc_FLE2InsertUpdatePayload_init (&payload);
 
-   // Parse the value ("v"), lower bound ("lb"), and upper bound ("ub") from
+   // Parse the value ("v"), min ("min"), and max ("max") from
    // FLE2EncryptionPlaceholder for range insert.
    mc_FLE2RangeInsertSpec_t insertSpec;
    if (!mc_FLE2RangeInsertSpec_parse (

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -575,33 +575,33 @@ get_edges (mc_FLE2RangeInsertSpec_t *insertSpec,
 {
    bson_type_t value_type = bson_iter_type (&insertSpec->v);
 
-#define GET_AND_RETURN_EDGES(BITS)                                       \
-   if (1) {                                                              \
-      mc_OSTType_Int##BITS OSTType;                                      \
-      {                                                                  \
-         mc_getTypeInfo##BITS##_args_t args = {                          \
-            .value = bson_iter_int##BITS (&insertSpec->v),               \
-            .min = OPT_I##BITS (bson_iter_int##BITS (&insertSpec->lb)),  \
-            .max = OPT_I##BITS (bson_iter_int##BITS (&insertSpec->ub))}; \
-                                                                         \
-         if (!mc_getTypeInfo##BITS (args, &OSTType, status)) {           \
-            return NULL;                                                 \
-         }                                                               \
-      }                                                                  \
-                                                                         \
-      mc_edges_t *edges;                                                 \
-      {                                                                  \
-         mc_getEdgesInt##BITS##_args_t args = {                          \
-            .value = OSTType.value,                                      \
-            .min = OPT_I##BITS (OSTType.min),                            \
-            .max = OPT_I##BITS (OSTType.max),                            \
-            .sparsity = sparsity};                                       \
-         if (!(edges = mc_getEdgesInt##BITS (args, status))) {           \
-            return NULL;                                                 \
-         }                                                               \
-      }                                                                  \
-      return edges;                                                      \
-   } else                                                                \
+#define GET_AND_RETURN_EDGES(BITS)                                        \
+   if (1) {                                                               \
+      mc_OSTType_Int##BITS OSTType;                                       \
+      {                                                                   \
+         mc_getTypeInfo##BITS##_args_t args = {                           \
+            .value = bson_iter_int##BITS (&insertSpec->v),                \
+            .min = OPT_I##BITS (bson_iter_int##BITS (&insertSpec->min)),  \
+            .max = OPT_I##BITS (bson_iter_int##BITS (&insertSpec->max))}; \
+                                                                          \
+         if (!mc_getTypeInfo##BITS (args, &OSTType, status)) {            \
+            return NULL;                                                  \
+         }                                                                \
+      }                                                                   \
+                                                                          \
+      mc_edges_t *edges;                                                  \
+      {                                                                   \
+         mc_getEdgesInt##BITS##_args_t args = {                           \
+            .value = OSTType.value,                                       \
+            .min = OPT_I##BITS (OSTType.min),                             \
+            .max = OPT_I##BITS (OSTType.max),                             \
+            .sparsity = sparsity};                                        \
+         if (!(edges = mc_getEdgesInt##BITS (args, status))) {            \
+            return NULL;                                                  \
+         }                                                                \
+      }                                                                   \
+      return edges;                                                       \
+   } else                                                                 \
       ((void) (0))
 
    if (value_type == BSON_TYPE_INT32) {

--- a/test/data/fle2-insert-range/int32/mongocryptd-reply.json
+++ b/test/data/fle2-insert-range/int32/mongocryptd-reply.json
@@ -9,7 +9,7 @@
                 "plainText": "sample",
                 "encrypted": {
                     "$binary": {
-                        "base64": "A3cAAAAQdAABAAAAEGEAAwAAAAVraQAQAAAABBI0VngSNJh2EjQSNFZ4kBIFa3UAEAAAAASrze+rEjSYdhI0EjRWeJASA3YAHAAAABB2AEDiAQAQbGIAAAAAABB1YgCH1hIAABJjbQAAAAAAAAAAABBzAAEAAAAA",
+                        "base64": "A30AAAAQdAABAAAAEGEAAwAAAAVraQAQAAAABBI0VngSNJh2EjQSNFZ4kBIFa3UAEAAAAASrze+rEjSYdhI0EjRWeJASA3YAHgAAABB2AEDiAQAQbWluAAAAAAAQbWF4AIfWEgAAEmNtAAAAAAAAAAAAEnMAAQAAAAAAAAAA",
                         "subType": "6"
                     }
                 }

--- a/test/data/fle2-insert-range/int64/mongocryptd-reply.json
+++ b/test/data/fle2-insert-range/int64/mongocryptd-reply.json
@@ -9,7 +9,7 @@
                 "plainText": "sample",
                 "encrypted": {
                     "$binary": {
-                        "base64": "A4MAAAAQdAABAAAAEGEAAwAAAAVraQAQAAAABBI0VngSNJh2EjQSNFZ4kBIFa3UAEAAAAASrze+rEjSYdhI0EjRWeJASA3YAKAAAABJ2AIdLa11U3CsAEmxiAAAAAAAAAAAAEnViABWB6X30ECIRABJjbQAAAAAAAAAAABBzAAEAAAAA",
+                        "base64": "A4kAAAAQdAABAAAAEGEAAwAAAAVraQAQAAAABBI0VngSNJh2EjQSNFZ4kBIFa3UAEAAAAASrze+rEjSYdhI0EjRWeJASA3YAKgAAABJ2AIdLa11U3CsAEm1pbgAAAAAAAAAAABJtYXgAFYHpffQQIhEAEmNtAAAAAAAAAAAAEnMAAQAAAAAAAAAA",
                         "subType": "6"
                     }
                 }

--- a/test/data/range-min-cover/mincover_int32.cstruct
+++ b/test/data/range-min-cover/mincover_int32.cstruct
@@ -1,143 +1,143 @@
 // This is a copy of test vectors from the mongodb/mongo repository.
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(-1),
     .sparsity = 1,
     .expectMincoverString = "100110001001011000011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(-1),
     .sparsity = 2,
     .expectMincoverString = "100110001001011000011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(-1),
     .sparsity = 3,
     .expectMincoverString = "100110001001011000011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(-1),
     .sparsity = 4,
     .expectMincoverString = "100110001001011000011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 1,
     .expectMincoverString = "100110001001011000011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 2,
     .expectMincoverString = "100110001001011000011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 3,
     .expectMincoverString = "100110001001011000011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 4,
     .expectMincoverString = "100110001001011000011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 1,
     .expectMincoverString = "100110001001011000011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 2,
     .expectMincoverString = "100110001001011000011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 3,
     .expectMincoverString = "100110001001011000011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 4,
     .expectMincoverString = "100110001001011000011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 1,
     .expectMincoverString = "100110001001011000011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 2,
     .expectMincoverString = "100110001001011000011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 3,
     .expectMincoverString = "100110001001011000011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 4,
     .expectMincoverString = "100110001001011000011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "0000000100110001001011000011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(-1),
     .sparsity = 1,
@@ -146,8 +146,8 @@
         "100110001001011001\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(-1),
     .sparsity = 2,
@@ -157,8 +157,8 @@
         "100110001001011001\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(-1),
     .sparsity = 3,
@@ -173,8 +173,8 @@
         "100110001001011001\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(-1),
     .sparsity = 4,
@@ -190,8 +190,8 @@
         "10011000100101100111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 1,
@@ -200,8 +200,8 @@
         "100110001001011001\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 2,
@@ -211,8 +211,8 @@
         "100110001001011001\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 3,
@@ -227,8 +227,8 @@
         "100110001001011001\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 4,
@@ -244,8 +244,8 @@
         "10011000100101100111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 1,
@@ -254,8 +254,8 @@
         "100110001001011001\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 2,
@@ -265,8 +265,8 @@
         "100110001001011001\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 3,
@@ -281,8 +281,8 @@
         "100110001001011001\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 4,
@@ -298,8 +298,8 @@
         "10011000100101100111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 1,
@@ -308,8 +308,8 @@
         "100110001001011001\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -319,8 +319,8 @@
         "100110001001011001\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 3,
@@ -335,8 +335,8 @@
         "100110001001011001\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 4,
@@ -352,8 +352,8 @@
         "10011000100101100111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -362,8 +362,8 @@
         "0000000100110001001011001\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 2,
@@ -374,8 +374,8 @@
         "00000001001100010010110011\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 3,
@@ -389,8 +389,8 @@
         "000000010011000100101100111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 1,
@@ -400,8 +400,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 2,
@@ -412,8 +412,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 3,
@@ -429,8 +429,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 4,
@@ -447,8 +447,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 1,
@@ -458,8 +458,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 2,
@@ -470,8 +470,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 3,
@@ -487,8 +487,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 4,
@@ -505,8 +505,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 1,
@@ -516,8 +516,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -528,8 +528,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 3,
@@ -545,8 +545,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 4,
@@ -563,8 +563,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -574,8 +574,8 @@
         "0000000100110001001011010000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 7,
+    .lowerBound = -100,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 1,
@@ -585,8 +585,8 @@
         "100110001001011010000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 7,
+    .lowerBound = -100,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 2,
@@ -598,8 +598,8 @@
         "1001100010010110100001\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 7,
+    .lowerBound = -100,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 3,
@@ -615,8 +615,8 @@
         "100110001001011010000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 7,
+    .lowerBound = -100,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 4,
@@ -640,8 +640,8 @@
         "100110001001011010000111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 7,
+    .lowerBound = -100,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 1,
@@ -651,8 +651,8 @@
         "100110001001011010000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 7,
+    .lowerBound = -100,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -664,8 +664,8 @@
         "1001100010010110100001\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 7,
+    .lowerBound = -100,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 3,
@@ -681,8 +681,8 @@
         "100110001001011010000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 7,
+    .lowerBound = -100,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 4,
@@ -706,8 +706,8 @@
         "100110001001011010000111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 7,
+    .lowerBound = -100,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -717,8 +717,8 @@
         "0000000100110001001011010000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 7,
+    .lowerBound = -100,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 2,
@@ -730,8 +730,8 @@
         "0000000100110001001011010000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 7,
+    .lowerBound = -100,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 3,
@@ -749,8 +749,8 @@
         "000000010011000100101101000011\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 32,
+    .lowerBound = -100,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 1,
@@ -761,8 +761,8 @@
         "100110001001011010100000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 32,
+    .lowerBound = -100,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -775,8 +775,8 @@
         "100110001001011010100000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 32,
+    .lowerBound = -100,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 3,
@@ -796,8 +796,8 @@
         "100110001001011010100000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 32,
+    .lowerBound = -100,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 4,
@@ -816,8 +816,8 @@
         "100110001001011010100000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 32,
+    .lowerBound = -100,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -828,8 +828,8 @@
         "0000000100110001001011010100000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 1879048192,
+    .lowerBound = -100,
+    .upperBound = 1879048192,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -865,208 +865,208 @@
         "1110000100110001001011010000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(-1),
     .sparsity = 1,
     .expectMincoverString = "100110001001011001111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(-1),
     .sparsity = 2,
     .expectMincoverString = "100110001001011001111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(-1),
     .sparsity = 3,
     .expectMincoverString = "100110001001011001111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(-1),
     .sparsity = 4,
     .expectMincoverString = "100110001001011001111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 1,
     .expectMincoverString = "100110001001011001111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 2,
     .expectMincoverString = "100110001001011001111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 3,
     .expectMincoverString = "100110001001011001111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 4,
     .expectMincoverString = "100110001001011001111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 1,
     .expectMincoverString = "100110001001011001111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 2,
     .expectMincoverString = "100110001001011001111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 3,
     .expectMincoverString = "100110001001011001111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 4,
     .expectMincoverString = "100110001001011001111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 1,
     .expectMincoverString = "100110001001011001111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 2,
     .expectMincoverString = "100110001001011001111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 3,
     .expectMincoverString = "100110001001011001111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 4,
     .expectMincoverString = "100110001001011001111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "0000000100110001001011001111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-1),
     .max = OPT_I32(0),
     .sparsity = 1,
     .expectMincoverString = "0\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 1,
     .expectMincoverString = "0000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 2,
     .expectMincoverString = "0000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 4,
     .expectMincoverString = "0000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 1,
     .expectMincoverString = "000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 2,
     .expectMincoverString = "000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 3,
     .expectMincoverString = "000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "0000000000000000000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 1,
@@ -1074,8 +1074,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 2,
@@ -1083,8 +1083,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 3,
@@ -1092,8 +1092,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 4,
@@ -1101,8 +1101,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 1,
@@ -1110,8 +1110,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 2,
@@ -1119,8 +1119,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 3,
@@ -1128,8 +1128,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 4,
@@ -1137,8 +1137,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 1,
@@ -1146,8 +1146,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -1155,8 +1155,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 3,
@@ -1164,8 +1164,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 4,
@@ -1173,8 +1173,8 @@
         "100110001001011010000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -1182,48 +1182,48 @@
         "0000000100110001001011010000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(0),
     .sparsity = 1,
     .expectMincoverString = "root\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(0),
     .sparsity = 2,
     .expectMincoverString = "root\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(0),
     .sparsity = 3,
     .expectMincoverString = "root\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(0),
     .sparsity = 4,
     .expectMincoverString = "root\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 1,
     .expectMincoverString = "000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 2,
@@ -1231,16 +1231,16 @@
         "0001\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 3,
     .expectMincoverString = "000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 4,
@@ -1248,16 +1248,16 @@
         "0001\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 1,
     .expectMincoverString = "00000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -1265,8 +1265,8 @@
         "000001\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 3,
@@ -1274,32 +1274,32 @@
         "000001\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "000000000000000000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 2,
     .expectMincoverString = "000000000000000000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 3,
     .expectMincoverString = "000000000000000000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 7,
+    .lowerBound = -1,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 1,
@@ -1307,8 +1307,8 @@
         "100110001001011010000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 7,
+    .lowerBound = -1,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 2,
@@ -1317,8 +1317,8 @@
         "1001100010010110100001\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 7,
+    .lowerBound = -1,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 3,
@@ -1326,8 +1326,8 @@
         "100110001001011010000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 7,
+    .lowerBound = -1,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 4,
@@ -1342,8 +1342,8 @@
         "100110001001011010000111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 7,
+    .lowerBound = -1,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 1,
@@ -1351,8 +1351,8 @@
         "100110001001011010000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 7,
+    .lowerBound = -1,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -1361,8 +1361,8 @@
         "1001100010010110100001\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 7,
+    .lowerBound = -1,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 3,
@@ -1370,8 +1370,8 @@
         "100110001001011010000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 7,
+    .lowerBound = -1,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 4,
@@ -1386,8 +1386,8 @@
         "100110001001011010000111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 7,
+    .lowerBound = -1,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -1395,8 +1395,8 @@
         "0000000100110001001011010000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 7,
+    .lowerBound = -1,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 1,
@@ -1404,8 +1404,8 @@
         "1000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 7,
+    .lowerBound = -1,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 2,
@@ -1414,8 +1414,8 @@
         "1000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 7,
+    .lowerBound = -1,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 4,
@@ -1430,8 +1430,8 @@
         "1000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 7,
+    .lowerBound = -1,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 1,
@@ -1439,8 +1439,8 @@
         "001000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 7,
+    .lowerBound = -1,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -1449,8 +1449,8 @@
         "001000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 7,
+    .lowerBound = -1,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 3,
@@ -1458,8 +1458,8 @@
         "001000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 7,
+    .lowerBound = -1,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -1467,8 +1467,8 @@
         "0000000000000000000000000001000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 32,
+    .lowerBound = -1,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 1,
@@ -1477,8 +1477,8 @@
         "100110001001011010100000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 32,
+    .lowerBound = -1,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -1488,8 +1488,8 @@
         "100110001001011010100000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 32,
+    .lowerBound = -1,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 3,
@@ -1501,8 +1501,8 @@
         "100110001001011010100000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 32,
+    .lowerBound = -1,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 4,
@@ -1512,8 +1512,8 @@
         "100110001001011010100000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 32,
+    .lowerBound = -1,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -1522,8 +1522,8 @@
         "0000000100110001001011010100000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 32,
+    .lowerBound = -1,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 1,
@@ -1531,8 +1531,8 @@
         "10000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 32,
+    .lowerBound = -1,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -1542,8 +1542,8 @@
         "100001\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 32,
+    .lowerBound = -1,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 3,
@@ -1555,8 +1555,8 @@
         "100001\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 32,
+    .lowerBound = -1,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -1564,8 +1564,8 @@
         "000000000000000000000000010000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 32,
+    .lowerBound = -1,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 2,
@@ -1573,8 +1573,8 @@
         "000000000000000000000000010000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 32,
+    .lowerBound = -1,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 3,
@@ -1583,8 +1583,8 @@
         "000000000000000000000000010000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 1879048192,
+    .lowerBound = -1,
+    .upperBound = 1879048192,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -1618,8 +1618,8 @@
         "1110000100110001001011010000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 1879048192,
+    .lowerBound = -1,
+    .upperBound = 1879048192,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -1629,8 +1629,8 @@
         "111000000000000000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 1879048192,
+    .lowerBound = -1,
+    .upperBound = 1879048192,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 2,
@@ -1642,8 +1642,8 @@
         "111000000000000000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 1879048192,
+    .lowerBound = -1,
+    .upperBound = 1879048192,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 3,
@@ -1657,232 +1657,232 @@
         "111000000000000000000000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 1,
     .expectMincoverString = "100110001001011010000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 2,
     .expectMincoverString = "100110001001011010000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 3,
     .expectMincoverString = "100110001001011010000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(0),
     .sparsity = 4,
     .expectMincoverString = "100110001001011010000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 1,
     .expectMincoverString = "100110001001011010000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 2,
     .expectMincoverString = "100110001001011010000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 3,
     .expectMincoverString = "100110001001011010000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 4,
     .expectMincoverString = "100110001001011010000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 1,
     .expectMincoverString = "100110001001011010000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 2,
     .expectMincoverString = "100110001001011010000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 3,
     .expectMincoverString = "100110001001011010000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 4,
     .expectMincoverString = "100110001001011010000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "0000000100110001001011010000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(0),
     .sparsity = 1,
     .expectMincoverString = "1\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 1,
     .expectMincoverString = "0001\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 2,
     .expectMincoverString = "0001\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 4,
     .expectMincoverString = "0001\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 1,
     .expectMincoverString = "000001\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 2,
     .expectMincoverString = "000001\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 3,
     .expectMincoverString = "000001\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "0000000000000000000000000000001\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(0),
     .max = OPT_I32(7),
     .sparsity = 1,
     .expectMincoverString = "000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(0),
     .max = OPT_I32(7),
     .sparsity = 3,
     .expectMincoverString = "000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 1,
     .expectMincoverString = "000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 2,
     .expectMincoverString = "000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 3,
     .expectMincoverString = "000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I32(0),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "0000000000000000000000000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 1,
     .expectMincoverString = "100110001001011010000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 2,
@@ -1890,16 +1890,16 @@
         "1001100010010110100001\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 3,
     .expectMincoverString = "100110001001011010000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 4,
@@ -1913,16 +1913,16 @@
         "100110001001011010000111\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 1,
     .expectMincoverString = "100110001001011010000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -1930,16 +1930,16 @@
         "1001100010010110100001\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 3,
     .expectMincoverString = "100110001001011010000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 4,
@@ -1953,24 +1953,24 @@
         "100110001001011010000111\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "0000000100110001001011010000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 2,
     .expectMincoverString = "0000000100110001001011010000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 3,
@@ -1980,16 +1980,16 @@
         "000000010011000100101101000011\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 4,
     .expectMincoverString = "0000000100110001001011010000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 1,
@@ -1999,8 +1999,8 @@
         "1000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 2,
@@ -2011,8 +2011,8 @@
         "1000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 4,
@@ -2026,8 +2026,8 @@
         "1000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 1,
@@ -2037,8 +2037,8 @@
         "001000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -2049,8 +2049,8 @@
         "001000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 3,
@@ -2064,8 +2064,8 @@
         "001000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -2075,48 +2075,48 @@
         "0000000000000000000000000001000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(0),
     .max = OPT_I32(7),
     .sparsity = 1,
     .expectMincoverString = "root\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(0),
     .max = OPT_I32(7),
     .sparsity = 2,
     .expectMincoverString = "root\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(0),
     .max = OPT_I32(7),
     .sparsity = 3,
     .expectMincoverString = "root\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(0),
     .max = OPT_I32(7),
     .sparsity = 4,
     .expectMincoverString = "root\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 1,
     .expectMincoverString = "000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -2124,16 +2124,16 @@
         "0001\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 3,
     .expectMincoverString = "000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 4,
@@ -2141,24 +2141,24 @@
         "0001\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(0),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "0000000000000000000000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(0),
     .max = OPT_I32(1879048192),
     .sparsity = 2,
     .expectMincoverString = "0000000000000000000000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(0),
     .max = OPT_I32(1879048192),
     .sparsity = 3,
@@ -2168,16 +2168,16 @@
         "000000000000000000000000000011\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 7,
+    .lowerBound = 0,
+    .upperBound = 7,
     .min = OPT_I32(0),
     .max = OPT_I32(1879048192),
     .sparsity = 4,
     .expectMincoverString = "0000000000000000000000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 32,
+    .lowerBound = 0,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 1,
@@ -2185,8 +2185,8 @@
         "100110001001011010100000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 32,
+    .lowerBound = 0,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -2195,8 +2195,8 @@
         "100110001001011010100000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 32,
+    .lowerBound = 0,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 3,
@@ -2207,8 +2207,8 @@
         "100110001001011010100000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 32,
+    .lowerBound = 0,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 4,
@@ -2217,8 +2217,8 @@
         "100110001001011010100000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 32,
+    .lowerBound = 0,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -2226,8 +2226,8 @@
         "0000000100110001001011010100000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 32,
+    .lowerBound = 0,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 1,
@@ -2239,8 +2239,8 @@
         "10000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 32,
+    .lowerBound = 0,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -2255,8 +2255,8 @@
         "100001\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 32,
+    .lowerBound = 0,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 3,
@@ -2274,8 +2274,8 @@
         "100001\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 32,
+    .lowerBound = 0,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -2287,8 +2287,8 @@
         "000000000000000000000000010000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 32,
+    .lowerBound = 0,
+    .upperBound = 32,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 1,
@@ -2296,8 +2296,8 @@
         "100000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 32,
+    .lowerBound = 0,
+    .upperBound = 32,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -2306,8 +2306,8 @@
         "100000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 32,
+    .lowerBound = 0,
+    .upperBound = 32,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 3,
@@ -2318,8 +2318,8 @@
         "100000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 32,
+    .lowerBound = 0,
+    .upperBound = 32,
     .min = OPT_I32(0),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -2327,8 +2327,8 @@
         "0000000000000000000000000100000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 1879048192,
+    .lowerBound = 0,
+    .upperBound = 1879048192,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -2361,8 +2361,8 @@
         "1110000100110001001011010000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 1879048192,
+    .lowerBound = 0,
+    .upperBound = 1879048192,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -2401,8 +2401,8 @@
         "111000000000000000000000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 1879048192,
+    .lowerBound = 0,
+    .upperBound = 1879048192,
     .min = OPT_I32(0),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -2412,200 +2412,200 @@
         "1110000000000000000000000000000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 1,
     .expectMincoverString = "100110001001011010000111\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 2,
     .expectMincoverString = "100110001001011010000111\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 3,
     .expectMincoverString = "100110001001011010000111\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(7),
     .sparsity = 4,
     .expectMincoverString = "100110001001011010000111\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 1,
     .expectMincoverString = "100110001001011010000111\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 2,
     .expectMincoverString = "100110001001011010000111\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 3,
     .expectMincoverString = "100110001001011010000111\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 4,
     .expectMincoverString = "100110001001011010000111\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "0000000100110001001011010000111\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 1,
     .expectMincoverString = "1000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 2,
     .expectMincoverString = "1000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(7),
     .sparsity = 4,
     .expectMincoverString = "1000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 1,
     .expectMincoverString = "001000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 2,
     .expectMincoverString = "001000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 3,
     .expectMincoverString = "001000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "0000000000000000000000000001000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(0),
     .max = OPT_I32(7),
     .sparsity = 1,
     .expectMincoverString = "111\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(0),
     .max = OPT_I32(7),
     .sparsity = 3,
     .expectMincoverString = "111\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 1,
     .expectMincoverString = "000111\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 2,
     .expectMincoverString = "000111\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 3,
     .expectMincoverString = "000111\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(0),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "0000000000000000000000000000111\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(7),
     .max = OPT_I32(32),
     .sparsity = 1,
     .expectMincoverString = "00000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 7,
+    .lowerBound = 7,
+    .upperBound = 7,
     .min = OPT_I32(7),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "0000000000000000000000000000000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 1,
@@ -2615,8 +2615,8 @@
         "100110001001011010100000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -2627,8 +2627,8 @@
         "100110001001011010100000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 3,
@@ -2639,8 +2639,8 @@
         "100110001001011010100000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 4,
@@ -2657,8 +2657,8 @@
         "100110001001011010100000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -2668,8 +2668,8 @@
         "0000000100110001001011010100000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 1,
@@ -2678,8 +2678,8 @@
         "10000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -2690,8 +2690,8 @@
         "100001\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 3,
@@ -2702,8 +2702,8 @@
         "100001\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -2712,8 +2712,8 @@
         "000000000000000000000000010000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 2,
@@ -2723,8 +2723,8 @@
         "000000000000000000000000010000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 3,
@@ -2736,8 +2736,8 @@
         "000000000000000000000000010000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 1,
@@ -2747,8 +2747,8 @@
         "100000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -2759,8 +2759,8 @@
         "100000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 3,
@@ -2771,8 +2771,8 @@
         "100000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(0),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -2782,8 +2782,8 @@
         "0000000000000000000000000100000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(7),
     .max = OPT_I32(32),
     .sparsity = 1,
@@ -2792,8 +2792,8 @@
         "1100\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(7),
     .max = OPT_I32(32),
     .sparsity = 2,
@@ -2803,8 +2803,8 @@
         "1100\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(7),
     .max = OPT_I32(32),
     .sparsity = 4,
@@ -2823,8 +2823,8 @@
         "1100\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(7),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -2833,8 +2833,8 @@
         "000000000000000000000000001100\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(7),
     .max = OPT_I32(1879048192),
     .sparsity = 2,
@@ -2844,8 +2844,8 @@
         "000000000000000000000000001100\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 32,
+    .lowerBound = 7,
+    .upperBound = 32,
     .min = OPT_I32(7),
     .max = OPT_I32(1879048192),
     .sparsity = 3,
@@ -2857,8 +2857,8 @@
         "000000000000000000000000001100\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 1879048192,
+    .lowerBound = 7,
+    .upperBound = 1879048192,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -2895,8 +2895,8 @@
         "1110000100110001001011010000000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 1879048192,
+    .lowerBound = 7,
+    .upperBound = 1879048192,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -2932,8 +2932,8 @@
         "111000000000000000000000000000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 1879048192,
+    .lowerBound = 7,
+    .upperBound = 1879048192,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 2,
@@ -2983,8 +2983,8 @@
         "111000000000000000000000000000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 1879048192,
+    .lowerBound = 7,
+    .upperBound = 1879048192,
     .min = OPT_I32(0),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -3021,8 +3021,8 @@
         "1110000000000000000000000000000\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 1879048192,
+    .lowerBound = 7,
+    .upperBound = 1879048192,
     .min = OPT_I32(7),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -3056,8 +3056,8 @@
         "110111111111111111111111111100\n" 
 },
 {
-    .range_min = 7,
-    .range_max = 1879048192,
+    .lowerBound = 7,
+    .upperBound = 1879048192,
     .min = OPT_I32(7),
     .max = OPT_I32(1879048192),
     .sparsity = 2,
@@ -3104,136 +3104,136 @@
         "110111111111111111111111111100\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 32,
+    .lowerBound = 32,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 1,
     .expectMincoverString = "100110001001011010100000\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 32,
+    .lowerBound = 32,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 2,
     .expectMincoverString = "100110001001011010100000\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 32,
+    .lowerBound = 32,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 3,
     .expectMincoverString = "100110001001011010100000\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 32,
+    .lowerBound = 32,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(32),
     .sparsity = 4,
     .expectMincoverString = "100110001001011010100000\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 32,
+    .lowerBound = 32,
+    .upperBound = 32,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "0000000100110001001011010100000\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 32,
+    .lowerBound = 32,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 1,
     .expectMincoverString = "100001\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 32,
+    .lowerBound = 32,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 2,
     .expectMincoverString = "100001\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 32,
+    .lowerBound = 32,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(32),
     .sparsity = 3,
     .expectMincoverString = "100001\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 32,
+    .lowerBound = 32,
+    .upperBound = 32,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "0000000000000000000000000100001\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 32,
+    .lowerBound = 32,
+    .upperBound = 32,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 1,
     .expectMincoverString = "100000\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 32,
+    .lowerBound = 32,
+    .upperBound = 32,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 2,
     .expectMincoverString = "100000\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 32,
+    .lowerBound = 32,
+    .upperBound = 32,
     .min = OPT_I32(0),
     .max = OPT_I32(32),
     .sparsity = 3,
     .expectMincoverString = "100000\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 32,
+    .lowerBound = 32,
+    .upperBound = 32,
     .min = OPT_I32(0),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "0000000000000000000000000100000\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 32,
+    .lowerBound = 32,
+    .upperBound = 32,
     .min = OPT_I32(7),
     .max = OPT_I32(32),
     .sparsity = 1,
     .expectMincoverString = "11001\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 32,
+    .lowerBound = 32,
+    .upperBound = 32,
     .min = OPT_I32(7),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "0000000000000000000000000011001\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 32,
+    .lowerBound = 32,
+    .upperBound = 32,
     .min = OPT_I32(32),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "0000000000000000000000000000000\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 1879048192,
+    .lowerBound = 32,
+    .upperBound = 1879048192,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -3267,8 +3267,8 @@
         "1110000100110001001011010000000\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 1879048192,
+    .lowerBound = 32,
+    .upperBound = 1879048192,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -3306,8 +3306,8 @@
         "111000000000000000000000000000\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 1879048192,
+    .lowerBound = 32,
+    .upperBound = 1879048192,
     .min = OPT_I32(0),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -3341,8 +3341,8 @@
         "1110000000000000000000000000000\n" 
 },
 {
-    .range_min = 32,
-    .range_max = 1879048192,
+    .lowerBound = 32,
+    .upperBound = 1879048192,
     .min = OPT_I32(32),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
@@ -3374,40 +3374,40 @@
         "1101111111111111111111111100000\n" 
 },
 {
-    .range_min = 1879048192,
-    .range_max = 1879048192,
+    .lowerBound = 1879048192,
+    .upperBound = 1879048192,
     .min = OPT_I32(-10000000),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "1110000100110001001011010000000\n" 
 },
 {
-    .range_min = 1879048192,
-    .range_max = 1879048192,
+    .lowerBound = 1879048192,
+    .upperBound = 1879048192,
     .min = OPT_I32(-1),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "1110000000000000000000000000001\n" 
 },
 {
-    .range_min = 1879048192,
-    .range_max = 1879048192,
+    .lowerBound = 1879048192,
+    .upperBound = 1879048192,
     .min = OPT_I32(0),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "1110000000000000000000000000000\n" 
 },
 {
-    .range_min = 1879048192,
-    .range_max = 1879048192,
+    .lowerBound = 1879048192,
+    .upperBound = 1879048192,
     .min = OPT_I32(7),
     .max = OPT_I32(1879048192),
     .sparsity = 1,
     .expectMincoverString = "1101111111111111111111111111001\n" 
 },
 {
-    .range_min = 1879048192,
-    .range_max = 1879048192,
+    .lowerBound = 1879048192,
+    .upperBound = 1879048192,
     .min = OPT_I32(32),
     .max = OPT_I32(1879048192),
     .sparsity = 1,

--- a/test/data/range-min-cover/mincover_int64.cstruct
+++ b/test/data/range-min-cover/mincover_int64.cstruct
@@ -1,71 +1,71 @@
 // This is a copy of test vectors from the mongodb/mongo repository.
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(-1),
     .sparsity = 1,
     .expectMincoverString = "11100011010111111010100100110001100111111110011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(-1),
     .sparsity = 2,
     .expectMincoverString = "11100011010111111010100100110001100111111110011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(0),
     .sparsity = 1,
     .expectMincoverString = "11100011010111111010100100110001100111111110011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(0),
     .sparsity = 2,
     .expectMincoverString = "11100011010111111010100100110001100111111110011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 1,
     .expectMincoverString = "11100011010111111010100100110001100111111110011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 2,
     .expectMincoverString = "11100011010111111010100100110001100111111110011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
     .expectMincoverString = "000000000000011100011010111111010100100110001100111111110011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -100,
+    .lowerBound = -100,
+    .upperBound = -100,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
     .expectMincoverString = "000000000000011100011010111111010100100110001100111111110011100\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(-1),
     .sparsity = 1,
@@ -74,8 +74,8 @@
         "11100011010111111010100100110001100111111111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(-1),
     .sparsity = 2,
@@ -85,8 +85,8 @@
         "11100011010111111010100100110001100111111111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(-1),
     .sparsity = 3,
@@ -96,8 +96,8 @@
         "111000110101111110101001001100011001111111111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(-1),
     .sparsity = 4,
@@ -113,8 +113,8 @@
         "11100011010111111010100100110001100111111111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(0),
     .sparsity = 1,
@@ -123,8 +123,8 @@
         "11100011010111111010100100110001100111111111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(0),
     .sparsity = 2,
@@ -134,8 +134,8 @@
         "11100011010111111010100100110001100111111111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(0),
     .sparsity = 3,
@@ -145,8 +145,8 @@
         "111000110101111110101001001100011001111111111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(0),
     .sparsity = 4,
@@ -162,8 +162,8 @@
         "11100011010111111010100100110001100111111111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 1,
@@ -172,8 +172,8 @@
         "11100011010111111010100100110001100111111111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 2,
@@ -183,8 +183,8 @@
         "11100011010111111010100100110001100111111111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 3,
@@ -194,8 +194,8 @@
         "111000110101111110101001001100011001111111111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 4,
@@ -211,8 +211,8 @@
         "11100011010111111010100100110001100111111111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -221,8 +221,8 @@
         "000000000000011100011010111111010100100110001100111111111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 2,
@@ -233,8 +233,8 @@
         "0000000000000111000110101111110101001001100011001111111111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = -1,
+    .lowerBound = -100,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -249,8 +249,8 @@
         "000000000000011100011010111111010100100110001100111111111\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(0),
     .sparsity = 1,
@@ -260,8 +260,8 @@
         "11100011010111111010100100110001101000000000000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(0),
     .sparsity = 2,
@@ -272,8 +272,8 @@
         "11100011010111111010100100110001101000000000000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 1,
@@ -283,8 +283,8 @@
         "11100011010111111010100100110001101000000000000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 2,
@@ -295,8 +295,8 @@
         "11100011010111111010100100110001101000000000000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -306,8 +306,8 @@
         "000000000000011100011010111111010100100110001101000000000000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 0,
+    .lowerBound = -100,
+    .upperBound = 0,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -323,8 +323,8 @@
         "000000000000011100011010111111010100100110001101000000000000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 823,
+    .lowerBound = -100,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 1,
@@ -338,8 +338,8 @@
         "11100011010111111010100100110001101000001100110\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 823,
+    .lowerBound = -100,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 2,
@@ -357,8 +357,8 @@
         "111000110101111110101001001100011010000011001101\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 823,
+    .lowerBound = -100,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 3,
@@ -378,8 +378,8 @@
         "111000110101111110101001001100011010000011001101\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 823,
+    .lowerBound = -100,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 4,
@@ -421,8 +421,8 @@
         "111000110101111110101001001100011010000011001101\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 823,
+    .lowerBound = -100,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -436,8 +436,8 @@
         "000000000000011100011010111111010100100110001101000001100110\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 823,
+    .lowerBound = -100,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 2,
@@ -455,8 +455,8 @@
         "000000000000011100011010111111010100100110001101000001100110\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 823,
+    .lowerBound = -100,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -483,8 +483,8 @@
         "000000000000011100011010111111010100100110001101000001100110\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 1024,
+    .lowerBound = -100,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 1,
@@ -495,8 +495,8 @@
         "11100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 1024,
+    .lowerBound = -100,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 2,
@@ -508,8 +508,8 @@
         "11100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 1024,
+    .lowerBound = -100,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -520,8 +520,8 @@
         "000000000000011100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 1024,
+    .lowerBound = -100,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -539,8 +539,8 @@
         "000000000000011100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 1879048192,
+    .lowerBound = -100,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -567,8 +567,8 @@
         "000000000000011100011010111111100010100110001101000000000000000\n" 
 },
 {
-    .range_min = -100,
-    .range_max = 1879048192,
+    .lowerBound = -100,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -619,104 +619,104 @@
         "000000000000011100011010111111100010100110001101000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(-1),
     .sparsity = 1,
     .expectMincoverString = "11100011010111111010100100110001100111111111111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(-1),
     .sparsity = 2,
     .expectMincoverString = "11100011010111111010100100110001100111111111111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(0),
     .sparsity = 1,
     .expectMincoverString = "11100011010111111010100100110001100111111111111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(0),
     .sparsity = 2,
     .expectMincoverString = "11100011010111111010100100110001100111111111111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 1,
     .expectMincoverString = "11100011010111111010100100110001100111111111111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 2,
     .expectMincoverString = "11100011010111111010100100110001100111111111111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
     .expectMincoverString = "000000000000011100011010111111010100100110001100111111111111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
     .expectMincoverString = "000000000000011100011010111111010100100110001100111111111111111\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I64(-1),
     .max = OPT_I64(0),
     .sparsity = 1,
     .expectMincoverString = "0\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I64(-1),
     .max = OPT_I64(1024),
     .sparsity = 1,
     .expectMincoverString = "00000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
     .expectMincoverString = "000000000000000000000000000000000000000000000000000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = -1,
+    .lowerBound = -1,
+    .upperBound = -1,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
     .expectMincoverString = "000000000000000000000000000000000000000000000000000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(0),
     .sparsity = 1,
@@ -724,8 +724,8 @@
         "11100011010111111010100100110001101000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(0),
     .sparsity = 2,
@@ -733,8 +733,8 @@
         "11100011010111111010100100110001101000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 1,
@@ -742,8 +742,8 @@
         "11100011010111111010100100110001101000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 2,
@@ -751,8 +751,8 @@
         "11100011010111111010100100110001101000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -760,8 +760,8 @@
         "000000000000011100011010111111010100100110001101000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -769,72 +769,72 @@
         "000000000000011100011010111111010100100110001101000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I64(-1),
     .max = OPT_I64(0),
     .sparsity = 1,
     .expectMincoverString = "root\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I64(-1),
     .max = OPT_I64(0),
     .sparsity = 2,
     .expectMincoverString = "root\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I64(-1),
     .max = OPT_I64(0),
     .sparsity = 3,
     .expectMincoverString = "root\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I64(-1),
     .max = OPT_I64(0),
     .sparsity = 4,
     .expectMincoverString = "root\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I64(-1),
     .max = OPT_I64(1024),
     .sparsity = 1,
     .expectMincoverString = "0000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I64(-1),
     .max = OPT_I64(1024),
     .sparsity = 2,
     .expectMincoverString = "0000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
     .expectMincoverString = "00000000000000000000000000000000000000000000000000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 2,
     .expectMincoverString = "00000000000000000000000000000000000000000000000000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 0,
+    .lowerBound = -1,
+    .upperBound = 0,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -842,8 +842,8 @@
         "000000000000000000000000000000000000000000000000000000000000001\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 823,
+    .lowerBound = -1,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 1,
@@ -855,8 +855,8 @@
         "11100011010111111010100100110001101000001100110\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 823,
+    .lowerBound = -1,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 2,
@@ -871,8 +871,8 @@
         "111000110101111110101001001100011010000011001101\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 823,
+    .lowerBound = -1,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -884,8 +884,8 @@
         "000000000000011100011010111111010100100110001101000001100110\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 823,
+    .lowerBound = -1,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -904,8 +904,8 @@
         "000000000000011100011010111111010100100110001101000001100110\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 823,
+    .lowerBound = -1,
+    .upperBound = 823,
     .min = OPT_I64(-1),
     .max = OPT_I64(1024),
     .sparsity = 1,
@@ -917,8 +917,8 @@
         "01100111000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 823,
+    .lowerBound = -1,
+    .upperBound = 823,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -930,8 +930,8 @@
         "000000000000000000000000000000000000000000000000000001100111000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 823,
+    .lowerBound = -1,
+    .upperBound = 823,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -950,8 +950,8 @@
         "000000000000000000000000000000000000000000000000000001100111000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 1024,
+    .lowerBound = -1,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 1,
@@ -960,8 +960,8 @@
         "11100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 1024,
+    .lowerBound = -1,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 2,
@@ -970,8 +970,8 @@
         "11100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 1024,
+    .lowerBound = -1,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -980,8 +980,8 @@
         "000000000000011100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 1024,
+    .lowerBound = -1,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -991,8 +991,8 @@
         "000000000000011100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 1024,
+    .lowerBound = -1,
+    .upperBound = 1024,
     .min = OPT_I64(-1),
     .max = OPT_I64(1024),
     .sparsity = 1,
@@ -1000,8 +1000,8 @@
         "1000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 1024,
+    .lowerBound = -1,
+    .upperBound = 1024,
     .min = OPT_I64(-1),
     .max = OPT_I64(1024),
     .sparsity = 2,
@@ -1010,8 +1010,8 @@
         "1000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 1024,
+    .lowerBound = -1,
+    .upperBound = 1024,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -1019,8 +1019,8 @@
         "00000000000000000000000000000000000000000000000000001000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 1024,
+    .lowerBound = -1,
+    .upperBound = 1024,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 2,
@@ -1029,8 +1029,8 @@
         "00000000000000000000000000000000000000000000000000001000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 1024,
+    .lowerBound = -1,
+    .upperBound = 1024,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -1040,8 +1040,8 @@
         "000000000000000000000000000000000000000000000000000010000000001\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 1879048192,
+    .lowerBound = -1,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -1066,8 +1066,8 @@
         "000000000000011100011010111111100010100110001101000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 1879048192,
+    .lowerBound = -1,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -1110,8 +1110,8 @@
         "000000000000011100011010111111100010100110001101000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 1879048192,
+    .lowerBound = -1,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -1121,8 +1121,8 @@
         "00000000000000000000000000000000111000000000000000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 1879048192,
+    .lowerBound = -1,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 2,
@@ -1134,8 +1134,8 @@
         "00000000000000000000000000000000111000000000000000000000000000\n" 
 },
 {
-    .range_min = -1,
-    .range_max = 1879048192,
+    .lowerBound = -1,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -1150,112 +1150,112 @@
         "000000000000000000000000000000001110000000000000000000000000001\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(0),
     .sparsity = 1,
     .expectMincoverString = "11100011010111111010100100110001101000000000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(0),
     .sparsity = 2,
     .expectMincoverString = "11100011010111111010100100110001101000000000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 1,
     .expectMincoverString = "11100011010111111010100100110001101000000000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 2,
     .expectMincoverString = "11100011010111111010100100110001101000000000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
     .expectMincoverString = "000000000000011100011010111111010100100110001101000000000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
     .expectMincoverString = "000000000000011100011010111111010100100110001101000000000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I64(-1),
     .max = OPT_I64(0),
     .sparsity = 1,
     .expectMincoverString = "1\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I64(-1),
     .max = OPT_I64(1024),
     .sparsity = 1,
     .expectMincoverString = "00000000001\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
     .expectMincoverString = "000000000000000000000000000000000000000000000000000000000000001\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
     .expectMincoverString = "000000000000000000000000000000000000000000000000000000000000001\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I64(0),
     .max = OPT_I64(1024),
     .sparsity = 1,
     .expectMincoverString = "00000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
     .expectMincoverString = "000000000000000000000000000000000000000000000000000000000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 0,
+    .lowerBound = 0,
+    .upperBound = 0,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
     .expectMincoverString = "000000000000000000000000000000000000000000000000000000000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 1,
@@ -1266,8 +1266,8 @@
         "11100011010111111010100100110001101000001100110\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 2,
@@ -1281,8 +1281,8 @@
         "111000110101111110101001001100011010000011001101\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 3,
@@ -1298,8 +1298,8 @@
         "111000110101111110101001001100011010000011001101\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 4,
@@ -1331,8 +1331,8 @@
         "111000110101111110101001001100011010000011001101\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -1343,8 +1343,8 @@
         "000000000000011100011010111111010100100110001101000001100110\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 2,
@@ -1357,8 +1357,8 @@
         "000000000000011100011010111111010100100110001101000001100110\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -1376,8 +1376,8 @@
         "000000000000011100011010111111010100100110001101000001100110\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 4,
@@ -1396,8 +1396,8 @@
         "000000000000011100011010111111010100100110001101000001100110\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(-1),
     .max = OPT_I64(1024),
     .sparsity = 1,
@@ -1417,8 +1417,8 @@
         "01100111000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -1438,8 +1438,8 @@
         "000000000000000000000000000000000000000000000000000001100111000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -1478,8 +1478,8 @@
         "000000000000000000000000000000000000000000000000000001100111000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(0),
     .max = OPT_I64(1024),
     .sparsity = 1,
@@ -1490,8 +1490,8 @@
         "01100110\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(0),
     .max = OPT_I64(1024),
     .sparsity = 2,
@@ -1504,8 +1504,8 @@
         "01100110\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(0),
     .max = OPT_I64(1024),
     .sparsity = 3,
@@ -1521,8 +1521,8 @@
         "011001101\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(0),
     .max = OPT_I64(1024),
     .sparsity = 4,
@@ -1541,8 +1541,8 @@
         "01100110\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -1553,8 +1553,8 @@
         "000000000000000000000000000000000000000000000000000001100110\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 2,
@@ -1567,8 +1567,8 @@
         "000000000000000000000000000000000000000000000000000001100110\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -1586,8 +1586,8 @@
         "000000000000000000000000000000000000000000000000000001100110\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 823,
+    .lowerBound = 0,
+    .upperBound = 823,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 4,
@@ -1606,8 +1606,8 @@
         "000000000000000000000000000000000000000000000000000001100110\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 1024,
+    .lowerBound = 0,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 1,
@@ -1615,8 +1615,8 @@
         "11100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 1024,
+    .lowerBound = 0,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 2,
@@ -1624,8 +1624,8 @@
         "11100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 1024,
+    .lowerBound = 0,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -1633,8 +1633,8 @@
         "000000000000011100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 1024,
+    .lowerBound = 0,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -1643,8 +1643,8 @@
         "000000000000011100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 1024,
+    .lowerBound = 0,
+    .upperBound = 1024,
     .min = OPT_I64(-1),
     .max = OPT_I64(1024),
     .sparsity = 1,
@@ -1661,8 +1661,8 @@
         "1000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 1024,
+    .lowerBound = 0,
+    .upperBound = 1024,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -1679,8 +1679,8 @@
         "00000000000000000000000000000000000000000000000000001000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 1024,
+    .lowerBound = 0,
+    .upperBound = 1024,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -1710,8 +1710,8 @@
         "000000000000000000000000000000000000000000000000000010000000001\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 1024,
+    .lowerBound = 0,
+    .upperBound = 1024,
     .min = OPT_I64(0),
     .max = OPT_I64(1024),
     .sparsity = 1,
@@ -1719,8 +1719,8 @@
         "10000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 1024,
+    .lowerBound = 0,
+    .upperBound = 1024,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -1728,8 +1728,8 @@
         "000000000000000000000000000000000000000000000000000010000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 1024,
+    .lowerBound = 0,
+    .upperBound = 1024,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -1738,8 +1738,8 @@
         "000000000000000000000000000000000000000000000000000010000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 1879048192,
+    .lowerBound = 0,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -1763,8 +1763,8 @@
         "000000000000011100011010111111100010100110001101000000000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 1879048192,
+    .lowerBound = 0,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -1806,8 +1806,8 @@
         "000000000000011100011010111111100010100110001101000000000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 1879048192,
+    .lowerBound = 0,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -1846,8 +1846,8 @@
         "00000000000000000000000000000000111000000000000000000000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 1879048192,
+    .lowerBound = 0,
+    .upperBound = 1879048192,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -1857,8 +1857,8 @@
         "000000000000000000000000000000001110000000000000000000000000000\n" 
 },
 {
-    .range_min = 0,
-    .range_max = 1879048192,
+    .lowerBound = 0,
+    .upperBound = 1879048192,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -1872,88 +1872,88 @@
         "000000000000000000000000000000001110000000000000000000000000000\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 823,
+    .lowerBound = 823,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 1,
     .expectMincoverString = "11100011010111111010100100110001101000001100110111\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 823,
+    .lowerBound = 823,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 2,
     .expectMincoverString = "11100011010111111010100100110001101000001100110111\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 823,
+    .lowerBound = 823,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
     .expectMincoverString = "000000000000011100011010111111010100100110001101000001100110111\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 823,
+    .lowerBound = 823,
+    .upperBound = 823,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
     .expectMincoverString = "000000000000011100011010111111010100100110001101000001100110111\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 823,
+    .lowerBound = 823,
+    .upperBound = 823,
     .min = OPT_I64(-1),
     .max = OPT_I64(1024),
     .sparsity = 1,
     .expectMincoverString = "01100111000\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 823,
+    .lowerBound = 823,
+    .upperBound = 823,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
     .expectMincoverString = "000000000000000000000000000000000000000000000000000001100111000\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 823,
+    .lowerBound = 823,
+    .upperBound = 823,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
     .expectMincoverString = "000000000000000000000000000000000000000000000000000001100111000\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 823,
+    .lowerBound = 823,
+    .upperBound = 823,
     .min = OPT_I64(0),
     .max = OPT_I64(1024),
     .sparsity = 1,
     .expectMincoverString = "01100110111\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 823,
+    .lowerBound = 823,
+    .upperBound = 823,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
     .expectMincoverString = "000000000000000000000000000000000000000000000000000001100110111\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 823,
+    .lowerBound = 823,
+    .upperBound = 823,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
     .expectMincoverString = "000000000000000000000000000000000000000000000000000001100110111\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 1024,
+    .lowerBound = 823,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 1,
@@ -1964,8 +1964,8 @@
         "11100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 1024,
+    .lowerBound = 823,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 2,
@@ -1978,8 +1978,8 @@
         "11100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 1024,
+    .lowerBound = 823,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -1990,8 +1990,8 @@
         "000000000000011100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 1024,
+    .lowerBound = 823,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -2003,8 +2003,8 @@
         "000000000000011100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 1024,
+    .lowerBound = 823,
+    .upperBound = 1024,
     .min = OPT_I64(-1),
     .max = OPT_I64(1024),
     .sparsity = 1,
@@ -2014,8 +2014,8 @@
         "1000000000\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 1024,
+    .lowerBound = 823,
+    .upperBound = 1024,
     .min = OPT_I64(-1),
     .max = OPT_I64(1024),
     .sparsity = 2,
@@ -2026,8 +2026,8 @@
         "1000000000\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 1024,
+    .lowerBound = 823,
+    .upperBound = 1024,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -2037,8 +2037,8 @@
         "00000000000000000000000000000000000000000000000000001000000000\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 1024,
+    .lowerBound = 823,
+    .upperBound = 1024,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 2,
@@ -2049,8 +2049,8 @@
         "00000000000000000000000000000000000000000000000000001000000000\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 1024,
+    .lowerBound = 823,
+    .upperBound = 1024,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -2062,8 +2062,8 @@
         "000000000000000000000000000000000000000000000000000010000000001\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 1024,
+    .lowerBound = 823,
+    .upperBound = 1024,
     .min = OPT_I64(0),
     .max = OPT_I64(1024),
     .sparsity = 1,
@@ -2074,8 +2074,8 @@
         "10000000000\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 1024,
+    .lowerBound = 823,
+    .upperBound = 1024,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -2086,8 +2086,8 @@
         "000000000000000000000000000000000000000000000000000010000000000\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 1024,
+    .lowerBound = 823,
+    .upperBound = 1024,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -2099,8 +2099,8 @@
         "000000000000000000000000000000000000000000000000000010000000000\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 1879048192,
+    .lowerBound = 823,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -2132,8 +2132,8 @@
         "000000000000011100011010111111100010100110001101000000000000000\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 1879048192,
+    .lowerBound = 823,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -2165,8 +2165,8 @@
         "00000000000000000000000000000000111000000000000000000000000000\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 1879048192,
+    .lowerBound = 823,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 2,
@@ -2210,8 +2210,8 @@
         "00000000000000000000000000000000111000000000000000000000000000\n" 
 },
 {
-    .range_min = 823,
-    .range_max = 1879048192,
+    .lowerBound = 823,
+    .upperBound = 1879048192,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -2244,104 +2244,104 @@
         "000000000000000000000000000000001110000000000000000000000000000\n" 
 },
 {
-    .range_min = 1024,
-    .range_max = 1024,
+    .lowerBound = 1024,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 1,
     .expectMincoverString = "11100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = 1024,
-    .range_max = 1024,
+    .lowerBound = 1024,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(1024),
     .sparsity = 2,
     .expectMincoverString = "11100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = 1024,
-    .range_max = 1024,
+    .lowerBound = 1024,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
     .expectMincoverString = "000000000000011100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = 1024,
-    .range_max = 1024,
+    .lowerBound = 1024,
+    .upperBound = 1024,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
     .expectMincoverString = "000000000000011100011010111111010100100110001101000010000000000\n" 
 },
 {
-    .range_min = 1024,
-    .range_max = 1024,
+    .lowerBound = 1024,
+    .upperBound = 1024,
     .min = OPT_I64(-1),
     .max = OPT_I64(1024),
     .sparsity = 1,
     .expectMincoverString = "10000000001\n" 
 },
 {
-    .range_min = 1024,
-    .range_max = 1024,
+    .lowerBound = 1024,
+    .upperBound = 1024,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
     .expectMincoverString = "000000000000000000000000000000000000000000000000000010000000001\n" 
 },
 {
-    .range_min = 1024,
-    .range_max = 1024,
+    .lowerBound = 1024,
+    .upperBound = 1024,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
     .expectMincoverString = "000000000000000000000000000000000000000000000000000010000000001\n" 
 },
 {
-    .range_min = 1024,
-    .range_max = 1024,
+    .lowerBound = 1024,
+    .upperBound = 1024,
     .min = OPT_I64(0),
     .max = OPT_I64(1024),
     .sparsity = 1,
     .expectMincoverString = "10000000000\n" 
 },
 {
-    .range_min = 1024,
-    .range_max = 1024,
+    .lowerBound = 1024,
+    .upperBound = 1024,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
     .expectMincoverString = "000000000000000000000000000000000000000000000000000010000000000\n" 
 },
 {
-    .range_min = 1024,
-    .range_max = 1024,
+    .lowerBound = 1024,
+    .upperBound = 1024,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
     .expectMincoverString = "000000000000000000000000000000000000000000000000000010000000000\n" 
 },
 {
-    .range_min = 1024,
-    .range_max = 1024,
+    .lowerBound = 1024,
+    .upperBound = 1024,
     .min = OPT_I64(1024),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
     .expectMincoverString = "000000000000000000000000000000000000000000000000000000000000000\n" 
 },
 {
-    .range_min = 1024,
-    .range_max = 1024,
+    .lowerBound = 1024,
+    .upperBound = 1024,
     .min = OPT_I64(1024),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
     .expectMincoverString = "000000000000000000000000000000000000000000000000000000000000000\n" 
 },
 {
-    .range_min = 1024,
-    .range_max = 1879048192,
+    .lowerBound = 1024,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -2369,8 +2369,8 @@
         "000000000000011100011010111111100010100110001101000000000000000\n" 
 },
 {
-    .range_min = 1024,
-    .range_max = 1879048192,
+    .lowerBound = 1024,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -2424,8 +2424,8 @@
         "000000000000011100011010111111100010100110001101000000000000000\n" 
 },
 {
-    .range_min = 1024,
-    .range_max = 1879048192,
+    .lowerBound = 1024,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -2463,8 +2463,8 @@
         "00000000000000000000000000000000111000000000000000000000000000\n" 
 },
 {
-    .range_min = 1024,
-    .range_max = 1879048192,
+    .lowerBound = 1024,
+    .upperBound = 1879048192,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -2493,8 +2493,8 @@
         "000000000000000000000000000000001110000000000000000000000000000\n" 
 },
 {
-    .range_min = 1024,
-    .range_max = 1879048192,
+    .lowerBound = 1024,
+    .upperBound = 1879048192,
     .min = OPT_I64(1024),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
@@ -2521,8 +2521,8 @@
         "000000000000000000000000000000001101111111111111111110000000000\n" 
 },
 {
-    .range_min = 1024,
-    .range_max = 1879048192,
+    .lowerBound = 1024,
+    .upperBound = 1879048192,
     .min = OPT_I64(1024),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
@@ -2576,64 +2576,64 @@
         "000000000000000000000000000000001101111111111111111110000000000\n" 
 },
 {
-    .range_min = 1879048192,
-    .range_max = 1879048192,
+    .lowerBound = 1879048192,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
     .expectMincoverString = "000000000000011100011010111111100010100110001101000000000000000\n" 
 },
 {
-    .range_min = 1879048192,
-    .range_max = 1879048192,
+    .lowerBound = 1879048192,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1000000000000000),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
     .expectMincoverString = "000000000000011100011010111111100010100110001101000000000000000\n" 
 },
 {
-    .range_min = 1879048192,
-    .range_max = 1879048192,
+    .lowerBound = 1879048192,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
     .expectMincoverString = "000000000000000000000000000000001110000000000000000000000000001\n" 
 },
 {
-    .range_min = 1879048192,
-    .range_max = 1879048192,
+    .lowerBound = 1879048192,
+    .upperBound = 1879048192,
     .min = OPT_I64(-1),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
     .expectMincoverString = "000000000000000000000000000000001110000000000000000000000000001\n" 
 },
 {
-    .range_min = 1879048192,
-    .range_max = 1879048192,
+    .lowerBound = 1879048192,
+    .upperBound = 1879048192,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
     .expectMincoverString = "000000000000000000000000000000001110000000000000000000000000000\n" 
 },
 {
-    .range_min = 1879048192,
-    .range_max = 1879048192,
+    .lowerBound = 1879048192,
+    .upperBound = 1879048192,
     .min = OPT_I64(0),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,
     .expectMincoverString = "000000000000000000000000000000001110000000000000000000000000000\n" 
 },
 {
-    .range_min = 1879048192,
-    .range_max = 1879048192,
+    .lowerBound = 1879048192,
+    .upperBound = 1879048192,
     .min = OPT_I64(1024),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 1,
     .expectMincoverString = "000000000000000000000000000000001101111111111111111110000000000\n" 
 },
 {
-    .range_min = 1879048192,
-    .range_max = 1879048192,
+    .lowerBound = 1879048192,
+    .upperBound = 1879048192,
     .min = OPT_I64(1024),
     .max = OPT_I64(8070450532247928832),
     .sparsity = 3,

--- a/test/test-mc-range-mincover.c
+++ b/test/test-mc-range-mincover.c
@@ -68,8 +68,8 @@ expectMincover_cleanup (mc_array_t *expectMincover)
 }
 
 typedef struct {
-   int32_t range_min;
-   int32_t range_max;
+   int32_t lowerBound;
+   int32_t upperBound;
    mc_optional_int32_t min;
    mc_optional_int32_t max;
    size_t sparsity;
@@ -80,8 +80,8 @@ typedef struct {
 } Int32Test;
 
 typedef struct {
-   int64_t range_min;
-   int64_t range_max;
+   int64_t lowerBound;
+   int64_t upperBound;
    mc_optional_int64_t min;
    mc_optional_int64_t max;
    size_t sparsity;
@@ -109,8 +109,8 @@ _test_getMincover32 (void *tests, size_t idx, mongocrypt_status_t *status)
    Int32Test *test = (Int32Test *) tests + idx;
 
    return mc_getMincoverInt32 (
-      (mc_getMincoverInt32_args_t){.range_min = test->range_min,
-                                   .range_max = test->range_max,
+      (mc_getMincoverInt32_args_t){.lowerBound = test->lowerBound,
+                                   .upperBound = test->upperBound,
                                    .min = test->min,
                                    .max = test->max,
                                    .sparsity = test->sparsity},
@@ -125,8 +125,8 @@ _test_getMincover64 (void *tests, size_t idx, mongocrypt_status_t *status)
    Int64Test *const test = (Int64Test *) tests + idx;
 
    return mc_getMincoverInt64 (
-      (mc_getMincoverInt64_args_t){.range_min = test->range_min,
-                                   .range_max = test->range_max,
+      (mc_getMincoverInt64_args_t){.lowerBound = test->lowerBound,
+                                   .upperBound = test->upperBound,
                                    .min = test->min,
                                    .max = test->max,
                                    .sparsity = test->sparsity},
@@ -184,9 +184,9 @@ _test_dump_32 (void *tests, size_t idx, mc_mincover_t *got)
    Int32Test *const test = (Int32Test *) tests + idx;
    fflush (stdout); // Avoid incomplete stdout output from prior tests on error
    fprintf (stderr,
-            "testcase: range_min=%" PRId32 " range_max=%" PRId32,
-            test->range_min,
-            test->range_max);
+            "testcase: lowerBound=%" PRId32 " upperBound=%" PRId32,
+            test->lowerBound,
+            test->upperBound);
    if (test->min.set) {
       fprintf (stderr, " min=%" PRId32, test->min.value);
    }
@@ -211,9 +211,9 @@ _test_dump_64 (void *tests, size_t idx, mc_mincover_t *got)
    Int64Test *const test = (Int64Test *) tests + idx;
    fflush (stdout); // Avoid incomplete stdout output from prior tests on error
    fprintf (stderr,
-            "testcase: range_min=%" PRId64 " range_max=%" PRId64,
-            test->range_min,
-            test->range_max);
+            "testcase: lowerBound=%" PRId64 " upperBound=%" PRId64,
+            test->lowerBound,
+            test->upperBound);
    if (test->min.set) {
       fprintf (stderr, " min=%" PRId64, test->min.value);
    }
@@ -289,27 +289,27 @@ static void
 _test_getMincoverInt32 (_mongocrypt_tester_t *tester)
 {
    Int32Test tests[] = {
-      {.range_min = 1,
-       .range_max = 3,
+      {.lowerBound = 1,
+       .upperBound = 3,
        .min = OPT_I32 (0),
        .max = OPT_I32 (7),
        .sparsity = 1,
        .expectMincoverString = "001\n"
                                "01\n"},
-      {.range_min = 3,
-       .range_max = 3,
+      {.lowerBound = 3,
+       .upperBound = 3,
        .min = OPT_I32 (0),
        .max = OPT_I32 (7),
        .sparsity = 1,
        .expectMincoverString = "011\n"},
-      {.range_min = 4,
-       .range_max = 3,
+      {.lowerBound = 4,
+       .upperBound = 3,
        .min = OPT_I32 (0),
        .max = OPT_I32 (7),
        .sparsity = 1,
        .expectError = "must be less than or equal to"},
-      {.range_min = 1,
-       .range_max = 8,
+      {.lowerBound = 1,
+       .upperBound = 8,
        .min = OPT_I32 (0),
        .max = OPT_I32 (7),
        .sparsity = 1,
@@ -334,27 +334,27 @@ static void
 _test_getMincoverInt64 (_mongocrypt_tester_t *tester)
 {
    Int64Test tests[] = {
-      {.range_min = 1,
-       .range_max = 3,
+      {.lowerBound = 1,
+       .upperBound = 3,
        .min = OPT_I64 (0),
        .max = OPT_I64 (7),
        .sparsity = 1,
        .expectMincoverString = "001\n"
                                "01\n"},
-      {.range_min = 3,
-       .range_max = 3,
+      {.lowerBound = 3,
+       .upperBound = 3,
        .min = OPT_I64 (0),
        .max = OPT_I64 (7),
        .sparsity = 1,
        .expectMincoverString = "011\n"},
-      {.range_min = 4,
-       .range_max = 3,
+      {.lowerBound = 4,
+       .upperBound = 3,
        .min = OPT_I64 (0),
        .max = OPT_I64 (7),
        .sparsity = 1,
        .expectError = "must be less than or equal to"},
-      {.range_min = 1,
-       .range_max = 8,
+      {.lowerBound = 1,
+       .upperBound = 8,
        .min = OPT_I64 (0),
        .max = OPT_I64 (7),
        .sparsity = 1,

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -2086,10 +2086,10 @@ _test_FLE2EncryptionPlaceholder_range_parse (_mongocrypt_tester_t *tester)
       status = mongocrypt_status_new ();
       _mongocrypt_buffer_copy_from_hex (
          &buf,
-         "03770000001074000100000010610003000000056b690010000000041234567812349"
+         "037d0000001074000100000010610003000000056b690010000000041234567812349"
          "8761234123456789012056b75001000000004abcdefab123498761234123456789012"
-         "0376001c00000010760040e20100106c6200000000001075620087d612000012636d0"
-         "000000000000000001073000100000000");
+         "0376001e00000010760040e20100106d696e0000000000106d61780087d6120000126"
+         "36d000000000000000000127300010000000000000000");
       ASSERT (bson_init_static (&as_bson, buf.data + 1, buf.len - 1));
       mc_FLE2EncryptionPlaceholder_init (&placeholder);
       ASSERT_OK_STATUS (
@@ -2124,11 +2124,11 @@ _test_FLE2EncryptionPlaceholder_range_parse (_mongocrypt_tester_t *tester)
          ASSERT (BSON_ITER_HOLDS_INT32 (&spec.v));
          ASSERT_CMPINT32 (bson_iter_int32 (&spec.v), ==, 123456);
 
-         ASSERT (BSON_ITER_HOLDS_INT32 (&spec.lb));
-         ASSERT_CMPINT32 (bson_iter_int32 (&spec.lb), ==, 0);
+         ASSERT (BSON_ITER_HOLDS_INT32 (&spec.min));
+         ASSERT_CMPINT32 (bson_iter_int32 (&spec.min), ==, 0);
 
-         ASSERT (BSON_ITER_HOLDS_INT32 (&spec.ub));
-         ASSERT_CMPINT32 (bson_iter_int32 (&spec.ub), ==, 1234567);
+         ASSERT (BSON_ITER_HOLDS_INT32 (&spec.max));
+         ASSERT_CMPINT32 (bson_iter_int32 (&spec.max), ==, 1234567);
       }
 
       mc_FLE2EncryptionPlaceholder_cleanup (&placeholder);
@@ -2146,11 +2146,12 @@ _test_FLE2EncryptionPlaceholder_range_parse (_mongocrypt_tester_t *tester)
       status = mongocrypt_status_new ();
       _mongocrypt_buffer_copy_from_hex (
          &buf,
-         "038e0000001074000200000010610003000000056b690010000000041234567812349"
+         "03ba0000001074000200000010610003000000056b690010000000041234567812349"
          "8761234123456789012056b75001000000004abcdefab123498761234123456789012"
-         "03760033000000106d696e0000000000086d696e496e636c756465640001106d61780"
-         "087d61200086d6178496e636c7564656400010012636d000000000000000000107300"
-         "0100000000");
+         "0376005b000000106c6f776572426f756e640000000000086c62496e636c756465640"
+         "001107570706572426f756e640087d61200087562496e636c75646564000110696e64"
+         "65784d696e000000000010696e6465784d61780087d612000012636d0000000000000"
+         "00000127300010000000000000000");
       ASSERT (bson_init_static (&as_bson, buf.data + 1, buf.len - 1));
       mc_FLE2EncryptionPlaceholder_init (&placeholder);
       ASSERT_OK_STATUS (
@@ -2174,21 +2175,29 @@ _test_FLE2EncryptionPlaceholder_range_parse (_mongocrypt_tester_t *tester)
 
       ASSERT_CMPINT32 (placeholder.sparsity, ==, 1);
 
-      // Parse FLE2RangeSpec.
+      // Parse FLE2RangeFindSpec.
       {
-         mc_FLE2RangeSpec_t spec;
+         mc_FLE2RangeFindSpec_t spec;
 
          ASSERT_OK_STATUS (
-            mc_FLE2RangeSpec_parse (&spec, &placeholder.v_iter, status),
+            mc_FLE2RangeFindSpec_parse (&spec, &placeholder.v_iter, status),
             status);
 
-         ASSERT (BSON_ITER_HOLDS_INT32 (&spec.min));
-         ASSERT_CMPINT32 (bson_iter_int32 (&spec.min), ==, 0);
-         ASSERT (spec.minIncluded);
+         ASSERT (BSON_ITER_HOLDS_INT32 (&spec.lowerBound));
+         ASSERT_CMPINT32 (bson_iter_int32 (&spec.lowerBound), ==, 0);
+         ASSERT (spec.lbIncluded);
 
-         ASSERT (BSON_ITER_HOLDS_INT32 (&spec.max));
-         ASSERT_CMPINT32 (bson_iter_int32 (&spec.max), ==, 1234567);
-         ASSERT (spec.maxIncluded);
+         ASSERT (BSON_ITER_HOLDS_INT32 (&spec.upperBound));
+         ASSERT_CMPINT32 (bson_iter_int32 (&spec.upperBound), ==, 1234567);
+         ASSERT (spec.ubIncluded);
+
+         ASSERT (BSON_ITER_HOLDS_INT32 (&spec.indexMin));
+         ASSERT_CMPINT32 (bson_iter_int32 (&spec.indexMin), ==, 0);
+         ASSERT (spec.ubIncluded);
+
+         ASSERT (BSON_ITER_HOLDS_INT32 (&spec.indexMax));
+         ASSERT_CMPINT32 (bson_iter_int32 (&spec.indexMax), ==, 1234567);
+         ASSERT (spec.ubIncluded);
       }
 
       mc_FLE2EncryptionPlaceholder_cleanup (&placeholder);

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -2111,7 +2111,7 @@ _test_FLE2EncryptionPlaceholder_range_parse (_mongocrypt_tester_t *tester)
       ASSERT_CMPBUF (placeholder.user_key_id, expect_user_key_id);
       _mongocrypt_buffer_cleanup (&expect_user_key_id);
 
-      ASSERT_CMPINT32 (placeholder.sparsity, ==, 1);
+      ASSERT_CMPINT64 (placeholder.sparsity, ==, 1);
 
       // Parse FLE2RangeInsertSpec.
       {
@@ -2173,7 +2173,7 @@ _test_FLE2EncryptionPlaceholder_range_parse (_mongocrypt_tester_t *tester)
       ASSERT_CMPBUF (placeholder.user_key_id, expect_user_key_id);
       _mongocrypt_buffer_cleanup (&expect_user_key_id);
 
-      ASSERT_CMPINT32 (placeholder.sparsity, ==, 1);
+      ASSERT_CMPINT64 (placeholder.sparsity, ==, 1);
 
       // Parse FLE2RangeFindSpec.
       {


### PR DESCRIPTION
# Summary

- Update range placeholder payloads to match https://github.com/mongodb/mongo/commit/241b350350eca6eddbc36f036ce824b8e75df0a5#diff-d854f7244c2c241eb65c905ebc150c8e8f5f44ba3d5ca2ac89ca0efd944dc8cf.
- Update fields in `getMincoverInt{32,64}_args_t`.

This PR does not fully resolve MONGOCRYPT-478.

# Background & Motivation

https://github.com/mongodb/mongo/commit/241b350350eca6eddbc36f036ce824b8e75df0a5#diff-d854f7244c2c241eb65c905ebc150c8e8f5f44ba3d5ca2ac89ca0efd944dc8cf made several changes to the existing payloads:
- FLE2RangeSpec is renamed to FLE2RangeFindSpec.
- FLE2RangeSpec has new indexMin/indexMax fields.
- The terms min/max now refer to the index bounds. lowerBound/upperBound refers to the query bounds.
- sparsity is now int64_t.

Test data was updated by printing output from server unit tests:
https://github.com/kevinAlbs/mongo/blob/SERVER-69013.range_support/kevinAlbs/range-find-output.txt

