### PR TITLE
MONGOCRYPT-483 fix int128 test on big endian

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -957,6 +957,13 @@ buildvariants:
   - name: publish-packages
     distros:
     - rhel70-small
+- name: rhel83-zseries
+  # rhel83-zseries has a new enough g++ to build the C++ tests.
+  # rhel72-zseries-test does not build the C++ tests.
+  display_name: "RHEL 8.3 on zSeries"
+  run_on: rhel83-zseries-small
+  tasks:
+  - build-and-test-and-upload
 - name: windows-vs2015-compile
   display_name: "Windows VS 2015 compile"
   run_on: windows-64-vs2015-test

--- a/src/mlib/endian.h
+++ b/src/mlib/endian.h
@@ -1,0 +1,42 @@
+#ifndef MLIB_ENDIAN_H_INCLUDED
+#define MLIB_ENDIAN_H_INCLUDED
+
+#ifdef __has_include
+// Some platforms require including other headers that will define the necessary
+// macros
+#if __has_include(<endian.h>)
+// This may recursively include our own file in a pathological case, but that
+// won't cause an issue. The default will include the system's version instead:
+#include <endian.h>
+#endif
+#if __has_include(<sys/param.h>)
+#include <sys/param.h>
+#endif
+#endif
+
+#include "./macros.h"
+
+enum mlib_endian_kind {
+#ifdef _MSC_VER // MSVC only targets little-endian arches at the moment
+   MLIB_ENDIAN_LITTLE = 1234,
+   MLIB_ENDIAN_BIG = 4321,
+   MLIB_ENDIAN_NATIVE = MLIB_ENDIAN_LITTLE,
+#elif defined(__BYTE_ORDER__) // Commonly built-in defined in newer compilers
+   MLIB_ENDIAN_LITTLE = __ORDER_LITTLE_ENDIAN__,
+   MLIB_ENDIAN_BIG = __ORDER_BIG_ENDIAN__,
+   MLIB_ENDIAN_NATIVE = __BYTE_ORDER__,
+#elif defined(__BYTE_ORDER)   // Common in <sys/param.h> or <endian.h>
+   MLIB_ENDIAN_LITTLE = __LITTLE_ENDIAN,
+   MLIB_ENDIAN_BIG = __BIG_ENDIAN,
+   MLIB_ENDIAN_NATIVE = __BYTE_ORDER,
+#else
+#error This compiler does not define an endianness macro.
+#endif
+};
+
+enum {
+   MLIB_IS_LITTLE_ENDIAN = MLIB_ENDIAN_NATIVE == MLIB_ENDIAN_LITTLE,
+   MLIB_IS_BIG_ENDIAN = MLIB_ENDIAN_NATIVE == MLIB_ENDIAN_BIG,
+};
+
+#endif // MLIB_ENDIAN_H_INCLUDED

--- a/src/mlib/int128.test.cpp
+++ b/src/mlib/int128.test.cpp
@@ -255,6 +255,16 @@ div_check (mlib_int128 num, mlib_int128 den)
    mlib_int128_divmod_result expect;
    memcpy (&expect.quotient.r, &q, sizeof q);
    memcpy (&expect.remainder.r, &r, sizeof r);
+   if (!mlib_int128_eq (expect.quotient, res.quotient) ||
+       !mlib_int128_eq (expect.remainder, res.remainder)) {
+      std::cout << "unexpected result in division"
+                << " num=" << mlib_int128_format (num).str
+                << " den=" << mlib_int128_format (den).str
+                << " expect.quotient="
+                << mlib_int128_format (expect.quotient).str
+                << " expect.remainder="
+                << mlib_int128_format (expect.remainder).str << std::endl;
+   }
    CHECK (expect.quotient == res.quotient);
    CHECK (expect.remainder == res.remainder);
 #endif


### PR DESCRIPTION
# Summary

- Add `rhel83-zseries-small` distro to run C++ tests on big endian architecture.
- Fix int128 tests on big endian.
- Add debug prints to int128 tests.

# Background & Motivation

Running tests on RHEL 8.3 zSeries in the C driver shows a test failure:
https://spruce.mongodb.com/task/mongo_c_driver_zseries_rhel83_debug_compile_sasl_openssl_cse_patch_a8560d7488778e480b7c61a0f8931ddbcc310c7d_63c6d3472fbabe0efe2f7708_23_01_17_16_56_40/logs?execution=0

```
[2023/01/17 16:59:25.279] num=27828649044156246570177174673037165454 den=499242349997913298655486252455941907 expect.quotient=0 expect.remainder27828649044156246570177174673037165454
[2023/01/17 16:59:25.279] /data/mci/14145729f69a17cdf3e60d1356dda1b7/mongoc/libmongocrypt/src/mlib/int128.test.cpp:203: CHECK( expect.quotient == res.quotient ) failed!
[2023/01/17 16:59:25.279] Expanded expression: 0 == 55
```

55 is correct, but the `expect` is incorrect. The failure appears to be caused by memcpy between `mlib_int128` and `__int128` not accounting for big endian.

The libmongocrypt zseries build [does not run the int128 tests](https://parsley.mongodb.com/evergreen/libmongocrypt_rhel72_zseries_test_build_and_test_and_upload_2c564d555b168e9bdb60ade186b6f3aa759e010b_23_01_13_13_36_03/0/task?bookmarks=0,5027&selectedLine=4660). I assume the C++ compiler does not support the necessary features to build the test. The [task logs](https://parsley.mongodb.com/evergreen/libmongocrypt_rhel72_zseries_test_build_and_test_and_upload_2c564d555b168e9bdb60ade186b6f3aa759e010b_23_01_13_13_36_03/0/task?bookmarks=0,5027&selectedLine=294) show `The CXX compiler identification is GNU 4.8.5`.
