### PR TITLE
MONGOCRYPT-513 Drop RHEL 6.7 on S390X

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -524,7 +524,7 @@ tasks:
   depends_on:
     - variant: rhel-62-64-bit
       name: build-and-test-and-upload
-    - variant: rhel-67-s390x
+    - variant: rhel72-zseries-test
       name: build-and-test-and-upload
     - variant: rhel-71-ppc64el
       name: build-and-test-and-upload
@@ -543,7 +543,7 @@ tasks:
     - func: "download tarball"
       vars: { variant_name: "rhel-62-64-bit" }
     - func: "download tarball"
-      vars: { variant_name: "rhel-67-s390x" }
+      vars: { variant_name: "rhel72-zseries-test" }
     - func: "download tarball"
       vars: { variant_name: "rhel-71-ppc64el" }
     - func: "download tarball"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -613,8 +613,6 @@ tasks:
       name: build-and-test-and-upload
     - variant: rhel-62-64-bit
       name: build-and-test-and-upload
-    - variant: rhel-67-s390x
-      name: build-and-test-and-upload
     - variant: rhel-70-64-bit
       name: build-and-test-and-upload
     - variant: rhel-71-ppc64el
@@ -668,8 +666,6 @@ tasks:
       vars: { variant_name: "debian92" }
     - func: "download tarball"
       vars: { variant_name: "rhel-62-64-bit" }
-    - func: "download tarball"
-      vars: { variant_name: "rhel-67-s390x" }
     - func: "download tarball"
       vars: { variant_name: "rhel-70-64-bit" }
     - func: "download tarball"
@@ -1106,21 +1102,6 @@ buildvariants:
     has_packages: true
     packager_distro: rhel62
     packager_arch: x86_64
-  tasks:
-  - build-and-test-and-upload
-  - build-and-test-shared-bson
-  - test-java
-  - name: publish-packages
-    distros:
-    - rhel70-small
-- name: rhel-67-s390x
-  display_name: "RHEL 6.7 s390x"
-  run_on: rhel67-zseries-test
-  expansions:
-    has_packages: true
-    packager_distro: rhel67
-    packager_arch: s390x
-    compile_env: CMAKE_EXE=/opt/cmake/bin/cmake
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson

--- a/bindings/java/mongocrypt/build.gradle.kts
+++ b/bindings/java/mongocrypt/build.gradle.kts
@@ -100,7 +100,7 @@ val downloadUrl: String = "https://mciuploads.s3.amazonaws.com/libmongocrypt/jav
 
 val jnaMapping: Map<String, String> = mapOf(
     "rhel-62-64-bit" to "linux-x86-64",
-    "rhel-67-s390x" to "linux-s390x",
+    "rhel72-zseries-test" to "linux-s390x",
     "rhel-71-ppc64el" to "linux-ppc64le",
     "ubuntu1604-arm64" to "linux-aarch64",
     "windows-test" to "win32-x86-64",


### PR DESCRIPTION
# Summary

- Remove `rhel-67-s390x` variant.
- Replace `rhel-67-s390x` with `rhel72-zseries-test` in Java tasks.

# Background & Motivation

Building on RHEL 6.7 on S390X adds difficulty for upgrading cmake. Upgrading cmake may be helpful for integrating the Intel Decimal Floating-Point Math Library library as part of MONGOCRYPT-483.

The latest documented server version to support RHEL 6 on S390X is MongoDB Server 4.2.17. Automatic encryption needs mongocryptd or the crypt_shared library on the same machine as the application. So it is already not possible to do automatic encryption with version > 4.2.17 of mongocryptd / crypt_shared.

RHEL 6 is End of life (EOL). Redhat does not support it any longer. Server does not support RHEL 6 for MongoDB 5.0 or later.