### PR TITLE
[MONGOCRYPT-524] Fix ILP32-target builds

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -855,14 +855,36 @@ tasks:
         script: |-
           set -o errexit
           set -o xtrace
-          export IS_PATCH="${is_patch}"
-          bash .evergreen/debian_package_build.sh
+          bash .evergreen/debian_package_build.sh --is-patch=${is_patch}
     - command: s3.put
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: deb.tar.gz
         remote_file: libmongocrypt/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/debian-packages.tar.gz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/x-gzip}
+        display_name: "deb.tar.gz"
+
+- name: debian-package-build-i386
+  commands:
+    - func: "fetch source"
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "libmongocrypt"
+        shell: bash
+        script: |-
+          set -o errexit
+          set -o xtrace
+          bash .evergreen/debian_package_build.sh --arch=i386 --is-patch=${is_patch}
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: deb.tar.gz
+        remote_file: libmongocrypt/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/debian-packages-i386.tar.gz
         bucket: mciuploads
         permissions: public-read
         content_type: ${content_type|application/x-gzip}
@@ -1350,6 +1372,7 @@ buildvariants:
   run_on: ubuntu2004-small
   tasks:
   - name: debian-package-build
+  - name: debian-package-build-i386
 - name: macos
   display_name: macOS m1 (Apple LLVM)
   run_on: macos-1100-arm64

--- a/Earthfile
+++ b/Earthfile
@@ -247,7 +247,6 @@ deb-build:
     RUN __install git-buildpackage fakeroot debhelper cmake libbson-dev \
                   libintelrdfpmath-dev
     DO +COPY_SOURCE
-    # COPY .git /s/libmongocrypt/.git
     WORKDIR /s/libmongocrypt
     RUN git clean -fdx && git reset --hard
     RUN python3 etc/calc_release_version.py > VERSION_CURRENT

--- a/Earthfile
+++ b/Earthfile
@@ -189,6 +189,9 @@ env.deb10:
     # A Debian 10.0 environment
     DO +ENV_DEBIAN --version 10.0
 
+env.deb-unstable:
+    DO +ENV_DEBIAN --version=unstable
+
 env.deb11:
     # A Debian 11.0 environment
     DO +ENV_DEBIAN --version 11.0
@@ -232,6 +235,28 @@ COPY_SOURCE:
         CMakeLists.txt \
         "/s/libmongocrypt"
     COPY --dir bindings/cs/ "/s/libmongocrypt/bindings/"
+
+# A target to build the debian package. Options:
+#   • --env=[...] (default: deb-unstable)
+#     · Set the environment for the build. Affects which packages are available
+#       for build dependencies.
+# NOTE: Uncommited local changes will be ignored and not affect the result!
+deb-build:
+    ARG env=deb-unstable
+    FROM +env.$env
+    RUN __install git-buildpackage fakeroot debhelper cmake libbson-dev \
+                  libintelrdfpmath-dev
+    DO +COPY_SOURCE
+    # COPY .git /s/libmongocrypt/.git
+    WORKDIR /s/libmongocrypt
+    RUN git clean -fdx && git reset --hard
+    RUN python3 etc/calc_release_version.py > VERSION_CURRENT
+    RUN git add -f VERSION_CURRENT && \
+        git -c user.name=anon -c user.email=anon@localhost \
+            commit VERSION_CURRENT -m 'Set version' && \
+        env LANG=C bash debian/build_snapshot.sh && \
+        debc ../*.changes && \
+        dpkg -i ../*.deb
 
 # The main "build" target. Options:
 #   • --env=[...] (default "u22")

--- a/src/mc-range-edge-generation-private.h
+++ b/src/mc-range-edge-generation-private.h
@@ -96,7 +96,7 @@ mc_count_leading_zeros_u64 (uint64_t in)
 #ifdef __has_builtin
 #if __has_builtin(__builtin_clzl)
 // Pointer-cast to ensure we are speaking the right type
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__ILP32__)
    unsigned long long *p = &in;
    return (size_t) (in ? __builtin_clzll (*p) : 64);
 #else


### PR DESCRIPTION
This fixes a confusion about the data model available on certain platforms.

This changeset also defines an additional `debian-package-build-i386` task that will validate this platform going forward. We also now have an Earthly target for the deb-build, and the changes were validated there (using `earthly --platform=i386 +deb-build`).