### PR TITLE
MONGOCRYPT-518 add missing header for GCC 13

### DIFF
--- a/src/csfle-markup.cpp
+++ b/src/csfle-markup.cpp
@@ -12,6 +12,7 @@ extern "C" {
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <cstdint>
 
 #include <mongo_crypt-v1.h>
 


### PR DESCRIPTION
Using GCC 13 (Fedora 38) the build is failing

```
/builddir/build/BUILD/libmongocrypt-1.6.2/src/csfle-markup.cpp: In function 'int {anonymous}::do_main(int, const char* const*)':
/builddir/build/BUILD/libmongocrypt-1.6.2/src/csfle-markup.cpp:201:24: error: 'uint32_t' in namespace 'std' does not name a type; did you mean 'wint_t'?
  201 |       static_cast<std::uint32_t> (strlen (doc_ns)),
      |                        ^~~~~~~~
      |                        wint_t

```

See https://gcc.gnu.org/gcc-13/porting_to.html