### PR TITLE
test(NODE-4897): bump release test timeout

### DIFF
--- a/bindings/node/test/release.test.js
+++ b/bindings/node/test/release.test.js
@@ -27,7 +27,7 @@ const REQUIRED_FILES = [
   'package/src/mongocrypt.h'
 ];
 
-describe(`Release ${packFile}`, () => {
+describe(`Release ${packFile}`, function () {
   this.timeout(5000);
 
   let tarFileList;

--- a/bindings/node/test/release.test.js
+++ b/bindings/node/test/release.test.js
@@ -28,6 +28,8 @@ const REQUIRED_FILES = [
 ];
 
 describe(`Release ${packFile}`, () => {
+  this.timeout(5000);
+
   let tarFileList;
   before(() => {
     expect(fs.existsSync(packFile)).to.equal(false);


### PR DESCRIPTION
Sometimes this test times out in the before hook running npm pack. Takes around ~600ms for me locally but sometimes on CI it takes over 2s. This moves the default timeout to 5s on that test.

https://spruce.mongodb.com/version/63d284791e2d177b176053f5/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC