### PR TITLE
MONGOCRYPT-506 Extend token API for server needs

### DIFF
--- a/src/mc-tokens-private.h
+++ b/src/mc-tokens-private.h
@@ -65,16 +65,18 @@
 #define DECL_TOKEN_TYPE(Name, ...) \
    DECL_TOKEN_TYPE_1 (Name, CONCAT (Name, _t), __VA_ARGS__)
 
-#define DECL_TOKEN_TYPE_1(Prefix, T, ...)                                 \
-   /* Opaque typedef the struct */                                        \
-   typedef struct T T;                                                    \
-   /* Data-getter */                                                      \
-   extern const _mongocrypt_buffer_t *CONCAT (Prefix, _get) (const T *t); \
-   /* Destructor */                                                       \
-   extern void CONCAT (Prefix, _destroy) (T * t);                         \
-   /* Constructor. Parameter list given as variadic args */               \
-   extern T *CONCAT (Prefix, _new) (_mongocrypt_crypto_t * crypto,        \
-                                    __VA_ARGS__,                          \
+#define DECL_TOKEN_TYPE_1(Prefix, T, ...)                                    \
+   /* Opaque typedef the struct */                                           \
+   typedef struct T T;                                                       \
+   /* Data-getter */                                                         \
+   extern const _mongocrypt_buffer_t *CONCAT (Prefix, _get) (const T *t);    \
+   /* Destructor */                                                          \
+   extern void CONCAT (Prefix, _destroy) (T * t);                            \
+   /* Constructor for server to create tokens from raw buffer */             \
+   extern T *CONCAT (Prefix, _new_from_buffer) (_mongocrypt_buffer_t * buf); \
+   /* Constructor. Parameter list given as variadic args */                  \
+   extern T *CONCAT (Prefix, _new) (_mongocrypt_crypto_t * crypto,           \
+                                    __VA_ARGS__,                             \
                                     mongocrypt_status_t * status)
 
 DECL_TOKEN_TYPE (mc_CollectionsLevel1Token, const _mongocrypt_buffer_t *);

--- a/src/mc-tokens.c
+++ b/src/mc-tokens.c
@@ -42,6 +42,14 @@
       _mongocrypt_buffer_cleanup (&self->data);                      \
       bson_free (self);                                              \
    }                                                                 \
+   /* Constructor. From raw buffer */                                \
+   T *CONCAT (Prefix, _new_from_buffer) (_mongocrypt_buffer_t * buf) \
+   {                                                                 \
+      BSON_ASSERT (buf->len == MONGOCRYPT_HMAC_SHA256_LEN);          \
+      T *t = bson_malloc (sizeof (T));                               \
+      _mongocrypt_buffer_set_to (buf, &t->data);                     \
+      return t;                                                      \
+   }                                                                 \
    /* Constructor. Parameter list given as variadic args. */         \
    T *CONCAT (Prefix, _new) (_mongocrypt_crypto_t * crypto,          \
                              __VA_ARGS__,                            \

--- a/test/test-mc-tokens.c
+++ b/test/test-mc-tokens.c
@@ -226,6 +226,11 @@ _test_mc_tokens_raw_buffer (_mongocrypt_tester_t *tester)
 
    ASSERT_CMPBUF (*mc_ServerDataEncryptionLevel1Token_get (token), expected);
 
+   /* Assert new_from_buffer references original buffer instead of a copy. */
+   test_input.data[0] = '0';
+   expected.data[0] = '0';
+   ASSERT_CMPBUF (*mc_ServerDataEncryptionLevel1Token_get (token), expected);
+
    _mongocrypt_buffer_cleanup (&test_input);
    _mongocrypt_buffer_cleanup (&expected);
    mc_ServerDataEncryptionLevel1Token_destroy (token);

--- a/test/test-mc-tokens.c
+++ b/test/test-mc-tokens.c
@@ -202,9 +202,38 @@ _test_mc_tokens_error (_mongocrypt_tester_t *tester)
    mongocrypt_status_destroy (status);
 }
 
+static void
+_test_mc_tokens_raw_buffer (_mongocrypt_tester_t *tester)
+{
+   mc_ServerDataEncryptionLevel1Token_t *token;
+   _mongocrypt_buffer_t test_input;
+   _mongocrypt_buffer_t expected;
+
+   _mongocrypt_buffer_copy_from_hex (
+      &test_input,
+      "6c6a349956c19f9c5e638e612011a71fbb71921edb540310c17cd0208b7f548b");
+
+   /* Make a token from a raw buffer */
+   token = mc_ServerDataEncryptionLevel1Token_new_from_buffer (&test_input);
+   /* Assert the new_from_buffer does not steal the buffer */
+   ASSERT (test_input.owned == true);
+   ASSERT (test_input.len == MONGOCRYPT_HMAC_SHA256_LEN);
+
+   _mongocrypt_buffer_copy_from_hex (
+      &expected,
+      "6c6a349956c19f9c5e638e612011a71fbb71921edb540310c17cd0208b7f548b");
+
+   ASSERT_CMPBUF (*mc_ServerDataEncryptionLevel1Token_get (token), expected);
+
+   _mongocrypt_buffer_cleanup (&test_input);
+   _mongocrypt_buffer_cleanup (&expected);
+   mc_ServerDataEncryptionLevel1Token_destroy (token);
+}
+
 void
 _mongocrypt_tester_install_mc_tokens (_mongocrypt_tester_t *tester)
 {
    INSTALL_TEST (_test_mc_tokens);
    INSTALL_TEST (_test_mc_tokens_error);
+   INSTALL_TEST (_test_mc_tokens_raw_buffer);
 }

--- a/test/test-mc-tokens.c
+++ b/test/test-mc-tokens.c
@@ -215,8 +215,9 @@ _test_mc_tokens_raw_buffer (_mongocrypt_tester_t *tester)
 
    /* Make a token from a raw buffer */
    token = mc_ServerDataEncryptionLevel1Token_new_from_buffer (&test_input);
-   /* Assert the new_from_buffer does not steal the buffer */
-   ASSERT (test_input.owned == true);
+
+   /* Assert new_from_buffer did not steal ownership. */
+   ASSERT (test_input.owned);
    ASSERT (test_input.len == MONGOCRYPT_HMAC_SHA256_LEN);
 
    _mongocrypt_buffer_copy_from_hex (


### PR DESCRIPTION
Server needs to be able to construct a libmongocrypt token `mc_ServerDataEncryptionLevel1Token_t` from a server token (i.e. `mongo::ServerDataEncryptionLevel1Token`). We use a raw buffer for this but let the server own the buffer rather then deep copy it in this case.

Feel free to suggest a better name.