### PR TITLE
MONGOCRYPT-520 fix tag upload

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -32,7 +32,7 @@ functions:
             echo "Setting tag_upload_location to '$head_tag'"
             use_tag="$head_tag"
           fi
-          echo "tag_upload_location: '$use_tag'" > tag_expansions.yml
+          echo "tag_upload_location: '$use_tag'" > tag_expansion.yml
     - command: expansions.update
       params:
         ignore_missing_file: true


### PR DESCRIPTION
# Background and Motivation

MONGOCRYPT-315 added an upload URL for the libmongocrypt-all.tar.gz of the form: `https://mciuploads.s3.amazonaws.com/libmongocrypt/all/<tag>/libmongocrypt-all.tar.gz`

The [1.7.0 upload-all task](https://spruce.mongodb.com/task/libmongocrypt_release_publish_snapshot_upload_all_a29f4d35d974e0ec32dd48cd57fba197873cf68e_23_01_20_22_08_03/files?execution=0&sortBy=STATUS&sortDir=ASC) does not have the expected tagged URL upload.

The [1.6.0 upload-all task](https://spruce.mongodb.com/task/libmongocrypt_release_publish_snapshot_upload_all_e78460cfbac270dc5e26b61c6b4355e6b9e9e460_22_12_06_17_32_15/files?execution=0) has the tagged URL upload.

The `expansions.update` command expects `tag_expansion.yml` spelling. https://github.com/mongodb/libmongocrypt/pull/465 changed the spelling from `tag_expansion.yml` to `tag_expansions.yml`. 

As a workaround, the 1.7.0 upload was manually uploaded with the `aws` command line:
```
wget https://mciuploads.s3.amazonaws.com/libmongocrypt/all/r1.7/a29f4d35d974e0ec32dd48cd57fba197873cf68e/libmongocrypt-all.tar.gz
aws s3 cp libmongocrypt-all.tar.gz s3://mciuploads/libmongocrypt/all/1.7.0/libmongocrypt-all.tar.gz --profile evergreen-libmongocrypt
aws s3api put-object-acl --bucket mciuploads --key libmongocrypt/all/1.7.0/libmongocrypt-all.tar.gz --acl public-read --profile evergreen-libmongocrypt
```
