### PR TITLE
Add a Basic Earthly File

### DIFF
--- a/.earthlyignore
+++ b/.earthlyignore
@@ -1,0 +1,3 @@
+camke-build/
+camke-build-deb/
+_build/

--- a/.earthlyignore
+++ b/.earthlyignore
@@ -1,3 +1,3 @@
-camke-build/
-camke-build-deb/
+cmake-build/
+cmake-build-deb/
 _build/

--- a/.evergreen/earthly.sh
+++ b/.evergreen/earthly.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/bash
+
+. "$(dirname "${BASH_SOURCE[0]}")/setup-env.sh"
+
+set -euo pipefail
+
+: "${EARTHLY_VERSION:=0.6.30}"
+
+# Calc the arch of the executable we want
+arch="$(uname -m)"
+case "$arch" in
+    x86_64)
+        arch=amd64
+        ;;
+    aarch64|arm64)
+        arch=arm64
+        ;;
+    *)
+        echo "Unknown architecture: $arch" 1>&1
+        exit 99
+        ;;
+esac
+
+# The location where the Earthly executable will live
+cache_dir="$USER_CACHES_DIR/earthly-sh/$EARTHLY_VERSION"
+mkdir -p "$cache_dir"
+
+exe_filename="earthly-$OS_NAME-$arch$EXE_SUFFIX"
+exe_path="$cache_dir/$exe_filename"
+
+# Download if it isn't already present
+if ! test -f "$exe_path"; then
+    echo "Downloading $exe_filename $EARTHLY_VERSION"
+    url="https://github.com/earthly/earthly/releases/download/v$EARTHLY_VERSION/$exe_filename"
+    curl --retry 5 -LsS --max-time 120 --fail "$url" --output "$exe_path"
+fi
+
+chmod a+x "$exe_path"
+
+"$exe_path" "$@"

