### PR TITLE
MONGOCRYPT-469 improved and more consistent null pointer checks

### DIFF
--- a/src/mongocrypt-ctx-decrypt.c
+++ b/src/mongocrypt-ctx-decrypt.c
@@ -227,6 +227,7 @@ _replace_ciphertext_with_plaintext (void *ctx,
    BSON_ASSERT_PARAM (ctx);
    BSON_ASSERT_PARAM (in);
    BSON_ASSERT_PARAM (out);
+   BSON_ASSERT (in->data);
 
    if (in->data[0] == MC_SUBTYPE_FLE2IndexedEqualityEncryptedValue ||
        in->data[0] == MC_SUBTYPE_FLE2IndexedRangeEncryptedValue) {
@@ -396,6 +397,7 @@ _collect_K_KeyID_from_FLE2IndexedEncryptedValue (void *ctx,
 
    BSON_ASSERT_PARAM (ctx);
    BSON_ASSERT_PARAM (in);
+   BSON_ASSERT (in->data);
 
    /* Ignore other ciphertext types. */
    if (in->data[0] != MC_SUBTYPE_FLE2IndexedEqualityEncryptedValue &&
@@ -561,6 +563,7 @@ _collect_key_from_ciphertext (void *ctx,
 
    BSON_ASSERT_PARAM (ctx);
    BSON_ASSERT_PARAM (in);
+   BSON_ASSERT (in->data);
 
    kb = (_mongocrypt_key_broker_t *) ctx;
 


### PR DESCRIPTION
Some additional assertions I missed when working on MONGOCRYPT-469.

Evergreen patch build: https://spruce.mongodb.com/version/635fe328d1fe0752e2e04f33/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC