### PR TITLE
MONGOCRYPT-511 Fix missing strings.h header in kms_port.h

### DIFF
--- a/kms-message/src/kms_port.h
+++ b/kms-message/src/kms_port.h
@@ -25,6 +25,8 @@
 char *
 kms_strndup (const char *src, size_t len);
 #else
+#include <strings.h>
+
 #define kms_strndup strndup
 #define kms_strcasecmp strcasecmp
 #endif


### PR DESCRIPTION
The build system in the server is different than the libmongocrypt build system. This is leading to the following error:

```src/third_party/libmongocrypt/dist/kms-message/src/kms_request.c:371:16: warning: call to undeclared function 'strcasecmp'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
          0 == kms_strcasecmp (previous_key->str, kv->key->str)) {
               ^
src/third_party/libmongocrypt/dist/kms-message/src/kms_port.h:29:24: note: expanded from macro 'kms_strcasecmp'
#define kms_strcasecmp strcasecmp
                       ^
```