--- a/.evergreen/ensure-cmake.sh
+++ b/.evergreen/ensure-cmake.sh
@@ -140,6 +140,9 @@ _ensure_cmake() {
 
     declare arch
     arch="$(uname -m)"
+    if test -f /etc/alpine-release; then
+        arch="$arch-musl"
+    fi
 
     # Otherwise we need to obtain it
     log "Obtaining CMake $CMAKE_VERSION for $OS_NAME-$arch"

--- a/.evergreen/ensure-ninja.sh
+++ b/.evergreen/ensure-ninja.sh
@@ -79,6 +79,9 @@ _build_ninja() {
 _ensure_ninja() {
     declare arch
     arch="$(uname -m)"
+    if test -f /etc/alpine-release; then
+        arch="$arch-musl"
+    fi
 
     case "$OS_NAME-$arch" in
     linux-x86_64|windows-x86_64|macos-*)

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,257 @@
+# Earthly Intro: https://docs.earthly.dev/
+# Earthfile Reference: https://docs.earthly.dev/docs/earthfile
+
+# Quick notes:
+    #   • The shell script at ".evergreen/earthly.sh" can be used to automatically
+    #     download and use a fixed version of Earthly that is compatible with
+    #     this file version. Execute the shell script as if it were the Earthly
+    #     executable itself.
+    #   • In this file, the convention is to copy the source tree into /s/libmongocrypt
+    #   • Earthly copies the "build context" (working directory) into the local buildkit
+    #     daemon before each build execution. (Similar to the Docker build context).
+    #     If you have a large amount of data in the working directory, this could be
+    #     slow. The ".earthlyignore" file specifies patterns of files and directories
+    #     to exclude from the context upload. Modify it to suite your needs, if necessary.
+    #   • Only a subset of the source tree is COPY'd into the build environment. Files
+    #     outside of this set will not be available in the build. See the COPY_SOURCE
+    #     command for the list.
+    #   • Modification at any layer will invalidate caching on all subsequent build
+    #     layers. This is important and by-design in Earthly. Push infrequently-modified
+    #     operations to earlier in the process the pipeline to make better use of
+    #     the cache.
+    #
+    # This file has a few major sections:
+    #   - Setup COMMANDs
+    #   - Utility COMMANDs
+    #   - Environment targets
+    #   - Build/test/CI targets
+    #
+    # All environment targets begin with "env.". All build targets (should) accept an "env"
+    # parameter that specifies the name of the environment to use for the task. The name
+    # of an environment is specified following the "env." prefix. For example, the
+    # Ubuntu 22.04 environment is named "u22", so its environment target is "env.u22",
+    # and can be used i.e. "earthly +build --env=u22"
+    #
+    # The following environment are defined in this file:
+    #   • u22 - Ubuntu 22.04
+    #   • u20 - Ubuntu 20.04
+    #   • u18 - Ubuntu 18.04
+    #   • u16 - Ubuntu 16.04
+    #   • u14 - Ubuntu 14.04
+    #   • rl8 - RockyLinux 8 - Stand-in for RHEL 8
+    #   • c7 - CentOS 7 - Stand-in for RHEL 7
+    #   • c6 - CentOS 6 - Stand-in for RHEL 6
+    #   • amzn1 - AmazonLinux (2018.03)
+    #   • amzn2 - AmazonLinux 2
+    #   • deb9 - Debian 9.2
+    #   • deb10 - Debian 10.0
+    #   • deb11 - Debian 11.0
+    #   • sles15 - OpenSUSE Leap 15.0
+    #   • sles15 - OpenSUSE Leap 15.0
+    #   • alpine - Alpine Linux 3.18
+    #
+    # When adding new environments, always pull from a fully-qualified image ID:
+    #   • DO NOT: "ubuntu"
+    #   • DO NOT: "ubuntu:latest"
+    #   • DO NOT: "ubuntu:22.10"
+    #   • DO: "docker.io/library/ubuntu:22.10"
+# ###
+
+VERSION --use-cache-command 0.6
+FROM docker.io/library/alpine:3.16
+WORKDIR /s
+
+init:
+    # Special initializing target that sets up the base image and adds the "__install"
+    # script. This scripts abstracts around the underlying package manager interface
+    # to "do the right thing" when you want to install packages. Package names will
+    # still need to be spelled correctly for the respective system.
+    #
+    # Invoke +init with a "--base" parameter that specifies the base image to pull
+    ARG --required base
+    FROM $base
+    COPY etc/install-package.sh /usr/local/bin/__install
+    RUN chmod +x /usr/local/bin/__install
+    ENV USER_CACHES_DIR=/Cache
+
+# Environment setup commands below. Each provides the basic environment for a
+# libmongocrypt build. Additional packages and setup may be required for
+# individual tasks.
+
+DEBIAN_SETUP:
+    # Setup for a debian-like build environment. Used for both Debain and Ubuntu
+    COMMAND
+    RUN __install build-essential g++ libssl-dev curl unzip python3 \
+                  libbson-dev pkg-config git ccache findutils ca-certificates
+
+REDHAT_SETUP:
+    # Setup for a redhat-like build environment. Used for CentOS and RockyLinux.
+    COMMAND
+    RUN __install epel-release && \
+        __install gcc-c++ make openssl-devel curl unzip git ccache findutils \
+                  patch
+
+CENTOS6_SETUP:
+    # Special setup for CentOS6: The packages have been moved to the vault, so
+    # we need to enable the vault repos before we perform any __installs
+    COMMAND
+    RUN rm /etc/yum.repos.d/*.repo
+    COPY etc/c6-vault.repo /etc/yum.repos.d/CentOS-Base.repo
+    DO +REDHAT_SETUP
+
+AMZ_SETUP:
+    # Setup for Amazon Linux.
+    COMMAND
+    # amzn1 has "python38", but amzn2 has "python3." Try both
+    RUN __install python3 || __install python38
+    RUN __install gcc-c++ make openssl-devel curl unzip tar gzip \
+                  openssh-clients patch git
+
+SLES_SETUP:
+    # Setup for a SLES/SUSE build environment
+    COMMAND
+    RUN __install gcc-c++ make libopenssl-devel curl unzip tar gzip python3 \
+                  patch git xz which
+
+ALPINE_SETUP:
+    # Setup for an Alpine Linux build environment
+    COMMAND
+    RUN __install make bash gcc g++ unzip curl tar gzip git musl-dev \
+                  linux-headers openssl-dev python3
+
+# Environment targets are defined below. These do not have build outputs, but
+# are rather themselves the "outputs" to be used as the environment for subsequent
+# tasks
+
+env.c6:
+    # A CentOS 6 environment.
+    FROM +init --base=docker.io/library/centos:6
+    DO +CENTOS6_SETUP
+
+env.c7:
+    # A CentOS 7 environment.
+    FROM +init --base=docker.io/library/centos:7
+    DO +REDHAT_SETUP
+
+env.rl8:
+    # CentOS 8 is cancelled. Use RockyLinux 8 for our RHEL 8 environment.
+    FROM +init --base=docker.io/library/rockylinux:8
+    DO +REDHAT_SETUP
+
+# Utility command for Ubuntu environments
+ENV_UBUNTU:
+    COMMAND
+    ARG --required version
+    FROM +init --base=docker.io/library/ubuntu:$version
+    DO +DEBIAN_SETUP
+
+env.u14:
+    # An Ubuntu 14.04 environment
+    DO +ENV_UBUNTU --version 14.04
+
+env.u16:
+    # An Ubuntu 16.04 environment
+    DO +ENV_UBUNTU --version 16.04
+
+env.u18:
+    # An Ubuntu 18.04 environment
+    DO +ENV_UBUNTU --version 18.04
+
+env.u20:
+    # An Ubuntu 20.04 environment
+    DO +ENV_UBUNTU --version 20.04
+
+env.u22:
+    # An Ubuntu 22.04 environment
+    DO +ENV_UBUNTU --version 22.04
+
+env.amzn1:
+    # An Amazon "1" environment. (AmazonLinux 2018)
+    FROM +init --base=docker.io/library/amazonlinux:2018.03
+    DO +AMZ_SETUP
+
+env.amzn2:
+    # An AmazonLinux 2 environment
+    FROM +init --base=docker.io/library/amazonlinux:2
+    DO +AMZ_SETUP
+
+# Utility command for Debian setup
+ENV_DEBIAN:
+    COMMAND
+    ARG --required version
+    FROM +init --base=docker.io/library/debian:$version
+    DO +DEBIAN_SETUP
+
+env.deb9:
+    # A Debian 9.2 environment
+    DO +ENV_DEBIAN --version 9.2
+
+env.deb10:
+    # A Debian 10.0 environment
+    DO +ENV_DEBIAN --version 10.0
+
+env.deb11:
+    # A Debian 11.0 environment
+    DO +ENV_DEBIAN --version 11.0
+
+env.sles15:
+    # An OpenSUSE Leap 15.0 environment.
+    FROM +init --base=docker.io/opensuse/leap:15.0
+    DO +SLES_SETUP
+
+env.alpine:
+    FROM +init --base=docker.io/library/alpine:3.17
+    DO +ALPINE_SETUP
+
+# Utility: Warm-up obtaining CMake and Ninja for the build. This is usually
+# very quick, but on some platforms we need to compile them from source.
+CACHE_WARMUP:
+    COMMAND
+    # Copy only the scripts that are strictly necessary for the operation, to
+    # avoid cache invalidation later on.
+    COPY .evergreen/setup-env.sh \
+         .evergreen/init.sh \
+         .evergreen/ensure-cmake.sh \
+         .evergreen/ensure-ninja.sh \
+         /T/
+    RUN bash /T/ensure-cmake.sh
+    RUN env NINJA_EXE=/usr/local/bin/ninja \
+        bash /T/ensure-ninja.sh
+
+COPY_SOURCE:
+    COMMAND
+    COPY --dir \
+        .git/ \
+        cmake/ \
+        kms-message/ \
+        test/ \
+        debian/ \
+        src/ \
+        etc/ \
+        LICENSE \
+        VERSION_CURRENT \
+        .evergreen/ \
+        CMakeLists.txt \
+        "/s/libmongocrypt"
+    COPY --dir bindings/cs/ "/s/libmongocrypt/bindings/"
+
+# The main "build" target. Options:
+#   • --env=[...] (default "u22")
+#     · Set the environment for the build. Any name of and "env.<name>" targets
+#       can be used.
+#   • --persist_build={true,false} (default "true")
+#     · Persist the build directory between executions. Enables incremental
+#       compilation and reusing of configuration between builds. The build
+#       directory is NOT shared between different "--env" environments, only
+#       within a single environment.
+build:
+    ARG env=u22
+    FROM +env.$env
+    DO +CACHE_WARMUP
+    DO +COPY_SOURCE
+    WORKDIR /s
+    ARG persist_build=true
+    IF $persist_build
+        CACHE /s/libmongocrypt/cmake-build
+    END
+    RUN env USE_NINJA=1 bash libmongocrypt/.evergreen/build_all.sh

--- a/Earthfile
+++ b/Earthfile
@@ -47,7 +47,6 @@
     #   • deb10 - Debian 10.0
     #   • deb11 - Debian 11.0
     #   • sles15 - OpenSUSE Leap 15.0
-    #   • sles15 - OpenSUSE Leap 15.0
     #   • alpine - Alpine Linux 3.18
     #
     # When adding new environments, always pull from a fully-qualified image ID:
@@ -79,10 +78,10 @@ init:
 # individual tasks.
 
 DEBIAN_SETUP:
-    # Setup for a debian-like build environment. Used for both Debain and Ubuntu
+    # Setup for a debian-like build environment. Used for both Debian and Ubuntu
     COMMAND
-    RUN __install build-essential g++ libssl-dev curl unzip python3 \
-                  libbson-dev pkg-config git ccache findutils ca-certificates
+    RUN __install build-essential g++ libssl-dev curl unzip python3 pkg-config \
+                  git ccache findutils ca-certificates
 
 REDHAT_SETUP:
     # Setup for a redhat-like build environment. Used for CentOS and RockyLinux.
@@ -229,7 +228,6 @@ COPY_SOURCE:
         src/ \
         etc/ \
         LICENSE \
-        VERSION_CURRENT \
         .evergreen/ \
         CMakeLists.txt \
         "/s/libmongocrypt"

--- a/etc/c6-vault.repo
+++ b/etc/c6-vault.repo
@@ -1,0 +1,39 @@
+[C6.10-base]
+name=CentOS-6.10 - Base
+baseurl=http://vault.centos.org/6.10/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+metadata_expire=never
+
+[C6.10-updates]
+name=CentOS-6.10 - Updates
+baseurl=http://vault.centos.org/6.10/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+metadata_expire=never
+
+[C6.10-extras]
+name=CentOS-6.10 - Extras
+baseurl=http://vault.centos.org/6.10/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+metadata_expire=never
+
+[C6.10-contrib]
+name=CentOS-6.10 - Contrib
+baseurl=http://vault.centos.org/6.10/contrib/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=0
+metadata_expire=never
+
+[C6.10-centosplus]
+name=CentOS-6.10 - CentOSPlus
+baseurl=http://vault.centos.org/6.10/centosplus/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=0
+metadata_expire=never

--- a/etc/install-package.sh
+++ b/etc/install-package.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+
+# Install the named packages using the platform's package manager.
+# This script "just does the right thing" to install a package as a step in a
+#   caching container build, as a bare "pkg-tool install" might be insufficient
+#   or subtly broken, and we only really care about installing a list of packages
+#
+# Usage: __install [pkgs...]
+
+set -eu
+
+if test -f /etc/debian_version ; then
+    # We *must* do a repo update as part of the install step in a single cache
+    # layer, as a cached apt-get update can become stale while a later
+    # apt-get install is invalidated
+    apt-get -y update
+    # DEBIAN_FRONTEND suppresses all interactivity. For some reason some
+    # packages like to prompt as part of their config, even if we're not on
+    # a TTY.
+    env DEBIAN_FRONTEND=noninteractive \
+        apt-get -y install -- "$@"
+elif test -f /etc/redhat-release || grep 'ID="amzn"' /etc/os-release >/dev/null 1>&2; then
+    if test -f /usr/bin/dnf; then
+        # 'dnf' will "do the right thing"
+        dnf install -y -- "$@"
+    elif test -f /usr/bin/yum; then
+        yum install -y -- "$@"
+        # 'yum' happily ignores missing packages. Use 'rpm -q' to check that
+        # everything we requested actually got installed.
+        if ! rpm -q -- "$@"; then
+            echo "__install: Failing because one or more packages requested are not available"
+            exit 1
+        fi
+    else
+        echo "No package manager here?" 1>&2
+        exit 1
+    fi
+elif test -f /etc/SuSE-brand \
+     || (test -f /etc/os-release && grep "opensuse" /etc/os-release); then
+    zypper --non-interactive install "$@"
+elif test -f /etc/arch-release; then
+    pacman -Sy --noconfirm -- "$@"
+elif test -f /etc/alpine-release; then
+    apk add -- "$@"
+else
+    echo "We don't know how to manage packages on this system" 1>&2
+    exit 1
+fi


### PR DESCRIPTION
I've been using a variation of this for local dev on most projects for a long time. Unlike the prior mongo-c-driver PR with the same purpose, this one is far simpler and trimmed down.

This does not modify CI or introduce any new EVG tasks. Perhaps in the future? For now, it's just useful for local dev. It only defines a target that runs `build_all.sh`, and does not export any artifacts. Adding new tasks and artifacts may be a task for the future.