### PR TITLE
MONGOCRYPT-501 fix conversion warning on clang 7 with glibc

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1220,6 +1220,16 @@ buildvariants:
   - name: publish-packages
     distros:
     - ubuntu2004-small
+- name: ubuntu1804-64-clang7
+  # ubuntu1804-64-clang7 is used to test Ubuntu 18.04 with Clang 7.0.1.
+  # This is a supported configuration built by the MongoDB Server.
+  # The MongoDB Server vendors libmongocrypt. Refer: MONGOCRYPT-501.
+  display_name: "Ubuntu 18.04 64-bit clang7"
+  run_on: ubuntu1804-test
+  expansions:
+    compile_env: LIBMONGOCRYPT_EXTRA_CMAKE_FLAGS="-DCMAKE_C_COMPILER=/opt/mongodbtoolchain/v3/bin/clang -DCMAKE_CXX_COMPILER=/opt/mongodbtoolchain/v3/bin/clang++"
+  tasks:
+  - build-and-test-and-upload
 - name: ubuntu1804-arm64
   display_name: "Ubuntu 18.04 arm64"
   run_on: ubuntu1804-arm64-build

--- a/src/mc-range-encoding.c
+++ b/src/mc-range-encoding.c
@@ -17,8 +17,9 @@
 #include "mc-check-conversions-private.h"
 #include "mc-range-encoding-private.h"
 #include "mongocrypt-private.h"
+#include "mongocrypt-util-private.h" // mc_isinf
 
-#include <math.h> // isinf
+#include <math.h> // pow
 
 /* mc-range-encoding.c assumes integers are encoded with two's complement for
  * correctness. */
@@ -190,7 +191,7 @@ mc_getTypeInfoDouble (mc_getTypeInfoDouble_args_t args,
       return false;
    }
 
