### PR TITLE
Reuse the proper DFP names from bid_conf.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,9 +245,9 @@ target_link_libraries (
       _mongocrypt::libbson_for_shared
       Threads::Threads
       kms_message_static
-      mongocrypt::intel_dfp
       $<BUILD_INTERFACE:mongo::mlib>
    PUBLIC
+      mongocrypt::intel_dfp
       ${CMAKE_DL_LIBS}
    )
 
@@ -303,9 +303,9 @@ target_link_libraries (
    PRIVATE
       _mongocrypt::libbson_for_static
       kms_message_static
-      mongocrypt::intel_dfp
       $<BUILD_INTERFACE:mongo::mlib>
    PUBLIC
+      mongocrypt::intel_dfp
       ${CMAKE_THREAD_LIBS_INIT}
       ${CMAKE_DL_LIBS}
    )

--- a/cmake/IntelDFP.cmake
+++ b/cmake/IntelDFP.cmake
@@ -387,6 +387,9 @@ target_sources (_mongocrypt_intel_dfp
     ]]
     INTERFACE $<BUILD_INTERFACE:$<TARGET_OBJECTS:intel_dfp_obj>>
     )
+target_include_directories (_mongocrypt_intel_dfp
+    INTERFACE $<BUILD_INTERFACE:${intel_dfp_SOURCE_DIR}/LIBRARY/src>
+    )
 # We do want to propagate an interface requirement: Some platforms need a
 # separate link library to support special math functions.
 target_link_libraries(_mongocrypt_intel_dfp INTERFACE $<$<PLATFORM_ID:Linux>:m>)


### PR DESCRIPTION
This will ensure that we get the proper function references, regardless of where DFP comes from.