### PR TITLE
feat(NODE-5049): add support for kms gcp service accounts

### DIFF
--- a/bindings/node/.evergreen/test.sh
+++ b/bindings/node/.evergreen/test.sh
@@ -16,6 +16,7 @@ bash ./etc/build-static.sh
 
 if [[ $OMIT_PEER_DEPS != "true" ]]; then
     npm install '@aws-sdk/credential-providers'
+    npm install 'gcp-metadata'
 fi
 
 # Run tests

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -43,10 +43,14 @@
       },
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.186.0",
+        "gcp-metadata": "^5.2.0",
         "mongodb": ">=3.4.0"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "gcp-metadata": {
           "optional": true
         }
       }

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -64,10 +64,14 @@
   },
   "peerDependencies": {
     "@aws-sdk/credential-providers": "^3.186.0",
+    "gcp-metadata": "^5.2.0",
     "mongodb": ">=3.4.0"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/credential-providers": {
+      "optional": true
+    },
+    "gcp-metadata": {
       "optional": true
     }
   },

--- a/bindings/node/test/requirements.helper.js
+++ b/bindings/node/test/requirements.helper.js
@@ -24,6 +24,15 @@ function isAWSCredentialProviderInstalled() {
   }
 }
 
+function isGCPCredentialProviderInstalled() {
+  try {
+    require.resolve('gcp-metadata');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 module.exports = {
   SKIP_LIVE_TESTS,
   SKIP_AWS_TESTS,
@@ -36,6 +45,7 @@ module.exports = {
   awsKmsProviders,
   awsDataKeyOptions,
   credentialProvidersInstalled: {
-    aws: isAWSCredentialProviderInstalled()
+    aws: isAWSCredentialProviderInstalled(),
+    gcp: isGCPCredentialProviderInstalled()
   }
 };


### PR DESCRIPTION
### Description

NODE-4462

#### What is changing?

- Added `gcp-metadata` dependency as peer optional
- If `gcp: {}` is an empty map we will auto fetch credentials
- added a simulated test, int tests will be in driver NODE-5050

#### What is the motivation for this change?

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