-   if (isinf (args.value) || isnan (args.value)) {
+   if (mc_isinf (args.value) || mc_isnan (args.value)) {
       CLIENT_ERR ("Infinity and Nan double values are not supported.");
       return false;
    }
@@ -244,14 +245,15 @@ mc_getTypeInfoDouble (mc_getTypeInfoDouble_args_t args,
 
       // We can overflow if max = max double and min = min double so make sure
       // we have finite number after we do subtraction
-      if (isfinite (range)) {
+      // Ignore conversion warnings to fix error with glibc.
+      if (mc_isfinite (range)) {
          // This creates a range which is wider then we permit by our min/max
          // bounds check with the +1 but it is as the algorithm is written in
          // WRITING-11907.
          double rangeAndPrecision =
             (range + 1) * exp10Double (args.precision.value);
 
-         if (isfinite (rangeAndPrecision)) {
+         if (mc_isfinite (rangeAndPrecision)) {
             double bits_range_double = log2 (rangeAndPrecision);
             bits_range = (uint32_t) ceil (bits_range_double);
 

--- a/src/mc-range-encoding.c
+++ b/src/mc-range-encoding.c
@@ -192,7 +192,7 @@ mc_getTypeInfoDouble (mc_getTypeInfoDouble_args_t args,
    }
 
    if (mc_isinf (args.value) || mc_isnan (args.value)) {
-      CLIENT_ERR ("Infinity and Nan double values are not supported.");
+      CLIENT_ERR ("Infinity and NaN double values are not supported.");
       return false;
    }
 

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -1008,7 +1008,7 @@ fail:
 static bool
 isInfinite (bson_iter_t *iter)
 {
-   return isinf (bson_iter_double (iter));
+   return mc_isinf (bson_iter_double (iter));
 }
 
 // mc_get_mincover_from_FLE2RangeFindSpec creates and returns a mincover from an

--- a/src/mongocrypt-util-private.h
+++ b/src/mongocrypt-util-private.h
@@ -70,4 +70,15 @@ mc_iter_document_as_bson (const bson_iter_t *iter,
                           bson_t *bson,
                           mongocrypt_status_t *status);
 
+// mc_isnan is a wrapper around isnan. It avoids a conversion warning on glibc.
+bool
+mc_isnan (double d);
+// mc_isinf is a wrapper around isinf. It avoids a conversion warning on glibc.
+bool
+mc_isinf (double d);
+// mc_isfinite is a wrapper around isfinite. It avoids a conversion warning on
+// glibc.
+bool
+mc_isfinite (double d);
+
 #endif /* MONGOCRYPT_UTIL_PRIVATE_H */

--- a/src/mongocrypt-util.c
+++ b/src/mongocrypt-util.c
@@ -31,18 +31,22 @@
 #endif
 #endif
 
+#include "mc-check-conversions-private.h"
 #include "mongocrypt-util-private.h"
 #include "mongocrypt-private.h" // CLIENT_ERR
 
 #include "mlib/thread.h"
 
 #include <errno.h>
+#include <math.h> // isinf, isnan, isfinite
 
 #ifdef _WIN32
 #include <windows.h>
 #else
 #include <dlfcn.h>
 #endif
+
+MC_BEGIN_CONVERSION_ERRORS
 
 bool
 size_to_uint32 (size_t in, uint32_t *out)
@@ -177,3 +181,27 @@ mc_iter_document_as_bson (const bson_iter_t *iter,
 
    return true;
 }
+
+/* Avoid a conversion warning on glibc for isnan, isinf, and isfinite. Refer:
+ * MONGOCRYPT-501. */
+MC_END_CONVERSION_ERRORS
+
+bool
+mc_isnan (double d)
+{
+   return isnan (d);
+}
+bool
+mc_isinf (double d)
+{
+   return isinf (d);
+}
+bool
+mc_isfinite (double d)
+{
+   return isfinite (d);
+}
+
+MC_BEGIN_CONVERSION_ERRORS
+
+MC_END_CONVERSION_ERRORS


### PR DESCRIPTION

# Summary
- Add helpers to ignore conversion warnings for `isinf`, `isnan`, and `isfinite`
- Add variant to test clang 7.0.1 with Ubuntu 18.04

# Background & Motivation

Conversion errors [were observed](https://spruce.mongodb.com/task/libmongocrypt_ubuntu1804_64_clang7_build_and_test_and_upload_patch_6bbbee8aa1b0ae6c46b4ed30d03f2016a3e03114_63866519850e6110e8bb51c7_22_11_29_20_01_30/logs?execution=0) on Ubuntu 18.04 with clang 7.0.1:

```
/opt/mongodbtoolchain/v3/bin/clang -DBSON_STATIC -DKMS_MSG_STATIC -DMLIB_HAVE_STRINGS_H -DMLIB_USER -DMONGOCRYPT_LITTLE_ENDIAN -DMONGOCRYPT_STATIC_DEFINE -I/data/mci/59ac622bce7b889019af64f1728d4e55/libmongocrypt/kms-message/src -I/data/mci/59ac622bce7b889019af64f1728d4e55/libmongocrypt/src -I/data/mci/59ac622bce7b889019af64f1728d4e55/libmongocrypt/cmake-build/src -I/data/mci/59ac622bce7b889019af64f1728d4e55/libmongocrypt/cmake-build/_deps/embedded_mcd-src/src/libbson/src -I/data/mci/59ac622bce7b889019af64f1728d4e55/libmongocrypt/cmake-build/_mongo-c-driver/src/libbson/src -I/data/mci/59ac622bce7b889019af64f1728d4e55/libmongocrypt/cmake-build/_mongo-c-driver/src/libbson/src/bson -O2 -g -DNDEBUG -Werror=implicit -Werror=return-type -Werror=incompatible-pointer-types -Werror=int-conversion -Werror=ignored-qualifiers -Werror=uninitialized -Wall -Werror -Wswitch-enum -Wswitch-default -fPIC -std=gnu99 -MD -MT CMakeFiles/mongocrypt_static.dir/src/mc-range-encoding.c.o -MF CMakeFiles/mongocrypt_static.dir/src/mc-range-encoding.c.o.d -o CMakeFiles/mongocrypt_static.dir/src/mc-range-encoding.c.o -c /data/mci/59ac622bce7b889019af64f1728d4e55/libmongocrypt/src/mc-range-encoding.c
/data/mci/59ac622bce7b889019af64f1728d4e55/libmongocrypt/src/mc-range-encoding.c:193:20: error: implicit conversion loses floating-point precision: 'double' to 'float' [-Werror,-Wconversion]
   if (isinf (args.value) || isnan (args.value)) {
       ~~~~~~~~~~~~^~~~~~
```



The cause of the warning appears to be how the macro of `isinf` is defined in glibc:



```c
#include <stdio.h>
#include <math.h>

int main () {
    double d = 1.23;
    if (isinf(d)) {
        printf ("d is infinite\n");
    }
}
```

After preprocessing `/opt/mongodbtoolchain/v3/bin/clang -E test.c`:

```c
int main () {
    double d = 1.23;
    if ((sizeof ((d)) == sizeof (float) ? __isinff (d) : sizeof ((d)) == sizeof (double) ? __isinf (d) : __isinfl (d))) {
        printf ("d is infinite\n");
    }
}
```

I think the call to `__isinff` causes the conversion warning.
