### PR TITLE
MONGOCRYPT-503 fix publish-packages on Ubuntu 22.04 build variant

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1318,7 +1318,9 @@ buildvariants:
   - build-and-test-csharp
   - test-java
   - upload-java
-  - publish-packages
+  - name: publish-packages
+    distros:
+    - ubuntu2004-small
 - name: ubuntu2204-arm64
   display_name: "Ubuntu 22.04 arm64"
   run_on: ubuntu2204-arm64-small


### PR DESCRIPTION
No patch build since it wouldn't show anything; the `publish-packages` task is skipped for patch builds.

The cause of the failure seems to be that I somehow failed to sync the build variant definitions.  While the artifacts are actually built in `build-*` tasks on the target platform (Ubuntu 22.04 in this case), we need the packaging task to run Ubuntu 20.04 because we reuse the server's `packager.py` script and it apparently fails with the newer Python in Ubuntu 22.04.  This change takes the Ubuntu 22.04 amd64 variant (which has the failing task) and applies to it the same pattern I used for the Ubuntu 22.04 arm64 variant (which I somehow figured out during development).