### PR TITLE
fix(NODE-4997): no strncasecmp on windows

### DIFF
--- a/bindings/node/src/mongocrypt.cc
+++ b/bindings/node/src/mongocrypt.cc
@@ -1,6 +1,11 @@
 #include "mongocrypt.h"
 #include <cassert>
 
+#ifdef _MSC_VER 
+#define strncasecmp _strnicmp
+#define strcasecmp _stricmp
+#endif
+
 namespace node_mongocrypt {
 
 using namespace Napi;


### PR DESCRIPTION
`strncasecmp` is not present in Windows so we redefine it in those environments.