### PR TITLE
feat(NODE-4234): add aws credentials provider

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -484,6 +484,7 @@ tasks:
   commands:
     - func: "fetch source"
     - func: "build and test node"
+    - func: "build and test node no optional dependencies"
     - func: "attach node xunit results"
 
 # Note: keep this disabled unless you want master to force-push

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -138,6 +138,20 @@ functions:
           DISTRO_ID: ${distro_id}
           BUILD_VARIANT: ${build_variant}
 
+  "build and test node no optional dependencies":
+    - command: "subprocess.exec"
+      params:
+        binary: bash
+        working_dir: "./libmongocrypt/bindings/node"
+        args:
+          - "./.evergreen/test.sh"
+        env:
+          PROJECT_DIRECTORY: ${project_directory}
+          NODE_GITHUB_TOKEN: ${node_github_token}
+          DISTRO_ID: ${distro_id}
+          BUILD_VARIANT: ${build_variant}
+          NPM_OPTIONS: "--no-optional"
+
   "attach node xunit results":
     - command: attach.xunit_results
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -484,6 +484,11 @@ tasks:
   commands:
     - func: "fetch source"
     - func: "build and test node"
+    - func: "attach node xunit results"
+
+- name: build-and-test-node-no-optional-dependencies
+  commands:
+    - func: "fetch source"
     - func: "build and test node no optional dependencies"
     - func: "attach node xunit results"
 
@@ -905,6 +910,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - test-java
   - name: publish-packages
     distros:
@@ -917,6 +923,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan-mac
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - build-and-test-csharp
   - test-python
   - test-java
@@ -948,6 +955,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-csharp
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - test-java
   - windows-upload-check
 - name: windows-test-python
@@ -972,6 +980,7 @@ buildvariants:
   - build-and-test-and-upload
   - build-and-test-shared-bson
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - test-java
   - name: publish-packages
     distros:
@@ -988,6 +997,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - test-java
   - name: publish-packages
     distros:
@@ -1004,6 +1014,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - name: publish-packages
     distros:
     - rhel70-small
@@ -1019,6 +1030,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - test-java
   - name: publish-packages
     distros:
@@ -1035,6 +1047,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - test-java
   - name: publish-packages
     distros:
@@ -1078,6 +1091,7 @@ buildvariants:
   - build-and-test-and-upload
   - build-and-test-shared-bson
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - test-python
   - test-java
   - name: publish-packages
@@ -1108,6 +1122,7 @@ buildvariants:
   - build-and-test-and-upload
   - build-and-test-shared-bson
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - test-java
   - name: publish-packages
     distros:
@@ -1124,6 +1139,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - test-java
   - name: publish-packages
     distros:
@@ -1140,6 +1156,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - test-java
   - name: publish-packages
     distros:
@@ -1156,6 +1173,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - test-java
   - name: publish-packages
     distros:
@@ -1172,6 +1190,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - build-and-test-csharp
   - test-java
   - name: publish-packages
@@ -1189,6 +1208,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - test-java
   - name: publish-packages
     distros:
@@ -1206,6 +1226,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - build-and-test-csharp
   - test-java
   - upload-java
@@ -1222,6 +1243,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - test-java
   - name: publish-packages
     distros:
@@ -1246,6 +1268,7 @@ buildvariants:
   tasks:
   - build-and-test-and-upload
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - test-python
   - test-java
 - name: windows-vs2017-32bit

--- a/bindings/node/.evergreen/setup_environment.sh
+++ b/bindings/node/.evergreen/setup_environment.sh
@@ -63,7 +63,7 @@ EOT
   echo "Running: nvm use lts"
   nvm use lts
   echo "Running: npm install -g npm@8.3.1"
-  npm install -g npm@8.3.1 ${NPM_OPTIONS} # https://github.com/npm/cli/issues/4341
+  npm install -g npm@8.3.1 # https://github.com/npm/cli/issues/4341
   set -o xtrace
 else
   set +o xtrace

--- a/bindings/node/.evergreen/setup_environment.sh
+++ b/bindings/node/.evergreen/setup_environment.sh
@@ -10,6 +10,7 @@ NPM_TMP_DIR="${NODE_ARTIFACTS_PATH}/tmp"
 BIN_DIR="$(pwd)/bin"
 NVM_WINDOWS_URL="https://github.com/coreybutler/nvm-windows/releases/download/1.1.9/nvm-noinstall.zip"
 NVM_URL="https://raw.githubusercontent.com/creationix/nvm/v0.38.0/install.sh"
+NPM_OPTIONS="${NPM_OPTIONS}"
 
 # create node artifacts path if needed
 mkdir -p "${NODE_ARTIFACTS_PATH}"
@@ -62,7 +63,7 @@ EOT
   echo "Running: nvm use lts"
   nvm use lts
   echo "Running: npm install -g npm@8.3.1"
-  npm install -g npm@8.3.1 # https://github.com/npm/cli/issues/4341
+  npm install -g npm@8.3.1 ${NPM_OPTIONS} # https://github.com/npm/cli/issues/4341
   set -o xtrace
 else
   set +o xtrace

--- a/bindings/node/.evergreen/test.sh
+++ b/bindings/node/.evergreen/test.sh
@@ -3,6 +3,7 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 echo "Setting up environment"
+export NPM_OPTIONS="${NPM_OPTIONS}"
 . ./.evergreen/setup_environment.sh
 
 # Handle the circular dependency when testing with a real client.

--- a/bindings/node/etc/build-static.sh
+++ b/bindings/node/etc/build-static.sh
@@ -5,6 +5,8 @@ BUILD_DIR=$DEPS_PREFIX/tmp
 LIBMONGOCRYPT_DIR="$(pwd)/../../"
 TOP_DIR="$(pwd)/../../../"
 
+export NPM_OPTIONS="${NPM_OPTIONS}"
+
 if [[ -z $CMAKE ]]; then
   CMAKE=`type -P cmake`
 fi
@@ -32,4 +34,4 @@ popd #./
 # build the `mongodb-client-encryption` addon
 # note the --unsafe-perm parameter to make the build work
 # when running as root. See https://github.com/npm/npm/issues/3497
-BUILD_TYPE=static npm install --unsafe-perm --build-from-source
+BUILD_TYPE=static npm install --unsafe-perm --build-from-source ${NPM_OPTIONS}

