### PR TITLE
ci(NODE-4666): pin to node18 instead of latest

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1059,6 +1059,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - test-java
   - name: publish-packages
     distros:
@@ -1325,6 +1326,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - build-and-test-csharp
   - test-java
   - upload-java
@@ -1343,6 +1345,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
+  - build-and-test-node-no-optional-dependencies
   - test-java
   - name: publish-packages
     distros:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -146,7 +146,7 @@ functions:
           NODE_GITHUB_TOKEN: ${node_github_token}
           DISTRO_ID: ${distro_id}
           BUILD_VARIANT: ${build_variant}
-          NODE_NVM_USE_VERSION: ${nvm_use_version|lts}
+          NODE_NVM_USE_VERSION: ${nvm_use_version|18}
 
   "build and test node no optional dependencies":
     - command: "subprocess.exec"
@@ -161,7 +161,7 @@ functions:
           DISTRO_ID: ${distro_id}
           BUILD_VARIANT: ${build_variant}
           NPM_OPTIONS: "--no-optional"
-          NODE_NVM_USE_VERSION: ${nvm_use_version|lts}
+          NODE_NVM_USE_VERSION: ${nvm_use_version|18}
 
   "attach node xunit results":
     - command: attach.xunit_results

--- a/bindings/node/.evergreen/setup_environment.sh
+++ b/bindings/node/.evergreen/setup_environment.sh
@@ -42,7 +42,7 @@ export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
 mkdir -p ${NVM_DIR}
 
 # install Node.js
-echo "Installing Node ${NODE_LTS_NAME}"
+echo "Installing Latest Node for Major Version ${NODE_NVM_USE_VERSION}"
 if [ "$OS" == "Windows_NT" ]; then
   set +o xtrace
 

--- a/bindings/node/.evergreen/setup_environment.sh
+++ b/bindings/node/.evergreen/setup_environment.sh
@@ -26,9 +26,6 @@ mkdir -p "${BIN_DIR}"
 # Add mongodb toolchain to path
 export PATH="$BIN_DIR:/opt/mongodbtoolchain/v2/bin:$PATH"
 
-test -n "${NODE_NVM_USE_VERSION-}" || echo "Defaulting to using the current Node LTS Release. Set NODE_NVM_USE_VERSION to change."
-: "${NODE_NVM_USE_VERSION:="18"}"
-
 # locate cmake
 if [ "$OS" == "Windows_NT" ]; then
   CMAKE=/cygdrive/c/cmake/bin/cmake

--- a/bindings/node/.evergreen/setup_environment.sh
+++ b/bindings/node/.evergreen/setup_environment.sh
@@ -13,7 +13,7 @@ NODE_ARTIFACTS_PATH="${NODE_BINDINGS_PATH}/node-artifacts"
 NPM_CACHE_DIR="${NODE_ARTIFACTS_PATH}/npm"
 NPM_TMP_DIR="${NODE_ARTIFACTS_PATH}/tmp"
 BIN_DIR="$(pwd)/bin"
-NVM_WINDOWS_URL="https://github.com/coreybutler/nvm-windows/releases/download/1.1.9/nvm-noinstall.zip"
+NVM_WINDOWS_URL="https://github.com/coreybutler/nvm-windows/releases/download/1.1.10/nvm-noinstall.zip"
 NVM_URL="https://raw.githubusercontent.com/creationix/nvm/v0.38.0/install.sh"
 NPM_OPTIONS="${NPM_OPTIONS}"
 

--- a/bindings/node/.evergreen/setup_environment.sh
+++ b/bindings/node/.evergreen/setup_environment.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ -z "$NODE_NVM_USE_VERSION" ]; then 
+  echo "NODE_NVM_USE_VERSION environment variable must be set."
+  exit 1
+fi
+
 set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
@@ -22,7 +27,7 @@ mkdir -p "${BIN_DIR}"
 export PATH="$BIN_DIR:/opt/mongodbtoolchain/v2/bin:$PATH"
 
 test -n "${NODE_NVM_USE_VERSION-}" || echo "Defaulting to using the current Node LTS Release. Set NODE_NVM_USE_VERSION to change."
-: "${NODE_NVM_USE_VERSION:="lts"}"
+: "${NODE_NVM_USE_VERSION:="18"}"
 
 # locate cmake
 if [ "$OS" == "Windows_NT" ]; then


### PR DESCRIPTION
### Description

This PR pins the Node CI the Node 18 (the current latest LTS node version).  It also makes two other small changes (see the notes sections below).

A requirement of the ticket is that we make sure our release will be pinned to Node16 since they build on rhel7.  This was already addressed and can be confirmed in the config.yml (see [here](https://github.com/mongodb/libmongocrypt/blob/4a520d7cccee09d3d4ce4cec207701f31e050c7e/.evergreen/config.yml#L1130)).

Note: you may see failing socks5 tests on the CI.  These tests are also failing on libmongocrypt master occasionally.

### Misc Other Changes

https://github.com/mongodb/libmongocrypt/commit/216f7854cbee5dbd9247099b6db88c38d9d2c53c added debian and ubuntu22 support but did not add `build-and-test-node-no-optional-dependencies` to the new variants.  This PR adds the missing tasks.

Switching to a pinned version instead of `lts` cause us to encounter this issue - https://github.com/coreybutler/nvm-windows/issues/706.  Windows nvm 1.1.10 has a fix for this issue so windows nvm was bumped to the latest version.