### PR TITLE
fix(NODE-5053): enforce empty map for kmsProvider auto credentials

### DIFF
--- a/bindings/node/lib/credentialsProvider.js
+++ b/bindings/node/lib/credentialsProvider.js
@@ -35,9 +35,11 @@ async function loadAWSCredentials(kmsProviders) {
     const provider = fromNodeProviderChain();
     // The state machine is the only place calling this so it will
     // catch if there is a rejection here.
-    const awsCreds = await provider();
-    return { ...kmsProviders, aws: awsCreds };
+    const aws = await provider();
+    return { ...kmsProviders, aws };
   }
+
+  return kmsProviders;
 }
 
 /**

--- a/bindings/node/test/credentialsProvider.test.js
+++ b/bindings/node/test/credentialsProvider.test.js
@@ -2,161 +2,185 @@
 
 const { expect } = require('chai');
 const requirements = require('./requirements.helper');
-const { loadCredentials } = require('../lib/credentialsProvider');
+const { loadCredentials, isEmptyCredentials } = require('../lib/credentialsProvider');
 
 const originalAccessKeyId = process.env.AWS_ACCESS_KEY_ID;
 const originalSecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
 const originalSessionToken = process.env.AWS_SESSION_TOKEN;
 
 describe('#loadCredentials', function () {
-  const accessKey = 'example';
-  const secretKey = 'example';
-  const sessionToken = 'example';
-
-  after(function () {
-    // After the entire suite runs, set the env back for the rest of the test run.
-    process.env.AWS_ACCESS_KEY_ID = originalAccessKeyId;
-    process.env.AWS_SECRET_ACCESS_KEY = originalSecretAccessKey;
-    process.env.AWS_SESSION_TOKEN = originalSessionToken;
-  });
-
-  context('when the credential provider finds credentials', function () {
-    before(function () {
-      process.env.AWS_ACCESS_KEY_ID = accessKey;
-      process.env.AWS_SECRET_ACCESS_KEY = secretKey;
-      process.env.AWS_SESSION_TOKEN = sessionToken;
+  context('isEmptyCredentials()', () => {
+    it('returns true for an empty object', () => {
+      expect(isEmptyCredentials('rainyCloud', { rainyCloud: {} })).to.be.true;
     });
 
-    context('when the credentials are empty', function () {
-      const kmsProviders = {};
+    it('returns false for an object with keys', () => {
+      expect(isEmptyCredentials('rainyCloud', { rainyCloud: { password: 'secret' } })).to.be.false;
+    });
+
+    it('returns false for an nullish credentials', () => {
+      expect(isEmptyCredentials('rainyCloud', { rainyCloud: null })).to.be.false;
+      expect(isEmptyCredentials('rainyCloud', { rainyCloud: undefined })).to.be.false;
+      expect(isEmptyCredentials('rainyCloud', {})).to.be.false;
+    });
+
+    it('returns false for non object credentials', () => {
+      expect(isEmptyCredentials('rainyCloud', { rainyCloud: 0 })).to.be.false;
+      expect(isEmptyCredentials('rainyCloud', { rainyCloud: false })).to.be.false;
+      expect(isEmptyCredentials('rainyCloud', { rainyCloud: Symbol('secret') })).to.be.false;
+    });
+  });
+
+  context('aws', () => {
+    const accessKey = 'example';
+    const secretKey = 'example';
+    const sessionToken = 'example';
+
+    after(function () {
+      // After the entire suite runs, set the env back for the rest of the test run.
+      process.env.AWS_ACCESS_KEY_ID = originalAccessKeyId;
+      process.env.AWS_SECRET_ACCESS_KEY = originalSecretAccessKey;
+      process.env.AWS_SESSION_TOKEN = originalSessionToken;
+    });
+
+    context('when the credential provider finds credentials', function () {
+      before(function () {
+        process.env.AWS_ACCESS_KEY_ID = accessKey;
+        process.env.AWS_SECRET_ACCESS_KEY = secretKey;
+        process.env.AWS_SESSION_TOKEN = sessionToken;
+      });
+
+      context('when the credentials are empty', function () {
+        const kmsProviders = { aws: {} };
+
+        before(function () {
+          if (!requirements.credentialProvidersInstalled.aws) {
+            this.currentTest.skipReason = 'Cannot refresh credentials without sdk provider';
+            this.currentTest.skip();
+            return;
+          }
+        });
+
+        it('refreshes the aws credentials', async function () {
+          const providers = await loadCredentials(kmsProviders);
+          expect(providers).to.deep.equal({
+            aws: {
+              accessKeyId: accessKey,
+              secretAccessKey: secretKey,
+              sessionToken: sessionToken
+            }
+          });
+        });
+      });
+
+      context('when the credentials are not empty', function () {
+        context('when aws is empty', function () {
+          const kmsProviders = {
+            local: {
+              key: Buffer.alloc(96)
+            },
+            aws: {}
+          };
+
+          before(function () {
+            if (!requirements.credentialProvidersInstalled.aws) {
+              this.currentTest.skipReason = 'Cannot refresh credentials without sdk provider';
+              this.currentTest.skip();
+              return;
+            }
+          });
+
+          it('refreshes only the aws credentials', async function () {
+            const providers = await loadCredentials(kmsProviders);
+            expect(providers).to.deep.equal({
+              local: {
+                key: Buffer.alloc(96)
+              },
+              aws: {
+                accessKeyId: accessKey,
+                secretAccessKey: secretKey,
+                sessionToken: sessionToken
+              }
+            });
+          });
+        });
+
+        context('when aws is not empty', function () {
+          const kmsProviders = {
+            local: {
+              key: Buffer.alloc(96)
+            },
+            aws: {
+              accessKeyId: 'example'
+            }
+          };
+
+          before(function () {
+            if (!requirements.credentialProvidersInstalled.aws) {
+              this.currentTest.skipReason = 'Cannot refresh credentials without sdk provider';
+              this.currentTest.skip();
+              return;
+            }
+          });
+
+          it('does not refresh credentials', async function () {
+            const providers = await loadCredentials(kmsProviders);
+            expect(providers).to.deep.equal(kmsProviders);
+          });
+        });
+
+        context.skip('when aws does not exist', function () {
+          const kmsProviders = {
+            local: {
+              key: Buffer.alloc(96)
+            }
+          };
+
+          before(function () {
+            if (!requirements.credentialProvidersInstalled.aws) {
+              this.currentTest.skipReason = 'Cannot refresh credentials without sdk provider';
+              this.currentTest.skip();
+              return;
+            }
+          });
+
+          it('refreshes ony the aws credentials', async function () {
+            const providers = await loadCredentials(kmsProviders);
+            expect(providers).to.deep.equal({
+              local: {
+                key: Buffer.alloc(96)
+              },
+              aws: {
+                accessKeyId: accessKey,
+                secretAccessKey: secretKey,
+                sessionToken: sessionToken
+              }
+            });
+          });
+        });
+      });
+    });
+
+    context('when the sdk is not installed', function () {
+      const kmsProviders = {
+        local: {
+          key: Buffer.alloc(96)
+        },
+        aws: {}
+      };
 
       before(function () {
-        if (!requirements.credentialProvidersInstalled.aws) {
-          this.currentTest.skipReason = 'Cannot refresh credentials without sdk provider';
+        if (requirements.credentialProvidersInstalled.aws) {
+          this.currentTest.skipReason = 'Credentials will be loaded when sdk present';
           this.currentTest.skip();
           return;
         }
       });
 
-      it('refreshes the aws credentials', async function () {
+      it('does not refresh credentials', async function () {
         const providers = await loadCredentials(kmsProviders);
-        expect(providers).to.deep.equal({
-          aws: {
-            accessKeyId: accessKey,
-            secretAccessKey: secretKey,
-            sessionToken: sessionToken
-          }
-        });
+        expect(providers).to.deep.equal(kmsProviders);
       });
-    });
-
-    context('when the credentials are not empty', function () {
-      context('when aws is empty', function () {
-        const kmsProviders = {
-          local: {
-            key: Buffer.alloc(96)
-          },
-          aws: {}
-        };
-
-        before(function () {
-          if (!requirements.credentialProvidersInstalled.aws) {
-            this.currentTest.skipReason = 'Cannot refresh credentials without sdk provider';
-            this.currentTest.skip();
-            return;
-          }
-        });
-
-        it('refreshes only the aws credentials', async function () {
-          const providers = await loadCredentials(kmsProviders);
-          expect(providers).to.deep.equal({
-            local: {
-              key: Buffer.alloc(96)
-            },
-            aws: {
-              accessKeyId: accessKey,
-              secretAccessKey: secretKey,
-              sessionToken: sessionToken
-            }
-          });
-        });
-      });
-
-      context('when aws is not empty', function () {
-        const kmsProviders = {
-          local: {
-            key: Buffer.alloc(96)
-          },
-          aws: {
-            accessKeyId: 'example'
-          }
-        };
-
-        before(function () {
-          if (!requirements.credentialProvidersInstalled.aws) {
-            this.currentTest.skipReason = 'Cannot refresh credentials without sdk provider';
-            this.currentTest.skip();
-            return;
-          }
-        });
-
-        it('does not refresh credentials', async function () {
-          const providers = await loadCredentials(kmsProviders);
-          expect(providers).to.deep.equal(kmsProviders);
-        });
-      });
-
-      context('when aws does not exist', function () {
-        const kmsProviders = {
-          local: {
-            key: Buffer.alloc(96)
-          }
-        };
-
-        before(function () {
-          if (!requirements.credentialProvidersInstalled.aws) {
-            this.currentTest.skipReason = 'Cannot refresh credentials without sdk provider';
-            this.currentTest.skip();
-            return;
-          }
-        });
-
-        it('refreshes ony the aws credentials', async function () {
-          const providers = await loadCredentials(kmsProviders);
-          expect(providers).to.deep.equal({
-            local: {
-              key: Buffer.alloc(96)
-            },
-            aws: {
-              accessKeyId: accessKey,
-              secretAccessKey: secretKey,
-              sessionToken: sessionToken
-            }
-          });
-        });
-      });
-    });
-  });
-
-  context('when the sdk is not installed', function () {
-    const kmsProviders = {
-      local: {
-        key: Buffer.alloc(96)
-      },
-      aws: {}
-    };
-
-    before(function () {
-      if (requirements.credentialProvidersInstalled.aws) {
-        this.currentTest.skipReason = 'Credentials will be loaded when sdk present';
-        this.currentTest.skip();
-        return;
-      }
-    });
-
-    it('does not refresh credentials', async function () {
-      const providers = await loadCredentials(kmsProviders);
-      expect(providers).to.deep.equal(kmsProviders);
     });
   });
 });

--- a/bindings/node/test/credentialsProvider.test.js
+++ b/bindings/node/test/credentialsProvider.test.js
@@ -31,7 +31,7 @@ describe('#loadCredentials', function () {
     });
   });
 
-  context('aws', () => {
+  context('when using aws', () => {
     const accessKey = 'example';
     const secretKey = 'example';
     const sessionToken = 'example';
@@ -126,36 +126,6 @@ describe('#loadCredentials', function () {
           it('does not refresh credentials', async function () {
             const providers = await loadCredentials(kmsProviders);
             expect(providers).to.deep.equal(kmsProviders);
-          });
-        });
-
-        context.skip('when aws does not exist', function () {
-          const kmsProviders = {
-            local: {
-              key: Buffer.alloc(96)
-            }
-          };
-
-          before(function () {
-            if (!requirements.credentialProvidersInstalled.aws) {
-              this.currentTest.skipReason = 'Cannot refresh credentials without sdk provider';
-              this.currentTest.skip();
-              return;
-            }
-          });
-
-          it('refreshes ony the aws credentials', async function () {
-            const providers = await loadCredentials(kmsProviders);
-            expect(providers).to.deep.equal({
-              local: {
-                key: Buffer.alloc(96)
-              },
-              aws: {
-                accessKeyId: accessKey,
-                secretAccessKey: secretKey,
-                sessionToken: sessionToken
-              }
-            });
           });
         });
       });

--- a/bindings/node/test/index.test.js
+++ b/bindings/node/test/index.test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const { expect } = require('chai');
+const mongodbClientEncryption = require('../lib/index');
+
+// Update this as you add exports, helps double check we don't accidentally remove something
+// since not all tests import from the root public export
+const EXPECTED_EXPORTS = [
+  'extension',
+  'MongoCryptError',
+  'MongoCryptCreateEncryptedCollectionError',
+  'MongoCryptCreateDataKeyError',
+  'AutoEncrypter',
+  'ClientEncryption'
+];
+
+describe('mongodb-client-encryption entrypoint', () => {
+  it('should export all and only the expected keys in expected_exports', () => {
+    expect(mongodbClientEncryption).to.have.keys(EXPECTED_EXPORTS);
+  });
+});

--- a/bindings/node/test/index.test.js
+++ b/bindings/node/test/index.test.js
@@ -16,6 +16,6 @@ const EXPECTED_EXPORTS = [
 
 describe('mongodb-client-encryption entrypoint', () => {
   it('should export all and only the expected keys in expected_exports', () => {
-    expect(mongodbClientEncryption).to.have.keys(EXPECTED_EXPORTS);
+    expect(mongodbClientEncryption).to.have.all.keys(EXPECTED_EXPORTS);
   });
 });

--- a/bindings/node/test/index.test.js
+++ b/bindings/node/test/index.test.js
@@ -18,4 +18,12 @@ describe('mongodb-client-encryption entrypoint', () => {
   it('should export all and only the expected keys in expected_exports', () => {
     expect(mongodbClientEncryption).to.have.all.keys(EXPECTED_EXPORTS);
   });
+
+  it('extension returns an object equal in shape to the default except for extension', () => {
+    const extensionResult = mongodbClientEncryption.extension(require('mongodb'));
+    const expectedExports = EXPECTED_EXPORTS.filter(exp => exp !== 'extension');
+    const exportsDefault = Object.keys(mongodbClientEncryption).filter(exp => exp !== 'extension');
+    expect(extensionResult).to.have.all.keys(expectedExports);
+    expect(extensionResult).to.have.all.keys(exportsDefault);
+  });
 });


### PR DESCRIPTION
### Description

#### What is changing?

We strictly check for an existing object but with zero keys for a kmsProviders credentials before attempting auto fetching.

##### Is there new documentation needed for these changes?

Yes, this could be surprising to existing AWS users that were able to leave kmsProviders empty. They need to provide an 'aws' key set to `{}`

#### What is the motivation for this change?

The kmsProviders settings needs to have a key that exists but is set to an empty object in order to enable auto obtaining credentials. Otherwise future credential providers will both be obtained without actually requesting it.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