--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -207,6 +207,9 @@ export interface ClientEncryptionOptions {
 
   /**
    * Optional callback to override KMS providers per-context.
+   *
+   * @deprecated Installing optional dependencies will automatically refresh kms
+   *             provider credentials.
    */
   onKmsProviderRefresh?: () => Promise<KMSProviders>;
 

--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -9,6 +9,7 @@ module.exports = function (modules) {
   const MongoClient = modules.mongodb.MongoClient;
   const MongoError = modules.mongodb.MongoError;
   const BSON = modules.mongodb.BSON;
+  const { loadCredentials } = require('./credentialsProvider');
   const cryptoCallbacks = require('./cryptoCallbacks');
 
   /**
@@ -101,6 +102,7 @@ module.exports = function (modules) {
       this._proxyOptions = options.proxyOptions || {};
       this._tlsOptions = options.tlsOptions || {};
       this._onKmsProviderRefresh = options.onKmsProviderRefresh;
+      this._kmsProviders = options.kmsProviders || {};
 
       const mongoCryptOptions = {};
       if (options.schemaMap) {
@@ -115,13 +117,9 @@ module.exports = function (modules) {
           : this._bson.serialize(options.encryptedFieldsMap);
       }
 
-      if (options.kmsProviders) {
-        mongoCryptOptions.kmsProviders = !Buffer.isBuffer(options.kmsProviders)
-          ? this._bson.serialize(options.kmsProviders)
-          : options.kmsProviders;
-      } else if (!options.onKmsProviderRefresh) {
-        throw new TypeError('Need to specify either kmsProviders ahead of time or when requested');
-      }
+      mongoCryptOptions.kmsProviders = !Buffer.isBuffer(this._kmsProviders)
+        ? this._bson.serialize(this._kmsProviders)
+        : this._kmsProviders;
 
       if (options.logger) {
         mongoCryptOptions.logger = options.logger;
@@ -321,7 +319,9 @@ module.exports = function (modules) {
      * the original ones.
      */
     async askForKMSCredentials() {
-      return this._onKmsProviderRefresh ? this._onKmsProviderRefresh() : {};
+      return this._onKmsProviderRefresh
+        ? this._onKmsProviderRefresh()
+        : loadCredentials(this._kmsProviders);
     }
 
     /**

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -8,6 +8,7 @@ module.exports = function (modules) {
   const promiseOrCallback = common.promiseOrCallback;
   const StateMachine = modules.stateMachine.StateMachine;
   const BSON = modules.mongodb.BSON;
+  const { loadCredentials } = require('./credentialsProvider');
   const cryptoCallbacks = require('./cryptoCallbacks');
   const { promisify } = require('util');
 
@@ -103,24 +104,22 @@ module.exports = function (modules) {
       this._bson = options.bson || BSON || client.topology.bson;
       this._proxyOptions = options.proxyOptions;
       this._tlsOptions = options.tlsOptions;
+      this._kmsProviders = options.kmsProviders || {};
 
       if (options.keyVaultNamespace == null) {
         throw new TypeError('Missing required option `keyVaultNamespace`');
       }
 
-      Object.assign(options, { cryptoCallbacks });
+      const mongoCryptOptions = { ...options, cryptoCallbacks };
 
-      // kmsProviders will be parsed by libmongocrypt, must be provided as BSON binary data
-      if (options.kmsProviders && !Buffer.isBuffer(options.kmsProviders)) {
-        options.kmsProviders = this._bson.serialize(options.kmsProviders);
-      } else if (!options.onKmsProviderRefresh) {
-        throw new TypeError('Need to specify either kmsProviders ahead of time or when requested');
-      }
+      mongoCryptOptions.kmsProviders = !Buffer.isBuffer(this._kmsProviders)
+        ? this._bson.serialize(this._kmsProviders)
+        : this._kmsProviders;
 
       this._onKmsProviderRefresh = options.onKmsProviderRefresh;
       this._keyVaultNamespace = options.keyVaultNamespace;
       this._keyVaultClient = options.keyVaultClient || client;
-      this._mongoCrypt = new mc.MongoCrypt(options);
+      this._mongoCrypt = new mc.MongoCrypt(mongoCryptOptions);
     }
 
     /**
@@ -685,7 +684,9 @@ module.exports = function (modules) {
      * the original ones.
      */
     async askForKMSCredentials() {
-      return this._onKmsProviderRefresh ? this._onKmsProviderRefresh() : {};
+      return this._onKmsProviderRefresh
+        ? this._onKmsProviderRefresh()
+        : loadCredentials(this._kmsProviders);
     }
 
     static get libmongocryptVersion() {

--- a/bindings/node/lib/credentialsProvider.js
+++ b/bindings/node/lib/credentialsProvider.js
@@ -21,12 +21,10 @@ async function loadCredentials(kmsProviders) {
     if (!aws || Object.keys(aws).length === 0) {
       const { fromNodeProviderChain } = awsCredentialProviders;
       const provider = fromNodeProviderChain();
-      try {
-        const awsCreds = await provider();
-        return { ...kmsProviders, aws: awsCreds };
-      } catch {
-        return kmsProviders;
-      }
+      // The state machine is the only place calling this so it will
+      // catch if there is a rejection here.
+      const awsCreds = await provider();
+      return { ...kmsProviders, aws: awsCreds };
     }
   }
   return kmsProviders;

--- a/bindings/node/lib/credentialsProvider.js
+++ b/bindings/node/lib/credentialsProvider.js
@@ -1,0 +1,35 @@
+'use strict';
+
+let awsCredentialProviders;
+
+try {
+  // Ensure you always wrap an optional require in the try block NODE-3199
+  awsCredentialProviders = require('@aws-sdk/credential-providers');
+} catch {} // eslint-disable-line
+
+/**
+ * Load cloud provider credentials for the user provided kms providers.
+ * Credentials will only attempt to get loaded if they do not exist
+ * and no existing credentials will get overwritten.
+ *
+ * @param {Object} kmsProviders - The user provided kms providers.
+ * @returns {Promise} The new kms providers.
+ */
+async function loadCredentials(kmsProviders) {
+  if (awsCredentialProviders) {
+    const aws = kmsProviders.aws;
+    if (!aws || Object.keys(aws).length === 0) {
+      const { fromNodeProviderChain } = awsCredentialProviders;
+      const provider = fromNodeProviderChain();
+      try {
+        const awsCreds = await provider();
+        return { ...kmsProviders, aws: awsCreds };
+      } catch {
+        return kmsProviders;
+      }
+    }
+  }
+  return kmsProviders;
+}
+
+module.exports = { loadCredentials };

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -38,8 +38,978 @@
       "engines": {
         "node": ">=12.9.0"
       },
+      "optionalDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0"
+      },
       "peerDependencies": {
         "mongodb": ">=3.4.0"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.190.0.tgz",
+      "integrity": "sha512-M6qo2exTzEfHT5RuW7K090OgesUojhb2JyWiV4ulu7ngY4DWBUBMKUqac696sHRUZvGE5CDzSi0606DMboM+kA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.190.0.tgz",
+      "integrity": "sha512-AmvSMlnd3nfAfJqElc9d0qC4Fl1fig8rXzjd7DC38DSpDBfuBfssZyh3dBZ0/eOdALFy/sVwiVnea9FRLbXC4Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.190.0",
+        "@aws-sdk/config-resolver": "3.190.0",
+        "@aws-sdk/credential-provider-node": "3.190.0",
+        "@aws-sdk/fetch-http-handler": "3.190.0",
+        "@aws-sdk/hash-node": "3.190.0",
+        "@aws-sdk/invalid-dependency": "3.190.0",
+        "@aws-sdk/middleware-content-length": "3.190.0",
+        "@aws-sdk/middleware-host-header": "3.190.0",
+        "@aws-sdk/middleware-logger": "3.190.0",
+        "@aws-sdk/middleware-recursion-detection": "3.190.0",
+        "@aws-sdk/middleware-retry": "3.190.0",
+        "@aws-sdk/middleware-serde": "3.190.0",
+        "@aws-sdk/middleware-signing": "3.190.0",
+        "@aws-sdk/middleware-stack": "3.190.0",
+        "@aws-sdk/middleware-user-agent": "3.190.0",
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/node-http-handler": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/smithy-client": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/url-parser": "3.190.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.188.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.190.0",
+        "@aws-sdk/util-defaults-mode-node": "3.190.0",
+        "@aws-sdk/util-user-agent-browser": "3.190.0",
+        "@aws-sdk/util-user-agent-node": "3.190.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.190.0.tgz",
+      "integrity": "sha512-joEKRjJEzgvXnEih/x2UDDCPlvXWCO3MAHmqi44yJ36Ph4YsFS299mOjPdVLuzUtpQ+cST1nRO7hXNFrulW2jQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.190.0",
+        "@aws-sdk/fetch-http-handler": "3.190.0",
+        "@aws-sdk/hash-node": "3.190.0",
+        "@aws-sdk/invalid-dependency": "3.190.0",
+        "@aws-sdk/middleware-content-length": "3.190.0",
+        "@aws-sdk/middleware-host-header": "3.190.0",
+        "@aws-sdk/middleware-logger": "3.190.0",
+        "@aws-sdk/middleware-recursion-detection": "3.190.0",
+        "@aws-sdk/middleware-retry": "3.190.0",
+        "@aws-sdk/middleware-serde": "3.190.0",
+        "@aws-sdk/middleware-stack": "3.190.0",
+        "@aws-sdk/middleware-user-agent": "3.190.0",
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/node-http-handler": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/smithy-client": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/url-parser": "3.190.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.188.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.190.0",
+        "@aws-sdk/util-defaults-mode-node": "3.190.0",
+        "@aws-sdk/util-user-agent-browser": "3.190.0",
+        "@aws-sdk/util-user-agent-node": "3.190.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.190.0.tgz",
+      "integrity": "sha512-s5MqfxqWxHAl1RhfQ6swjawsVPBqmq5F+SfzZcGLBCnVv03GaSL8J9K42O1Cc0+HwPQH2miY+Avy0zAr6VpY+Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.190.0",
+        "@aws-sdk/credential-provider-node": "3.190.0",
+        "@aws-sdk/fetch-http-handler": "3.190.0",
+        "@aws-sdk/hash-node": "3.190.0",
+        "@aws-sdk/invalid-dependency": "3.190.0",
+        "@aws-sdk/middleware-content-length": "3.190.0",
+        "@aws-sdk/middleware-host-header": "3.190.0",
+        "@aws-sdk/middleware-logger": "3.190.0",
+        "@aws-sdk/middleware-recursion-detection": "3.190.0",
+        "@aws-sdk/middleware-retry": "3.190.0",
+        "@aws-sdk/middleware-sdk-sts": "3.190.0",
+        "@aws-sdk/middleware-serde": "3.190.0",
+        "@aws-sdk/middleware-signing": "3.190.0",
+        "@aws-sdk/middleware-stack": "3.190.0",
+        "@aws-sdk/middleware-user-agent": "3.190.0",
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/node-http-handler": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/smithy-client": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/url-parser": "3.190.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.188.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.190.0",
+        "@aws-sdk/util-defaults-mode-node": "3.190.0",
+        "@aws-sdk/util-user-agent-browser": "3.190.0",
+        "@aws-sdk/util-user-agent-node": "3.190.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.188.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.190.0.tgz",
+      "integrity": "sha512-K+VnDtjTgjpf7yHEdDB0qgGbHToF0pIL0pQMSnmk2yc8BoB3LGG/gg1T0Ki+wRlrFnDCJ6L+8zUdawY2qDsbyw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-config-provider": "3.188.0",
+        "@aws-sdk/util-middleware": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.190.0.tgz",
+      "integrity": "sha512-EXJ+qPPLZJoD8sObVJrsdFnNqmtfCmKFxhGchqPvpFaAD0wsTXasbvCgYwOMkW8VzM6VQJpjJn479ejrSy74ig==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.190.0.tgz",
+      "integrity": "sha512-GTY7l3SJhTmRGFpWddbdJOihSqoMN8JMo3CsCtIjk4/h3xirBi02T4GSvbrMyP7FP3Fdl4NAdT+mHJ4q2Bvzxw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.190.0.tgz",
+      "integrity": "sha512-gI5pfBqGYCKdmx8igPvq+jLzyE2kuNn9Q5u73pdM/JZxiq7GeWYpE/MqqCubHxPtPcTFgAwxCxCFoXlUTBh/2g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/url-parser": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.190.0.tgz",
+      "integrity": "sha512-Z7NN/evXJk59hBQlfOSWDfHntwmxwryu6uclgv7ECI6SEVtKt1EKIlPuCLUYgQ4lxb9bomyO5lQAl/1WutNT5w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.190.0",
+        "@aws-sdk/credential-provider-imds": "3.190.0",
+        "@aws-sdk/credential-provider-sso": "3.190.0",
+        "@aws-sdk/credential-provider-web-identity": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/shared-ini-file-loader": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.190.0.tgz",
+      "integrity": "sha512-ctCG5+TsIK2gVgvvFiFjinPjc5nGpSypU3nQKCaihtPh83wDN6gCx4D0p9M8+fUrlPa5y+o/Y7yHo94ATepM8w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.190.0",
+        "@aws-sdk/credential-provider-imds": "3.190.0",
+        "@aws-sdk/credential-provider-ini": "3.190.0",
+        "@aws-sdk/credential-provider-process": "3.190.0",
+        "@aws-sdk/credential-provider-sso": "3.190.0",
+        "@aws-sdk/credential-provider-web-identity": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/shared-ini-file-loader": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.190.0.tgz",
+      "integrity": "sha512-sIJhICR80n5XY1kW/EFHTh5ZzBHb5X+744QCH3StcbKYI44mOZvNKfFdeRL2fQ7yLgV7npte2HJRZzQPWpZUrw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/shared-ini-file-loader": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.190.0.tgz",
+      "integrity": "sha512-uarU9vk471MHHT+GJj3KWFSmaaqLNL5n1KcMer2CCAZfjs+mStAi8+IjZuuKXB4vqVs5DxdH8cy5aLaJcBlXwQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/shared-ini-file-loader": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.190.0.tgz",
+      "integrity": "sha512-nlIBeK9hGHKWC874h+ITAfPZ9Eaok+x/ydZQVKsLHiQ9PH3tuQ8AaGqhuCwBSH0hEAHZ/BiKeEx5VyWAE8/x+Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.190.0.tgz",
+      "integrity": "sha512-9WNqALZg1UmaREy0Q/W2ul4ooJCIVJoaXOvf+oxNNhd2handYLZBCqYMOU4icfSTGf+dYSOMN7vc3M8u59za4A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.190.0",
+        "@aws-sdk/client-sso": "3.190.0",
+        "@aws-sdk/client-sts": "3.190.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.190.0",
+        "@aws-sdk/credential-provider-env": "3.190.0",
+        "@aws-sdk/credential-provider-imds": "3.190.0",
+        "@aws-sdk/credential-provider-ini": "3.190.0",
+        "@aws-sdk/credential-provider-node": "3.190.0",
+        "@aws-sdk/credential-provider-process": "3.190.0",
+        "@aws-sdk/credential-provider-sso": "3.190.0",
+        "@aws-sdk/credential-provider-web-identity": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/shared-ini-file-loader": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.190.0.tgz",
+      "integrity": "sha512-5riRpKydARXAPLesTZm6eP6QKJ4HJGQ3k0Tepi3nvxHVx3UddkRNoX0pLS3rvbajkykWPNC2qdfRGApWlwOYsA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/querystring-builder": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.190.0.tgz",
+      "integrity": "sha512-DNwVT3O8zc9Jk/bXiXcN0WsD98r+JJWryw9F1/ZZbuzbf6rx2qhI8ZK+nh5X6WMtYPU84luQMcF702fJt/1bzg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-buffer-from": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.190.0.tgz",
+      "integrity": "sha512-crCh63e8d/Uw9y3dQlVTPja7+IZiXpNXyH6oSuAadTDQwMq6KK87Av1/SDzVf6bAo2KgAOo41MyO2joaCEk0dQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
+      "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.190.0.tgz",
+      "integrity": "sha512-sSU347SuC6I8kWum1jlJlpAqeV23KP7enG+ToWcEcgFrJhm3AvuqB//NJxDbkKb2DNroRvJjBckBvrwNAjQnBQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.190.0.tgz",
+      "integrity": "sha512-cL7Vo/QSpGx/DDmFxjeV0Qlyi1atvHQDPn3MLBBmi1icu+3GKZkCMAJwzsrV3U4+WoVoDYT9FJ9yMQf2HaIjeQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.190.0.tgz",
+      "integrity": "sha512-rrfLGYSZCBtiXNrIa8pJ2uwUoUMyj6Q82E8zmduTvqKWviCr6ZKes0lttGIkWhjvhql2m4CbjG5MPBnY7RXL4A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.190.0.tgz",
+      "integrity": "sha512-5tc1AIIZe5jDNdyuJW+7vIFmQOxz3q031ZVrEtUEIF7cz2ySho2lkOWziz+v+UGSLhjHGKMz3V26+aN1FLZNxQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.190.0.tgz",
+      "integrity": "sha512-h1bPopkncf2ue/erJdhqvgR2AEh0bIvkNsIHhx93DckWKotZd/GAVDq0gpKj7/f/7B+teHH8Fg5GDOwOOGyKcg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/service-error-classification": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-middleware": "3.190.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.190.0.tgz",
+      "integrity": "sha512-eUHrsr35mkD/cAFKoYuFYz0zE7QPBWvSzMzqmEJC+YXzAF6IABP3FL/htAFpWkje5XDl5dQ6dAxzV+ebK8RNXQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/signature-v4": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.190.0.tgz",
+      "integrity": "sha512-S132hEOK4jwbtZ1bGAgSuQ0DMFG4TiD4ulAwbQRBYooC7tiWZbRiR0Pkt2hV8d7WhOHgUpg7rvqlA7/HXXBAsA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.190.0.tgz",
+      "integrity": "sha512-Xj5MmXZq8UIpY8wOwyqei5q6MgqKxsO9Plo2zUgW7JR0w7R21MlqY2kzzvcM9R0FFhi9dqhniFT2ZMRUb1v73w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/signature-v4": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-middleware": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.190.0.tgz",
+      "integrity": "sha512-h1mqiWNJdi1OTSEY8QovpiHgDQEeRG818v8yShpqSYXJKEqdn54MA3Z1D2fg/Wv/8ZJsFrBCiI7waT1JUYOmCg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.190.0.tgz",
+      "integrity": "sha512-y/2cTE1iYHKR0nkb3DvR3G8vt12lcTP95r/iHp8ZO+Uzpc25jM/AyMHWr2ZjqQiHKNlzh8uRw1CmQtgg4sBxXQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.190.0.tgz",
+      "integrity": "sha512-TJPUchyeK5KeEXWrwb6oW5/OkY3STCSGR1QIlbPcaTGkbo4kXAVyQmmZsY4KtRPuDM6/HlfUQV17bD716K65rQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/shared-ini-file-loader": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.190.0.tgz",
+      "integrity": "sha512-3Klkr73TpZkCzcnSP+gmFF0Baluzk3r7BaWclJHqt2LcFUWfIJzYlnbBQNZ4t3EEq7ZlBJX85rIDHBRlS+rUyA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/querystring-builder": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.190.0.tgz",
+      "integrity": "sha512-uzdKjHE2blbuceTC5zeBgZ0+Uo/hf9pH20CHpJeVNtrrtF3GALtu4Y1Gu5QQVIQBz8gjHnqANx0XhfYzorv69Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
+      "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.190.0.tgz",
+      "integrity": "sha512-w9mTKkCsaLIBC8EA4RAHrqethNGbf60CbpPzN/QM7yCV3ZZJAXkppFfjTVVOMbPaI8GUEOptJtzgqV68CRB7ow==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-uri-escape": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.190.0.tgz",
+      "integrity": "sha512-vCKP0s33VtS47LSYzEWRRr2aTbi3qNkUuQyIrc5LMqBfS5hsy79P1HL4Q7lCVqZB5fe61N8fKzOxDxWRCF0sXg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.190.0.tgz",
+      "integrity": "sha512-g+s6xtaMa5fCMA2zJQC4BiFGMP7FN5/L1V/UwxCnKy8skCwaN0K5A1tFffBjjbYiPI7Gu7LVorWD2A0Y4xl01Q==",
+      "optional": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.190.0.tgz",
+      "integrity": "sha512-CZC/xsGReUEl5w+JgfancrxfkaCbEisyIFy6HALUYrioWQe80WMqLAdUMZSXHWjIaNK9mH0J/qvcSV2MuIoMzQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.190.0.tgz",
+      "integrity": "sha512-L/R/1X2T+/Kg2k/sjoYyDFulVUGrVcRfyEKKVFIUNg0NwUtw5UKa1/gS7geTKcg4q8M2pd/v+OCBrge2X7phUw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.188.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-hex-encoding": "3.188.0",
+        "@aws-sdk/util-middleware": "3.190.0",
+        "@aws-sdk/util-uri-escape": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.190.0.tgz",
+      "integrity": "sha512-f5EoCwjBLXMyuN491u1NmEutbolL0cJegaJbtgK9OJw2BLuRHiBknjDF4OEVuK/WqK0kz2JLMGi9xwVPl4BKCA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
+      "optional": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.190.0.tgz",
+      "integrity": "sha512-FKFDtxA9pvHmpfWmNVK5BAVRpDgkWMz3u4Sg9UzB+WAFN6UexRypXXUZCFAo8S04FbPKfYOR3O0uVlw7kzmj9g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
+      "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.188.0.tgz",
+      "integrity": "sha512-r1dccRsRjKq+OhVRUfqFiW3sGgZBjHbMeHLbrAs9jrOjU2PTQ8PSzAXLvX/9lmp7YjmX17Qvlsg0NCr1tbB9OA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.188.0.tgz",
+      "integrity": "sha512-XwqP3vxk60MKp4YDdvDeCD6BPOiG2e+/Ou4AofZOy5/toB6NKz2pFNibQIUg2+jc7mPMnGnvOW3MQEgSJ+gu/Q==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz",
+      "integrity": "sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.188.0.tgz",
+      "integrity": "sha512-LBA7tLbi7v4uvbOJhSnjJrxbcRifKK/1ZVK94JTV2MNSCCyNkFotyEI5UWDl10YKriTIUyf7o5cakpiDZ3O4xg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.190.0.tgz",
+      "integrity": "sha512-FKxTU4tIbFk2pdUbBNneStF++j+/pB4NYJ1HRSEAb/g4D2+kxikR/WKIv3p0JTVvAkwcuX/ausILYEPUyDZ4HQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.190.0.tgz",
+      "integrity": "sha512-qBiIMjNynqAP7p6urG1+ZattYkFaylhyinofVcLEiDvM9a6zGt6GZsxru2Loq0kRAXXGew9E9BWGt45HcDc20g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.190.0",
+        "@aws-sdk/credential-provider-imds": "3.190.0",
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
+      "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.188.0.tgz",
+      "integrity": "sha512-SxobBVLZkkLSawTCfeQnhVX3Azm9O+C2dngZVe1+BqtF8+retUbVTs7OfYeWBlawVkULKF2e781lTzEHBBjCzw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.190.0.tgz",
+      "integrity": "sha512-qzTJ/qhFDzHZS+iXdHydQ/0sWAuNIB5feeLm55Io/I8Utv3l3TKYOhbgGwTsXY+jDk7oD+YnAi7hLN5oEBCwpg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
+      "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.190.0.tgz",
+      "integrity": "sha512-c074wjsD+/u9vT7DVrBLkwVhn28I+OEHuHaqpTVCvAIjpueZ3oms0e99YJLfpdpEgdLavOroAsNFtAuRrrTZZw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.190.0.tgz",
+      "integrity": "sha512-R36BMvvPX8frqFhU4lAsrOJ/2PJEHH/Jz1WZzO3GWmVSEAQQdHmo8tVPE3KOM7mZWe5Hj1dZudFAIxWHHFYKJA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.188.0.tgz",
+      "integrity": "sha512-hCgP4+C0Lekjpjt2zFJ2R/iHes5sBGljXa5bScOFAEkRUc0Qw0VNgTv7LpEbIOAwGmqyxBoCwBW0YHPW1DfmYQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -762,6 +1732,12 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "optional": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2680,6 +3656,22 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "optional": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
     },
     "node_modules/figures": {
       "version": "3.2.0",
@@ -7081,6 +8073,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "optional": true
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7387,6 +8385,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -7895,6 +8899,827 @@
     }
   },
   "dependencies": {
+    "@aws-crypto/ie11-detection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+      "optional": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.190.0.tgz",
+      "integrity": "sha512-M6qo2exTzEfHT5RuW7K090OgesUojhb2JyWiV4ulu7ngY4DWBUBMKUqac696sHRUZvGE5CDzSi0606DMboM+kA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-cognito-identity": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.190.0.tgz",
+      "integrity": "sha512-AmvSMlnd3nfAfJqElc9d0qC4Fl1fig8rXzjd7DC38DSpDBfuBfssZyh3dBZ0/eOdALFy/sVwiVnea9FRLbXC4Q==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.190.0",
+        "@aws-sdk/config-resolver": "3.190.0",
+        "@aws-sdk/credential-provider-node": "3.190.0",
+        "@aws-sdk/fetch-http-handler": "3.190.0",
+        "@aws-sdk/hash-node": "3.190.0",
+        "@aws-sdk/invalid-dependency": "3.190.0",
+        "@aws-sdk/middleware-content-length": "3.190.0",
+        "@aws-sdk/middleware-host-header": "3.190.0",
+        "@aws-sdk/middleware-logger": "3.190.0",
+        "@aws-sdk/middleware-recursion-detection": "3.190.0",
+        "@aws-sdk/middleware-retry": "3.190.0",
+        "@aws-sdk/middleware-serde": "3.190.0",
+        "@aws-sdk/middleware-signing": "3.190.0",
+        "@aws-sdk/middleware-stack": "3.190.0",
+        "@aws-sdk/middleware-user-agent": "3.190.0",
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/node-http-handler": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/smithy-client": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/url-parser": "3.190.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.188.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.190.0",
+        "@aws-sdk/util-defaults-mode-node": "3.190.0",
+        "@aws-sdk/util-user-agent-browser": "3.190.0",
+        "@aws-sdk/util-user-agent-node": "3.190.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.190.0.tgz",
+      "integrity": "sha512-joEKRjJEzgvXnEih/x2UDDCPlvXWCO3MAHmqi44yJ36Ph4YsFS299mOjPdVLuzUtpQ+cST1nRO7hXNFrulW2jQ==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.190.0",
+        "@aws-sdk/fetch-http-handler": "3.190.0",
+        "@aws-sdk/hash-node": "3.190.0",
+        "@aws-sdk/invalid-dependency": "3.190.0",
+        "@aws-sdk/middleware-content-length": "3.190.0",
+        "@aws-sdk/middleware-host-header": "3.190.0",
+        "@aws-sdk/middleware-logger": "3.190.0",
+        "@aws-sdk/middleware-recursion-detection": "3.190.0",
+        "@aws-sdk/middleware-retry": "3.190.0",
+        "@aws-sdk/middleware-serde": "3.190.0",
+        "@aws-sdk/middleware-stack": "3.190.0",
+        "@aws-sdk/middleware-user-agent": "3.190.0",
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/node-http-handler": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/smithy-client": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/url-parser": "3.190.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.188.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.190.0",
+        "@aws-sdk/util-defaults-mode-node": "3.190.0",
+        "@aws-sdk/util-user-agent-browser": "3.190.0",
+        "@aws-sdk/util-user-agent-node": "3.190.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.190.0.tgz",
+      "integrity": "sha512-s5MqfxqWxHAl1RhfQ6swjawsVPBqmq5F+SfzZcGLBCnVv03GaSL8J9K42O1Cc0+HwPQH2miY+Avy0zAr6VpY+Q==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.190.0",
+        "@aws-sdk/credential-provider-node": "3.190.0",
+        "@aws-sdk/fetch-http-handler": "3.190.0",
+        "@aws-sdk/hash-node": "3.190.0",
+        "@aws-sdk/invalid-dependency": "3.190.0",
+        "@aws-sdk/middleware-content-length": "3.190.0",
+        "@aws-sdk/middleware-host-header": "3.190.0",
+        "@aws-sdk/middleware-logger": "3.190.0",
+        "@aws-sdk/middleware-recursion-detection": "3.190.0",
+        "@aws-sdk/middleware-retry": "3.190.0",
+        "@aws-sdk/middleware-sdk-sts": "3.190.0",
+        "@aws-sdk/middleware-serde": "3.190.0",
+        "@aws-sdk/middleware-signing": "3.190.0",
+        "@aws-sdk/middleware-stack": "3.190.0",
+        "@aws-sdk/middleware-user-agent": "3.190.0",
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/node-http-handler": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/smithy-client": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/url-parser": "3.190.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.188.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.190.0",
+        "@aws-sdk/util-defaults-mode-node": "3.190.0",
+        "@aws-sdk/util-user-agent-browser": "3.190.0",
+        "@aws-sdk/util-user-agent-node": "3.190.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.188.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.190.0.tgz",
+      "integrity": "sha512-K+VnDtjTgjpf7yHEdDB0qgGbHToF0pIL0pQMSnmk2yc8BoB3LGG/gg1T0Ki+wRlrFnDCJ6L+8zUdawY2qDsbyw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/signature-v4": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-config-provider": "3.188.0",
+        "@aws-sdk/util-middleware": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.190.0.tgz",
+      "integrity": "sha512-EXJ+qPPLZJoD8sObVJrsdFnNqmtfCmKFxhGchqPvpFaAD0wsTXasbvCgYwOMkW8VzM6VQJpjJn479ejrSy74ig==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.190.0.tgz",
+      "integrity": "sha512-GTY7l3SJhTmRGFpWddbdJOihSqoMN8JMo3CsCtIjk4/h3xirBi02T4GSvbrMyP7FP3Fdl4NAdT+mHJ4q2Bvzxw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.190.0.tgz",
+      "integrity": "sha512-gI5pfBqGYCKdmx8igPvq+jLzyE2kuNn9Q5u73pdM/JZxiq7GeWYpE/MqqCubHxPtPcTFgAwxCxCFoXlUTBh/2g==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/url-parser": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.190.0.tgz",
+      "integrity": "sha512-Z7NN/evXJk59hBQlfOSWDfHntwmxwryu6uclgv7ECI6SEVtKt1EKIlPuCLUYgQ4lxb9bomyO5lQAl/1WutNT5w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.190.0",
+        "@aws-sdk/credential-provider-imds": "3.190.0",
+        "@aws-sdk/credential-provider-sso": "3.190.0",
+        "@aws-sdk/credential-provider-web-identity": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/shared-ini-file-loader": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.190.0.tgz",
+      "integrity": "sha512-ctCG5+TsIK2gVgvvFiFjinPjc5nGpSypU3nQKCaihtPh83wDN6gCx4D0p9M8+fUrlPa5y+o/Y7yHo94ATepM8w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.190.0",
+        "@aws-sdk/credential-provider-imds": "3.190.0",
+        "@aws-sdk/credential-provider-ini": "3.190.0",
+        "@aws-sdk/credential-provider-process": "3.190.0",
+        "@aws-sdk/credential-provider-sso": "3.190.0",
+        "@aws-sdk/credential-provider-web-identity": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/shared-ini-file-loader": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.190.0.tgz",
+      "integrity": "sha512-sIJhICR80n5XY1kW/EFHTh5ZzBHb5X+744QCH3StcbKYI44mOZvNKfFdeRL2fQ7yLgV7npte2HJRZzQPWpZUrw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/shared-ini-file-loader": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.190.0.tgz",
+      "integrity": "sha512-uarU9vk471MHHT+GJj3KWFSmaaqLNL5n1KcMer2CCAZfjs+mStAi8+IjZuuKXB4vqVs5DxdH8cy5aLaJcBlXwQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-sso": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/shared-ini-file-loader": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.190.0.tgz",
+      "integrity": "sha512-nlIBeK9hGHKWC874h+ITAfPZ9Eaok+x/ydZQVKsLHiQ9PH3tuQ8AaGqhuCwBSH0hEAHZ/BiKeEx5VyWAE8/x+Q==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-providers": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.190.0.tgz",
+      "integrity": "sha512-9WNqALZg1UmaREy0Q/W2ul4ooJCIVJoaXOvf+oxNNhd2handYLZBCqYMOU4icfSTGf+dYSOMN7vc3M8u59za4A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.190.0",
+        "@aws-sdk/client-sso": "3.190.0",
+        "@aws-sdk/client-sts": "3.190.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.190.0",
+        "@aws-sdk/credential-provider-env": "3.190.0",
+        "@aws-sdk/credential-provider-imds": "3.190.0",
+        "@aws-sdk/credential-provider-ini": "3.190.0",
+        "@aws-sdk/credential-provider-node": "3.190.0",
+        "@aws-sdk/credential-provider-process": "3.190.0",
+        "@aws-sdk/credential-provider-sso": "3.190.0",
+        "@aws-sdk/credential-provider-web-identity": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/shared-ini-file-loader": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.190.0.tgz",
+      "integrity": "sha512-5riRpKydARXAPLesTZm6eP6QKJ4HJGQ3k0Tepi3nvxHVx3UddkRNoX0pLS3rvbajkykWPNC2qdfRGApWlwOYsA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/querystring-builder": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.190.0.tgz",
+      "integrity": "sha512-DNwVT3O8zc9Jk/bXiXcN0WsD98r+JJWryw9F1/ZZbuzbf6rx2qhI8ZK+nh5X6WMtYPU84luQMcF702fJt/1bzg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-buffer-from": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.190.0.tgz",
+      "integrity": "sha512-crCh63e8d/Uw9y3dQlVTPja7+IZiXpNXyH6oSuAadTDQwMq6KK87Av1/SDzVf6bAo2KgAOo41MyO2joaCEk0dQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
+      "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.190.0.tgz",
+      "integrity": "sha512-sSU347SuC6I8kWum1jlJlpAqeV23KP7enG+ToWcEcgFrJhm3AvuqB//NJxDbkKb2DNroRvJjBckBvrwNAjQnBQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.190.0.tgz",
+      "integrity": "sha512-cL7Vo/QSpGx/DDmFxjeV0Qlyi1atvHQDPn3MLBBmi1icu+3GKZkCMAJwzsrV3U4+WoVoDYT9FJ9yMQf2HaIjeQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.190.0.tgz",
+      "integrity": "sha512-rrfLGYSZCBtiXNrIa8pJ2uwUoUMyj6Q82E8zmduTvqKWviCr6ZKes0lttGIkWhjvhql2m4CbjG5MPBnY7RXL4A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.190.0.tgz",
+      "integrity": "sha512-5tc1AIIZe5jDNdyuJW+7vIFmQOxz3q031ZVrEtUEIF7cz2ySho2lkOWziz+v+UGSLhjHGKMz3V26+aN1FLZNxQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.190.0.tgz",
+      "integrity": "sha512-h1bPopkncf2ue/erJdhqvgR2AEh0bIvkNsIHhx93DckWKotZd/GAVDq0gpKj7/f/7B+teHH8Fg5GDOwOOGyKcg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/service-error-classification": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-middleware": "3.190.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.190.0.tgz",
+      "integrity": "sha512-eUHrsr35mkD/cAFKoYuFYz0zE7QPBWvSzMzqmEJC+YXzAF6IABP3FL/htAFpWkje5XDl5dQ6dAxzV+ebK8RNXQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/signature-v4": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.190.0.tgz",
+      "integrity": "sha512-S132hEOK4jwbtZ1bGAgSuQ0DMFG4TiD4ulAwbQRBYooC7tiWZbRiR0Pkt2hV8d7WhOHgUpg7rvqlA7/HXXBAsA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.190.0.tgz",
+      "integrity": "sha512-Xj5MmXZq8UIpY8wOwyqei5q6MgqKxsO9Plo2zUgW7JR0w7R21MlqY2kzzvcM9R0FFhi9dqhniFT2ZMRUb1v73w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/signature-v4": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-middleware": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.190.0.tgz",
+      "integrity": "sha512-h1mqiWNJdi1OTSEY8QovpiHgDQEeRG818v8yShpqSYXJKEqdn54MA3Z1D2fg/Wv/8ZJsFrBCiI7waT1JUYOmCg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.190.0.tgz",
+      "integrity": "sha512-y/2cTE1iYHKR0nkb3DvR3G8vt12lcTP95r/iHp8ZO+Uzpc25jM/AyMHWr2ZjqQiHKNlzh8uRw1CmQtgg4sBxXQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.190.0.tgz",
+      "integrity": "sha512-TJPUchyeK5KeEXWrwb6oW5/OkY3STCSGR1QIlbPcaTGkbo4kXAVyQmmZsY4KtRPuDM6/HlfUQV17bD716K65rQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/shared-ini-file-loader": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.190.0.tgz",
+      "integrity": "sha512-3Klkr73TpZkCzcnSP+gmFF0Baluzk3r7BaWclJHqt2LcFUWfIJzYlnbBQNZ4t3EEq7ZlBJX85rIDHBRlS+rUyA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/abort-controller": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/querystring-builder": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.190.0.tgz",
+      "integrity": "sha512-uzdKjHE2blbuceTC5zeBgZ0+Uo/hf9pH20CHpJeVNtrrtF3GALtu4Y1Gu5QQVIQBz8gjHnqANx0XhfYzorv69Q==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
+      "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.190.0.tgz",
+      "integrity": "sha512-w9mTKkCsaLIBC8EA4RAHrqethNGbf60CbpPzN/QM7yCV3ZZJAXkppFfjTVVOMbPaI8GUEOptJtzgqV68CRB7ow==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-uri-escape": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.190.0.tgz",
+      "integrity": "sha512-vCKP0s33VtS47LSYzEWRRr2aTbi3qNkUuQyIrc5LMqBfS5hsy79P1HL4Q7lCVqZB5fe61N8fKzOxDxWRCF0sXg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.190.0.tgz",
+      "integrity": "sha512-g+s6xtaMa5fCMA2zJQC4BiFGMP7FN5/L1V/UwxCnKy8skCwaN0K5A1tFffBjjbYiPI7Gu7LVorWD2A0Y4xl01Q==",
+      "optional": true
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.190.0.tgz",
+      "integrity": "sha512-CZC/xsGReUEl5w+JgfancrxfkaCbEisyIFy6HALUYrioWQe80WMqLAdUMZSXHWjIaNK9mH0J/qvcSV2MuIoMzQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.190.0.tgz",
+      "integrity": "sha512-L/R/1X2T+/Kg2k/sjoYyDFulVUGrVcRfyEKKVFIUNg0NwUtw5UKa1/gS7geTKcg4q8M2pd/v+OCBrge2X7phUw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.188.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-hex-encoding": "3.188.0",
+        "@aws-sdk/util-middleware": "3.190.0",
+        "@aws-sdk/util-uri-escape": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.190.0.tgz",
+      "integrity": "sha512-f5EoCwjBLXMyuN491u1NmEutbolL0cJegaJbtgK9OJw2BLuRHiBknjDF4OEVuK/WqK0kz2JLMGi9xwVPl4BKCA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
+      "optional": true
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.190.0.tgz",
+      "integrity": "sha512-FKFDtxA9pvHmpfWmNVK5BAVRpDgkWMz3u4Sg9UzB+WAFN6UexRypXXUZCFAo8S04FbPKfYOR3O0uVlw7kzmj9g==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
+      "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.188.0.tgz",
+      "integrity": "sha512-r1dccRsRjKq+OhVRUfqFiW3sGgZBjHbMeHLbrAs9jrOjU2PTQ8PSzAXLvX/9lmp7YjmX17Qvlsg0NCr1tbB9OA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.188.0.tgz",
+      "integrity": "sha512-XwqP3vxk60MKp4YDdvDeCD6BPOiG2e+/Ou4AofZOy5/toB6NKz2pFNibQIUg2+jc7mPMnGnvOW3MQEgSJ+gu/Q==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz",
+      "integrity": "sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.188.0.tgz",
+      "integrity": "sha512-LBA7tLbi7v4uvbOJhSnjJrxbcRifKK/1ZVK94JTV2MNSCCyNkFotyEI5UWDl10YKriTIUyf7o5cakpiDZ3O4xg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.190.0.tgz",
+      "integrity": "sha512-FKxTU4tIbFk2pdUbBNneStF++j+/pB4NYJ1HRSEAb/g4D2+kxikR/WKIv3p0JTVvAkwcuX/ausILYEPUyDZ4HQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.190.0.tgz",
+      "integrity": "sha512-qBiIMjNynqAP7p6urG1+ZattYkFaylhyinofVcLEiDvM9a6zGt6GZsxru2Loq0kRAXXGew9E9BWGt45HcDc20g==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/config-resolver": "3.190.0",
+        "@aws-sdk/credential-provider-imds": "3.190.0",
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
+      "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.188.0.tgz",
+      "integrity": "sha512-SxobBVLZkkLSawTCfeQnhVX3Azm9O+C2dngZVe1+BqtF8+retUbVTs7OfYeWBlawVkULKF2e781lTzEHBBjCzw==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-middleware": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.190.0.tgz",
+      "integrity": "sha512-qzTJ/qhFDzHZS+iXdHydQ/0sWAuNIB5feeLm55Io/I8Utv3l3TKYOhbgGwTsXY+jDk7oD+YnAi7hLN5oEBCwpg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
+      "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.190.0.tgz",
+      "integrity": "sha512-c074wjsD+/u9vT7DVrBLkwVhn28I+OEHuHaqpTVCvAIjpueZ3oms0e99YJLfpdpEgdLavOroAsNFtAuRrrTZZw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.190.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.190.0.tgz",
+      "integrity": "sha512-R36BMvvPX8frqFhU4lAsrOJ/2PJEHH/Jz1WZzO3GWmVSEAQQdHmo8tVPE3KOM7mZWe5Hj1dZudFAIxWHHFYKJA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.188.0.tgz",
+      "integrity": "sha512-hCgP4+C0Lekjpjt2zFJ2R/iHes5sBGljXa5bScOFAEkRUc0Qw0VNgTv7LpEbIOAwGmqyxBoCwBW0YHPW1DfmYQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
@@ -8480,6 +10305,12 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
+    },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "optional": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -10025,6 +11856,15 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "optional": true,
+      "requires": {
+        "strnum": "^1.0.5"
+      }
     },
     "figures": {
       "version": "3.2.0",
@@ -13507,6 +15347,12 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "optional": true
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -13765,6 +15611,12 @@
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
+    },
+    "tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -59,6 +59,9 @@
     "standard-version": "^9.3.2",
     "tar": "^6.1.11"
   },
