### PR TITLE
MONGOCRYPT-492 Add check if datakey provider and the initial KMS provider set match

### DIFF
--- a/src/mongocrypt-ctx-datakey.c
+++ b/src/mongocrypt-ctx-datakey.c
@@ -489,6 +489,24 @@ mongocrypt_ctx_datakey_init (mongocrypt_ctx_t *ctx)
       return false;
    }
 
+   /* Check that the kms provider initially set and the datakey kms provider
+    * match */
+   if (_mongocrypt_needs_credentials (ctx->crypt) &&
+       !(ctx->crypt->opts.kms_providers.need_credentials &
+         ctx->opts.kek.kms_provider)) {
+      return _mongocrypt_ctx_fail_w_msg (
+         ctx,
+         "Invalid encryption key: datakey provider does not match the provider "
+         "set in mongocrypt_setopt_kms_providers");
+
+   } else if (!(ctx->crypt->opts.kms_providers.configured_providers &
+                ctx->opts.kek.kms_provider)) {
+      return _mongocrypt_ctx_fail_w_msg (
+         ctx,
+         "Invalid encryption key: datakey provider does not match the provider "
+         "set in mongocrypt_setopt_kms_providers");
+   }
+
    dkctx = (_mongocrypt_ctx_datakey_t *) ctx;
    ctx->type = _MONGOCRYPT_TYPE_CREATE_DATA_KEY;
    ctx->vtable.mongo_op_keys = NULL;

--- a/src/mongocrypt-ctx-datakey.c
+++ b/src/mongocrypt-ctx-datakey.c
@@ -489,24 +489,6 @@ mongocrypt_ctx_datakey_init (mongocrypt_ctx_t *ctx)
       return false;
    }
 
-   /* Check that the kms provider initially set and the datakey kms provider
-    * match */
-   if (_mongocrypt_needs_credentials (ctx->crypt) &&
-       !(ctx->crypt->opts.kms_providers.need_credentials &
-         ctx->opts.kek.kms_provider)) {
-      return _mongocrypt_ctx_fail_w_msg (
-         ctx,
-         "Invalid data key: datakey provider does not match the provider "
-         "set in mongocrypt_setopt_kms_providers");
-
-   } else if (!(ctx->crypt->opts.kms_providers.configured_providers &
-                ctx->opts.kek.kms_provider)) {
-      return _mongocrypt_ctx_fail_w_msg (
-         ctx,
-         "Invalid data key: datakey provider does not match the provider "
-         "set in mongocrypt_setopt_kms_providers");
-   }
-
    dkctx = (_mongocrypt_ctx_datakey_t *) ctx;
    ctx->type = _MONGOCRYPT_TYPE_CREATE_DATA_KEY;
    ctx->vtable.mongo_op_keys = NULL;

--- a/src/mongocrypt-ctx-datakey.c
+++ b/src/mongocrypt-ctx-datakey.c
@@ -496,14 +496,14 @@ mongocrypt_ctx_datakey_init (mongocrypt_ctx_t *ctx)
          ctx->opts.kek.kms_provider)) {
       return _mongocrypt_ctx_fail_w_msg (
          ctx,
-         "Invalid encryption key: datakey provider does not match the provider "
+         "Invalid data key: datakey provider does not match the provider "
          "set in mongocrypt_setopt_kms_providers");
 
    } else if (!(ctx->crypt->opts.kms_providers.configured_providers &
                 ctx->opts.kek.kms_provider)) {
       return _mongocrypt_ctx_fail_w_msg (
          ctx,
-         "Invalid encryption key: datakey provider does not match the provider "
+         "Invalid data key: datakey provider does not match the provider "
          "set in mongocrypt_setopt_kms_providers");
    }
 

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -901,20 +901,18 @@ _mongocrypt_ctx_init (mongocrypt_ctx_t *ctx,
       }
    }
 
