### PR TITLE
MONGOCRYPT-495 Add support for MSVC 2022

### DIFF
--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -998,9 +998,9 @@ fail:
 }
 
 static bool
-isInfinite (bson_iter_t iter)
+isInfinite (bson_iter_t *iter)
 {
-   return isinf (bson_iter_double (&iter));
+   return isinf (bson_iter_double (iter));
 }
 
 // mc_get_mincover_from_FLE2RangeFindSpec creates and returns a mincover from an
@@ -1034,11 +1034,11 @@ mc_get_mincover_from_FLE2RangeFindSpec (mc_FLE2RangeFindSpec_t *findSpec,
    // Open-ended ranges are represented with infinity as the other endpoint.
    // Resolve infinite bounds at this point to end at the min or max for this
    // index.
-   if (isInfinite (lowerBound)) {
+   if (isInfinite (&lowerBound)) {
       lowerBound = findSpec->edgesInfo.indexMin;
       includeLowerBound = true;
    }
-   if (isInfinite (upperBound)) {
+   if (isInfinite (&upperBound)) {
       upperBound = findSpec->edgesInfo.indexMax;
       includeUpperBound = true;
    }


### PR DESCRIPTION
Currently, MSVC 2022 throws this error:
```
D:\repo\libmongocrypt\src\mongocrypt-marking.c(1002,1): error C2719: 'iter': formal parameter with requested alignment of 128 won't be aligned [D:\repo\libmongocrypt\mongocrypt_static.vcxproj]
```

I changed `isInfinite (bson_iter_t *iter)` to pass iter by pointer instead of by value. 

I also need #487 to get MSVC 2022 clean. But I need only this PR to compile the portion the server needs though.
