### PR TITLE
Disable snappy on C driver build

### DIFF
--- a/cmake/ImportBSON.cmake
+++ b/cmake/ImportBSON.cmake
@@ -134,6 +134,8 @@ function (_import_bson)
       set (ENABLE_STATIC BUILD_ONLY)
       # Disable libzstd, which isn't necessary for libmongocrypt and isn't necessarily available.
       set (ENABLE_ZSTD OFF CACHE BOOL "Toggle libzstd for the mongoc subproject (not required by libmongocrypt)")
+      # Disable snappy, which isn't necessary for libmongocrypt and isn't necessarily available.
+      set (ENABLE_SNAPPY OFF CACHE BOOL "Toggle snappy for the mongoc subproject (not required by libmongocrypt)")
       # Disable deprecated automatic init and cleanup. (May be overridden by the user)
       set (ENABLE_AUTOMATIC_INIT_AND_CLEANUP OFF CACHE BOOL "Enable automatic init and cleanup (GCC only)")
       # Disable over-alignment of bson types. (May be overridden by the user)


### PR DESCRIPTION
# Summary
- Disable snappy on C driver build

# Background & Motivation
This resolves the currently failing [build-and-test-and-upload](https://evergreen.mongodb.com/task/libmongocrypt_macos_build_and_test_and_upload_8d6d64f0d8461e6f088bd6d9d1af10bfd32a0bfd_23_01_02_22_27_58) task:

```
[2023/01/02 22:28:47.588] [354/399] Linking C executable csfle
[2023/01/02 22:28:47.588] FAILED: csfle
[2023/01/02 22:28:47.588] : && /Applications/Xcode13.2.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -O2 -g -DNDEBUG -arch arm64 -arch x86_64 -isysroot /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk -mmacosx-version-min=11.6 -Wl,-search_paths_first -Wl,-headerpad_max_install_names  CMakeFiles/csfle.dir/test/util/csfle.c.o CMakeFiles/csfle.dir/test/util/util.c.o -o csfle  libmongocrypt-static.a  _mongo-c-driver/src/libmongoc/libmongoc-static-1.0.a  kms-message/libkms_message-static.a  -framework Security -framework CoreFoundation  /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/usr/lib/libsasl2.tbd  -framework CoreFoundation -framework Security  -lresolv  /opt/homebrew/lib/libsnappy.dylib  /Applications/Xcode13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/usr/lib/libz.tbd  _mongo-c-driver/src/libbson/libbson-static-for-libmongocrypt.a && :
[2023/01/02 22:28:47.588] ld: warning: ignoring file /opt/homebrew/lib/libsnappy.dylib, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
[2023/01/02 22:28:47.588] Undefined symbols for architecture x86_64:
[2023/01/02 22:28:47.588]   "_snappy_compress", referenced from:
[2023/01/02 22:28:47.588]       _mongoc_compress in libmongoc-static-1.0.a(mongoc-compression.c.o)
[2023/01/02 22:28:47.588]   "_snappy_max_compressed_length", referenced from:
[2023/01/02 22:28:47.588]       _mongoc_compressor_max_compressed_length in libmongoc-static-1.0.a(mongoc-compression.c.o)
[2023/01/02 22:28:47.588]   "_snappy_uncompress", referenced from:
[2023/01/02 22:28:47.588]       _mongoc_uncompress in libmongoc-static-1.0.a(mongoc-compression.c.o)
[2023/01/02 22:28:47.588] ld: symbol(s) not found for architecture x86_64
```

As of MONGOCRYPT-372, libmongocrypt builds a universal binary supporting both x86_64 and arm64 architectures.
BUILD-16428 recently added snappy to the list of packages installed with Homebrew.
[A patch build](https://parsley.mongodb.com/evergreen/libmongocrypt_macos_build_and_test_and_upload_patch_8d6d64f0d8461e6f088bd6d9d1af10bfd32a0bfd_63b6ea9dd6d80a31a09fa83a_23_01_05_15_19_58/0/task?bookmarks=0,861&selectedLine=69) confirmed that the installed libsnappy.dylib only supports arm64:

```
[2023/01/05 15:22:52.254] Checking /opt/homebrew/lib/libsnappy.dylib
[2023/01/05 15:22:52.254] arm64
```

Snappy is not needed by libmongocrypt.