-   /* Check that the kms provider set and the datakey kms provider match. */
+   if (opts_spec->kek == OPT_PROHIBITED && ctx->opts.kek.kms_provider) {
+      return _mongocrypt_ctx_fail_w_msg (ctx, "master key prohibited");
+   }
+
+   /* Check that the kms provider required by the datakey is configured.  */
    if (ctx->opts.kek.kms_provider) {
       if (!((ctx->crypt->opts.kms_providers.need_credentials |
              ctx->crypt->opts.kms_providers.configured_providers) &
             ctx->opts.kek.kms_provider)) {
          return _mongocrypt_ctx_fail_w_msg (
-            ctx,
-            "datakey provider does not match the provider set in "
-            "mongocrypt_setopt_kms_providers");
+            ctx, "kms provider required by datakey is not configured");
       }
-   }
-
-   if (opts_spec->kek == OPT_PROHIBITED && ctx->opts.kek.kms_provider) {
-      return _mongocrypt_ctx_fail_w_msg (ctx, "master key prohibited");
    }
 
    /* Special case. key_descriptor applies to explicit encryption. It must be

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -904,10 +904,8 @@ _mongocrypt_ctx_init (mongocrypt_ctx_t *ctx,
    /* Check that the kms provider initially set and the datakey kms provider
     * match. */
    if (ctx->opts.kek.kms_provider) {
-      if (!(ctx->crypt->opts.kms_providers.need_credentials &
-            ctx->opts.kek.kms_provider) &&
-
-          !(ctx->crypt->opts.kms_providers.configured_providers &
+      if (!((ctx->crypt->opts.kms_providers.need_credentials |
+             ctx->crypt->opts.kms_providers.configured_providers) &
             ctx->opts.kek.kms_provider)) {
          return _mongocrypt_ctx_fail_w_msg (
             ctx,

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -901,8 +901,7 @@ _mongocrypt_ctx_init (mongocrypt_ctx_t *ctx,
       }
    }
 
-   /* Check that the kms provider initially set and the datakey kms provider
-    * match. */
+   /* Check that the kms provider set and the datakey kms provider match. */
    if (ctx->opts.kek.kms_provider) {
       if (!((ctx->crypt->opts.kms_providers.need_credentials |
              ctx->crypt->opts.kms_providers.configured_providers) &

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -902,16 +902,10 @@ _mongocrypt_ctx_init (mongocrypt_ctx_t *ctx,
    }
 
    /* Check that the kms provider initially set and the datakey kms provider
-    * match */
-   if (_mongocrypt_needs_credentials (ctx->crypt) &&
-       !(ctx->crypt->opts.kms_providers.need_credentials &
-         ctx->opts.kek.kms_provider)) {
-      return _mongocrypt_ctx_fail_w_msg (
-         ctx,
-         "datakey provider does not match the provider set in "
-         "mongocrypt_setopt_kms_providers");
-   }
-   if (ctx->crypt->opts.kms_providers.configured_providers &&
+    * match. */
+   if (!(ctx->crypt->opts.kms_providers.need_credentials &
+         ctx->opts.kek.kms_provider) &&
+
        !(ctx->crypt->opts.kms_providers.configured_providers &
          ctx->opts.kek.kms_provider)) {
       return _mongocrypt_ctx_fail_w_msg (

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -908,16 +908,16 @@ _mongocrypt_ctx_init (mongocrypt_ctx_t *ctx,
          ctx->opts.kek.kms_provider)) {
       return _mongocrypt_ctx_fail_w_msg (
          ctx,
-         "Invalid data key: datakey provider does not match the provider "
-         "set in mongocrypt_setopt_kms_providers");
+         "datakey provider does not match the provider set in "
+         "mongocrypt_setopt_kms_providers");
    }
    if (ctx->crypt->opts.kms_providers.configured_providers &&
        !(ctx->crypt->opts.kms_providers.configured_providers &
          ctx->opts.kek.kms_provider)) {
       return _mongocrypt_ctx_fail_w_msg (
          ctx,
-         "Invalid data key: datakey provider does not match the provider "
-         "set in mongocrypt_setopt_kms_providers");
+         "datakey provider does not match the provider set in "
+         "mongocrypt_setopt_kms_providers");
    }
 
    if (opts_spec->kek == OPT_PROHIBITED && ctx->opts.kek.kms_provider) {

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -903,15 +903,17 @@ _mongocrypt_ctx_init (mongocrypt_ctx_t *ctx,
 
    /* Check that the kms provider initially set and the datakey kms provider
     * match. */
-   if (!(ctx->crypt->opts.kms_providers.need_credentials &
-         ctx->opts.kek.kms_provider) &&
+   if (ctx->opts.kek.kms_provider) {
+      if (!(ctx->crypt->opts.kms_providers.need_credentials &
+            ctx->opts.kek.kms_provider) &&
 
-       !(ctx->crypt->opts.kms_providers.configured_providers &
-         ctx->opts.kek.kms_provider)) {
-      return _mongocrypt_ctx_fail_w_msg (
-         ctx,
-         "datakey provider does not match the provider set in "
-         "mongocrypt_setopt_kms_providers");
+          !(ctx->crypt->opts.kms_providers.configured_providers &
+            ctx->opts.kek.kms_provider)) {
+         return _mongocrypt_ctx_fail_w_msg (
+            ctx,
+            "datakey provider does not match the provider set in "
+            "mongocrypt_setopt_kms_providers");
+      }
    }
 
    if (opts_spec->kek == OPT_PROHIBITED && ctx->opts.kek.kms_provider) {

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -901,6 +901,25 @@ _mongocrypt_ctx_init (mongocrypt_ctx_t *ctx,
       }
    }
 
+   /* Check that the kms provider initially set and the datakey kms provider
+    * match */
+   if (_mongocrypt_needs_credentials (ctx->crypt) &&
+       !(ctx->crypt->opts.kms_providers.need_credentials &
+         ctx->opts.kek.kms_provider)) {
+      return _mongocrypt_ctx_fail_w_msg (
+         ctx,
+         "Invalid data key: datakey provider does not match the provider "
+         "set in mongocrypt_setopt_kms_providers");
+   }
+   if (ctx->crypt->opts.kms_providers.configured_providers &&
+       !(ctx->crypt->opts.kms_providers.configured_providers &
+         ctx->opts.kek.kms_provider)) {
+      return _mongocrypt_ctx_fail_w_msg (
+         ctx,
+         "Invalid data key: datakey provider does not match the provider "
+         "set in mongocrypt_setopt_kms_providers");
+   }
+
    if (opts_spec->kek == OPT_PROHIBITED && ctx->opts.kek.kms_provider) {
       return _mongocrypt_ctx_fail_w_msg (ctx, "master key prohibited");
    }

--- a/test/test-gcp-auth.c
+++ b/test/test-gcp-auth.c
@@ -196,10 +196,9 @@ _test_createdatakey_with_accesstoken (_mongocrypt_tester_t *tester)
    ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
                        MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
    {
-      ASSERT_OK (
-         mongocrypt_ctx_provide_kms_providers (
-            ctx, TEST_BSON ("{'gcp': { 'accessToken': { 'foobar' } } }")),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_provide_kms_providers (
+                    ctx, TEST_BSON ("{'gcp': { 'accessToken': 'foobar' } }")),
+                 ctx);
    }
 
    /* Assert first CTX_NEED_KMS state requests encryption. */
@@ -301,10 +300,9 @@ _test_encrypt_with_accesstoken (_mongocrypt_tester_t *tester)
    ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),
                        MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
    {
-      ASSERT_OK (
-         mongocrypt_ctx_provide_kms_providers (
-            ctx, TEST_BSON ("{'gcp': { 'accessToken': { 'foobar' } } }")),
-         ctx);
+      ASSERT_OK (mongocrypt_ctx_provide_kms_providers (
+                    ctx, TEST_BSON ("{'gcp': { 'accessToken': 'foobar' } }")),
+                 ctx);
    }
 
    ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx),

--- a/test/test-gcp-auth.c
+++ b/test/test-gcp-auth.c
@@ -253,7 +253,7 @@ _test_createdatakey_with_wrong_kms_provider (_mongocrypt_tester_t *tester)
    ASSERT_FAILS (
       mongocrypt_ctx_datakey_init (ctx),
       ctx,
-      "Invalid encryption key: datakey provider does not match the provider "
+      "Invalid data key: datakey provider does not match the provider "
       "set in mongocrypt_setopt_kms_providers");
 
    mongocrypt_ctx_destroy (ctx);

--- a/test/test-gcp-auth.c
+++ b/test/test-gcp-auth.c
@@ -230,49 +230,6 @@ _test_createdatakey_with_accesstoken (_mongocrypt_tester_t *tester)
 }
 
 static void
-_test_createdatakey_with_wrong_kms_provider_helper (
-   _mongocrypt_tester_t *tester, mongocrypt_binary_t *kms_provider)
-{
-   mongocrypt_t *crypt;
-   mongocrypt_ctx_t *ctx;
-   const char *kek = "{"
-                     "'provider': 'azure',"
-                     "'keyName': 'foo',"
-                     "'keyVaultEndpoint': 'example.com'"
-                     "}";
-
-   crypt = mongocrypt_new ();
-   ASSERT_OK (mongocrypt_setopt_kms_providers (crypt, kms_provider), crypt);
-   mongocrypt_setopt_use_need_kms_credentials_state (crypt);
-   ASSERT_OK (mongocrypt_init (crypt), crypt);
-   ctx = mongocrypt_ctx_new (crypt);
-   ASSERT_OK (mongocrypt_ctx_setopt_key_encryption_key (ctx, TEST_BSON (kek)),
-              ctx);
-   ASSERT_FAILS (mongocrypt_ctx_datakey_init (ctx),
-                 ctx,
-                 "datakey provider does not match the provider "
-                 "set in mongocrypt_setopt_kms_providers");
-
-   mongocrypt_ctx_destroy (ctx);
-   mongocrypt_destroy (crypt);
-}
-
-static void
-_test_createdatakey_with_wrong_kms_provider_configured (
-   _mongocrypt_tester_t *tester)
-{
-   _test_createdatakey_with_wrong_kms_provider_helper (
-      tester, TEST_BSON ("{'gcp': { 'accessToken': '1234' } }"));
-}
-
-static void
-_test_createdatakey_with_wrong_kms_provider_empty (_mongocrypt_tester_t *tester)
-{
-   _test_createdatakey_with_wrong_kms_provider_helper (
-      tester, TEST_BSON ("{'gcp': {}}"));
-}
-
-static void
 _test_encrypt_with_accesstoken (_mongocrypt_tester_t *tester)
 {
    mongocrypt_t *crypt;
@@ -352,6 +309,4 @@ _mongocrypt_tester_install_gcp_auth (_mongocrypt_tester_t *tester)
    INSTALL_TEST (_test_encrypt_with_credentials);
    INSTALL_TEST (_test_createdatakey_with_accesstoken);
    INSTALL_TEST (_test_encrypt_with_accesstoken);
-   INSTALL_TEST (_test_createdatakey_with_wrong_kms_provider_configured);
-   INSTALL_TEST (_test_createdatakey_with_wrong_kms_provider_empty);
 }

--- a/test/test-gcp-auth.c
+++ b/test/test-gcp-auth.c
@@ -231,7 +231,8 @@ _test_createdatakey_with_accesstoken (_mongocrypt_tester_t *tester)
 }
 
 static void
-_test_createdatakey_with_wrong_kms_provider (_mongocrypt_tester_t *tester)
+_test_createdatakey_with_wrong_kms_provider_helper (
+   _mongocrypt_tester_t *tester, mongocrypt_binary_t *initial_kms)
 {
    mongocrypt_t *crypt;
    mongocrypt_ctx_t *ctx;
@@ -242,9 +243,7 @@ _test_createdatakey_with_wrong_kms_provider (_mongocrypt_tester_t *tester)
                      "}";
 
    crypt = mongocrypt_new ();
-   ASSERT_OK (
-      mongocrypt_setopt_kms_providers (crypt, TEST_BSON ("{'gcp': {}}")),
-      crypt);
+   ASSERT_OK (mongocrypt_setopt_kms_providers (crypt, initial_kms), crypt);
    mongocrypt_setopt_use_need_kms_credentials_state (crypt);
    ASSERT_OK (mongocrypt_init (crypt), crypt);
    ctx = mongocrypt_ctx_new (crypt);
@@ -258,6 +257,21 @@ _test_createdatakey_with_wrong_kms_provider (_mongocrypt_tester_t *tester)
 
    mongocrypt_ctx_destroy (ctx);
    mongocrypt_destroy (crypt);
+}
+
+static void
+_test_createdatakey_with_wrong_kms_provider_configured (
+   _mongocrypt_tester_t *tester)
+{
+   _test_createdatakey_with_wrong_kms_provider_helper (
+      tester, TEST_BSON ("{'gcp': { 'accessToken': '1234' } }"));
+}
+
+static void
+_test_createdatakey_with_wrong_kms_provider_empty (_mongocrypt_tester_t *tester)
+{
+   _test_createdatakey_with_wrong_kms_provider_helper (
+      tester, TEST_BSON ("{'gcp': {}}"));
 }
 
 static void
@@ -341,5 +355,6 @@ _mongocrypt_tester_install_gcp_auth (_mongocrypt_tester_t *tester)
    INSTALL_TEST (_test_encrypt_with_credentials);
    INSTALL_TEST (_test_createdatakey_with_accesstoken);
    INSTALL_TEST (_test_encrypt_with_accesstoken);
-   INSTALL_TEST (_test_createdatakey_with_wrong_kms_provider);
+   INSTALL_TEST (_test_createdatakey_with_wrong_kms_provider_configured);
+   INSTALL_TEST (_test_createdatakey_with_wrong_kms_provider_empty);
 }

--- a/test/test-gcp-auth.c
+++ b/test/test-gcp-auth.c
@@ -249,11 +249,10 @@ _test_createdatakey_with_wrong_kms_provider_helper (
    ctx = mongocrypt_ctx_new (crypt);
    ASSERT_OK (mongocrypt_ctx_setopt_key_encryption_key (ctx, TEST_BSON (kek)),
               ctx);
-   ASSERT_FAILS (
-      mongocrypt_ctx_datakey_init (ctx),
-      ctx,
-      "Invalid data key: datakey provider does not match the provider "
-      "set in mongocrypt_setopt_kms_providers");
+   ASSERT_FAILS (mongocrypt_ctx_datakey_init (ctx),
+                 ctx,
+                 "datakey provider does not match the provider "
+                 "set in mongocrypt_setopt_kms_providers");
 
    mongocrypt_ctx_destroy (ctx);
    mongocrypt_destroy (crypt);

--- a/test/test-gcp-auth.c
+++ b/test/test-gcp-auth.c
@@ -232,7 +232,7 @@ _test_createdatakey_with_accesstoken (_mongocrypt_tester_t *tester)
 
 static void
 _test_createdatakey_with_wrong_kms_provider_helper (
-   _mongocrypt_tester_t *tester, mongocrypt_binary_t *initial_kms)
+   _mongocrypt_tester_t *tester, mongocrypt_binary_t *kms_provider)
 {
    mongocrypt_t *crypt;
    mongocrypt_ctx_t *ctx;
@@ -243,7 +243,7 @@ _test_createdatakey_with_wrong_kms_provider_helper (
                      "}";
 
    crypt = mongocrypt_new ();
-   ASSERT_OK (mongocrypt_setopt_kms_providers (crypt, initial_kms), crypt);
+   ASSERT_OK (mongocrypt_setopt_kms_providers (crypt, kms_provider), crypt);
    mongocrypt_setopt_use_need_kms_credentials_state (crypt);
    ASSERT_OK (mongocrypt_init (crypt), crypt);
    ctx = mongocrypt_ctx_new (crypt);

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -977,6 +977,7 @@ main (int argc, char **argv)
    _mongocrypt_tester_install_range_mincover (&tester);
    _mongocrypt_tester_install_mc_RangeOpts (&tester);
    _mongocrypt_tester_install_mc_FLE2RangeFindDriverSpec (&tester);
+   _mongocrypt_tester_install_gcp_auth (&tester);
 
 #ifdef MONGOCRYPT_ENABLE_CRYPTO_COMMON_CRYPTO
    char osversion[32];


### PR DESCRIPTION
These changes will raise an error and not create a datakey when the datakay uses a different KMs provider than the initial KMS provider configured in `mongocrypt_setopt_kms_providers`. There are two added tests: one with a configured KMS provider and one with KMS provider that needs credential (when it is configured with an empty object). 