### PR TITLE
ci(NODE-4779): Pin to an earlier Node LTS release on platforms that are not supported by prebuilt Node 18+

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -137,6 +137,7 @@ functions:
           NODE_GITHUB_TOKEN: ${node_github_token}
           DISTRO_ID: ${distro_id}
           BUILD_VARIANT: ${build_variant}
+          NODE_NVM_USE_VERSION: ${nvm_use_version|lts}
 
   "build and test node no optional dependencies":
     - command: "subprocess.exec"
@@ -151,6 +152,7 @@ functions:
           DISTRO_ID: ${distro_id}
           BUILD_VARIANT: ${build_variant}
           NPM_OPTIONS: "--no-optional"
+          NODE_NVM_USE_VERSION: ${nvm_use_version|lts}
 
   "attach node xunit results":
     - command: attach.xunit_results
@@ -905,6 +907,7 @@ buildvariants:
     has_packages: true
     packager_distro: ubuntu1604
     packager_arch: x86_64
+    nvm_use_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -976,6 +979,7 @@ buildvariants:
     has_packages: true
     packager_distro: amazon
     packager_arch: x86_64
+    nvm_use_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -992,6 +996,7 @@ buildvariants:
     has_packages: true
     packager_distro: amazon2
     packager_arch: x86_64
+    nvm_use_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1009,6 +1014,7 @@ buildvariants:
     has_packages: true
     packager_distro: amazon2
     packager_arch: arm64
+    nvm_use_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1042,6 +1048,7 @@ buildvariants:
     has_packages: true
     packager_distro: debian92
     packager_arch: x86_64
+    nvm_use_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1087,6 +1094,7 @@ buildvariants:
     has_packages: true
     packager_distro: rhel70
     packager_arch: x86_64
+    nvm_use_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1134,6 +1142,7 @@ buildvariants:
     has_packages: true
     packager_distro: suse12
     packager_arch: x86_64
+    nvm_use_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1168,6 +1177,7 @@ buildvariants:
     has_packages: true
     packager_distro: ubuntu1604
     packager_arch: arm64
+    nvm_use_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1185,6 +1195,7 @@ buildvariants:
     has_packages: true
     packager_distro: ubuntu1804
     packager_arch: x86_64
+    nvm_use_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1203,6 +1214,7 @@ buildvariants:
     has_packages: true
     packager_distro: ubuntu1804
     packager_arch: arm64
+    nvm_use_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson

--- a/bindings/node/.evergreen/setup_environment.sh
+++ b/bindings/node/.evergreen/setup_environment.sh
@@ -21,6 +21,9 @@ mkdir -p "${BIN_DIR}"
 # Add mongodb toolchain to path
 export PATH="$BIN_DIR:/opt/mongodbtoolchain/v2/bin:$PATH"
 
+test -n "${NODE_NVM_USE_VERSION-}" || echo "Defaulting to using the current Node LTS Release. Set NODE_NVM_USE_VERSION to change."
+: "${NODE_NVM_USE_VERSION:="lts"}"
+
 # locate cmake
 if [ "$OS" == "Windows_NT" ]; then
   CMAKE=/cygdrive/c/cmake/bin/cmake
@@ -58,10 +61,10 @@ root: $NVM_HOME
 path: $NVM_SYMLINK
 EOT
 
-  echo "Running: nvm install lts"
-  nvm install lts
-  echo "Running: nvm use lts"
-  nvm use lts
+  echo "Running: nvm install $NODE_NVM_USE_VERSION"
+  nvm install $NODE_NVM_USE_VERSION
+  echo "Running: nvm use $NODE_NVM_USE_VERSION"
+  nvm use $NODE_NVM_USE_VERSION
   echo "Running: npm install -g npm@8.3.1"
   npm install -g npm@8.3.1 # https://github.com/npm/cli/issues/4341
   set -o xtrace
@@ -72,10 +75,14 @@ else
   curl -o- $NVM_URL | bash
   [ -s "${NVM_DIR}/nvm.sh" ] && \. "${NVM_DIR}/nvm.sh"
 
-  echo "Running: nvm install --lts --latest-npm"
-  nvm install --lts --latest-npm
-  echo "Running: nvm use --lts"
-  nvm use --lts
+  declare _arg="$NODE_NVM_USE_VERSION"
+  if test "$NODE_NVM_USE_VERSION" = "lts"; then _arg="--lts"; fi
+
+  echo "Running: nvm install \"$_arg\" --latest-npm"
+  nvm install "$_arg" --latest-npm
+  echo "Running: nvm use \"$_arg\""
+  nvm use "$_arg"
+  node --version
 
   set -o xtrace
 fi


### PR DESCRIPTION
On Oct 25, 2022, Node LTS "Hydrogen" 18 went active, and this changed the major version downloaded by `nvm {use,install} --lts`. The new Node binaries have a runtime-link dependency on some newer versions of glibc symbols that are not available on older Linux distros under test. The downloaded `node` executable can not be launched on these older systems, confusing `nvm` and preventing the CI from running properly.

This changeset pins the older build variants to download the prior LTS release (16.x).