### PR TITLE
Address leaks in test-mongocrypt-crypto.c

### DIFF
--- a/test/test-mongocrypt-crypto.c
+++ b/test/test-mongocrypt-crypto.c
@@ -23,14 +23,13 @@ static void
 _test_roundtrip (_mongocrypt_tester_t *tester)
 {
    mongocrypt_t *crypt;
-   mongocrypt_status_t *status;
+   mongocrypt_status_t *const status = mongocrypt_status_new ();
    _mongocrypt_buffer_t key = {0}, iv = {0}, associated_data = {0},
                         plaintext = {0}, ciphertext = {0}, decrypted = {0};
    uint32_t bytes_written;
    bool ret;
 
    crypt = _mongocrypt_tester_mongocrypt (TESTER_MONGOCRYPT_DEFAULT);
-   status = mongocrypt_status_new ();
    plaintext.data = (uint8_t *) "test";
    plaintext.len = 5; /* include NULL. */
 
@@ -54,7 +53,6 @@ _test_roundtrip (_mongocrypt_tester_t *tester)
    iv.len = MONGOCRYPT_IV_LEN;
    iv.owned = true;
 
-   status = mongocrypt_status_new ();
    ret = _mongocrypt_do_encryption (crypt->crypto,
                                     &iv,
                                     &associated_data,
@@ -157,7 +155,7 @@ static void
 _test_mcgrew (_mongocrypt_tester_t *tester)
 {
    mongocrypt_t *crypt;
-   mongocrypt_status_t *status;
+   mongocrypt_status_t *const status = mongocrypt_status_new ();
    _mongocrypt_buffer_t key, iv, associated_data, plaintext,
       ciphertext_expected, ciphertext_actual;
    uint32_t bytes_written;
@@ -192,7 +190,6 @@ _test_mcgrew (_mongocrypt_tester_t *tester)
       "96b2e2e6609e31e6e02cc837f053d21f37ff4f51950bbe2638d09dd7a4930"
       "930806d0703b1f64dd3b4c088a7f45c216839645b2012bf2e6269a8c56a81"
       "6dbc1b267761955bc5");
-   status = mongocrypt_status_new ();
 
    ciphertext_actual.len =
       _mongocrypt_calculate_ciphertext_len (plaintext.len, status);
@@ -203,7 +200,6 @@ _test_mcgrew (_mongocrypt_tester_t *tester)
 
    /* Force the crypto stack to initialize with mongocrypt_new */
    crypt = _mongocrypt_tester_mongocrypt (TESTER_MONGOCRYPT_DEFAULT);
-   status = mongocrypt_status_new ();
    ret = _mongocrypt_do_encryption (crypt->crypto,
                                     &iv,
                                     &associated_data,
@@ -774,7 +770,7 @@ _test_fle2_roundtrip (_mongocrypt_tester_t *tester)
       _mongocrypt_buffer_t ciphertext;
       _mongocrypt_buffer_t plaintext_got;
       _mongocrypt_buffer_t ciphertext_got;
-      mongocrypt_status_t *status;
+      mongocrypt_status_t *const status = mongocrypt_status_new ();
       uint32_t bytes_written;
 
       printf ("Begin test '%s'.\n", test->testname);
@@ -788,11 +784,9 @@ _test_fle2_roundtrip (_mongocrypt_tester_t *tester)
          _mongocrypt_buffer_resize (&plaintext_got, plaintext.len);
       }
       _mongocrypt_buffer_init (&ciphertext_got);
-      status = mongocrypt_status_new ();
       _mongocrypt_buffer_resize (
          &ciphertext_got,
          _mongocrypt_fle2_calculate_ciphertext_len (plaintext.len, status));
-      status = mongocrypt_status_new ();
 
       /* Test encrypt. */
       ret = _mongocrypt_fle2_do_encryption (crypt->crypto,


### PR DESCRIPTION
Some `status` objects were being leaked by duplicate `status = mongocrypt_status_new ()` assignments.