### PR TITLE
Define a new EVG task that runs the RPM build

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -917,7 +917,7 @@ tasks:
     - func: fetch source
     - func: earthly
       vars:
-        args: +rpm-build
+        args: +rpm-runtime-test
 
 pre:
   # Update the evergreen expansion to dynamically set the ${libmongocrypt_s3_suffix} and ${libmongocrypt_s3_suffix_copy} expansions.

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -352,6 +352,12 @@ functions:
         permissions: public-read
         content_type: ${content_type|application/gzip}
         display_name: Release Python files all
+  earthly:
+    - command: shell.exec
+      params:
+        shell: bash
+        working_dir: ${working_dir|libmongocrypt}
+        script: bash ${workdir}/libmongocrypt/.evergreen/earthly.sh ${args}
 
 tasks:
 - name: build-and-test-and-upload
@@ -845,6 +851,10 @@ tasks:
         content_type: '${content_type|application/x-gzip}'
 
 - name: debian-package-build
+  run_on: &deb-package-build-run_on
+    - ubuntu2004
+    - ubuntu2004-small
+  tags: [packaging]
   commands:
     - func: "fetch source"
     - command: shell.exec
@@ -868,6 +878,8 @@ tasks:
         display_name: "deb.tar.gz"
 
 - name: debian-package-build-i386
+  run_on: *deb-package-build-run_on
+  tags: [packaging]
   commands:
     - func: "fetch source"
     - command: shell.exec
@@ -889,6 +901,23 @@ tasks:
         permissions: public-read
         content_type: ${content_type|application/x-gzip}
         display_name: "deb.tar.gz"
+
+- name: rpm-package-build
+  tags: [packaging]
+  run_on: &docker-distros
+    - rhel76-docker
+    - ubuntu2004
+    - ubuntu2004-small
+    - ubuntu1804
+    - ubuntu1804-medium
+    - debian10
+    - debian11
+    - amazon2
+  commands:
+    - func: fetch source
+    - func: earthly
+      vars:
+        args: +rpm-build
 
 pre:
   # Update the evergreen expansion to dynamically set the ${libmongocrypt_s3_suffix} and ${libmongocrypt_s3_suffix_copy} expansions.
@@ -1369,10 +1398,7 @@ buildvariants:
     - "publish-java"
 - name: packaging
   display_name: "Linux Distro Packaging"
-  run_on: ubuntu2004-small
-  tasks:
-  - name: debian-package-build
-  - name: debian-package-build-i386
+  tasks: [.packaging]
 - name: macos
   display_name: macOS m1 (Apple LLVM)
   run_on: macos-1100-arm64

--- a/Earthfile
+++ b/Earthfile
@@ -223,6 +223,7 @@ CACHE_WARMUP:
 COPY_SOURCE:
     COMMAND
     COPY --dir \
+        .git/ \
         cmake/ \
         kms-message/ \
         test/ \
@@ -301,7 +302,6 @@ deb-build:
     RUN __install git-buildpackage fakeroot debhelper cmake libbson-dev \
                   libintelrdfpmath-dev
     DO +COPY_SOURCE
-    COPY --dir .git /s/libmongocrypt/
     WORKDIR /s/libmongocrypt
     RUN git clean -fdx && git reset --hard
     RUN python3 etc/calc_release_version.py > VERSION_CURRENT

--- a/cmake/IntelDFP.cmake
+++ b/cmake/IntelDFP.cmake
@@ -23,11 +23,9 @@ set (patch_command)
 if (NOT INTEL_DFP_LIBRARY_PATCH_ENABLED)
     set (patch_command "${CMAKE_COMMAND}" -E true)
 elseif (GIT_EXECUTABLE)
-    set (patch_command "${GIT_EXECUTABLE}")
-    set (dir_arg --work-tree=<SOURCE_DIR>)
+    set (patch_command "${GIT_EXECUTABLE}" --work-tree=<SOURCE_DIR> apply)
 else ()
-    set (patch_command "${PATCH_EXECUTABLE}")
-    set (dir_arg --dir=<SOURCE_DIR>)
+    set (patch_command "${PATCH_EXECUTABLE}" --dir=<SOURCE_DIR>)
 endif ()
 
 # NOTE: The applying of the patch expects the correct input directly from the
@@ -40,7 +38,7 @@ FetchContent_Declare (
     URL "${_default_url}"
     ${_hash_arg}
     PATCH_COMMAND
-        ${patch_command} "${dir_arg}"
+        ${patch_command}
             -p 4 # Strip four path components
             "${PROJECT_SOURCE_DIR}/etc/mongo-inteldfp-s390x.patch"
             --verbose

--- a/etc/rpm/tweak.awk
+++ b/etc/rpm/tweak.awk
@@ -10,8 +10,7 @@
 
 # Replace the autosetup with one that copies the source tree into place
 /%autosetup/ {
-    print "cd %{_topdir}/BUILD\n" \
-          "cp -rf %{_sourcedir}/. $PWD\n" \
+    print "cp -rf %{_sourcedir}/. %{_builddir}/\n" \
           "%autopatch 0 -p1"
     next
 }


### PR DESCRIPTION
This PR adds a new EVG task to the "Linux Distro Packaging" group that builds an RPM using Fedora Rawhide, based on the same RPM spec that is used in the upstream. This will be the first Earthly-based task running in EVG.

This changeset also caught an accidental new built-time dependency on Git that wasn't listed in the upstream `libmongocrypt.spec`. I hope that this will allow us to preempt RPM-related build issues in the future, before merging errant changesets.

Tweaks:
  - Don't BuildRequires git, and just use 'patch' on the IntelDFP sources if possible.
  - Only install exactly what is requried by BuildRequires for creating the RPM, to detect accidental new build dependencies.

(I note that the Docker availability and stability in the EVG distros isn't entirely stable, but I have narrowed it down to a generally reliable set.)