### PR TITLE
MONGOCRYPT-525 do not assert on base64 decode error

### DIFF
--- a/src/mongocrypt-kms-ctx.c
+++ b/src/mongocrypt-kms-ctx.c
@@ -583,17 +583,19 @@ _ctx_done_aws (mongocrypt_kms_ctx_t *kms, const char *json_field)
 
    b64_str = (char *) bson_iter_utf8 (&iter, &b64_strlen);
    BSON_ASSERT (b64_str);
-   kms->result.data = bson_malloc ((size_t) b64_strlen + 1u);
-   BSON_ASSERT (kms->result.data);
+   uint8_t *result_data = bson_malloc ((size_t) b64_strlen + 1u);
+   BSON_ASSERT (result_data);
 
-   result_len = kms_message_b64_pton (b64_str, kms->result.data, b64_strlen);
+   result_len = kms_message_b64_pton (b64_str, result_data, b64_strlen);
    if (result_len < 0) {
       CLIENT_ERR (
          "Failed to base64 decode response. HTTP status=%d. Response body=\n%s",
          http_status,
          body);
+      bson_free (result_data);
       goto fail;
    }
+   kms->result.data = result_data;
    kms->result.len = (uint32_t) result_len;
    kms->result.owned = true;
    ret = true;
@@ -751,15 +753,19 @@ _ctx_done_azure_wrapkey_unwrapkey (mongocrypt_kms_ctx_t *kms)
       CLIENT_ERR ("Error converting base64url to base64");
       goto fail;
    }
-   kms->result.data = bson_malloc0 (b64_len);
-   result_len = kms_message_b64_pton (b64_data, kms->result.data, b64_len);
+
+   uint8_t *result_data = bson_malloc0 (b64_len);
+   result_len = kms_message_b64_pton (b64_data, result_data, b64_len);
    if (result_len < 0) {
       CLIENT_ERR (
          "Failed to base64 decode response. HTTP status=%d. Response body=\n%s",
          http_status,
          body);
+      bson_free (result_data);
       goto fail;
    }
+
+   kms->result.data = result_data;
    kms->result.len = (uint32_t) result_len;
    kms->result.owned = true;
 

--- a/src/mongocrypt-kms-ctx.c
+++ b/src/mongocrypt-kms-ctx.c
@@ -755,6 +755,7 @@ _ctx_done_azure_wrapkey_unwrapkey (mongocrypt_kms_ctx_t *kms)
    }
 
    uint8_t *result_data = bson_malloc0 (b64_len);
+   BSON_ASSERT (result_data);
    result_len = kms_message_b64_pton (b64_data, result_data, b64_len);
    if (result_len < 0) {
       CLIENT_ERR (

--- a/src/mongocrypt-kms-ctx.c
+++ b/src/mongocrypt-kms-ctx.c
@@ -754,7 +754,7 @@ _ctx_done_azure_wrapkey_unwrapkey (mongocrypt_kms_ctx_t *kms)
       goto fail;
    }
 
-   uint8_t *result_data = bson_malloc0 (b64_len);
+   uint8_t *result_data = bson_malloc (b64_len);
    BSON_ASSERT (result_data);
    result_len = kms_message_b64_pton (b64_data, result_data, b64_len);
    if (result_len < 0) {

--- a/src/mongocrypt-kms-ctx.c
+++ b/src/mongocrypt-kms-ctx.c
@@ -587,7 +587,13 @@ _ctx_done_aws (mongocrypt_kms_ctx_t *kms, const char *json_field)
    BSON_ASSERT (kms->result.data);
 
    result_len = kms_message_b64_pton (b64_str, kms->result.data, b64_strlen);
-   BSON_ASSERT (result_len >= 0);
+   if (result_len < 0) {
+      CLIENT_ERR (
+         "Failed to base64 decode response. HTTP status=%d. Response body=\n%s",
+         http_status,
+         body);
+      goto fail;
+   }
    kms->result.len = (uint32_t) result_len;
    kms->result.owned = true;
    ret = true;
@@ -747,7 +753,13 @@ _ctx_done_azure_wrapkey_unwrapkey (mongocrypt_kms_ctx_t *kms)
    }
    kms->result.data = bson_malloc0 (b64_len);
    result_len = kms_message_b64_pton (b64_data, kms->result.data, b64_len);
-   BSON_ASSERT (result_len >= 0);
+   if (result_len < 0) {
+      CLIENT_ERR (
+         "Failed to base64 decode response. HTTP status=%d. Response body=\n%s",
+         http_status,
+         body);
+      goto fail;
+   }
    kms->result.len = (uint32_t) result_len;
    kms->result.owned = true;
 

--- a/test/data/kms-tests.json
+++ b/test/data/kms-tests.json
@@ -279,5 +279,19 @@
       "HTTP status=200. Response body=\n",
       "{\"x\": 1}"
     ]
+  },
+  {
+    "description": "Encryption response with invalid base64",
+    "ctx": ["datakey"],
+    "http_reply": [
+      "HTTP/1.1 200 OK\r\n",
+      "x-amzn-RequestId: deeb35e5-4ecb-4bf1-9af5-84a54ff0af0e\r\n",
+      "Content-Type: application/x-amz-json-1.1\r\n",
+      "Content-Length: 111\r\n",
+      "Connection: close\r\n",
+      "\r\n",
+      "{\"KeyId\": \"arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0\", \"CiphertextBlob\": \"A\"}"
+    ],
+    "expect": "Failed to base64 decode"
   }
 ]


### PR DESCRIPTION
# Summary

- do not assert on base64 decode error

# Background & Motivation

Without the fix, `./cmake-build/test-mongocrypt _test_kms_responses` results in the assert:

```
- Encryption response with invalid base64
/Users/kevin.albertson/code/libmongocrypt-M525/src/mongocrypt-kms-ctx.c:590 _ctx_done_aws(): precondition failed: result_len >= 0
```