### PR TITLE
MONGOCRYPT-494 rename queryType and algorithm from "range" to "rangePreview"

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -1810,7 +1810,7 @@ _fle2_finalize_explicit (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
    marking.type = MONGOCRYPT_MARKING_FLE2_ENCRYPTION;
    if (ctx->opts.query_type.set) {
       switch (ctx->opts.query_type.value) {
-      case MONGOCRYPT_QUERY_TYPE_RANGE:
+      case MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW:
       case MONGOCRYPT_QUERY_TYPE_EQUALITY:
          marking.fle2.type = MONGOCRYPT_FLE2_PLACEHOLDER_TYPE_FIND;
          break;
@@ -1830,7 +1830,7 @@ _fle2_finalize_explicit (mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out)
    case MONGOCRYPT_INDEX_TYPE_NONE:
       marking.fle2.algorithm = MONGOCRYPT_FLE2_ALGORITHM_UNINDEXED;
       break;
-   case MONGOCRYPT_INDEX_TYPE_RANGE:
+   case MONGOCRYPT_INDEX_TYPE_RANGEPREVIEW:
       marking.fle2.algorithm = MONGOCRYPT_FLE2_ALGORITHM_RANGE;
       break;
    default:
@@ -2446,7 +2446,7 @@ mongocrypt_ctx_explicit_encrypt_init (mongocrypt_ctx_t *ctx,
    }
 
    if (ctx->opts.index_type.set &&
-       ctx->opts.index_type.value == MONGOCRYPT_INDEX_TYPE_RANGE) {
+       ctx->opts.index_type.value == MONGOCRYPT_INDEX_TYPE_RANGEPREVIEW) {
       if (!ctx->opts.contention_factor.set) {
          return _mongocrypt_ctx_fail_w_msg (
             ctx, "contention factor is required for range indexed algorithm");
@@ -2470,8 +2470,9 @@ mongocrypt_ctx_explicit_encrypt_init (mongocrypt_ctx_t *ctx,
       bool matches = false;
 
       switch (ctx->opts.query_type.value) {
-      case MONGOCRYPT_QUERY_TYPE_RANGE:
-         matches = (ctx->opts.index_type.value == MONGOCRYPT_INDEX_TYPE_RANGE);
+      case MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW:
+         matches =
+            (ctx->opts.index_type.value == MONGOCRYPT_INDEX_TYPE_RANGEPREVIEW);
          break;
       case MONGOCRYPT_QUERY_TYPE_EQUALITY:
          matches =

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -39,7 +39,7 @@ typedef enum {
 typedef enum {
    MONGOCRYPT_INDEX_TYPE_NONE = 1,
    MONGOCRYPT_INDEX_TYPE_EQUALITY = 2,
-   MONGOCRYPT_INDEX_TYPE_RANGE = 3
+   MONGOCRYPT_INDEX_TYPE_RANGEPREVIEW = 3
 } mongocrypt_index_type_t;
 
 const char *
@@ -47,7 +47,7 @@ _mongocrypt_index_type_to_string (mongocrypt_index_type_t val);
 
 typedef enum {
    MONGOCRYPT_QUERY_TYPE_EQUALITY = 1,
-   MONGOCRYPT_QUERY_TYPE_RANGE = 2
+   MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW = 2
 } mongocrypt_query_type_t;
 
 const char *

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -303,8 +303,8 @@ mongocrypt_ctx_setopt_algorithm (mongocrypt_ctx_t *ctx,
       ctx->opts.index_type.value = MONGOCRYPT_INDEX_TYPE_NONE;
       ctx->opts.index_type.set = true;
    } else if (mstr_eq_ignore_case (
-                 algo_str, mstrv_lit (MONGOCRYPT_ALGORITHM_RANGE_STR))) {
-      ctx->opts.index_type.value = MONGOCRYPT_INDEX_TYPE_RANGE;
+                 algo_str, mstrv_lit (MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR))) {
+      ctx->opts.index_type.value = MONGOCRYPT_INDEX_TYPE_RANGEPREVIEW;
       ctx->opts.index_type.set = true;
    } else {
       char *error = bson_strdup_printf ("unsupported algorithm string \"%.*s\"",
@@ -1196,8 +1196,8 @@ mongocrypt_ctx_setopt_query_type (mongocrypt_ctx_t *ctx,
       ctx->opts.query_type.value = MONGOCRYPT_QUERY_TYPE_EQUALITY;
       ctx->opts.query_type.set = true;
    } else if (mstr_eq_ignore_case (
-                 qt_str, mstrv_lit (MONGOCRYPT_QUERY_TYPE_RANGE_STR))) {
-      ctx->opts.query_type.value = MONGOCRYPT_QUERY_TYPE_RANGE;
+                 qt_str, mstrv_lit (MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR))) {
+      ctx->opts.query_type.value = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW;
       ctx->opts.query_type.set = true;
    } else {
       char *error = bson_strdup_printf (
@@ -1217,8 +1217,8 @@ _mongocrypt_index_type_to_string (mongocrypt_index_type_t val)
       return "None";
    case MONGOCRYPT_INDEX_TYPE_EQUALITY:
       return "Equality";
-   case MONGOCRYPT_INDEX_TYPE_RANGE:
-      return "Range";
+   case MONGOCRYPT_INDEX_TYPE_RANGEPREVIEW:
+      return "RangePreview";
    default:
       return "Unknown";
    }
@@ -1230,8 +1230,8 @@ _mongocrypt_query_type_to_string (mongocrypt_query_type_t val)
    switch (val) {
    case MONGOCRYPT_QUERY_TYPE_EQUALITY:
       return "Equality";
-   case MONGOCRYPT_QUERY_TYPE_RANGE:
-      return "Range";
+   case MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW:
+      return "RangePreview";
    default:
       return "Unknown";
    }

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -740,10 +740,10 @@ mongocrypt_ctx_setopt_algorithm (mongocrypt_ctx_t *ctx,
 #define MONGOCRYPT_ALGORITHM_INDEXED_STR "Indexed"
 /// String constant for setopt_algorithm "Unindexed" explicit encryption
 #define MONGOCRYPT_ALGORITHM_UNINDEXED_STR "Unindexed"
-/// String constant for setopt_algorithm "Range" explicit encryption
-/// NOTE: The Range algorithm is experimental only. It is not intended for
-/// public use.
-#define MONGOCRYPT_ALGORITHM_RANGE_STR "Range"
+/// String constant for setopt_algorithm "rangePreview" explicit encryption
+/// NOTE: The RangePreview algorithm is experimental only. It is not intended
+/// for public use.
+#define MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR "RangePreview"
 
 
 /**
@@ -916,7 +916,7 @@ mongocrypt_ctx_encrypt_init (mongocrypt_ctx_t *ctx,
  * This method expects the passed-in BSON to be of the form:
  * { "v" : BSON value to encrypt | FLE2RangeFindDriverSpec }
  *
- * FLE2RangeFindDriverSpec may only be used when query_type is "range".
+ * FLE2RangeFindDriverSpec may only be used when query_type is "rangePreview".
  * FLE2RangeFindDriverSpec is a BSON document with one of these forms:
  *
  * 1. A Match Expression of this form:
@@ -1539,9 +1539,9 @@ mongocrypt_ctx_setopt_query_type (mongocrypt_ctx_t *ctx,
                                   int len);
 
 /**
- * Set options for explicit encryption with the "range" algorithm.
- * NOTE: The Range algorithm is experimental only. It is not intended for public
- * use.
+ * Set options for explicit encryption with the "rangePreview" algorithm.
+ * NOTE: The RangePreview algorithm is experimental only. It is not intended for
+ * public use.
  *
  * @p opts is a BSON document of the form:
  * {
@@ -1564,8 +1564,8 @@ mongocrypt_ctx_setopt_algorithm_range (mongocrypt_ctx_t *ctx,
 
 /// String constants for setopt_query_type
 #define MONGOCRYPT_QUERY_TYPE_EQUALITY_STR "equality"
-// NOTE: The Range algorithm is experimental only. It is not intended for public
-// use.
-#define MONGOCRYPT_QUERY_TYPE_RANGE_STR "range"
+// NOTE: The RangePreview algorithm is experimental only. It is not intended for
+// public use.
+#define MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR "rangePreview"
 
 #endif /* MONGOCRYPT_H */

--- a/test/data/fle2-find-range/date/encrypted-field-map.json
+++ b/test/data/fle2-find-range/date/encrypted-field-map.json
@@ -14,7 +14,7 @@
             "path": "encrypted",
             "bsonType": "date",
             "queries": {
-               "queryType": "range",
+               "queryType": "rangePreview",
                "contention": {
                   "$numberInt": "0"
                },

--- a/test/data/fle2-find-range/date/encrypted-payload.json
+++ b/test/data/fle2-find-range/date/encrypted-payload.json
@@ -26,7 +26,7 @@
                         "path": "encrypted",
                         "bsonType": "date",
                         "queries": {
-                            "queryType": "range",
+                            "queryType": "rangePreview",
                             "contention": {
                                 "$numberInt": "0"
                             },

--- a/test/data/fle2-find-range/date/mongocryptd-reply.json
+++ b/test/data/fle2-find-range/date/mongocryptd-reply.json
@@ -32,7 +32,7 @@
                             "path": "encrypted",
                             "bsonType": "date",
                             "queries": {
-                                "queryType": "range",
+                                "queryType": "rangePreview",
                                 "contention": {
                                     "$numberInt": "0"
                                 },

--- a/test/data/fle2-find-range/double/encrypted-field-map.json
+++ b/test/data/fle2-find-range/double/encrypted-field-map.json
@@ -14,7 +14,7 @@
             "path": "encrypted",
             "bsonType": "double",
             "queries": {
-               "queryType": "range",
+               "queryType": "rangePreview",
                "contention": {
                   "$numberInt": "0"
                },

--- a/test/data/fle2-find-range/double/encrypted-payload.json
+++ b/test/data/fle2-find-range/double/encrypted-payload.json
@@ -26,7 +26,7 @@
                         "path": "encrypted",
                         "bsonType": "double",
                         "queries": {
-                            "queryType": "range",
+                            "queryType": "rangePreview",
                             "contention": {
                                 "$numberInt": "0"
                             },

--- a/test/data/fle2-find-range/double/mongocryptd-reply.json
+++ b/test/data/fle2-find-range/double/mongocryptd-reply.json
@@ -32,7 +32,7 @@
                             "path": "encrypted",
                             "bsonType": "double",
                             "queries": {
-                                "queryType": "range",
+                                "queryType": "rangePreview",
                                 "contention": {
                                     "$numberInt": "0"
                                 },

--- a/test/data/fle2-find-range/int32/encrypted-field-map.json
+++ b/test/data/fle2-find-range/int32/encrypted-field-map.json
@@ -14,7 +14,7 @@
             "path": "encrypted",
             "bsonType": "int",
             "queries": {
-               "queryType": "range",
+               "queryType": "rangePreview",
                "contention": {
                   "$numberInt": "0"
                },

--- a/test/data/fle2-find-range/int32/encrypted-payload.json
+++ b/test/data/fle2-find-range/int32/encrypted-payload.json
@@ -26,7 +26,7 @@
                         "path": "encrypted",
                         "bsonType": "int",
                         "queries": {
-                            "queryType": "range",
+                            "queryType": "rangePreview",
                             "contention": {
                                 "$numberInt": "0"
                             },

--- a/test/data/fle2-find-range/int32/mongocryptd-reply.json
+++ b/test/data/fle2-find-range/int32/mongocryptd-reply.json
@@ -32,7 +32,7 @@
                             "path": "encrypted",
                             "bsonType": "int",
                             "queries": {
-                                "queryType": "range",
+                                "queryType": "rangePreview",
                                 "contention": {
                                     "$numberInt": "0"
                                 },

--- a/test/data/fle2-find-range/int64/encrypted-field-map.json
+++ b/test/data/fle2-find-range/int64/encrypted-field-map.json
@@ -14,7 +14,7 @@
             "path": "encrypted",
             "bsonType": "long",
             "queries": {
-               "queryType": "range",
+               "queryType": "rangePreview",
                "contention": {
                   "$numberInt": "0"
                },

--- a/test/data/fle2-find-range/int64/encrypted-payload.json
+++ b/test/data/fle2-find-range/int64/encrypted-payload.json
@@ -26,7 +26,7 @@
                         "path": "encrypted",
                         "bsonType": "long",
                         "queries": {
-                            "queryType": "range",
+                            "queryType": "rangePreview",
                             "contention": {
                                 "$numberInt": "0"
                             },

--- a/test/data/fle2-find-range/int64/mongocryptd-reply.json
+++ b/test/data/fle2-find-range/int64/mongocryptd-reply.json
@@ -32,7 +32,7 @@
                             "path": "encrypted",
                             "bsonType": "int",
                             "queries": {
-                                "queryType": "range",
+                                "queryType": "rangePreview",
                                 "contention": {
                                     "$numberInt": "0"
                                 },

--- a/test/data/fle2-insert-range/date/encrypted-field-map.json
+++ b/test/data/fle2-insert-range/date/encrypted-field-map.json
@@ -14,7 +14,7 @@
             "path": "encrypted",
             "bsonType": "date",
             "queries": {
-               "queryType": "range",
+               "queryType": "rangePreview",
                "contention": {
                   "$numberInt": "0"
                },

--- a/test/data/fle2-insert-range/date/encrypted-payload.json
+++ b/test/data/fle2-insert-range/date/encrypted-payload.json
@@ -29,7 +29,7 @@
                         "path": "encrypted",
                         "bsonType": "date",
                         "queries": {
-                            "queryType": "range",
+                            "queryType": "rangePreview",
                             "contention": {
                                 "$numberInt": "0"
                             },

--- a/test/data/fle2-insert-range/date/mongocryptd-reply.json
+++ b/test/data/fle2-insert-range/date/mongocryptd-reply.json
@@ -35,7 +35,7 @@
                             "path": "encrypted",
                             "bsonType": "long",
                             "queries": {
-                                "queryType": "range",
+                                "queryType": "rangePreview",
                                 "contention": {
                                     "$numberInt": "0"
                                 },

--- a/test/data/fle2-insert-range/double/encrypted-field-map.json
+++ b/test/data/fle2-insert-range/double/encrypted-field-map.json
@@ -14,7 +14,7 @@
             "path": "encrypted",
             "bsonType": "double",
             "queries": {
-               "queryType": "range",
+               "queryType": "rangePreview",
                "contention": {
                   "$numberInt": "0"
                },

--- a/test/data/fle2-insert-range/double/encrypted-payload.json
+++ b/test/data/fle2-insert-range/double/encrypted-payload.json
@@ -29,7 +29,7 @@
                         "path": "encrypted",
                         "bsonType": "double",
                         "queries": {
-                            "queryType": "range",
+                            "queryType": "rangePreview",
                             "contention": {
                                 "$numberInt": "0"
                             },

--- a/test/data/fle2-insert-range/double/mongocryptd-reply.json
+++ b/test/data/fle2-insert-range/double/mongocryptd-reply.json
@@ -35,7 +35,7 @@
                             "path": "encrypted",
                             "bsonType": "long",
                             "queries": {
-                                "queryType": "range",
+                                "queryType": "rangePreview",
                                 "contention": {
                                     "$numberInt": "0"
                                 },

--- a/test/data/fle2-insert-range/int32/encrypted-field-map.json
+++ b/test/data/fle2-insert-range/int32/encrypted-field-map.json
@@ -14,7 +14,7 @@
             "path": "encrypted",
             "bsonType": "int",
             "queries": {
-               "queryType": "range",
+               "queryType": "rangePreview",
                "contention": {
                   "$numberInt": "0"
                },

--- a/test/data/fle2-insert-range/int32/encrypted-payload.json
+++ b/test/data/fle2-insert-range/int32/encrypted-payload.json
@@ -29,7 +29,7 @@
                         "path": "encrypted",
                         "bsonType": "int",
                         "queries": {
-                            "queryType": "range",
+                            "queryType": "rangePreview",
                             "contention": {
                                 "$numberInt": "0"
                             },

--- a/test/data/fle2-insert-range/int32/mongocryptd-reply.json
+++ b/test/data/fle2-insert-range/int32/mongocryptd-reply.json
@@ -35,7 +35,7 @@
                             "path": "encrypted",
                             "bsonType": "int",
                             "queries": {
-                                "queryType": "range",
+                                "queryType": "rangePreview",
                                 "contention": {
                                     "$numberInt": "0"
                                 },

--- a/test/data/fle2-insert-range/int64/encrypted-field-map.json
+++ b/test/data/fle2-insert-range/int64/encrypted-field-map.json
@@ -14,7 +14,7 @@
             "path": "encrypted",
             "bsonType": "long",
             "queries": {
-               "queryType": "range",
+               "queryType": "rangePreview",
                "contention": {
                   "$numberInt": "0"
                },

--- a/test/data/fle2-insert-range/int64/encrypted-payload.json
+++ b/test/data/fle2-insert-range/int64/encrypted-payload.json
@@ -29,7 +29,7 @@
                         "path": "encrypted",
                         "bsonType": "long",
                         "queries": {
-                            "queryType": "range",
+                            "queryType": "rangePreview",
                             "contention": {
                                 "$numberInt": "0"
                             },

--- a/test/data/fle2-insert-range/int64/mongocryptd-reply.json
+++ b/test/data/fle2-insert-range/int64/mongocryptd-reply.json
@@ -35,7 +35,7 @@
                             "path": "encrypted",
                             "bsonType": "long",
                             "queries": {
-                                "queryType": "range",
+                                "queryType": "rangePreview",
                                 "contention": {
                                     "$numberInt": "0"
                                 },

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -3012,7 +3012,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       tc.rng_data = (_test_rng_data_source){
          .buf = {.data = (uint8_t *) RNG_DATA, .len = sizeof (RNG_DATA) - 1}};
 #undef RNG_DATA
-      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
+      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
       tc.user_key_id = &keyABC_id;
       tc.index_key_id = &key123_id;
       tc.contention_factor = OPT_I64 (0);
@@ -3034,7 +3034,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       tc.rng_data = (_test_rng_data_source){
          .buf = {.data = (uint8_t *) RNG_DATA, .len = sizeof (RNG_DATA) - 1}};
 #undef RNG_DATA
-      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
+      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
       tc.user_key_id = &keyABC_id;
       tc.index_key_id = &key123_id;
       tc.contention_factor = OPT_I64 (0);
@@ -3053,11 +3053,11 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
    {
       ee_testcase tc = {0};
       tc.desc = "algorithm='Range' with query_type='range' with int32";
-      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
+      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
       tc.user_key_id = &keyABC_id;
       tc.index_key_id = &keyABC_id;
       tc.contention_factor = OPT_I64 (4);
-      tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGE_STR;
+      tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR;
       tc.range_opts = TEST_FILE ("./test/data/fle2-find-range-explicit/"
                                  "int32/rangeopts.json");
       tc.msg = TEST_FILE ("./test/data/fle2-find-range-explicit/int32/"
@@ -3071,7 +3071,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
    {
       ee_testcase tc = {0};
       tc.desc = "An unsupported range BSON type is an error";
-      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
+      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
       tc.user_key_id = &keyABC_id;
       tc.contention_factor = OPT_I64 (0);
       tc.range_opts =
@@ -3086,11 +3086,11 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       ee_testcase tc = {0};
       tc.desc = "algorithm='Range' with query_type='range' with double with "
                 "precision";
-      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
+      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
       tc.user_key_id = &keyABC_id;
       tc.index_key_id = &key123_id;
       tc.contention_factor = OPT_I64 (0);
-      tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGE_STR;
+      tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR;
       tc.range_opts =
          TEST_FILE ("./test/data/fle2-find-range-explicit/double-precision/"
                     "rangeopts.json");
@@ -3110,7 +3110,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       tc.rng_data = (_test_rng_data_source){
          .buf = {.data = (uint8_t *) RNG_DATA, .len = sizeof (RNG_DATA) - 1}};
 #undef RNG_DATA
-      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
+      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
       tc.user_key_id = &keyABC_id;
       tc.index_key_id = &key123_id;
       tc.contention_factor = OPT_I64 (0);
@@ -3131,11 +3131,11 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       ee_testcase tc = {0};
       tc.desc = "algorithm='Range' with query_type='range' with double without "
                 "precision";
-      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
+      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
       tc.user_key_id = &keyABC_id;
       tc.index_key_id = &key123_id;
       tc.contention_factor = OPT_I64 (0);
-      tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGE_STR;
+      tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR;
       tc.range_opts = TEST_FILE ("./test/data/fle2-find-range-explicit/double/"
                                  "rangeopts.json");
       tc.msg = TEST_FILE (
@@ -3154,7 +3154,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       tc.rng_data = (_test_rng_data_source){
          .buf = {.data = (uint8_t *) RNG_DATA, .len = sizeof (RNG_DATA) - 1}};
 #undef RNG_DATA
-      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
+      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
       tc.user_key_id = &keyABC_id;
       tc.index_key_id = &key123_id;
       tc.contention_factor = OPT_I64 (0);
@@ -3177,7 +3177,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       tc.rng_data = (_test_rng_data_source){
          .buf = {.data = (uint8_t *) RNG_DATA, .len = sizeof (RNG_DATA) - 1}};
 #undef RNG_DATA
-      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
+      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
       tc.user_key_id = &keyABC_id;
       tc.contention_factor = OPT_I64 (0);
       tc.range_opts = TEST_FILE ("./test/data/fle2-insert-range-explicit/"
@@ -3195,8 +3195,8 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
       ee_testcase tc = {0};
       tc.desc = "algorithm='Range' and query_type='range' with int32 with "
                 "default min/max";
-      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
-      tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGE_STR;
+      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+      tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR;
       tc.user_key_id = &keyABC_id;
       tc.contention_factor = OPT_I64 (0);
       tc.range_opts = TEST_FILE ("./test/data/fle2-find-range-explicit/"
@@ -3213,7 +3213,7 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
    {
       ee_testcase tc = {0};
       tc.desc = "min > max for insert";
-      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
+      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
       tc.user_key_id = &keyABC_id;
       tc.contention_factor = OPT_I64 (0);
       tc.range_opts =
@@ -3229,8 +3229,8 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
    {
       ee_testcase tc = {0};
       tc.desc = "min > max for find";
-      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
-      tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGE_STR;
+      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+      tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR;
       tc.user_key_id = &keyABC_id;
       tc.contention_factor = OPT_I64 (0);
       tc.range_opts =
@@ -3246,8 +3246,8 @@ _test_encrypt_fle2_explicit (_mongocrypt_tester_t *tester)
    {
       ee_testcase tc = {0};
       tc.desc = "open interval";
-      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
-      tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGE_STR;
+      tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+      tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR;
       tc.user_key_id = &keyABC_id;
       tc.contention_factor = OPT_I64 (0);
       tc.range_opts = TEST_FILE ("./test/data/fle2-find-range-explicit/"

--- a/test/test-mongocrypt-ctx-setopt.c
+++ b/test/test-mongocrypt-ctx-setopt.c
@@ -932,7 +932,7 @@ _test_setopt_for_explicit_encrypt (_mongocrypt_tester_t *tester)
       ASSERT_EX_ENCRYPT_INIT_FAILS (bson, "contention factor is required");
    }
 
-   /* Contention factor is required for "Range" algorithm. */
+   /* Contention factor is required for "rangePreview" algorithm. */
    {
       REFRESH;
       /* Set key ID to get past the 'either key id or key alt name required'
@@ -940,12 +940,12 @@ _test_setopt_for_explicit_encrypt (_mongocrypt_tester_t *tester)
       ASSERT_KEY_ID_OK (uuid);
       ASSERT_OK (mongocrypt_ctx_setopt_algorithm_range (ctx, rangeopts), ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
-                    ctx, MONGOCRYPT_ALGORITHM_RANGE_STR, -1),
+                    ctx, MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR, -1),
                  ctx);
       ASSERT_EX_ENCRYPT_INIT_FAILS (bson, "contention factor is required");
    }
 
-   /* Range opts is required for "Range" algorithm. */
+   /* Range opts is required for "rangePreview" algorithm. */
    {
       REFRESH;
       /* Set key ID to get past the 'either key id or key alt name required'
@@ -953,7 +953,7 @@ _test_setopt_for_explicit_encrypt (_mongocrypt_tester_t *tester)
       ASSERT_KEY_ID_OK (uuid);
       ASSERT_OK (mongocrypt_ctx_setopt_contention_factor (ctx, 0), ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
-                    ctx, MONGOCRYPT_ALGORITHM_RANGE_STR, -1),
+                    ctx, MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR, -1),
                  ctx);
       ASSERT_EX_ENCRYPT_INIT_FAILS (bson, "range opts are required");
    }
@@ -972,17 +972,17 @@ _test_setopt_for_explicit_encrypt (_mongocrypt_tester_t *tester)
          ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_contention_factor (ctx, 0), ctx);
       ASSERT_OK (mongocrypt_ctx_setopt_algorithm (
-                    ctx, MONGOCRYPT_ALGORITHM_RANGE_STR, -1),
+                    ctx, MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR, -1),
                  ctx);
       ASSERT_EX_ENCRYPT_INIT_FAILS (bson, "sparsity must be non-negative");
    }
 
-   /* Error if query_type == "range" and algorithm != "range". */
+   /* Error if query_type == "rangePreview" and algorithm != "rangePreview". */
    {
       REFRESH;
       ASSERT_KEY_ID_OK (uuid);
       ASSERT_ALGORITHM_OK (MONGOCRYPT_ALGORITHM_INDEXED_STR, -1);
-      ASSERT_QUERY_TYPE_OK (MONGOCRYPT_QUERY_TYPE_RANGE_STR, -1);
+      ASSERT_QUERY_TYPE_OK (MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR, -1);
       ASSERT_OK (mongocrypt_ctx_setopt_contention_factor (ctx, 0), ctx);
       ASSERT_EX_ENCRYPT_INIT_FAILS (bson, "must match index_type");
    }


### PR DESCRIPTION
# Summary

- Rename queryType and algorithm from "range" to "rangePreview"

# Background & Motivation

The `encryptedFields` in the server now expects the string `rangePreview`: https://github.com/mongodb/mongo/commit/484eee157ecc039fafbbef6a4aae0286c8bbc3b5#diff-64f7154b6f37606f91956209094c8cc9005f11ee48d8f54210a65cbb8bd102b8R56

It is expected to change back to "range" once the feature is stabilized.