### PR TITLE
MONGOCRYPT-514 check more KMS errors

### DIFF
--- a/src/mongocrypt-kms-ctx.c
+++ b/src/mongocrypt-kms-ctx.c
@@ -226,11 +226,22 @@ _mongocrypt_kms_ctx_init_aws_decrypt (
       key->key_material.data, key->key_material.len, opt);
 
    kms_request_opt_destroy (opt);
-   kms_request_set_service (kms->req, "kms");
+   if (!kms_request_set_service (kms->req, "kms")) {
+      CLIENT_ERR ("failed to set service: %s",
+                  kms_request_get_error (kms->req));
+      _mongocrypt_status_append (status, ctx_with_status.status);
+      goto done;
+   }
 
    if (kms_providers->aws.session_token) {
-      kms_request_add_header_field (
-         kms->req, "X-Amz-Security-Token", kms_providers->aws.session_token);
+      if (!kms_request_add_header_field (kms->req,
+                                         "X-Amz-Security-Token",
+                                         kms_providers->aws.session_token)) {
+         CLIENT_ERR ("failed to set session token: %s",
+                     kms_request_get_error (kms->req));
+         _mongocrypt_status_append (status, ctx_with_status.status);
+         goto done;
+      }
    }
 
    if (kms_request_get_error (kms->req)) {
@@ -252,20 +263,22 @@ _mongocrypt_kms_ctx_init_aws_decrypt (
    }
 
    if (!kms_request_set_region (kms->req, key->kek.provider.aws.region)) {
-      CLIENT_ERR ("failed to set region");
+      CLIENT_ERR ("failed to set region: %s", kms_request_get_error (kms->req));
       _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
 
    if (!kms_request_set_access_key_id (kms->req,
                                        kms_providers->aws.access_key_id)) {
-      CLIENT_ERR ("failed to set aws access key id");
+      CLIENT_ERR ("failed to set aws access key id: %s",
+                  kms_request_get_error (kms->req));
       _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
    if (!kms_request_set_secret_key (kms->req,
                                     kms_providers->aws.secret_access_key)) {
-      CLIENT_ERR ("failed to set aws secret access key");
+      CLIENT_ERR ("failed to set aws secret access key: %s",
+                  kms_request_get_error (kms->req));
       _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
@@ -273,7 +286,8 @@ _mongocrypt_kms_ctx_init_aws_decrypt (
    _mongocrypt_buffer_init (&kms->msg);
    kms->msg.data = (uint8_t *) kms_request_get_signed (kms->req);
    if (!kms->msg.data) {
-      CLIENT_ERR ("failed to create KMS message");
+      CLIENT_ERR ("failed to create KMS message: %s",
+                  kms_request_get_error (kms->req));
       _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
@@ -367,11 +381,22 @@ _mongocrypt_kms_ctx_init_aws_encrypt (
                                        opt);
 
    kms_request_opt_destroy (opt);
-   kms_request_set_service (kms->req, "kms");
+   if (!kms_request_set_service (kms->req, "kms")) {
+      CLIENT_ERR ("failed to set service: %s",
+                  kms_request_get_error (kms->req));
+      _mongocrypt_status_append (status, ctx_with_status.status);
+      goto done;
+   }
 
    if (kms_providers->aws.session_token) {
-      kms_request_add_header_field (
-         kms->req, "X-Amz-Security-Token", kms_providers->aws.session_token);
+      if (!kms_request_add_header_field (kms->req,
+                                         "X-Amz-Security-Token",
+                                         kms_providers->aws.session_token)) {
+         CLIENT_ERR ("failed to set session token: %s",
+                     kms_request_get_error (kms->req));
+         _mongocrypt_status_append (status, ctx_with_status.status);
+         goto done;
+      }
    }
 
    if (kms_request_get_error (kms->req)) {
@@ -393,20 +418,22 @@ _mongocrypt_kms_ctx_init_aws_encrypt (
    }
 
    if (!kms_request_set_region (kms->req, ctx_opts->kek.provider.aws.region)) {
-      CLIENT_ERR ("failed to set region");
+      CLIENT_ERR ("failed to set region: %s", kms_request_get_error (kms->req));
       _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
 
    if (!kms_request_set_access_key_id (kms->req,
                                        kms_providers->aws.access_key_id)) {
-      CLIENT_ERR ("failed to set aws access key id");
+      CLIENT_ERR ("failed to set aws access key id: %s",
+                  kms_request_get_error (kms->req));
       _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
    if (!kms_request_set_secret_key (kms->req,
                                     kms_providers->aws.secret_access_key)) {
-      CLIENT_ERR ("failed to set aws secret access key");
+      CLIENT_ERR ("failed to set aws secret access key: %s",
+                  kms_request_get_error (kms->req));
       _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }
@@ -414,7 +441,8 @@ _mongocrypt_kms_ctx_init_aws_encrypt (
    _mongocrypt_buffer_init (&kms->msg);
    kms->msg.data = (uint8_t *) kms_request_get_signed (kms->req);
    if (!kms->msg.data) {
-      CLIENT_ERR ("failed to create KMS message");
+      CLIENT_ERR ("failed to create KMS message: %s",
+                  kms_request_get_error (kms->req));
       _mongocrypt_status_append (status, ctx_with_status.status);
       goto done;
    }


### PR DESCRIPTION
# Summary

- Include KMS error in libmongocrypt status.

# Background & Motivation

KMS message reports errors with the `kms_request_get_error` function.

C# tests got [this error](https://evergreen.mongodb.com/test_log/dot_net_driver_tests_zlib_compression_posix__version~4.2_os~ubuntu_1804_topology~standalone_auth~noauth_ssl~nossl_compressor~zlib_test_netstandard20_6a203a450f97af76bcba73ea0815170bf63aa2a8_22_12_01_22_59_28/0?test_name=7dd4a46e3db12d370732f583af2d313c&group_id=&text=true): `failed to create KMS message` with no additional information.