### PR TITLE
MONGOCRYPT-488 set context error state in provide_kms_providers

### DIFF
--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -585,7 +585,7 @@ mongocrypt_ctx_provide_kms_providers (
                                          &ctx->per_ctx_kms_providers,
                                          ctx->status,
                                          &ctx->crypt->log)) {
-      return false;
+      return _mongocrypt_ctx_fail (ctx);
    }
 
    if (!_mongocrypt_opts_kms_providers_validate (
@@ -594,7 +594,7 @@ mongocrypt_ctx_provide_kms_providers (
       _mongocrypt_opts_kms_providers_cleanup (&ctx->per_ctx_kms_providers);
       memset (
          &ctx->per_ctx_kms_providers, 0, sizeof (ctx->per_ctx_kms_providers));
-      return false;
+      return _mongocrypt_ctx_fail (ctx);
    }
 
    memcpy (&ctx->kms_providers,

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1510,6 +1510,33 @@ _test_encrypt_per_ctx_credentials (_mongocrypt_tester_t *tester)
    mongocrypt_destroy (crypt);
 }
 
+// Regression test for MONGOCRYPT-488.
+static void
+_test_encrypt_per_ctx_credentials_given_empty (_mongocrypt_tester_t *tester)
+{
+   mongocrypt_t *crypt;
+   mongocrypt_ctx_t *ctx;
+
+   crypt = mongocrypt_new ();
+   mongocrypt_setopt_use_need_kms_credentials_state (crypt);
+   mongocrypt_setopt_kms_providers (crypt, TEST_BSON ("{'aws': {}}"));
+   ASSERT_OK (mongocrypt_init (crypt), crypt);
+   ctx = mongocrypt_ctx_new (crypt);
+   ASSERT_OK (mongocrypt_ctx_encrypt_init (
+                 ctx, "test", -1, TEST_FILE ("./test/example/cmd.json")),
+              ctx);
+   _mongocrypt_tester_run_ctx_to (
+      tester, ctx, MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
+   ASSERT_FAILS (mongocrypt_ctx_provide_kms_providers (ctx, TEST_BSON ("{}")),
+                 ctx,
+                 "no kms provider set");
+
+   ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_ERROR);
+   mongocrypt_ctx_destroy (ctx);
+   mongocrypt_destroy (crypt);
+}
+
+
 static void
 _test_encrypt_per_ctx_credentials_local (_mongocrypt_tester_t *tester)
 {
@@ -4668,6 +4695,7 @@ _mongocrypt_tester_install_ctx_encrypt (_mongocrypt_tester_t *tester)
    INSTALL_TEST (_test_encrypt_caches_empty_collinfo);
    INSTALL_TEST (_test_encrypt_caches_collinfo_without_jsonschema);
    INSTALL_TEST (_test_encrypt_per_ctx_credentials);
+   INSTALL_TEST (_test_encrypt_per_ctx_credentials_given_empty);
    INSTALL_TEST (_test_encrypt_per_ctx_credentials_local);
    INSTALL_TEST (_test_encrypt_with_encrypted_field_config_map);
    INSTALL_TEST (_test_encrypt_with_encrypted_field_config_map_bypassed);


### PR DESCRIPTION
# Summary

- Update error returns in `mongocrypt_ctx_provide_kms_providers` to set the `ctx->state` to `MONGOCRYPT_CTX_ERROR`

# Background & Motivation
An error in a context function is expected to set the state of the context as `MONGOCRYPT_CTX_ERROR`. Some drivers require this behavior for correctness. For example, the Node.JS bindings [do not always check the return values](https://github.com/mongodb/libmongocrypt/blob/400167e2092036babd2f000b13a0c87f5503442f/bindings/node/src/mongocrypt.cc#L822) of some `mongocrypt_ctx_*` functions, and may rely on the [context state to return an error](https://github.com/mongodb/libmongocrypt/blob/400167e2092036babd2f000b13a0c87f5503442f/bindings/node/lib/stateMachine.js#L230).