### PR TITLE
MONGOCRYPT-446 add build variant and package publications for Debian 11 and Ubuntu 22.04

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -116,7 +116,7 @@ functions:
       params:
         script: |-
           if test "$OS_NAME" != "windows"; then export USE_NINJA=ON; fi
-          env ${compile_env|} CONFIGURE_ONLY=ON CC=clang CXX=clang++ \
+          env ${compile_env|} CONFIGURE_ONLY=ON ${clang_env|CC=clang CXX=clang++} \
               bash libmongocrypt/.evergreen/build_all.sh
           ./libmongocrypt/.evergreen/clang-tidy.sh
 
@@ -635,6 +635,10 @@ tasks:
       name: build-and-test-and-upload
     - variant: ubuntu2004-arm64
       name: build-and-test-and-upload
+    - variant: ubuntu2204-64
+      name: build-and-test-and-upload
+    - variant: ubuntu2204-arm64
+      name: build-and-test-and-upload
     - variant: macos
       name: build-and-test-and-upload
   commands:
@@ -686,6 +690,10 @@ tasks:
       vars: { variant_name: "ubuntu2004-64" }
     - func: "download tarball"
       vars: { variant_name: "ubuntu2004-arm64" }
+    - func: "download tarball"
+      vars: { variant_name: "ubuntu2204-64" }
+    - func: "download tarball"
+      vars: { variant_name: "ubuntu2204-arm64" }
     - func: "download tarball"
       vars: { variant_name: "macos" }
     - command: archive.targz_pack
@@ -1289,6 +1297,40 @@ buildvariants:
   - build-and-test-asan
   - build-and-test-node
   - build-and-test-node-no-optional-dependencies
+  - test-java
+  - name: publish-packages
+    distros:
+    - ubuntu2004-small
+- name: ubuntu2204-64
+  display_name: "Ubuntu 22.04 64-bit"
+  run_on: ubuntu2204-small
+  expansions:
+    has_packages: true
+    packager_distro: ubuntu2204
+    packager_arch: x86_64
+    clang_env: CC=clang-12 CXX=clang++-12
+  tasks:
+  - clang-tidy
+  - build-and-test-and-upload
+  - build-and-test-shared-bson
+  - build-and-test-asan
+  - build-and-test-node
+  - build-and-test-csharp
+  - test-java
+  - upload-java
+  - publish-packages
+- name: ubuntu2204-arm64
+  display_name: "Ubuntu 22.04 arm64"
+  run_on: ubuntu2204-arm64-small
+  expansions:
+    has_packages: true
+    packager_distro: ubuntu2204
+    packager_arch: arm64
+  tasks:
+  - build-and-test-and-upload
+  - build-and-test-shared-bson
+  - build-and-test-asan
+  - build-and-test-node
   - test-java
   - name: publish-packages
     distros:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -605,6 +605,8 @@ tasks:
       name: build-and-test-and-upload
     - variant: amazon2-arm64
       name: build-and-test-and-upload
+    - variant: debian11
+      name: build-and-test-and-upload
     - variant: debian10
       name: build-and-test-and-upload
     - variant: debian92
@@ -654,6 +656,8 @@ tasks:
       vars: { variant_name: "amazon2" }
     - func: "download tarball"
       vars: { variant_name: "amazon2-arm64" }
+    - func: "download tarball"
+      vars: { variant_name: "debian11" }
     - func: "download tarball"
       vars: { variant_name: "debian10" }
     - func: "download tarball"
@@ -1035,6 +1039,22 @@ buildvariants:
   - name: publish-packages
     distros:
     - rhel70-small
