### PR TITLE
Permit -DENABLE_MONGOC=OFF when compiling libmongocrypt

### DIFF
--- a/cmake/ImportBSON.cmake
+++ b/cmake/ImportBSON.cmake
@@ -149,12 +149,14 @@ function (_import_bson)
       else ()
          add_subdirectory ("${MONGOCRYPT_MONGOC_DIR}" _mongo-c-driver EXCLUDE_FROM_ALL)
       endif ()
-      # Workaround: Embedded mongoc_static does not set its INCLUDE_DIRECTORIES for user targets
-      target_include_directories (mongoc_static
-         PUBLIC
-            "$<BUILD_INTERFACE:${MONGOCRYPT_MONGOC_DIR}/src/libmongoc/src>"
-            "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/_mongo-c-driver/src/libmongoc/src/mongoc>"
-         )
+      if (TARGET mongoc_static)
+         # Workaround: Embedded mongoc_static does not set its INCLUDE_DIRECTORIES for user targets
+         target_include_directories (mongoc_static
+            PUBLIC
+               "$<BUILD_INTERFACE:${MONGOCRYPT_MONGOC_DIR}/src/libmongoc/src>"
+               "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/_mongo-c-driver/src/libmongoc/src/mongoc>"
+            )
+      endif ()
    endif ()
 endfunction ()
 

--- a/src/mc-fle2-payload-iev.c
+++ b/src/mc-fle2-payload-iev.c
@@ -183,7 +183,7 @@ mc_FLE2IndexedEncryptedValue_write (
    const uint8_t subtype =
       (uint8_t) MC_SUBTYPE_FLE2IndexedEqualityEncryptedValue;
 
-   if ((original_bson_type < 0) || (original_bson_type > 0xFF)) {
+   if (((int) original_bson_type < 0) || ((int) original_bson_type > 0xFF)) {
       CLIENT_ERR ("Field 't' must be a valid BSON type, got: %d",
                   original_bson_type);
       CHECK_AND_GOTO (false);


### PR DESCRIPTION
Addresses the following error when compiling with `-DENABLE_MONGOC=OFF`:

```
CMake Error at cmake/ImportBSON.cmake:153 (target_include_directories):
  Cannot specify include directories for target "mongoc_static" which is not
  built by this project.
Call Stack (most recent call first):
  cmake/ImportBSON.cmake:162 (_import_bson)
  CMakeLists.txt:22 (include)
```

The conditional presence of `mongoc_static` is already being handled correctly further below in ImportBSON.cmake:

```cmake
if (TARGET mongoc_static)
   # And an alias to the mongoc target for use in some test cases
   add_library (_mongocrypt::mongoc ALIAS mongoc_static)
endif ()
```

As a drive-by fix, also addresses a -Wtautological-compare warning in mc-fle2-payload-iev.c which may hinder compilation from source by the C Driver.