### PR TITLE
fix(NODE-4987): node csfle uses promises instead of callbacks

### DIFF
--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -230,7 +230,14 @@ module.exports = function (modules) {
      */
     teardown(force, callback) {
       if (this._mongocryptdClient) {
-        this._mongocryptdClient.close(force).then(callback);
+        this._mongocryptdClient.close(force).then(
+          result => {
+            return callback(null, result);
+          },
+          error => {
+            callback(error);
+          }
+        );
       } else {
         callback();
       }

--- a/bindings/node/lib/autoEncrypter.js
+++ b/bindings/node/lib/autoEncrypter.js
@@ -202,10 +202,26 @@ module.exports = function (modules) {
       };
 
       if (this._mongocryptdManager.bypassSpawn) {
-        return this._mongocryptdClient.connect(_callback);
+        return this._mongocryptdClient.connect().then(
+          result => {
+            return _callback(null, result);
+          },
+          error => {
+            _callback(error, null);
+          }
+        );
       }
 
-      this._mongocryptdManager.spawn(() => this._mongocryptdClient.connect(_callback));
+      this._mongocryptdManager.spawn(() => {
+        this._mongocryptdClient.connect().then(
+          result => {
+            return _callback(null, result);
+          },
+          error => {
+            _callback(error, null);
+          }
+        );
+      });
     }
 
     /**
@@ -214,7 +230,7 @@ module.exports = function (modules) {
      */
     teardown(force, callback) {
       if (this._mongocryptdClient) {
-        this._mongocryptdClient.close(force, callback);
+        this._mongocryptdClient.close(force).then(callback);
       } else {
         callback();
       }

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -263,12 +263,14 @@ module.exports = function (modules) {
             .db(dbName)
             .collection(collectionName)
             .insertOne(dataKey, { writeConcern: { w: 'majority' } })
-            .then(result => {
-              cb(null, result.insertedId);
-            })
-            .catch(err => {
-              cb(err, null);
-            });
+            .then(
+              result => {
+                return cb(null, result.insertedId);
+              },
+              err => {
+                cb(err, null);
+              }
+            );
         });
       });
     }

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -262,13 +262,12 @@ module.exports = function (modules) {
           this._keyVaultClient
             .db(dbName)
             .collection(collectionName)
-            .insertOne(dataKey, { writeConcern: { w: 'majority' } }, (err, result) => {
-              if (err) {
-                cb(err, null);
-                return;
-              }
-
+            .insertOne(dataKey, { writeConcern: { w: 'majority' } })
+            .then(result => {
               cb(null, result.insertedId);
+            })
+            .catch(err => {
+              cb(err, null);
             });
         });
       });

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -410,15 +410,16 @@ module.exports = function (modules) {
           promoteValues: false,
           session: this.options.session
         })
-        .toArray((err, collections) => {
-          if (err) {
+        .toArray()
+        .then(
+          collections => {
+            const info = collections.length > 0 ? bson.serialize(collections[0]) : null;
+            return callback(null, info);
+          },
+          err => {
             callback(err, null);
-            return;
           }
-
-          const info = collections.length > 0 ? bson.serialize(collections[0]) : null;
-          callback(null, info);
-        });
+        );
     }
 
     /**
@@ -440,12 +441,14 @@ module.exports = function (modules) {
       client
         .db(dbName)
         .command(rawCommand, options)
-        .then(response => {
-          callback(null, bson.serialize(response, this.options));
-        })
-        .catch(err => {
-          callback(err, null);
-        });
+        .then(
+          response => {
+            return callback(null, bson.serialize(response, this.options));
+          },
+          err => {
+            callback(err, null);
+          }
+        );
     }
 
     /**
@@ -468,14 +471,15 @@ module.exports = function (modules) {
         .db(dbName)
         .collection(collectionName, { readConcern: { level: 'majority' } })
         .find(filter, { session: this.options.session })
-        .toArray((err, keys) => {
-          if (err) {
+        .toArray()
+        .then(
+          keys => {
+            return callback(null, keys);
+          },
+          err => {
             callback(err, null);
-            return;
           }
-
-          callback(null, keys);
-        });
+        );
     }
   }
 

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -437,13 +437,15 @@ module.exports = function (modules) {
       const dbName = databaseNamespace(ns);
       const rawCommand = bson.deserialize(command, options);
 
-      client.db(dbName).command(rawCommand, options, (err, response) => {
-        if (err) {
+      client
+        .db(dbName)
+        .command(rawCommand, options)
+        .then(response => {
+          callback(null, bson.serialize(response, this.options));
+        })
+        .catch(err => {
           callback(err, null);
-          return;
-        }
-        callback(err, bson.serialize(response, this.options));
-      });
+        });
     }
 
     /**

--- a/bindings/node/test/stateMachine.test.js
+++ b/bindings/node/test/stateMachine.test.js
@@ -43,7 +43,7 @@ describe('StateMachine', function () {
 
     beforeEach(function () {
       this.sinon = sinon.createSandbox();
-      runCommandStub = this.sinon.stub();
+      runCommandStub = this.sinon.stub().resolves({});
       dbStub = this.sinon.createStubInstance(mongodb.Db, {
         command: runCommandStub
       });


### PR DESCRIPTION
Node driver v5 removes callback support so we needed to update `createDataKey` and `markCommand` to use the promise API.

This included searches through the codebase for all CRUD methods - all other usage already uses async await or promises.

Patch build on the Node driver pointing at this commit: https://spruce.mongodb.com/version/63cac4515623431af90fd308/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC