### PR TITLE
fix(NODE-4880): specify family of ipv4 when connecting to default mongocryptd uri

### DIFF
--- a/bindings/node/.eslintrc.json
+++ b/bindings/node/.eslintrc.json
@@ -10,7 +10,7 @@
     "es6": true
   },
   "parserOptions": {
-    "ecmaVersion": 2022
+    "ecmaVersion": 2019
   },
   "plugins": [
     "prettier"

--- a/bindings/node/.eslintrc.json
+++ b/bindings/node/.eslintrc.json
@@ -10,7 +10,7 @@
     "es6": true
   },
   "parserOptions": {
-    "ecmaVersion": 2019
+    "ecmaVersion": 2022
   },
   "plugins": [
     "prettier"

--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -165,7 +165,7 @@ module.exports = function (modules) {
           serverSelectionTimeoutMS: 10000
         };
 
-        const wasURIProvided = typeof options.extraOptions === 'object' && !!options.extraOptions.mongocryptdURI;
+        const wasURIProvided = options.extraOptions && !!options.extraOptions.mongocryptdURI;
         if (!wasURIProvided) {
           clientOptions.family = 4;
         }

--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -165,8 +165,7 @@ module.exports = function (modules) {
           serverSelectionTimeoutMS: 10000
         };
 
-        const wasURIProvided = options.extraOptions && !!options.extraOptions.mongocryptdURI;
-        if (!wasURIProvided) {
+        if (options.extraOptions == null || typeof options.extraOptions.mongocryptdURI !== 'string')
           clientOptions.family = 4;
         }
 

--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -158,12 +158,22 @@ module.exports = function (modules) {
       // Only instantiate mongocryptd manager/client once we know for sure
       // that we are not using the CSFLE shared library.
       if (!this._bypassMongocryptdAndCryptShared && !this.cryptSharedLibVersionInfo) {
+        const wasUriProvided =
+          typeof options.extraOptions === 'object' && !!options.extraOptions.mongocryptdURI;
         this._mongocryptdManager = new MongocryptdManager(options.extraOptions);
-        this._mongocryptdClient = new MongoClient(this._mongocryptdManager.uri, {
+        const clientOptions = {
           useNewUrlParser: true,
           useUnifiedTopology: true,
           serverSelectionTimeoutMS: 10000
-        });
+        };
+
+        if (
+          this._mongocryptdManager.uri === MongocryptdManager.DEFAULT_MONGOCRYPTD_URI &&
+          !wasUriProvided
+        ) {
+          clientOptions.family = 4;
+        }
+        this._mongocryptdClient = new MongoClient(this._mongocryptdManager.uri, clientOptions);
       }
     }
 

--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -165,7 +165,10 @@ module.exports = function (modules) {
           serverSelectionTimeoutMS: 10000
         };
 
-        if (options.extraOptions == null || typeof options.extraOptions.mongocryptdURI !== 'string')
+        if (
+          options.extraOptions == null ||
+          typeof options.extraOptions.mongocryptdURI !== 'string'
+        ) {
           clientOptions.family = 4;
         }
 

--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -158,8 +158,6 @@ module.exports = function (modules) {
       // Only instantiate mongocryptd manager/client once we know for sure
       // that we are not using the CSFLE shared library.
       if (!this._bypassMongocryptdAndCryptShared && !this.cryptSharedLibVersionInfo) {
-        const wasUriProvided =
-          typeof options.extraOptions === 'object' && !!options.extraOptions.mongocryptdURI;
         this._mongocryptdManager = new MongocryptdManager(options.extraOptions);
         const clientOptions = {
           useNewUrlParser: true,
@@ -167,12 +165,11 @@ module.exports = function (modules) {
           serverSelectionTimeoutMS: 10000
         };
 
-        if (
-          this._mongocryptdManager.uri === MongocryptdManager.DEFAULT_MONGOCRYPTD_URI &&
-          !wasUriProvided
-        ) {
+        const wasURIProvided = typeof options.extraOptions === 'object' && !!options.extraOptions.mongocryptdURI;
+        if (!wasURIProvided) {
           clientOptions.family = 4;
         }
+
         this._mongocryptdClient = new MongoClient(this._mongocryptdManager.uri, clientOptions);
       }
     }

--- a/bindings/node/lib/mongocryptdManager.js
+++ b/bindings/node/lib/mongocryptdManager.js
@@ -61,8 +61,6 @@ class MongocryptdManager {
   }
 }
 
-Object.defineProperty(MongocryptdManager, 'DEFAULT_MONGOCRYPTD_URI', {
-  value: 'mongodb://localhost:27020'
-});
+MongocryptdManager.DEFAULT_MONGOCRYPTD_URI = 'mongodb://localhost:27020';
 
 module.exports = { MongocryptdManager };

--- a/bindings/node/lib/mongocryptdManager.js
+++ b/bindings/node/lib/mongocryptdManager.js
@@ -7,6 +7,8 @@ const spawn = require('child_process').spawn;
  * An internal class that handles spawning a mongocryptd.
  */
 class MongocryptdManager {
+  static DEFAULT_MONGOCRYPTD_URI = 'mongodb://localhost:27020/?serverSelectionTimeoutMS=1000';
+
   /**
    * @ignore
    * Creates a new Mongocryptd Manager
@@ -22,7 +24,7 @@ class MongocryptdManager {
     } else {
       // TODO: eventually support connecting on Linux Socket for non-windows,
       // blocked by SERVER-41029
-      this.uri = 'mongodb://localhost:27020/?serverSelectionTimeoutMS=1000';
+      this.uri = MongocryptdManager.DEFAULT_MONGOCRYPTD_URI;
     }
 
     this.bypassSpawn = !!extraOptions.mongocryptdBypassSpawn;
@@ -44,7 +46,7 @@ class MongocryptdManager {
   /**
    * @ignore
    * Will check to see if a mongocryptd is up. If it is not up, it will attempt
-   * to spawn a mongocryptd in a detached process, and then wait for it to be up.
+   * to spawn a mongocryptd in a detached plocess, and then wait for it to be up.
    * @param {Function} callback Invoked when we think a mongocryptd is up
    */
   spawn(callback) {

--- a/bindings/node/lib/mongocryptdManager.js
+++ b/bindings/node/lib/mongocryptdManager.js
@@ -17,7 +17,10 @@ class MongocryptdManager {
   constructor(extraOptions) {
     extraOptions = extraOptions || {};
 
-    this.uri = extraOptions.mongocryptdURI ?? MongocryptdManager.DEFAULT_MONGOCRYPTD_URI;
+    this.uri =
+      typeof extraOptions.mongocryptdURI === 'string' && extraOptions.mongocryptdURI.length > 0
+        ? extraOptions.mongocryptdURI
+        : MongocryptdManager.DEFAULT_MONGOCRYPTD_URI;
 
     this.bypassSpawn = !!extraOptions.mongocryptdBypassSpawn;
 

--- a/bindings/node/lib/mongocryptdManager.js
+++ b/bindings/node/lib/mongocryptdManager.js
@@ -7,8 +7,6 @@ const spawn = require('child_process').spawn;
  * An internal class that handles spawning a mongocryptd.
  */
 class MongocryptdManager {
-  static DEFAULT_MONGOCRYPTD_URI = 'mongodb://localhost:27020';
-
   /**
    * @ignore
    * Creates a new Mongocryptd Manager
@@ -62,5 +60,9 @@ class MongocryptdManager {
     process.nextTick(callback);
   }
 }
+
+Object.defineProperty(MongocryptdManager, 'DEFAULT_MONGOCRYPTD_URI', {
+  value: 'mongodb://localhost:27020'
+});
 
 module.exports = { MongocryptdManager };

--- a/bindings/node/lib/mongocryptdManager.js
+++ b/bindings/node/lib/mongocryptdManager.js
@@ -7,7 +7,7 @@ const spawn = require('child_process').spawn;
  * An internal class that handles spawning a mongocryptd.
  */
 class MongocryptdManager {
-  static DEFAULT_MONGOCRYPTD_URI = 'mongodb://localhost:27020/?serverSelectionTimeoutMS=1000';
+  static DEFAULT_MONGOCRYPTD_URI = 'mongodb://localhost:27020';
 
   /**
    * @ignore
@@ -17,15 +17,7 @@ class MongocryptdManager {
   constructor(extraOptions) {
     extraOptions = extraOptions || {};
 
-    // TODO: this is not actually supported by the spec, so we should clarify
-    // with the spec or get rid of this
-    if (extraOptions.mongocryptdURI) {
-      this.uri = extraOptions.mongocryptdURI;
-    } else {
-      // TODO: eventually support connecting on Linux Socket for non-windows,
-      // blocked by SERVER-41029
-      this.uri = MongocryptdManager.DEFAULT_MONGOCRYPTD_URI;
-    }
+    this.uri = extraOptions.mongocryptdURI ?? MongocryptdManager.DEFAULT_MONGOCRYPTD_URI;
 
     this.bypassSpawn = !!extraOptions.mongocryptdBypassSpawn;
 
@@ -46,7 +38,7 @@ class MongocryptdManager {
   /**
    * @ignore
    * Will check to see if a mongocryptd is up. If it is not up, it will attempt
-   * to spawn a mongocryptd in a detached plocess, and then wait for it to be up.
+   * to spawn a mongocryptd in a detached process, and then wait for it to be up.
    * @param {Function} callback Invoked when we think a mongocryptd is up
    */
   spawn(callback) {

--- a/bindings/node/test/autoEncrypter.test.js
+++ b/bindings/node/test/autoEncrypter.test.js
@@ -59,8 +59,7 @@ const MOCK_KEYDOCUMENT_RESPONSE = readExtendedJsonToBuffer(`${__dirname}/data/ke
 const MOCK_KMS_DECRYPT_REPLY = readHttpResponse(`${__dirname}/data/kms-decrypt-reply.txt`);
 
 class MockClient {
-  constructor(uri) {
-    this.uri = uri;
+  constructor() {
     this.topology = {
       bson: BSON
     };

--- a/bindings/node/test/autoEncrypter.test.js
+++ b/bindings/node/test/autoEncrypter.test.js
@@ -241,7 +241,7 @@ describe('AutoEncrypter', function () {
         expect(options).to.have.property('serverSelectionTimeoutMS', 10000);
       });
 
-      context('when no uri is specified', () => {
+      context('when mongocryptdURI is not specified', () => {
         it('sets the ip address family to ipv4', function () {
           expect(autoEncrypter).to.have.nested.property('_mongocryptdClient.s.options');
           const options = autoEncrypter._mongocryptdClient.s.options;
@@ -249,20 +249,7 @@ describe('AutoEncrypter', function () {
         });
       });
 
-      context('when the default mongocryptd uri is specified', function () {
-        it('does not set the ip address family to ipv4', function () {
-          const autoEncrypter = new AutoEncrypter(client, {
-            ...autoEncrypterOptions,
-            extraOptions: { mongocryptdURI: MongocryptdManager.DEFAULT_MONGOCRYPTD_URI }
-          });
-
-          expect(autoEncrypter).to.have.nested.property('_mongocryptdClient.s.options');
-          const options = autoEncrypter._mongocryptdClient.s.options;
-          expect(options).not.to.have.property('family', 4);
-        });
-      });
-
-      context('when a uri is specified', () => {
+      context('when mongocryptdURI is specified', () => {
         it('does not set the ip address family to ipv4', function () {
           const autoEncrypter = new AutoEncrypter(client, {
             ...autoEncrypterOptions,


### PR DESCRIPTION
Node18 changed the default dns resolution ordering from "ipv4 always first" to "returned in the order that the dns resolver returns them in".  This breaks some environments that use mongocryptd, since by default mongocryptd does not listen on ipv6 addresses.

There are workarounds

- configure mongocryptd to listen on ipv6 addresses
- specify a `mongocryptdURI` that uses `127.0.0.1` instead of `localhost`
- set the resolution globally on the node process

But none of these are ideal for customers or for driver CI.

This PR adds logic to force the driver to use ipv4 addresses when no `mongocryptdURI` is specified.

Driver CI task successfully passing with these changes - https://spruce.mongodb.com/version/639752c0c9ec447a54d40daa/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC.