### PR TITLE
ci(NODE-4779): Missing Pin of Node 16 on SUSE15 Variant

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1160,6 +1160,7 @@ buildvariants:
     has_packages: true
     packager_distro: suse15
     packager_arch: x86_64
+    nvm_use_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson


### PR DESCRIPTION
Now that SUSE15 hosts are spawning, I realized that I missed one variant in #488. Oops, that's embarrassing.