### PR TITLE
MONGOCRYPT-483 make `CMAKE_BUILD_TYPE` configurable.

### DIFF
--- a/.evergreen/build_all.sh
+++ b/.evergreen/build_all.sh
@@ -13,6 +13,7 @@ echo "Begin compile process"
 _cxxflags=""
 
 : "${CONFIGURE_ONLY:=}"
+: "${LIBMONGOCRYPT_BUILD_TYPE:=RelWithDebInfo}"
 
 if [ "$OS_NAME" = "windows" ]; then
     # Enable exception handling for MSVC
@@ -56,7 +57,7 @@ common_cmake_args=(
     -DCMAKE_C_FLAGS="$LIBMONGOCRYPT_EXTRA_CFLAGS"
     -DCMAKE_CXX_FLAGS="$LIBMONGOCRYPT_EXTRA_CFLAGS $_cxxflags"
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-    -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    -DCMAKE_BUILD_TYPE="$LIBMONGOCRYPT_BUILD_TYPE"
     -H"$LIBMONGOCRYPT_DIR"
     -B"$build_dir"
 )
@@ -81,10 +82,10 @@ if [ "$CONFIGURE_ONLY" ]; then
     exit 0;
 fi
 echo "Installing libmongocrypt"
-run_cmake --build "$build_dir" --target install --config RelWithDebInfo
-run_cmake --build "$build_dir" --target test-mongocrypt --config RelWithDebInfo
-run_cmake --build "$build_dir" --target test_kms_request --config RelWithDebInfo
-run_chdir "$build_dir" run_ctest -C RelWithDebInfo
+run_cmake --build "$build_dir" --target install --config "$LIBMONGOCRYPT_BUILD_TYPE"
+run_cmake --build "$build_dir" --target test-mongocrypt --config "$LIBMONGOCRYPT_BUILD_TYPE"
+run_cmake --build "$build_dir" --target test_kms_request --config "$LIBMONGOCRYPT_BUILD_TYPE"
+run_chdir "$build_dir" run_ctest -C "$LIBMONGOCRYPT_BUILD_TYPE"
 
 # MONGOCRYPT-372, ensure macOS universal builds contain both x86_64 and arm64 architectures.
 if [ "$MACOS_UNIVERSAL" = "ON" ]; then
@@ -114,9 +115,9 @@ run_cmake \
     -DCMAKE_INSTALL_PREFIX="$MONGOCRYPT_INSTALL_PREFIX/nocrypto" \
     "${common_cmake_args[@]}"
 
-run_cmake --build "$build_dir" --target install --config RelWithDebInfo
-run_cmake --build "$build_dir" --target test-mongocrypt --config RelWithDebInfo
-run_chdir "$build_dir" run_ctest -C RelWithDebInfo
+run_cmake --build "$build_dir" --target install --config "$LIBMONGOCRYPT_BUILD_TYPE"
+run_cmake --build "$build_dir" --target test-mongocrypt --config "$LIBMONGOCRYPT_BUILD_TYPE"
+run_chdir "$build_dir" run_ctest -C "$LIBMONGOCRYPT_BUILD_TYPE"
 
 # Build and install libmongocrypt without statically linking libbson
 run_cmake \
@@ -125,5 +126,5 @@ run_cmake \
     -DCMAKE_INSTALL_PREFIX="$MONGOCRYPT_INSTALL_PREFIX/sharedbson" \
     "${common_cmake_args[@]}"
 
-run_cmake --build "$build_dir" --target install  --config RelWithDebInfo
-run_chdir "$build_dir" run_ctest -C RelWithDebInfo
+run_cmake --build "$build_dir" --target install  --config "$LIBMONGOCRYPT_BUILD_TYPE"
+run_chdir "$build_dir" run_ctest -C "$LIBMONGOCRYPT_BUILD_TYPE"

--- a/.evergreen/build_all.sh
+++ b/.evergreen/build_all.sh
@@ -39,8 +39,6 @@ if [ "$MACOS_UNIVERSAL" = "ON" ]; then
     ADDITIONAL_CMAKE_FLAGS="$ADDITIONAL_CMAKE_FLAGS -DCMAKE_OSX_ARCHITECTURES='arm64;x86_64'"
 fi
 
-: "${CMAKE:=cmake}"
-
 for suffix in "dll" "dylib" "so"; do
     cand="$(abspath "$LIBMONGOCRYPT_DIR/../mongocrypt_v1.$suffix")"
     if test -f "$cand"; then


### PR DESCRIPTION
# Summary

- add `LIBMONGOCRYPT_BUILD_TYPE` option to make `CMAKE_BUILD_TYPE` configurable.

# Background & Motivation

This is motivated by updating libmongocrypt to support decimal128 Range Index CDRIVER-4394.

The C driver currently builds libmongocrypt by invoking `cmake` directly in `compile-unix.sh` and `compile-windows.sh`. Here is the [snippet from compile-windows.sh](https://github.com/mongodb/mongo-c-driver/blob/9e18dd1b08591242a4da33be1f55f3a33c629d07/.evergreen/compile-windows.sh#L125-L130):

```bash
   git clone --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0-alpha1
   mkdir libmongocrypt/cmake-build
   cd libmongocrypt/cmake-build
   "$CMAKE" -G "$CC" "-DCMAKE_PREFIX_PATH=${INSTALL_DIR}/lib/cmake" -DENABLE_SHARED_BSON=ON -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" ../
   "$CMAKE" --build . --target INSTALL --config $BUILD_CONFIG -- $BUILD_FLAGS
   cd ../../
```

https://github.com/mongodb/libmongocrypt/pull/522#discussion_r1072337705 notes the required version of cmake to build libmongocrypt is cmake will soon be 3.12.0. The C driver builds with older versions of cmake in some distros. libmongocrypt's `ensure-cmake.sh` script ensures the presence of a CMake executable matching a specific version. Therefore, the C driver will transition to building libmongocrypt using the `compile.sh` script (as is [currently done in the Go driver](https://github.com/mongodb/mongo-go-driver/blob/60cfd91eb66c2646de5034327c50208d13c05db3/.evergreen/config.yml#L123)). Here is a proposed change in `compile-windows.sh`

```bash
   git clone https://github.com/kevinAlbs/libmongocrypt --branch decimal128_with_BUILD_CONFIG
   MONGOCRYPT_INSTALL_PREFIX=$INSTALL_DIR \
   DEFAULT_BUILD_ONLY=true \
   LIBMONGOCRYPT_EXTRA_CMAKE_FLAGS="-DBUILD_VERSION=1.7.0-pre" \
   LIBMONGOCRYPT_BUILD_TYPE=$BUILD_CONFIG \
      ./libmongocrypt/.evergreen/compile.sh
```

Adding the `LIBMONGOCRYPT_BUILD_TYPE` option enables the C driver to continue building libmongocrypt with the same `CMAKE_BUILD_TYPE` as the C driver.