### PR TITLE
MONGOCRYPT-483: A 128-bit integer abstraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,10 +480,11 @@ foreach (test IN ITEMS path str)
    target_link_libraries (mlib.${test}.test PRIVATE mongo::mlib)
 endforeach ()
 
-if ("cxx_std_14" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+if ("cxx_relaxed_constexpr" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
    add_executable(mlib.int128.test src/mlib/int128.test.cpp)
    add_Test (mlib.int128 mlib.int128.test)
    target_link_libraries (mlib.int128.test PRIVATE mongo::mlib)
+   target_compile_features (mlib.int128.test PRIVATE cxx_relaxed_constexpr)
 endif ()
 
 if ("cxx_std_20" IN_LIST CMAKE_CXX_COMPILE_FEATURES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -481,9 +481,9 @@ foreach (test IN ITEMS path str)
 endforeach ()
 
 if ("cxx_relaxed_constexpr" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
-   add_executable(mlib.int128.test src/mlib/int128.test.cpp)
-   add_Test (mlib.int128 mlib.int128.test)
-   target_link_libraries (mlib.int128.test PRIVATE mongo::mlib)
+   add_executable(mlib.int128.test src/mlib/int128.test.cpp src/mlib/int128.test.c)
+   add_test (mlib.int128 mlib.int128.test)
+   target_link_libraries (mlib.int128.test PRIVATE mongo::mlib Threads::Threads)
    target_compile_features (mlib.int128.test PRIVATE cxx_relaxed_constexpr)
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,6 +480,12 @@ foreach (test IN ITEMS path str)
    target_link_libraries (mlib.${test}.test PRIVATE mongo::mlib)
 endforeach ()
 
+if ("cxx_std_14" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+   add_executable(mlib.int128.test src/mlib/int128.test.cpp)
+   add_Test (mlib.int128 mlib.int128.test)
+   target_link_libraries (mlib.int128.test PRIVATE mongo::mlib)
+endif ()
+
 if ("cxx_std_20" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
    add_executable (csfle-markup src/csfle-markup.cpp)
    target_link_libraries (csfle-markup PRIVATE mongocrypt_static _mongocrypt::libbson_for_static mongo::mlib)

--- a/src/mlib/int128.h
+++ b/src/mlib/int128.h
@@ -284,7 +284,8 @@ _mlibKnuth431D (uint32_t *const u,
                 const int vlen,
                 uint32_t *quotient)
 {
-   // Part D1 (normalization) is done by caller, normalized in u and v (b is 32)
+   // Part D1 (normalization) is done by caller,
+   // normalized in u and v (radix b is 2^32)
    typedef uint64_t u64;
    typedef int64_t i64;
    typedef uint32_t u32;
@@ -347,7 +348,7 @@ _mlibKnuth431D (uint32_t *const u,
       }
    }
 
-   // Denomralization (D8) is done by caller.
+   // Denormalization (D8) is done by caller.
 }
 
 /// The result of 128-bit division
@@ -379,7 +380,7 @@ _mlibDivide_u128_by_u64 (const mlib_int128 numer, const uint64_t denom)
       const u64 n0 = (u32) (numer.r.lo);
       const u64 n1 = (u32) (numer.r.lo >> 32);
 
-      // We don't need to split n2 and n3. (n3,n2) will be the first parital
+      // We don't need to split n2 and n3. (n3,n2) will be the first partial
       // dividend
       const u64 n3_n2 = numer.r.hi;
 
@@ -655,7 +656,7 @@ static mlib_constexpr_fn mlib_int128_charbuf
 mlib_int128_format (mlib_int128 i)
 {
    mlib_int128_charbuf into = {0};
-   char *out = into.str + sizeof into - 1;
+   char *out = into.str + (sizeof into) - 1;
    int len = 0;
    if (mlib_int128_eq (i, MLIB_INT128 (0))) {
       *out-- = '0';

--- a/src/mlib/int128.h
+++ b/src/mlib/int128.h
@@ -19,7 +19,7 @@ typedef union {
       uint64_t hi;
    } r;
 #if defined(__SIZEOF_INT128__)
-   // These union members are only for the purpoes of debugging visualization
+   // These union members are only for the purpose of debugging visualization
    // and testing, and will only appear correctly on little-endian platforms.
    __int128_t signed_;
    __uint128_t unsigned_;

--- a/src/mlib/int128.h
+++ b/src/mlib/int128.h
@@ -31,9 +31,9 @@ typedef union {
 #define MLIB_INT128(N) MLIB_INIT (mlib_int128) MLIB_INT128_C (N)
 /// Define an int128 from a literal within [INT64_MIN, INT64_MAX] (usable as a
 /// constant init)
-#define MLIB_INT128_C(N)                 \
-   MLIB_INT128_FROM_PARTS (UINT64_C (N), \
-                           (UINT64_C (N) > INT64_MAX ? UINT64_MAX : 0))
+#define MLIB_INT128_C(N)                           \
+   MLIB_INT128_FROM_PARTS ((uint64_t) INT64_C (N), \
+                           (INT64_C (N) < 0 ? UINT64_MAX : 0))
 /**
  * @brief Cast an integral value to an mlib_int128
  *

--- a/src/mlib/int128.h
+++ b/src/mlib/int128.h
@@ -360,9 +360,9 @@ _mlibDivide_u128_by_u64 (const mlib_int128 numer, const uint64_t denom)
 {
    mlib_int128 adjusted = numer;
    adjusted.r.hi %= denom;
-   int d = _mlibCountLeadingZeros_u64 (denom >> 32) - 32;
+   int d = _mlibCountLeadingZeros_u64 (denom);
 
-   if (d == 32) {
+   if (d >= 32) {
       // jk: We're dividing by less than UINT32_MAX: We can take a shortcut
       uint64_t rem = adjusted.r.hi << 32 | adjusted.r.lo >> 32;
       uint64_t quo = rem / (uint32_t) denom;
@@ -389,7 +389,7 @@ _mlibDivide_u128_by_u64 (const mlib_int128 numer, const uint64_t denom)
    if (d != 0) {
       // Extra bits from overlap:
       u[2] |= (uint32_t) (adjusted.r.lo >> (64 - d));
-      u[4] |= (uint32_t) (adjusted.r.lo >> (64 - d));
+      u[4] |= (uint32_t) (adjusted.r.hi >> (64 - d));
    }
 
    uint32_t v[2] = {
@@ -405,7 +405,7 @@ _mlibDivide_u128_by_u64 (const mlib_int128 numer, const uint64_t denom)
    uint64_t quo = ((uint64_t) qparts[1] << 32) | qparts[0];
    return MLIB_INIT (mlib_int128_divmod_result){
       MLIB_INIT (mlib_int128) MLIB_INT128_FROM_PARTS (quo, numer.r.hi / denom),
-      MLIB_INIT (mlib_int128) MLIB_INT128_FROM_PARTS (rem, numer.r.hi % denom),
+      MLIB_INIT (mlib_int128) MLIB_INT128_FROM_PARTS (rem, 0),
    };
 }
 

--- a/src/mlib/int128.h
+++ b/src/mlib/int128.h
@@ -1,0 +1,615 @@
+#ifndef MLIB_INT128_H_INCLUDED
+#define MLIB_INT128_H_INCLUDED
+
+#include "./macros.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <inttypes.h>
+#include <string.h>
+#include <stdlib.h>
+
+MLIB_C_LINKAGE_BEGIN
+
+/**
+ * @brief A 128-bit binary integer
+ */
+typedef union mlib_int128_ {
+   struct {
+      uint64_t lo;
+      uint64_t hi;
+   };
+#ifdef __SIZEOF_INT128__
+   // These union members are only for the purpoes of debugging visualization
+   // and testing, and will only appear correctly on little-endian platforms.
+   __int128_t signed_;
+   __uint128_t unsigned_;
+#endif
+} mlib_int128;
+
+/// Construct an mlib_in128 from an integer literal
+#define MLIB_INT128(N) MLIB_INIT (mlib_int128) MLIB_INT128_C (N)
+/// Construct an mlib_in128 from an integer literal (usable as a constant init)
+#define MLIB_INT128_C(N)                 \
+   MLIB_INT128_FROM_PARTS (UINT64_C (N), \
+                           (UINT64_C (N) > INT64_MAX ? UINT64_MAX : 0))
+/**
+ * @brief Cast an integral value to an mlib_int128
+ *
+ * If the argument is signed and less-than zero, it will be sign-extended
+ */
+#define MLIB_INT128_CAST(N) \
+   MLIB_INIT (mlib_int128)  \
+   MLIB_INT128_FROM_PARTS ((uint64_t) (N), ((N) < 0 ? UINT64_MAX : 0))
+
+/**
+ * @brief Create an mlib_int128 from the low and high parts of the integer
+ *
+ * @param LowWord_u64 The low-value 64 bits of the number
+ * @param HighWord_u64 The high-value 64 bits of the number
+ */
+#define MLIB_INT128_FROM_PARTS(LowWord_u64, HighWord_u64) \
+   {                                                      \
+      {LowWord_u64, HighWord_u64},                        \
+   }
+
+/// Maximum value of int128 when treated as a signed integer
+#define MLIB_INT128_SMAX \
+   MLIB_INT128_FROM_PARTS (UINT64_MAX, UINT64_MAX & ~(UINT64_C (1) << 63))
+
+/// Minimum value of int128, when treated as a signed integer
+#define MLIB_INT128_SMIN MLIB_INT128_FROM_PARTS (0, UINT64_C (1) << 63)
+
+/// Maximum value of int128, when treated as an unsigned integer
+#define MLIB_INT128_UMAX MLIB_INT128_FROM_PARTS (UINT64_MAX, UINT64_MAX)
+
+/**
+ * @brief Compare two 128-bit integers as unsigned integers
+ *
+ * @return (R < 0) if (left < right)
+ * @return (R > 0) if (left > right)
+ * @return (R = 0) if (left == right)
+ */
+static mlib_constexpr_fn int
+mlib_int128_ucmp (mlib_int128 left, mlib_int128 right)
+{
+   if (left.hi > right.hi) {
+      return 1;
+   } else if (left.hi < right.hi) {
+      return -1;
+   } else if (left.lo > right.lo) {
+      return 1;
+   } else if (left.lo < right.lo) {
+      return -1;
+   } else {
+      return 0;
+   }
+}
+
+/**
+ * @brief Compare two 128-bit integers as signed integers
+ *
+ * @return (R < 0) if (left < right)
+ * @return (R > 0) if (left > right)
+ * @return (R = 0) if (left == right)
+ */
+static mlib_constexpr_fn int
+mlib_int128_scmp (mlib_int128 left, mlib_int128 right)
+{
+   if ((left.hi & (1ull << 63)) == (right.hi & (1ull << 63))) {
+      // Same signed-ness, so they are as comparable as unsigned
+      return mlib_int128_ucmp (left, right);
+   } else if (left.hi & (1ull << 63)) {
+      // The left is negative
+      return -1;
+   } else {
+      // The right is negative
+      return 1;
+   }
+}
+
+/**
+ * @brief Determine whether the two 128-bit integers are equal
+ *
+ * @retval true If left == right
+ * @retval false Otherwise
+ */
+static mlib_constexpr_fn bool
+mlib_int128_eq (mlib_int128 left, mlib_int128 right)
+{
+   return mlib_int128_ucmp (left, right) == 0;
+}
+
+/**
+ * @brief Add two 128-bit integers together
+ *
+ * @return mlib_int128 The sum of the two addends. Overflow will wrap.
+ */
+static mlib_constexpr_fn mlib_int128
+mlib_int128_add (mlib_int128 left, mlib_int128 right)
+{
+   uint64_t losum = left.lo + right.lo;
+   // Overflow check
+   int carry = (losum < left.lo || losum < right.lo);
+   uint64_t hisum = left.hi + right.hi + carry;
+   return (mlib_int128) MLIB_INT128_FROM_PARTS (losum, hisum);
+}
+
+/**
+ * @brief Treat the given 128-bit integer as signed, and return its
+ * negated value
+ */
+static mlib_constexpr_fn mlib_int128
+mlib_int128_negate (mlib_int128 v)
+{
+   mlib_int128 r = MLIB_INT128_FROM_PARTS (~v.lo, ~v.hi);
+   r = mlib_int128_add (r, MLIB_INT128 (1));
+   return r;
+}
+
+/**
+ * @brief Subtract two 128-bit integers
+ *
+ * @return mlib_int128 The difference between `from` and `less`
+ */
+static mlib_constexpr_fn mlib_int128
+mlib_int128_sub (mlib_int128 from, mlib_int128 less)
+{
+   int borrow = from.lo < less.lo;
+   uint64_t low = from.lo - less.lo;
+   uint64_t high = from.hi - less.hi;
+   high -= borrow;
+   return (mlib_int128) MLIB_INT128_FROM_PARTS (low, high);
+}
+
+/**
+ * @brief Bitwise left-shift a 128-bit integer
+ *
+ * @param val The value to modify
+ * @param off The offset to shift left. If negative, shifts right
+ * @return The result of the shift operation
+ */
+static mlib_constexpr_fn mlib_int128
+mlib_int128_lshift (mlib_int128 val, int off)
+{
+   if (off > 0) {
+      if (off >= 64) {
+         off -= 64;
+         uint64_t high = val.lo << off;
+         return (mlib_int128) MLIB_INT128_FROM_PARTS (0, high);
+      } else {
+         uint64_t low = val.lo << off;
+         uint64_t high = val.hi << off;
+         high |= val.lo >> (64 - off);
+         return (mlib_int128) MLIB_INT128_FROM_PARTS (low, high);
+      }
+   } else if (off < 0) {
+      off = -off;
+      if (off >= 64) {
+         off -= 64;
+         uint64_t low = val.hi >> off;
+         return (mlib_int128) MLIB_INT128_FROM_PARTS (low, 0);
+      } else {
+         uint64_t high = val.hi >> off;
+         uint64_t low = val.lo >> off;
+         low |= val.hi << (64 - off);
+         return (mlib_int128) MLIB_INT128_FROM_PARTS (low, high);
+      }
+   } else {
+      return val;
+   }
+}
+
+/**
+ * @brief Bitwise righ-shift a 128-bit integer
+ *
+ * @param val The value to modify
+ * @param off The offset to shift righ. If negative, shifts left
+ * @return The result of the shift operation
+ */
+static mlib_constexpr_fn mlib_int128
+mlib_int128_rshift (mlib_int128 val, int off)
+{
+   return mlib_int128_lshift (val, -off);
+}
+
+/**
+ * @brief Bitwise-or two 128-bit integers
+ */
+static mlib_constexpr_fn mlib_int128
+mlib_int128_bitor (mlib_int128 l, mlib_int128 r)
+{
+   return (mlib_int128) MLIB_INT128_FROM_PARTS (l.lo | r.lo, l.hi | r.hi);
+}
+
+// Multiply two 64bit integers to get a 128-bit result without overflow
+static mlib_constexpr_fn mlib_int128
+_mlibUnsignedMult128 (uint64_t left, uint64_t right)
+{
+   // Perform a Knuth 4.2.1M multiplication
+   uint32_t u[2] = {(uint32_t) left, (uint32_t) (left >> 32)};
+   uint32_t v[2] = {(uint32_t) right, (uint32_t) (right >> 32)};
+   uint32_t w[4] = {0};
+
+   for (int j = 0; j < 2; ++j) {
+      uint64_t t = 0;
+      for (int i = 0; i < 2; ++i) {
+         t += (uint64_t) (u[i]) * v[j] + w[i + j];
+         w[i + j] = (uint32_t) t;
+         t >>= 32;
+      }
+      w[j + 2] = (uint32_t) t;
+   }
+
+   return (mlib_int128) MLIB_INT128_FROM_PARTS (((uint64_t) w[1] << 32) | w[0],
+                                                ((uint64_t) w[3] << 32) | w[2]);
+}
+
+/**
+ * @brief Multiply two mlib_int128s together. Overflow will wrap.
+ */
+static mlib_constexpr_fn mlib_int128
+mlib_int128_mul (mlib_int128 l, mlib_int128 r)
+{
+   // Multiply the low-order word
+   mlib_int128 ret = _mlibUnsignedMult128 (l.lo, r.lo);
+   // Accumulate the high-order parts:
+   ret.hi += l.lo * r.hi;
+   ret.hi += l.hi * r.lo;
+   return ret;
+}
+
+/// Get the number of leading zeros in a 64bit number.
+static mlib_constexpr_fn int
+_mlibCountLeadingZeros_u64 (uint64_t bits)
+{
+   int n = 0;
+   if (bits == 0) {
+      return 64;
+   }
+   while (!(1ull << 63 & bits)) {
+      ++n;
+      bits <<= 1;
+   }
+   return n;
+}
+
+/// Implementation of Knuth's algorithm 4.3.1 D for unsigned integer division
+static mlib_constexpr_fn void
+_mlibKnuth431D (uint32_t *const u,
+                const int ulen,
+                const uint32_t *const v,
+                const int vlen,
+                uint32_t *quotient)
+{
+   // Part D1 (normalization) is done by caller, normalized in u and v (b is
+   // 1<<32)
+   typedef uint64_t u64;
+   typedef int64_t i64;
+   typedef uint32_t u32;
+   const int m = ulen - vlen - 1;
+   const int n = vlen;
+
+   // D2
+   int j = m;
+   for (;;) {
+      // D3: Select two u32 as a u64:
+      u64 two = ((u64) (u[j + n]) << 32) | u[j + n - 1];
+      // D3: Partial quotient: q̂
+      u64 q = two / v[n - 1];
+      // D3: Partial remainder: r̂
+      u64 r = two % v[n - 1];
+
+      // D3: Compute q̂ and r̂
+      while (q >> 32 || q * (u64) v[n - 2] > (r << 32 | u[j + n - 2])) {
+         q--;
+         r += v[n - 1];
+         if (r >> 32) {
+            break;
+         }
+      }
+
+      // D4: Multiply and subtract
+      i64 k = 0;
+      i64 t = 0;
+      for (int i = 0; i < n; ++i) {
+         u64 prod = (u32) q * (u64) (v[i]);
+         t = u[i + j] - k - (u32) prod;
+         u[i + j] = (u32) t;
+         k = (i64) (prod >> 32) - (t >> 32);
+      }
+      t = u[j + n] - k;
+      u[j + n] = (u32) t;
+
+      quotient[j] = (u32) q;
+
+      // D5: Test remainder
+      if (t < 0) {
+         // D6: Add back
+         --quotient[j];
+         k = 0;
+         for (int i = 0; i < n; ++i) {
+            t = u[i + j] + k + v[i];
+            u[i + j] = (u32) (t);
+            k = t >> 32;
+         }
+         u[j + n] += (int32_t) k;
+      }
+
+      // D7:
+      --j;
+      if (j < 0) {
+         break;
+      }
+   }
+
+   // Denomralization (D8) is done by caller.
+}
+
+/// The result of 128-bit division
+typedef struct mlib_int128_divmod_result {
+   /// The quotient of the division operation (rounds to zero)
+   mlib_int128 quotient;
+   /// The remainder of the division operation
+   mlib_int128 remainder;
+} mlib_int128_divmod_result;
+
+/// Divide a 128-bit number by a 64bit number.
+static mlib_constexpr_fn struct mlib_int128_divmod_result
+_mlibDivide_u128_by_u64 (const mlib_int128 numer, const uint64_t denom)
+{
+   mlib_int128 adjusted = numer;
+   adjusted.hi %= denom;
+   int d = _mlibCountLeadingZeros_u64 (denom >> 32) - 32;
+
+   if (d == 32) {
+      // jk: We're dividing by less than UINT32_MAX: We can take a shortcut
+      uint64_t rem = adjusted.hi << 32 | adjusted.lo >> 32;
+      uint64_t quo = rem / (uint32_t) denom;
+      rem = ((rem % (uint32_t) denom) << 32) | (uint32_t) adjusted.lo;
+      quo = quo << 32 | rem / (uint32_t) denom;
+      rem = rem % (uint32_t) denom;
+      return MLIB_INIT (mlib_int128_divmod_result){
+         MLIB_INIT (mlib_int128) MLIB_INT128_FROM_PARTS (quo, numer.hi / denom),
+         MLIB_INIT (mlib_int128) MLIB_INT128_FROM_PARTS (rem, 0),
+      };
+   }
+
+   // Normalize for a Knuth 4.3.1D division. Convert the integers into two
+   // base-32 numbers, with u and v being arrays of digits:
+   uint32_t u[5] = {
+      (uint32_t) (adjusted.lo << d),
+      (uint32_t) (adjusted.lo >> (32 - d)),
+      (uint32_t) (adjusted.hi << d),
+      (uint32_t) (adjusted.hi >> (32 - d)),
+      0,
+   };
+
+   if (d != 0) {
+      // Extra bits from overlap:
+      u[2] |= (uint32_t) (adjusted.lo >> (64 - d));
+      u[4] |= (uint32_t) (adjusted.lo >> (64 - d));
+   }
+
+   uint32_t v[2] = {
+      (uint32_t) (denom << d),
+      (uint32_t) (denom >> (32 - d)),
+   };
+
+   uint32_t qparts[3] = {0};
+
+   _mlibKnuth431D (u, 5, v, 2, qparts);
+
+   uint64_t rem = ((uint64_t) u[1] << (32 - d)) | (u[0] >> d);
+   uint64_t quo = ((uint64_t) qparts[1] << 32) | qparts[0];
+   return MLIB_INIT (mlib_int128_divmod_result){
+      MLIB_INIT (mlib_int128) MLIB_INT128_FROM_PARTS (quo, numer.hi / denom),
+      MLIB_INIT (mlib_int128) MLIB_INT128_FROM_PARTS (rem, numer.hi % denom),
+   };
+}
+
+/**
+ * @brief Perform a combined division+remainder of two 128-bit numbers
+ *
+ * @param numer The dividend
+ * @param denom The divisor
+ * @return A struct with .quotient and .remainder results
+ */
+static mlib_constexpr_fn mlib_int128_divmod_result
+mlib_int128_divmod (mlib_int128 numer, mlib_int128 denom)
+{
+   const uint64_t nhi = numer.hi;
+   const uint64_t nlo = numer.lo;
+   const uint64_t dhi = denom.hi;
+   const uint64_t dlo = denom.lo;
+   if (dhi > nhi) {
+      // Denominator is definitely larger than numerator. Quotient is zero,
+      // remainder is full numerator.
+      return MLIB_INIT (mlib_int128_divmod_result){MLIB_INT128 (0), numer};
+   } else if (dhi == nhi) {
+      // High words are equal
+      if (nhi == 0) {
+         // Both high words are zero, so this is just a division of two 64bit
+         // numbers
+         return MLIB_INIT (mlib_int128_divmod_result){
+            MLIB_INT128_CAST (nlo / dlo),
+            MLIB_INT128_CAST (nlo % dlo),
+         };
+      } else if (nlo > dlo) {
+         // The numerator is larger than the denom and the high word on the
+         // denom is non-zero, so this cannot divide to anything greater than 1.
+         return MLIB_INIT (mlib_int128_divmod_result){
+            MLIB_INT128 (1),
+            mlib_int128_sub (numer, denom),
+         };
+      } else if (nlo < dlo) {
+         // numer.low < denom.low and denom.high > denom.low, so the integer
+         // division becomes zero
+         return MLIB_INIT (mlib_int128_divmod_result){
+            MLIB_INT128 (0),
+            numer,
+         };
+      } else {
+         // N / N is one
+         return MLIB_INIT (mlib_int128_divmod_result){MLIB_INT128 (1),
+                                                      MLIB_INT128 (0)};
+      }
+   } else if (dhi == 0) {
+      // No high in denominator. We can use a u128/u64
+      return _mlibDivide_u128_by_u64 (numer, denom.lo);
+   } else {
+      // We'll need to do a full u128/u128 division
+      // Normalize for Knuth 4.3.1D
+      int d = _mlibCountLeadingZeros_u64 (denom.hi);
+      // Does the denom have only three base32 digits?
+      const bool has_three = d >= 32;
+      d &= 31;
+
+      uint32_t u[5] = {
+         (uint32_t) (numer.lo << d),
+         (uint32_t) (numer.lo >> (32 - d)),
+         (uint32_t) (numer.hi << d),
+         (uint32_t) (numer.hi >> (32 - d)),
+         0,
+      };
+      uint32_t v[4] = {
+         (uint32_t) (denom.lo << d),
+         (uint32_t) (denom.lo >> (32 - d)),
+         (uint32_t) (denom.hi << d),
+         (uint32_t) (denom.hi >> (32 - d)),
+      };
+      if (d != 0) {
+         u[2] |= numer.lo >> (64 - d);
+         u[4] |= numer.hi >> (64 - d);
+         v[2] |= denom.lo >> (64 - d);
+      };
+
+      uint32_t q[2] = {0};
+      if (has_three) {
+         _mlibKnuth431D (u, 5, v, 3, q);
+      } else {
+         _mlibKnuth431D (u, 5, v, 4, q);
+         // This quotient will always fit in 32 bits
+         assert (q[1] == 0);
+      }
+
+      mlib_int128 remainder = MLIB_INT128_FROM_PARTS (
+         ((uint64_t) u[1] << 32) | u[0], ((uint64_t) u[3] << 32) | u[2]);
+      remainder = mlib_int128_rshift (remainder, d);
+
+      return MLIB_INIT (mlib_int128_divmod_result){
+         MLIB_INT128_CAST (q[0] | (uint64_t) q[1] << 32),
+         remainder,
+      };
+   }
+}
+
+/**
+ * @brief Perform a division of two 128-bit numbers
+ */
+static mlib_constexpr_fn mlib_int128
+mlib_int128_div (mlib_int128 numer, mlib_int128 denom)
+{
+   return mlib_int128_divmod (numer, denom).quotient;
+}
+
+/**
+ * @brief Perform a modulus of two 128-bit numbers
+ */
+static mlib_constexpr_fn mlib_int128
+mlib_int128_mod (mlib_int128 numer, mlib_int128 denom)
+{
+   return mlib_int128_divmod (numer, denom).remainder;
+}
+
+/**
+ * @brief Get the nth power of ten as a 128-bit number
+ */
+static mlib_constexpr_fn mlib_int128
+mlib_int128_pow10 (long nth)
+{
+   mlib_int128 r = MLIB_INT128 (1);
+   while (nth-- > 0) {
+      r = mlib_int128_mul (r, MLIB_INT128 (10));
+   }
+   return r;
+}
+
+/**
+ * @brief Get the Nth power of two as a 128-bit number
+ */
+static mlib_constexpr_fn mlib_int128
+mlib_int128_pow2 (long nth)
+{
+   return mlib_int128_lshift (MLIB_INT128 (1), nth);
+}
+
+/**
+ * @brief Read a 128-bit unsigned integer from a base-10 string
+ */
+static mlib_constexpr_fn mlib_int128
+mlib_int128_from_string (const char *s)
+{
+   mlib_int128 ret = MLIB_INT128 (0);
+   while (*s) {
+      int dig = *s - '0';
+      if (dig > 9 || dig < 0) {
+         break;
+      }
+      ret = mlib_int128_mul (ret, MLIB_INT128 (10));
+      ret = mlib_int128_add (ret, MLIB_INT128_CAST (dig));
+      ++s;
+   }
+   return ret;
+}
+
+/**
+ * @brief Truncate a 128-bit number to a 64-bit number
+ */
+static mlib_constexpr_fn uint64_t
+mlib_int128_to_u64 (mlib_int128 v)
+{
+   return v.lo;
+}
+
+/// The result type of formatting a 128-bit number
+typedef struct {
+   /// The character array of the number as a base10 string. Null-terminated.
+   char str[40];
+} mlib_int128_charbuf;
+
+/**
+ * @brief Format a 128-bit integer into a string of base10 digits.
+ *
+ * @return mlib_int128_charbuf a struct containing a .str character array
+ */
+static mlib_constexpr_fn mlib_int128_charbuf
+mlib_int128_format (mlib_int128 i)
+{
+   mlib_int128_charbuf into = {0};
+   char *out = into.str + sizeof into - 1;
+   int len = 0;
+   if (mlib_int128_eq (i, MLIB_INT128 (0))) {
+      *out-- = '0';
+      len = 1;
+   }
+   while (!mlib_int128_eq (i, MLIB_INT128 (0))) {
+      mlib_int128_divmod_result dm = mlib_int128_divmod (i, MLIB_INT128 (10));
+      uint64_t v = mlib_int128_to_u64 (dm.remainder);
+      assert (v >= 0 && v <= 9);
+      char digits[] = "0123456789";
+      char d = digits[v];
+      *out = d;
+      --out;
+      i = dm.quotient;
+      ++len;
+      assert (len < sizeof into.str);
+   }
+   memmove (into.str, out + 1, len);
+   into.str[len] = 0;
+   return into;
+}
+
+MLIB_C_LINKAGE_END
+
+#endif // MLIB_INT128_H_INCLUDED

--- a/src/mlib/int128.h
+++ b/src/mlib/int128.h
@@ -26,9 +26,10 @@ typedef union {
 #endif
 } mlib_int128;
 
-/// Construct an mlib_in128 from an integer literal
+/// Define an int128 from a literal within [INT64_MIN, INT64_MAX]
 #define MLIB_INT128(N) MLIB_INIT (mlib_int128) MLIB_INT128_C (N)
-/// Construct an mlib_in128 from an integer literal (usable as a constant init)
+/// Define an int128 from a literal within [INT64_MIN, INT64_MAX] (usable as a
+/// constant init)
 #define MLIB_INT128_C(N)                 \
    MLIB_INT128_FROM_PARTS (UINT64_C (N), \
                            (UINT64_C (N) > INT64_MAX ? UINT64_MAX : 0))
@@ -200,10 +201,10 @@ mlib_int128_lshift (mlib_int128 val, int off)
 }
 
 /**
- * @brief Bitwise righ-shift a 128-bit integer
+ * @brief Bitwise logical right-shift a 128-bit integer
  *
- * @param val The value to modify
- * @param off The offset to shift righ. If negative, shifts left
+ * @param val The value to modify. No "sign bit" is respected.
+ * @param off The offset to shift right. If negative, shifts left
  * @return The result of the shift operation
  */
 static mlib_constexpr_fn mlib_int128
@@ -226,7 +227,7 @@ mlib_int128_bitor (mlib_int128 l, mlib_int128 r)
 static mlib_constexpr_fn mlib_int128
 _mlibUnsignedMult128 (uint64_t left, uint64_t right)
 {
-   // Perform a Knuth 4.2.1M multiplication
+   // Perform a Knuth 4.3.1M multiplication
    uint32_t u[2] = {(uint32_t) left, (uint32_t) (left >> 32)};
    uint32_t v[2] = {(uint32_t) right, (uint32_t) (right >> 32)};
    uint32_t w[4] = {0};

--- a/src/mlib/int128.h
+++ b/src/mlib/int128.h
@@ -2,6 +2,7 @@
 #define MLIB_INT128_H_INCLUDED
 
 #include "./macros.h"
+#include "./str.h"
 
 #include <stdbool.h>
 #include <inttypes.h>
@@ -584,7 +585,7 @@ static mlib_constexpr_fn mlib_int128
 mlib_int128_from_string (const char *s, const char **end)
 {
    int radix = 10;
-   if (strlen (s) > 2 && s[0] == '0') {
+   if (mlib_strlen (s) > 2 && s[0] == '0') {
       // Check for a different radix
       char b = s[1];
       if (b == 'b' || b == 'B') {

--- a/src/mlib/int128.test.c
+++ b/src/mlib/int128.test.c
@@ -1,0 +1,3 @@
+#include "./int128.h"
+
+// This file checks for C compilability. Other tests are defined in .test.cpp

--- a/src/mlib/int128.test.cpp
+++ b/src/mlib/int128.test.cpp
@@ -294,6 +294,9 @@ main ()
    auto four_v2 = mlib_int128_lshift (eight, -1);
    CHECK (four == four_v2);
 
+   // Negative literals:
+   CHECK (MLIB_INT128 (-64) == mlib_int128_negate (64_i128));
+
    CHECK (mlib_int128_mul (1_i128, 2_i128) == 2_i128);
    CHECK (mlib_int128_mul (1_i128, 0_i128) == 0_i128);
    CHECK (mlib_int128_mul (0_i128, 0_i128) == 0_i128);

--- a/src/mlib/int128.test.cpp
+++ b/src/mlib/int128.test.cpp
@@ -4,6 +4,7 @@
 #include <random>
 #include <thread>
 #include <string>
+#include <vector>
 
 #if (defined(__GNUC__) && __GNUC__ < 7 && !defined(__clang__)) || \
    (defined(_MSC_VER) && _MSC_VER < 1920)
@@ -312,7 +313,7 @@ main ()
    CHECK (mlib_int128_mul (MLIB_INT128_CAST (-7), MLIB_INT128_CAST (-7)) ==
           49_i128);
 
-   // It's useful it specify bit patterns directly
+   // It's useful to specify bit patterns directly
    auto in_binary =
       0b110101010110100100001101111001111010100010111100100101101011010110101001010110110011000100000100011110010101101001111110001000_i128;
    CHECK (in_binary == 70917759074396274376598533126648930184_i128);
@@ -379,14 +380,13 @@ main ()
       // division checks. It doesn't need to be rigorous or optimal, it only
       // needs to "just work."
       std::vector<std::thread> threads;
-      threads.resize (15);
       // Pick every denominator bit pattern from 0b00'01 to 0b11'11:
       for (auto dbits = 1u; dbits < 16u; ++dbits) {
          // Randomness:
          std::mt19937 random;
          random.seed (seed);
          // Spawn a thread for this denominator bit pattern:
-         threads[dbits - 1] = std::thread{[nbits, dbits, random] () mutable {
+         threads.emplace_back ([nbits, dbits, random] () mutable {
             std::uniform_int_distribution<std::uint32_t> dist;
             // 100k random divisions:
             for (auto i = 0; i < 100000; ++i) {
@@ -412,7 +412,7 @@ main ()
                // Divide them:
                div_check (num, den);
             }
-         }};
+         });
       }
       // Join the threads that are dividing:
       for (auto &t : threads) {

--- a/src/mlib/int128.test.cpp
+++ b/src/mlib/int128.test.cpp
@@ -293,8 +293,8 @@ main ()
       // Attempt a division, even if we have no "reference" value
       auto q = mlib_int128_divmod (num, denom);
       (void) q;
+
 #ifdef __SIZEOF_INT128__
-      std::cerr << "Testing: " << num << " ÷ " << denom << '\n';
       // When we have an existing i128 impl, test against that:
       mlib_int128 exp = {.unsigned_ = (num.unsigned_ / denom.unsigned_)};
       mlib_int128 exp2 = {.unsigned_ = (num.unsigned_ % denom.unsigned_)};

--- a/src/mlib/int128.test.cpp
+++ b/src/mlib/int128.test.cpp
@@ -294,6 +294,17 @@ main ()
    auto four_v2 = mlib_int128_lshift (eight, -1);
    CHECK (four == four_v2);
 
+   CHECK (mlib_int128_mul (1_i128, 2_i128) == 2_i128);
+   CHECK (mlib_int128_mul (1_i128, 0_i128) == 0_i128);
+   CHECK (mlib_int128_mul (0_i128, 0_i128) == 0_i128);
+   CHECK (mlib_int128_mul (2_i128, 73_i128) == 146_i128);
+   CHECK (mlib_int128_mul (28468554863115876158655557_i128, 73_i128) ==
+          2078204505007458959581855661_i128);
+   CHECK (mlib_int128_mul (MLIB_INT128_CAST (-7), 4_i128) ==
+          MLIB_INT128_CAST (-28));
+   CHECK (mlib_int128_mul (MLIB_INT128_CAST (-7), MLIB_INT128_CAST (-7)) ==
+          49_i128);
+
    // It's useful it specify bit patterns directly
    auto in_binary =
       0b110101010110100100001101111001111010100010111100100101101011010110101001010110110011000100000100011110010101101001111110001000_i128;

--- a/src/mlib/int128.test.cpp
+++ b/src/mlib/int128.test.cpp
@@ -64,6 +64,19 @@ constexpr
    return mlib_int128_from_string (s, NULL);
 }
 
+// Operators, for test convenience
+constexpr bool
+operator== (mlib_int128 l, mlib_int128 r)
+{
+   return mlib_int128_eq (l, r);
+}
+
+constexpr bool
+operator<(mlib_int128 l, mlib_int128 r)
+{
+   return mlib_int128_scmp (l, r) < 0;
+}
+
 #ifndef BROKEN_CONSTEXPR
 static_assert (mlib_int128_eq (MLIB_INT128 (0), 0_i128), "fail");
 static_assert (mlib_int128_eq (MLIB_INT128 (65025), 65025_i128), "fail");
@@ -110,6 +123,24 @@ static_assert (
    mlib_int128_scmp (mlib_int128_rshift (mlib_int128_lshift (1_i128, 127), 127),
                      1_i128) == 0,
    "fail");
+
+// With no high-32 bits in the denominator
+static_assert (mlib_int128_div (316356263640858117670580590964547584140_i128,
+                                13463362962560749016052695684_i128) ==
+               23497566285_i128);
+
+// Remainder correctness with high bit set:
+static_assert (mlib_int128_mod (292590981272581782572061492191999425232_i128,
+                                221673222198185508195462959065350495048_i128) ==
+               70917759074396274376598533126648930184_i128);
+
+// Remainder with 64bit denom:
+static_assert (mlib_int128_mod (2795722437127403543495742528_i128,
+                                708945413_i128) == 619266642_i128);
+
+// 10-div:
+static_assert (mlib_int128_div (MLIB_INT128_SMAX, 10_i128) ==
+               17014118346046923173168730371588410572_i128);
 #endif // BROKEN_CONSTEXPR
 
 inline std::ostream &
@@ -185,20 +216,6 @@ struct check_consume {
 #undef CHECK
 #define CHECK(Cond) \
    check_consume{} = check_magic{check_info{__FILE__, __LINE__, #Cond}}->*Cond
-
-
-// Operators, for test convenience
-constexpr bool
-operator== (mlib_int128 l, mlib_int128 r)
-{
-   return mlib_int128_eq (l, r);
-}
-
-constexpr bool
-operator<(mlib_int128 l, mlib_int128 r)
-{
-   return mlib_int128_scmp (l, r) < 0;
-}
 
 #ifndef BROKEN_CONSTEXPR
 static_assert (mlib_int128 (MLIB_INT128_UMAX) ==

--- a/src/mlib/int128.test.cpp
+++ b/src/mlib/int128.test.cpp
@@ -1,0 +1,243 @@
+#include "./int128.h"
+
+#include <iostream>
+#include <random>
+#include <string_view>
+
+// Basic checks with static_asserts, check constexpr correctness and fail fast
+static_assert (mlib_int128_eq (MLIB_INT128 (0), MLIB_INT128_FROM_PARTS (0, 0)));
+static_assert (mlib_int128_eq (MLIB_INT128 (4), MLIB_INT128_FROM_PARTS (4, 0)));
+static_assert (mlib_int128_eq (MLIB_INT128 (34),
+                               MLIB_INT128_FROM_PARTS (34, 0)));
+static_assert (mlib_int128_eq (MLIB_INT128 (34 + 8),
+                               MLIB_INT128_FROM_PARTS (42, 0)));
+static_assert (mlib_int128_eq (MLIB_INT128_CAST (94),
+                               MLIB_INT128_FROM_PARTS (94, 0)));
+static_assert (mlib_int128_eq (mlib_int128_lshift (MLIB_INT128_CAST (1), 64),
+                               MLIB_INT128_FROM_PARTS (0, 1)));
+static_assert (mlib_int128_eq (mlib_int128_lshift (MLIB_INT128_CAST (1), 127),
+                               MLIB_INT128_FROM_PARTS (0, 1ull << 63)));
+
+static_assert (mlib_int128_scmp (MLIB_INT128_CAST (2), MLIB_INT128 (0)) > 0);
+static_assert (mlib_int128_scmp (MLIB_INT128_CAST (-2), MLIB_INT128 (0)) < 0);
+static_assert (mlib_int128_scmp (MLIB_INT128_CAST (0), MLIB_INT128 (0)) == 0);
+// Unsigned compare doesn't believe in negative numbers:
+static_assert (mlib_int128_ucmp (MLIB_INT128_CAST (-2), MLIB_INT128 (0)) > 0);
+
+// Literals, for test convenience:
+constexpr mlib_int128 operator""_i128 (const char *s)
+{
+   return mlib_int128_from_string (s);
+}
+
+static_assert (mlib_int128_eq (MLIB_INT128 (0), 0_i128));
+static_assert (mlib_int128_eq (MLIB_INT128 (65025), 65025_i128));
+static_assert (mlib_int128_eq (MLIB_INT128_FROM_PARTS (0, 1),
+                               18446744073709551616_i128));
+static_assert (mlib_int128_eq (MLIB_INT128_UMAX,
+                               340282366920938463463374607431768211455_i128));
+
+
+static_assert (mlib_int128_scmp (MLIB_INT128_SMIN, MLIB_INT128_SMAX) < 0);
+static_assert (mlib_int128_scmp (MLIB_INT128_SMAX, MLIB_INT128_SMIN) > 0);
+static_assert (mlib_int128_scmp (MLIB_INT128 (-12), MLIB_INT128 (0)) < 0);
+static_assert (mlib_int128_scmp (MLIB_INT128 (12), MLIB_INT128 (0)) > 0);
+
+// Simple arithmetic:
+static_assert (mlib_int128_scmp (mlib_int128_add (MLIB_INT128_SMAX, 1_i128),
+                                 MLIB_INT128_SMIN) == 0);
+static_assert (mlib_int128_scmp (mlib_int128_negate (MLIB_INT128 (-42)),
+                                 MLIB_INT128 (42)) == 0);
+static_assert (mlib_int128_scmp (mlib_int128_sub (5_i128, 3_i128), 2_i128) ==
+               0);
+static_assert (mlib_int128_scmp (mlib_int128_sub (3_i128, 5_i128),
+                                 mlib_int128_negate (2_i128)) == 0);
+static_assert (mlib_int128_ucmp (mlib_int128_sub (3_i128, 5_i128),
+                                 mlib_int128_sub (MLIB_INT128_UMAX, 1_i128)) ==
+               0);
+
+static_assert (mlib_int128_scmp (mlib_int128_lshift (1_i128, 127),
+                                 MLIB_INT128_SMIN) == 0);
+
+static_assert (
+   mlib_int128_scmp (mlib_int128_rshift (mlib_int128_lshift (1_i128, 127), 127),
+                     1_i128) == 0);
+
+
+inline std::ostream &
+operator<< (std::ostream &out, mlib_int128 v)
+{
+   out << mlib_int128_format (v).str;
+   return out;
+}
+
+struct check_info {
+   const char *filename;
+   int line;
+   const char *expr;
+};
+
+template <typename Left> struct [[nodiscard]] bound_lhs {
+   check_info info;
+   Left value;
+
+#define DEFOP(Oper)                                              \
+   template <typename Rhs> void operator Oper (Rhs rhs) noexcept \
+   {                                                             \
+      if (value Oper rhs) {                                      \
+         return;                                                 \
+      }                                                          \
+      fprintf (stderr,                                           \
+               "%s:%d: CHECK( %s ) failed!\n",                   \
+               info.filename,                                    \
+               info.line,                                        \
+               info.expr);                                       \
+      fprintf (stderr, "Expanded expression: ");                 \
+      std::cerr << value << " " #Oper " " << rhs << '\n';        \
+      exit (2);                                                  \
+   }
+   DEFOP (==)
+   DEFOP (!=)
+   DEFOP (<)
+   DEFOP (<=)
+   DEFOP (>)
+   DEFOP (>=)
+#undef DEFOP
+};
+
+struct check_magic {
+   check_info info;
+
+   template <typename Oper>
+   bound_lhs<Oper>
+   operator->*(Oper op)
+   {
+      return bound_lhs<Oper>{info, op};
+   }
+};
+
+#undef CHECK
+#define CHECK(Cond) check_magic{check_info{__FILE__, __LINE__, #Cond}}->*Cond
+
+
+// Operators, for test convenience
+constexpr bool
+operator== (mlib_int128 l, mlib_int128 r)
+{
+   return mlib_int128_eq (l, r);
+}
+
+constexpr bool
+operator<(mlib_int128 l, mlib_int128 r)
+{
+   return mlib_int128_scmp (l, r) < 0;
+}
+static_assert (mlib_int128 (MLIB_INT128_UMAX) ==
+               340282366920938463463374607431768211455_i128);
+
+// Check sign extension works correctly:
+static_assert (mlib_int128 (MLIB_INT128_CAST (INT64_MIN)) ==
+               mlib_int128_negate (9223372036854775808_i128));
+static_assert (mlib_int128 (MLIB_INT128_CAST (INT64_MIN)) <
+               mlib_int128_negate (9223372036854775807_i128));
+static_assert (mlib_int128_negate (9223372036854775809_i128) <
+               mlib_int128 (MLIB_INT128_CAST (INT64_MIN)));
+
+// Runtime checks, easier to debug that static_asserts
+int
+main ()
+{
+   mlib_int128 zero = MLIB_INT128 (0);
+   CHECK (true == mlib_int128_eq (zero, MLIB_INT128 (0)));
+   CHECK (true == mlib_int128_eq (zero, 0_i128));
+   CHECK (zero == mlib_int128{0});
+   CHECK (zero == 0_i128);
+
+   auto two = MLIB_INT128 (2);
+   auto four = mlib_int128_add (two, two);
+   CHECK (four == MLIB_INT128 (4));
+   CHECK (four == 4_i128);
+   CHECK (two == mlib_int128_add (two, zero));
+
+   // Addition wraps:
+   mlib_int128 max = MLIB_INT128_SMAX;
+   auto more = mlib_int128_add (max, four);
+   CHECK (more == mlib_int128_add (MLIB_INT128_SMIN, MLIB_INT128 (3)));
+
+   // "Wrap" around zero:
+   auto ntwo = MLIB_INT128 (-2);
+   auto sum = mlib_int128_add (ntwo, four);
+   CHECK (sum == two);
+
+   auto eight = mlib_int128_lshift (two, 2);
+   CHECK (eight == MLIB_INT128 (8));
+
+   auto big = mlib_int128_lshift (two, 72);
+   CHECK (mlib_int128_scmp (big, MLIB_INT128 (0)) > 0);
+
+   auto four_v2 = mlib_int128_lshift (eight, -1);
+   CHECK (four == four_v2);
+
+   auto r = mlib_int128_divmod (27828649044156246570177174673037165454_i128,
+                                499242349997913298655486252455941907_i128);
+
+   CHECK (r.quotient == 55_i128);
+   CHECK (r.remainder == 370319794271015144125430787960360569_i128);
+
+   // Self-divide:
+   r = mlib_int128_divmod (628698094597401606590302208_i128,
+                           628698094597401606590302208_i128);
+   CHECK (r.quotient == 1_i128);
+   CHECK (r.remainder == 0_i128);
+
+   // With no high-32 bits in the denominator
+   r = mlib_int128_divmod (316356263640858117670580590964547584140_i128,
+                           13463362962560749016052695684_i128);
+   CHECK (r.quotient == 23497566285_i128);
+
+   // Remainder correctness with high bit set:
+   auto rem = mlib_int128_mod (292590981272581782572061492191999425232_i128,
+                               221673222198185508195462959065350495048_i128);
+   CHECK (rem == 70917759074396274376598533126648930184_i128);
+
+   // Remainder with 64bit denom:
+   rem = mlib_int128_mod (2795722437127403543495742528_i128, 708945413_i128);
+   CHECK (rem == 619266642_i128);
+
+   // 10-div:
+   CHECK (mlib_int128_div (MLIB_INT128_SMAX, 10_i128) ==
+          17014118346046923173168730371588410572_i128);
+
+   int8_t n = -12;
+   CHECK (mlib_int128_scmp (zero, MLIB_INT128_CAST (n)) > 0);
+   CHECK (mlib_int128_ucmp (zero, MLIB_INT128_CAST (n)) < 0);
+
+   auto _2pow127 = mlib_int128_pow2 (127);
+   CHECK (std::string (mlib_int128_format (_2pow127).str) ==
+          "170141183460469231731687303715884105728");
+
+   for (int i = 0; i < 1'000'000; ++i) {
+      std::uniform_int_distribution<std::uint64_t> dist;
+      std::random_device r;
+      auto bits = r ();
+      mlib_int128 num = MLIB_INT128_FROM_PARTS (bits & 0b0001 * dist (r),
+                                                bits & 0b0010 * dist (r));
+      mlib_int128 denom = MLIB_INT128_FROM_PARTS (bits & 0b0100 * dist (r),
+                                                  bits & 0b1000 * dist (r));
+      if (mlib_int128_eq (denom, 0_i128)) {
+         continue;
+      }
+
+      // Attempt a division, even if we have no "reference" value
+      auto q = mlib_int128_divmod (num, denom);
+      (void) q;
+#ifdef __SIZEOF_INT128__
+      std::cerr << "Testing: " << num << " ÷ " << denom << '\n';
+      // When we have an existing i128 impl, test against that:
+      mlib_int128 exp = {.unsigned_ = (num.unsigned_ / denom.unsigned_)};
+      mlib_int128 exp2 = {.unsigned_ = (num.unsigned_ % denom.unsigned_)};
+      CHECK (q.quotient == exp);
+      CHECK (q.remainder == exp2);
+#endif
+   }
+}

--- a/src/mlib/int128.test.cpp
+++ b/src/mlib/int128.test.cpp
@@ -2,9 +2,10 @@
 
 #include <iostream>
 #include <random>
+#include <thread>
 #include <string>
 
-#if (defined(__GNUC__) && __GNUC__ < 7) || \
+#if (defined(__GNUC__) && __GNUC__ < 7 && !defined(__clang__)) || \
    (defined(_MSC_VER) && _MSC_VER < 1920)
 // Old GCC and old MSVC have partially-broken constexpr that prevents us from
 // properly using static_assert with from_string()
@@ -51,7 +52,16 @@ constexpr
    mlib_int128
    operator""_i128 (const char *s)
 {
-   return mlib_int128_from_string (s);
+   return mlib_int128_from_string (s, NULL);
+}
+
+#ifndef BROKEN_CONSTEXPR
+constexpr
+#endif
+   mlib_int128
+   operator""_i128 (const char *s, size_t)
+{
+   return mlib_int128_from_string (s, NULL);
 }
 
 #ifndef BROKEN_CONSTEXPR
@@ -135,7 +145,8 @@ template <typename Left> struct bound_lhs {
                info.expr);                                            \
       fprintf (stderr, "Expanded expression: ");                      \
       std::cerr << value << " " #Oper " " << rhs << '\n';             \
-      exit (2);                                                       \
+      std::exit (1);                                                  \
+      return {};                                                      \
    }
    DEFOP (==)
    DEFOP (!=)
@@ -206,6 +217,32 @@ static_assert (mlib_int128_negate (9223372036854775809_i128) <
                "fail");
 #endif
 
+static mlib_int128_divmod_result
+div_check (mlib_int128 num, mlib_int128 den)
+{
+   // std::cout << "Check: " << num << " ÷ " << den << '\n';
+   mlib_int128_divmod_result res = mlib_int128_divmod (num, den);
+#ifdef __SIZEOF_INT128__
+   // When we have an existing i128 impl, test against that:
+   __uint128_t num1;
+   __uint128_t den1;
+   memcpy (&num1, &num.r, sizeof num);
+   memcpy (&den1, &den.r, sizeof den);
+   __uint128_t q = num1 / den1;
+   __uint128_t r = num1 % den1;
+   mlib_int128_divmod_result expect;
+   memcpy (&expect.quotient.r, &q, sizeof q);
+   memcpy (&expect.remainder.r, &r, sizeof r);
+   CHECK (expect.quotient == res.quotient);
+   CHECK (expect.remainder == res.remainder);
+#endif
+   // Check inversion by multiplication provides the correct result
+   auto invert = mlib_int128_mul (res.quotient, den);
+   invert = mlib_int128_add (invert, res.remainder);
+   CHECK (invert == num);
+   return res;
+}
+
 // Runtime checks, easier to debug that static_asserts
 int
 main ()
@@ -240,35 +277,17 @@ main ()
    auto four_v2 = mlib_int128_lshift (eight, -1);
    CHECK (four == four_v2);
 
-   auto r = mlib_int128_divmod (27828649044156246570177174673037165454_i128,
-                                499242349997913298655486252455941907_i128);
+   // It's useful it specify bit patterns directly
+   auto in_binary =
+      0b110101010110100100001101111001111010100010111100100101101011010110101001010110110011000100000100011110010101101001111110001000_i128;
+   CHECK (in_binary == 70917759074396274376598533126648930184_i128);
+   CHECK (
+      in_binary ==
+      "0b110101010110100100001101111001111010100010111100100101101011010110101001010110110011000100000100011110010101101001111110001000"_i128);
 
-   CHECK (r.quotient == 55_i128);
-   CHECK (r.remainder == 370319794271015144125430787960360569_i128);
-
-   // Self-divide:
-   r = mlib_int128_divmod (628698094597401606590302208_i128,
-                           628698094597401606590302208_i128);
-   CHECK (r.quotient == 1_i128);
-   CHECK (r.remainder == 0_i128);
-
-   // With no high-32 bits in the denominator
-   r = mlib_int128_divmod (316356263640858117670580590964547584140_i128,
-                           13463362962560749016052695684_i128);
-   CHECK (r.quotient == 23497566285_i128);
-
-   // Remainder correctness with high bit set:
-   auto rem = mlib_int128_mod (292590981272581782572061492191999425232_i128,
-                               221673222198185508195462959065350495048_i128);
-   CHECK (rem == 70917759074396274376598533126648930184_i128);
-
-   // Remainder with 64bit denom:
-   rem = mlib_int128_mod (2795722437127403543495742528_i128, 708945413_i128);
-   CHECK (rem == 619266642_i128);
-
-   // 10-div:
-   CHECK (mlib_int128_div (MLIB_INT128_SMAX, 10_i128) ==
-          17014118346046923173168730371588410572_i128);
+   // Or hexadecimal
+   auto in_hex = 0x355a4379ea2f25ad6a56cc411e569f88_i128;
+   CHECK (in_hex == 70917759074396274376598533126648930184_i128);
 
    int8_t n = -12;
    CHECK (mlib_int128_scmp (zero, MLIB_INT128_CAST (n)) > 0);
@@ -278,28 +297,91 @@ main ()
    CHECK (std::string (mlib_int128_format (_2pow127).str) ==
           "170141183460469231731687303715884105728");
 
-   for (int i = 0; i < 100000; ++i) {
-      std::uniform_int_distribution<std::uint64_t> dist;
-      std::random_device r;
-      auto bits = r ();
-      mlib_int128 num = MLIB_INT128_FROM_PARTS (bits & 0b0001 * dist (r),
-                                                bits & 0b0010 * dist (r));
-      mlib_int128 denom = MLIB_INT128_FROM_PARTS (bits & 0b0100 * dist (r),
-                                                  bits & 0b1000 * dist (r));
-      if (mlib_int128_eq (denom, 0_i128)) {
-         continue;
+   auto r = div_check (27828649044156246570177174673037165454_i128,
+                       499242349997913298655486252455941907_i128);
+
+   CHECK (r.quotient == 55_i128);
+   CHECK (r.remainder == 370319794271015144125430787960360569_i128);
+
+   r = div_check (64208687961221311123721027584_i128, 3322092839076102144_i128);
+   CHECK (r.remainder == 3155565729965670400_i128);
+
+   // This division will trigger the rare Knuth 4.3.1D/D6 condition:
+   r = div_check (31322872034807296605612234499929458960_i128,
+                  34573864092216774938021667884_i128);
+   CHECK (r.quotient == 905969663_i128);
+   CHECK (r.remainder == 34573864092065898160364055868_i128);
+
+   // Self-divide:
+   r = div_check (628698094597401606590302208_i128,
+                  628698094597401606590302208_i128);
+   CHECK (r.quotient == 1_i128);
+   CHECK (r.remainder == 0_i128);
+
+   // With no high-32 bits in the denominator
+   r = div_check (316356263640858117670580590964547584140_i128,
+                  13463362962560749016052695684_i128);
+   CHECK (r.quotient == 23497566285_i128);
+
+   // Remainder correctness with high bit set:
+   r = div_check (292590981272581782572061492191999425232_i128,
+                  221673222198185508195462959065350495048_i128);
+   CHECK (r.remainder == 70917759074396274376598533126648930184_i128);
+
+   // Remainder with 64bit denom:
+   r = div_check (2795722437127403543495742528_i128, 708945413_i128);
+   CHECK (r.remainder == 619266642_i128);
+
+   // 10-div:
+   CHECK (mlib_int128_div (MLIB_INT128_SMAX, 10_i128) ==
+          17014118346046923173168730371588410572_i128);
+
+   std::random_device rd;
+   std::seed_seq seed ({rd (), rd (), rd (), rd ()});
+   // Pick every numerator bit pattern from 0b00'00 to 0b11'11
+   for (auto nbits = 0u; nbits < 16u; ++nbits) {
+      // This is an extremely rudimentary thread pool to parallelize the
+      // division checks. It doesn't need to be rigorous or optimal, it only
+      // needs to "just work."
+      std::vector<std::thread> threads;
+      threads.resize (15);
+      // Pick every denominator bit pattern from 0b00'01 to 0b11'11:
+      for (auto dbits = 1u; dbits < 16u; ++dbits) {
+         // Randomness:
+         std::mt19937 random;
+         random.seed (seed);
+         // Spawn a thread for this denominator bit pattern:
+         threads[dbits - 1] = std::thread{[nbits, dbits, random] () mutable {
+            std::uniform_int_distribution<std::uint32_t> dist;
+            // 100k random divisions:
+            for (auto i = 0; i < 100000; ++i) {
+               // Generate a denominator
+               auto den = 0_i128;
+               while (den == 0_i128) {
+                  // Regenerate until we don't have zero (very
+                  // unlikely, but be safe!)
+                  uint64_t dlo = 0, dhi = 0;
+                  (dbits & 1) && (dlo |= dist (random));
+                  (dbits & 2) && (dlo |= (uint64_t) dist (random) << 32);
+                  (dbits & 4) && (dhi |= dist (random));
+                  (dbits & 8) && (dhi |= (uint64_t) dist (random) << 32);
+                  den = MLIB_INT128_FROM_PARTS (dlo, dhi);
+               }
+               // Generate a numerator
+               uint64_t nlo = 0, nhi = 0;
+               (nbits & 1) && (nlo |= dist (random));
+               (nbits & 2) && (nlo |= (uint64_t) dist (random) << 32);
+               (nbits & 4) && (nhi |= dist (random));
+               (nbits & 8) && (nhi |= (uint64_t) dist (random) << 32);
+               mlib_int128 num = MLIB_INT128_FROM_PARTS (nlo, nhi);
+               // Divide them:
+               div_check (num, den);
+            }
+         }};
       }
-
-      // Attempt a division, even if we have no "reference" value
-      auto q = mlib_int128_divmod (num, denom);
-      (void) q;
-
-#ifdef __SIZEOF_INT128__
-      // When we have an existing i128 impl, test against that:
-      mlib_int128 exp = {.unsigned_ = (num.unsigned_ / denom.unsigned_)};
-      mlib_int128 exp2 = {.unsigned_ = (num.unsigned_ % denom.unsigned_)};
-      CHECK (q.quotient == exp);
-      CHECK (q.remainder == exp2);
-#endif
+      // Join the threads that are dividing:
+      for (auto &t : threads) {
+         t.join ();
+      }
    }
 }

--- a/src/mlib/int128.test.cpp
+++ b/src/mlib/int128.test.cpp
@@ -127,20 +127,24 @@ static_assert (
 // With no high-32 bits in the denominator
 static_assert (mlib_int128_div (316356263640858117670580590964547584140_i128,
                                 13463362962560749016052695684_i128) ==
-               23497566285_i128);
+                  23497566285_i128,
+               "fail");
 
 // Remainder correctness with high bit set:
 static_assert (mlib_int128_mod (292590981272581782572061492191999425232_i128,
                                 221673222198185508195462959065350495048_i128) ==
-               70917759074396274376598533126648930184_i128);
+                  70917759074396274376598533126648930184_i128,
+               "fail");
 
 // Remainder with 64bit denom:
 static_assert (mlib_int128_mod (2795722437127403543495742528_i128,
-                                708945413_i128) == 619266642_i128);
+                                708945413_i128) == 619266642_i128,
+               "fail");
 
 // 10-div:
 static_assert (mlib_int128_div (MLIB_INT128_SMAX, 10_i128) ==
-               17014118346046923173168730371588410572_i128);
+                  17014118346046923173168730371588410572_i128,
+               "fail");
 #endif // BROKEN_CONSTEXPR
 
 inline std::ostream &

--- a/src/mlib/macros.h
+++ b/src/mlib/macros.h
@@ -27,7 +27,9 @@
 /// End a C-language-linkage section
 #define MLIB_C_LINKAGE_END _mlibCLinkageEnd
 
-#if defined(__cpp_constexpr) && __cpp_constexpr >= 201304L
+#if (defined(__cpp_constexpr) && __cpp_constexpr >= 201304L) || \
+   (defined(__cplusplus) && __cplusplus >= 201402L) ||          \
+   (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
 #define _mlibConstexprFn constexpr inline
 #else
 #define _mlibConstexprFn inline

--- a/src/mlib/macros.h
+++ b/src/mlib/macros.h
@@ -14,4 +14,31 @@
 #define MLIB_INIT(T) (T)
 #endif
 
+#ifdef __cplusplus
+#define _mlibCLinkageBegin extern "C" {
+#define _mlibCLinkageEnd }
+#else
+#define _mlibCLinkageBegin
+#define _mlibCLinkageEnd
+#endif
+
+/// Mark the beginning of a C-language-linkage section
+#define MLIB_C_LINKAGE_BEGIN _mlibCLinkageBegin
+/// End a C-language-linkage section
+#define MLIB_C_LINKAGE_END _mlibCLinkageEnd
+
+#if defined(__cpp_constexpr) && __cpp_constexpr >= 201304L
+#define _mlibConstexprFn constexpr inline
+#else
+#define _mlibConstexprFn inline
+#endif
+
+/**
+ * @brief Mark a function as constexpr
+ *
+ * Expands to `constexpr` in C++14 and above (and someday C26...?). "inline"
+ * otherwise.
+ */
+#define mlib_constexpr_fn _mlibConstexprFn
+
 #endif // MLIB_MACROS_H_INCLUDED

--- a/src/mlib/macros.h
+++ b/src/mlib/macros.h
@@ -38,8 +38,8 @@
 /**
  * @brief Mark a function as constexpr
  *
- * Expands to `constexpr` in C++14 and above (and someday C26...?). "inline"
- * otherwise.
+ * Expands to `constexpr inline` in C++14 and above (and someday C26...?).
+ * "inline" otherwise.
  */
 #define mlib_constexpr_fn _mlibConstexprFn
 

--- a/src/mlib/str.h
+++ b/src/mlib/str.h
@@ -16,6 +16,8 @@
 #include <strings.h> /* For strncasecmp. */
 #endif
 
+MLIB_C_LINKAGE_BEGIN
+
 /**
  * @brief A simple non-owning string-view type.
  *
@@ -946,5 +948,19 @@ _mstr_split_iter_done_ (struct _mstr_split_iter_ *iter)
            _iter_var_.once;                                       \
            --_iter_var_.once)
 // clang-format on
+
+/**
+ * @brief Equivalent to strlen(), but has a constexpr annotation.
+ */
+static mlib_constexpr_fn size_t
+mlib_strlen (const char *s)
+{
+   size_t r = 0;
+   for (; *s; ++r, ++s) {
+   }
+   return r;
+}
+
+MLIB_C_LINKAGE_END
 
 #endif // MONGOCRYPT_STR_PRIVATE_H


### PR DESCRIPTION
This changeset adds a new trivial type `mlib_int128`, which presents a method of performing 128-bit binary arithmetic. This is a prerequesite to MONGOCRYPT-483, which requires 128-bit integers and integer arithmetic.

Some platforms, such as 64-bit GCC, provide an `__int128` abstraction, but other platforms do not. MSVC and all 32-bit targets do not have such extensions. For this reason, this PR implements 128-bit arithmetic using only standard C99.

Usage looks like this:

- `mlib_int128` a typedef of a trivial type that occupies 16 bytes of storage. There is no distinction between signed/unsigned: Operations that depend on sign (for now, just integer comparison) require specifying whether you want a signed compare or an unsigned compare.
- `MLIB_INT128(N)` a macro that creates a 128-bit integer from an integer literal. The literal should not have a suffix. Negation within the macro "just works" (but may generate a false-positive compiler warning).
- `MLIB_INT128_CAST(N)` cast an arbitrary integral value `N` to a 128-bit integer.
- `MLIB_INT128_FROM_PARTS(Low64, High64)` the actual "constructor" for `mlib_in128`: Glues together the low bits and the high bits from two 64-bit integers.
- `MLIB_INT128_SMAX`, `MLIB_INT128_SMIN`, `MLIB_INT128_UMAX`: The signed-maximum, signed-minimum, and unsigned-maximum values for 128-bit integers.

The following functions all have an `mlib_int128_` prefix:

- `ucmp(L, R) -> int` and `scmp(L, R) -> int` Compare two integers as either unsigned or signed, respectively. Returns `n < 0`, `n > 0`, or `n = 0` for less, greater, and equal, respectively.
- `eq(L, R) -> bool` - Determine whether `L` and `R` are equal.
- `add(L, R) -> int128` - Return `L + R`. Overflow wraps.
- `sub(L, R) -> int128` - Returns `L - R`. Overflow wraps.
- `negate(N) -> int128` - Treat `N` as a signed integer. Return `-N`.
- `lshift(N, c) -> int128` - Return `N << c`
- `rshift(N, c) -> int128` - Return `N >> c`
- `bitor(L, R) -> int128` - Return `L | R`
- `mul(L, R) -> int128` - Return `L * R`. Overflow wraps.
- `div(L, R) -> int128` - Treats `L` and `R` as unsigned: Return `L / R` (round toward zero).
- `mod(L, R) -> int128` - Treats `L` and `R` as unsigned: Return `L % R` (remainder after integer division).
- `divmod(L, R)-> {quotient, remainder}` - Obtain both the quotient and remainder of an integer division.
- `pow10(N) -> int128` - Obtain the `N`th power of ten.
- `pow2(N) -> int128` - Obtain the `N`th power of two. (No general `pow()` is defined.)
- `from_string(S) -> int128` - Parse `S` as a string of decimal digits.
- `to_u64(N) -> uint64_t` - Return the low 64 bits of `N`.
- `format(N)` - Render the `N` as a string of decimal digits. Returns a struct containing the result array.

The implementations of `add`, `sub`, the bitshifts, to/from string, compare, and equality are all fairly straightforward extensions of 64-bit operations (with carry/borrow).

Multiplication here is implemented using Knuth's 4.3.1M multiplication algorithm (from _The Art of Computer Programming_). Here 4.3.1M is used to multiply the two low 64-bit words to obtain the 128-bit product. The high word of the result is then adjusted by two more regular 64-bit multiplications.

Division is the most complicated operation and took a lot of testing to ensure correct. It uses Knuth's 4.3.1D algorithm for arbitrary precision unsigned division (defined in `_mlibKnuth431D`). Certain optimizations and shortcuts were learned from the existing STL `constexpr` implementation. Future optimization to use actual intrinsics and hardware are not done here, since we just need these 128-bit integers and want platform-equivalence.

Most of the code has been marked as `constexpr`, and a lot of functionality is tested via `static_asserts` for failing CI as-fast-as-possible and immediate IDE feedback.

---

The PR tests are implemented in C++ and defined a test macro `CHECK`, since I miss Catch2 🥲.