### PR TITLE
[MONGOCRYPT-470] Support SO path queries on FreeBSD

### DIFF
--- a/src/mongocrypt-util.c
+++ b/src/mongocrypt-util.c
@@ -80,7 +80,7 @@ current_module_path ()
       }
       free (path);
    }
-#elif defined(_GNU_SOURCE) || defined(_DARWIN_C_SOURCE)
+#elif defined(_GNU_SOURCE) || defined(_DARWIN_C_SOURCE) || defined(__FreeBSD__)
    // Darwin/BSD/glibc define extensions for finding dynamic library info from
    // the address of a symbol.
    Dl_info info;

--- a/src/os_posix/os_dll.c
+++ b/src/os_posix/os_dll.c
@@ -105,7 +105,7 @@ mcr_dll_path (mcr_dll dll)
       .error_string = mstr_copy_cstr ("Handle not found in loaded modules")};
 }
 
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__FreeBSD__)
 
 #include <link.h>
 


### PR DESCRIPTION
FreeBSD is not an officially support platform, but it supports the runtime library extensions sufficient that we can implement the SO module querying functions on it.

These changes have been built and verified in FreeBSD 13.