+  "optionalDependencies": {
+    "@aws-sdk/credential-providers": "^3.186.0"
+  },
   "peerDependencies": {
     "mongodb": ">=3.4.0"
   },

--- a/bindings/node/test/autoEncrypter.test.js
+++ b/bindings/node/test/autoEncrypter.test.js
@@ -368,7 +368,7 @@ describe('AutoEncrypter', function () {
       });
     });
 
-    context('when no refresh function is provided', function () {
+    context('when no refresh function is provided and no optional sdk', function () {
       const accessKey = 'example';
       const secretKey = 'example';
 
@@ -399,8 +399,10 @@ describe('AutoEncrypter', function () {
             aws: {}
           }
         });
-        mc.decrypt(input, (err) => {
-          expect(err.message).to.equal('client not configured with KMS provider necessary to decrypt');
+        mc.decrypt(input, err => {
+          expect(err.message).to.equal(
+            'client not configured with KMS provider necessary to decrypt'
+          );
           done();
         });
       });

--- a/bindings/node/test/autoEncrypter.test.js
+++ b/bindings/node/test/autoEncrypter.test.js
@@ -329,7 +329,7 @@ describe('AutoEncrypter', function () {
       });
     });
 
-    context('when no refresh function is provided', function (done) {
+    context('when no refresh function is provided', function () {
       const accessKey = 'example';
       const secretKey = 'example';
 

--- a/bindings/node/test/autoEncrypter.test.js
+++ b/bindings/node/test/autoEncrypter.test.js
@@ -66,6 +66,9 @@ class MockClient {
   }
 }
 
+const originalAccessKeyId = process.env.AWS_ACCESS_KEY_ID;
+const originalSecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+
 const AutoEncrypter = require('../lib/autoEncrypter')({ mongodb, stateMachine }).AutoEncrypter;
 describe('AutoEncrypter', function () {
   this.timeout(12000);
@@ -323,6 +326,40 @@ describe('AutoEncrypter', function () {
         if (err) return done(err);
         expect(decrypted).to.eql({ filter: { find: 'test', ssn: '457-55-5462' } });
         done();
+      });
+    });
+
+    context('when no refresh function is provided', function (done) {
+      const accessKey = 'example';
+      const secretKey = 'example';
+
+      before(function () {
+        // After the entire suite runs, set the env back for the rest of the test run.
+        process.env.AWS_ACCESS_KEY_ID = accessKey;
+        process.env.AWS_SECRET_ACCESS_KEY = secretKey;
+      });
+
+      after(function () {
+        // After the entire suite runs, set the env back for the rest of the test run.
+        process.env.AWS_ACCESS_KEY_ID = originalAccessKeyId;
+        process.env.AWS_SECRET_ACCESS_KEY = originalSecretAccessKey;
+      });
+
+      it('should decrypt mock data with KMS credentials from the environment', function (done) {
+        const input = readExtendedJsonToBuffer(`${__dirname}/data/encrypted-document.json`);
+        const client = new MockClient();
+        const mc = new AutoEncrypter(client, {
+          keyVaultNamespace: 'admin.datakeys',
+          logger: () => {},
+          kmsProviders: {
+            aws: {}
+          }
+        });
+        mc.decrypt(input, (err, decrypted) => {
+          if (err) return done(err);
+          expect(decrypted).to.eql({ filter: { find: 'test', ssn: '457-55-5462' } });
+          done();
+        });
       });
     });
 

--- a/bindings/node/test/credentialsProvider.test.js
+++ b/bindings/node/test/credentialsProvider.test.js
@@ -23,11 +23,6 @@ describe('#loadCredentials', function () {
 
   context('when the credential provider finds credentials', function () {
     before(function () {
-      if (process.env.NPM_OPTIONS === '--no-optional') {
-        this.currentTest.skipReason = 'Cannot refresh credentials without sdk provider';
-        this.currentTest.skip();
-        return;
-      }
       process.env.AWS_ACCESS_KEY_ID = accessKey;
       process.env.AWS_SECRET_ACCESS_KEY = secretKey;
       process.env.AWS_SESSION_TOKEN = sessionToken;
@@ -35,6 +30,14 @@ describe('#loadCredentials', function () {
 
     context('when the credentials are empty', function () {
       const kmsProviders = {};
+
+      before(function () {
+        if (process.env.NPM_OPTIONS === '--no-optional') {
+          this.currentTest.skipReason = 'Cannot refresh credentials without sdk provider';
+          this.currentTest.skip();
+          return;
+        }
+      });
 
       it('refreshes the aws credentials', async function () {
         const providers = await loadCredentials(kmsProviders);
@@ -56,6 +59,14 @@ describe('#loadCredentials', function () {
           },
           aws: {}
         };
+
+        before(function () {
+          if (process.env.NPM_OPTIONS === '--no-optional') {
+            this.currentTest.skipReason = 'Cannot refresh credentials without sdk provider';
+            this.currentTest.skip();
+            return;
+          }
+        });
 
         it('refreshes only the aws credentials', async function () {
           const providers = await loadCredentials(kmsProviders);
@@ -82,6 +93,14 @@ describe('#loadCredentials', function () {
           }
         };
 
+        before(function () {
+          if (process.env.NPM_OPTIONS === '--no-optional') {
+            this.currentTest.skipReason = 'Cannot refresh credentials without sdk provider';
+            this.currentTest.skip();
+            return;
+          }
+        });
+
         it('does not refresh credentials', async function () {
           const providers = await loadCredentials(kmsProviders);
           expect(providers).to.deep.equal(kmsProviders);
@@ -94,6 +113,14 @@ describe('#loadCredentials', function () {
             key: Buffer.alloc(96)
           }
         };
+
+        before(function () {
+          if (process.env.NPM_OPTIONS === '--no-optional') {
+            this.currentTest.skipReason = 'Cannot refresh credentials without sdk provider';
+            this.currentTest.skip();
+            return;
+          }
+        });
 
         it('refreshes ony the aws credentials', async function () {
           const providers = await loadCredentials(kmsProviders);

--- a/bindings/node/test/credentialsProvider.test.js
+++ b/bindings/node/test/credentialsProvider.test.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+
+const { loadCredentials } = require('../lib/credentialsProvider');
+
+const originalAccessKeyId = process.env.AWS_ACCESS_KEY_ID;
+const originalSecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+const originalSessionToken = process.env.AWS_SESSION_TOKEN;
+
+describe('#loadCredentials', function () {
+  const accessKey = 'accessKey';
+  const secretKey = 'secretKey';
+  const sessionToken = 'sessionToken';
+
+  after(function () {
+    // After the entire suite runs, set the env back for the rest of the test run.
+    process.env.AWS_ACCESS_KEY_ID = originalAccessKeyId;
+    process.env.AWS_SECRET_ACCESS_KEY = originalSecretAccessKey;
+    process.env.AWS_SESSION_TOKEN = originalSessionToken;
+  });
+
+  // Note that the aws credential provider caches the credentials and there is no way
+  // to clear it, so the opposite case for this context isn't really testable when
+  // deleting the env vars and mocking out the aws sdk internals is not a viable
+  // solution.
+  context('when the credential provider finds credentials', function () {
+    before(function () {
+      process.env.AWS_ACCESS_KEY_ID = accessKey;
+      process.env.AWS_SECRET_ACCESS_KEY = secretKey;
+      process.env.AWS_SESSION_TOKEN = sessionToken;
+    });
+
+    context('when the credentials are empty', function () {
+      const kmsProviders = {};
+
+      it('refreshes the aws credentials', async function () {
+        const providers = await loadCredentials(kmsProviders);
+        expect(providers).to.deep.equal({
+          aws: {
+            accessKeyId: accessKey,
+            secretAccessKey: secretKey,
+            sessionToken: sessionToken
+          }
+        });
+      });
+    });
+
+    context('when the credentials are not empty', function () {
+      context('when aws is empty', function () {
+        const kmsProviders = {
+          local: {
+            key: Buffer.alloc(96)
+          },
+          aws: {}
+        };
+
+        it('refreshes only the aws credentials', async function () {
+          const providers = await loadCredentials(kmsProviders);
+          expect(providers).to.deep.equal({
+            local: {
+              key: Buffer.alloc(96)
+            },
+            aws: {
+              accessKeyId: accessKey,
+              secretAccessKey: secretKey,
+              sessionToken: sessionToken
+            }
+          });
+        });
+      });
+
+      context('when aws is not empty', function () {
+        const kmsProviders = {
+          local: {
+            key: Buffer.alloc(96)
+          },
+          aws: {
+            accessKeyId: 'example'
+          }
+        };
+
+        it('does not refresh credentials', async function () {
+          const providers = await loadCredentials(kmsProviders);
+          expect(providers).to.deep.equal(kmsProviders);
+        });
+      });
+
+      context('when aws does not exist', function () {
+        const kmsProviders = {
+          local: {
+            key: Buffer.alloc(96)
+          }
+        };
+
+        it('refreshes ony the aws credentials', async function () {
+          const providers = await loadCredentials(kmsProviders);
+          expect(providers).to.deep.equal({
+            local: {
+              key: Buffer.alloc(96)
+            },
+            aws: {
+              accessKeyId: accessKey,
+              secretAccessKey: secretKey,
+              sessionToken: sessionToken
+            }
+          });
+        });
+      });
+    });
+  });
+});

--- a/bindings/node/test/credentialsProvider.test.js
+++ b/bindings/node/test/credentialsProvider.test.js
@@ -10,9 +10,9 @@ const originalSecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
 const originalSessionToken = process.env.AWS_SESSION_TOKEN;
 
 describe('#loadCredentials', function () {
-  const accessKey = 'accessKey';
-  const secretKey = 'secretKey';
-  const sessionToken = 'sessionToken';
+  const accessKey = 'example';
+  const secretKey = 'example';
+  const sessionToken = 'example';
 
   after(function () {
     // After the entire suite runs, set the env back for the rest of the test run.

--- a/bindings/node/test/release.test.js
+++ b/bindings/node/test/release.test.js
@@ -16,6 +16,7 @@ const REQUIRED_FILES = [
   'package/lib/buffer_pool.js',
   'package/lib/clientEncryption.js',
   'package/lib/common.js',
+  'package/lib/credentialsProvider.js',
   'package/lib/cryptoCallbacks.js',
   'package/lib/mongocryptdManager.js',
   'package/lib/stateMachine.js',


### PR DESCRIPTION
Allows the state machine to load kms provider credentials from the environment for AWS.

- Adds the @aws-sdk/credential-providers module as an optional dependency.
- Will attempt to load missing credentials if user does not supply their own refresh function.
- Deprecates the `onKmsProviderRefresh` option. See: https://jira.mongodb.org/browse/NODE-4731
- Changes evergreen config to run both with and without the optional dependency.