+- name: debian11
+  display_name: "Debian 11.0"
+  run_on: debian11-large
+  expansions:
+    has_packages: true
+    packager_distro: debian11
+    packager_arch: x86_64
+  tasks:
+  - build-and-test-and-upload
+  - build-and-test-shared-bson
+  - build-and-test-asan
+  - build-and-test-node
+  - test-java
+  - name: publish-packages
+    distros:
+    - ubuntu2004-small
 - name: debian10
   display_name: "Debian 10.0"
   run_on: debian10-test

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ First, import the public key used to sign the package repositories:
 sudo sh -c 'curl -s --location https://www.mongodb.org/static/pgp/libmongocrypt.asc | gpg --dearmor >/etc/apt/trusted.gpg.d/libmongocrypt.gpg'
 ```
 
-Second, create a list entry for the repository.  For Ubuntu systems (be sure to change `<release>` to `xenial` or `bionic`, as appropriate to your system):
+Second, create a list entry for the repository.  For Ubuntu systems (be sure to change `<release>` to `xenial`, `bionic`, `focal`, or `jammy`, as appropriate to your system):
 
 ```
 echo "deb https://libmongocrypt.s3.amazonaws.com/apt/ubuntu <release>/libmongocrypt/1.6 universe" | sudo tee /etc/apt/sources.list.d/libmongocrypt.list

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Second, create a list entry for the repository.  For Ubuntu systems (be sure to 
 echo "deb https://libmongocrypt.s3.amazonaws.com/apt/ubuntu <release>/libmongocrypt/1.6 universe" | sudo tee /etc/apt/sources.list.d/libmongocrypt.list
 ```
 
-For Debian systems (be sure to change `<release>` to `stretch` or `buster`, as appropriate to your system):
+For Debian systems (be sure to change `<release>` to `stretch`, `buster`, or `bullseye`, as appropriate to your system):
 
 ```
 echo "deb https://libmongocrypt.s3.amazonaws.com/apt/debian <release>/libmongocrypt/1.6 main" | sudo tee /etc/apt/sources.list.d/libmongocrypt.list

--- a/etc/packager.py
+++ b/etc/packager.py
@@ -300,6 +300,8 @@ class Distro(object):
                 return "bionic"
             elif build_os == 'ubuntu2004':
                 return "focal"
+            elif build_os == 'ubuntu2204':
+                return "jammy"
             else:
                 raise Exception("unsupported build_os: %s" % build_os)
         elif self.dname == 'debian':
@@ -349,6 +351,7 @@ class Distro(object):
                 "ubuntu1604",
                 "ubuntu1804",
                 "ubuntu2004",
+                "ubuntu2204",
             ]
         elif self.dname == 'debian':
             return ["debian81", "debian92", "debian10", "debian11"]

--- a/etc/packager.py
+++ b/etc/packager.py
@@ -309,6 +309,8 @@ class Distro(object):
                 return 'stretch'
             elif build_os == 'debian10':
                 return 'buster'
+            elif build_os == 'debian11':
+                return 'bullseye'
             else:
                 raise Exception("unsupported build_os: %s" % build_os)
         else:
@@ -349,7 +351,7 @@ class Distro(object):
                 "ubuntu2004",
             ]
         elif self.dname == 'debian':
-            return ["debian81", "debian92", "debian10"]
+            return ["debian81", "debian92", "debian10", "debian11"]
         else:
             raise Exception("BUG: unsupported platform?")
 

--- a/etc/repo_config.yaml
+++ b/etc/repo_config.yaml
@@ -241,3 +241,17 @@ repos:
       - arm64
     repos:
       - apt/ubuntu/dists/focal/libmongocrypt
+
+  - name: ubuntu2204
+    type: deb
+    code_name: "jammy"
+    edition: org
+    bucket: libmongocrypt
+    region: us-east-1
+    component: universe
+    architectures:
+      - amd64
+      - i386
+      - arm64
+    repos:
+      - apt/ubuntu/dists/jammy/libmongocrypt

--- a/etc/repo_config.yaml
+++ b/etc/repo_config.yaml
@@ -175,6 +175,18 @@ repos:
     repos:
       - apt/debian/dists/buster/libmongocrypt
 
+  - name: debian11
+    type: deb
+    code_name: "bullseye"
+    bucket: libmongocrypt
+    region: us-east-1
+    edition: org
+    component: main
+    architectures:
+      - amd64
+    repos:
+      - apt/debian/dists/bullseye/libmongocrypt
+
   - name: ubuntu1404
     type: deb
     code_name: "trusty"


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/version/6384eb75850e615387a38ee9/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Note that the `build-and-test-csharp` task is failing on Ubuntu 22.04.  I have communicated with @DmitryLukyanov about this and we concluded that it would best for me to go ahead with this PR and let the C# team address the failing task when it makes sense for the team's priorities.