### PR TITLE
MONGOCRYPT-519 wrap errors from processing crypt_shared markings

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -1075,15 +1075,25 @@ _try_run_csfle_marking (mongocrypt_ctx_t *ctx)
    mongocrypt_binary_t *marked =
       mongocrypt_binary_new_from_data (marked_bson, marked_bson_len);
    if (!_mongo_feed_markings (ctx, marked)) {
-      _mongocrypt_ctx_fail_w_msg (
-         ctx, "Consuming the generated csfle markings failed");
+      // Wrap error with additional information.
+      _mongocrypt_set_error (
+         ctx->status,
+         MONGOCRYPT_STATUS_ERROR_CLIENT,
+         MONGOCRYPT_GENERIC_ERROR_CODE,
+         "Consuming the generated csfle markings failed: %s",
+         mongocrypt_status_message (ctx->status, NULL /* len */));
       goto fail_feed_markings;
    }
 
    okay = _mongo_done_markings (ctx);
    if (!okay) {
-      _mongocrypt_ctx_fail_w_msg (
-         ctx, "Finalizing the generated csfle markings failed");
+      // Wrap error with additional information.
+      _mongocrypt_set_error (
+         ctx->status,
+         MONGOCRYPT_STATUS_ERROR_CLIENT,
+         MONGOCRYPT_GENERIC_ERROR_CODE,
+         "Finalizing the generated csfle markings failed: %s",
+         mongocrypt_status_message (ctx->status, NULL /* len */));
    }
 
 fail_feed_markings:

--- a/src/mongocrypt-private.h
+++ b/src/mongocrypt-private.h
@@ -66,7 +66,15 @@ tmp_json (const bson_t *bson);
 const char *
 tmp_buf (const _mongocrypt_buffer_t *buf);
 
-
+// _mongocrypt_set_error sets an error status.
+// `status->message` is set after evaluating `format` and variadic args.
+// It is safe to uses a `status->message` as an argument to wrap an error. For example:
+// _mongocrypt_set_error (
+//    status,
+//    MONGOCRYPT_STATUS_ERROR_CLIENT,
+//    MONGOCRYPT_GENERIC_ERROR_CODE,
+//    "Error occurred. Original error: %s",
+//    mongocrypt_status_message (status, NULL /* len */));
 MLIB_ANNOTATE_PRINTF (4, 5)
 void
 _mongocrypt_set_error (mongocrypt_status_t *status,


### PR DESCRIPTION
# Summary
- wrap errors from processing crypt_shared markings

# Background & Motivation

`_mongo_feed_markings` and `_mongo_done_markings` set an error on the context on failure. The original error is currently overwritten. Attempting to run a Range Index test in Go using libmongocrypt 1.6.0 results in the following error reported from libmongocrypt:

```
unified_spec_test.go:337: 
            Error Trace:    /Users/kevin.albertson/code/mongo-go-driver-G2433/mongo/integration/unified_spec_test.go:337
                                                    /Users/kevin.albertson/code/mongo-go-driver-G2433/mongo/integration/mongotest.go:263
            Error:          Expected nil, but got: &errors.errorString{s:"did not expect error but got mongocrypt error 1: Consuming the generated csfle markings failed"}
            Test:           TestClientSideEncryptionSpec/fle2-Range-Date-Aggregate.json/FLE2_Range_Date._Aggregate.
            Messages:       error running operation "insertOne" at index 0: did not expect error but got mongocrypt error 1: Consuming the generated csfle markings failed
```

After this change, the original error is wrapped:

```
unified_spec_test.go:337: 
Error Trace:    /Users/kevin.albertson/code/mongo-go-driver-G2433/mongo/integration/unified_spec_test.go:337
                                        /Users/kevin.albertson/code/mongo-go-driver-G2433/mongo/integration/mongotest.go:263
Error:          Expected nil, but got: &errors.errorString{s:"did not expect error but got mongocrypt error 1: Consuming the generated csfle markings failed: invalid algorithm value: 3"}
Test:           TestClientSideEncryptionSpec/fle2-Range-Date-Aggregate.json/FLE2_Range_Date._Aggregate.
Messages:       error running operation "insertOne" at index 0: did not expect error but got mongocrypt error 1: Consuming the generated csfle markings failed: invalid algorithm value: 3
```

This may improve the error message for users if using an old libmongocrypt version with markings produced by crypt_shared that are not supported.
