### PR TITLE
Remove xtrace in build_all.sh

### DIFF
--- a/.evergreen/build_all.sh
+++ b/.evergreen/build_all.sh
@@ -4,7 +4,6 @@
 # Set extra cflags for libmongocrypt variables by setting LIBMONGOCRYPT_EXTRA_CFLAGS.
 #
 
-set -x
 echo "Begin compile process"
 
 . "$(dirname "${BASH_SOURCE[0]}")/setup-env.sh"


### PR DESCRIPTION
Reduces verbosity of build output when compiling libmongocrypt. If xtrace is desirable, users invoking build_all.sh (directly or indirectly via compile.sh) can opt into enabling xtrace themselves by setting `set -o xtrace` before invoking `build_all.sh`.