### PR TITLE
feat(NODE-5066): add automatic credential usage to TS definitions

### DIFF
--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -103,23 +103,25 @@ export interface KMSProviders {
   /**
    * Configuration options for using 'aws' as your KMS provider
    */
-  aws?: {
-    /**
-     * The access key used for the AWS KMS provider
-     */
-    accessKeyId: string;
+  aws?:
+    | {
+        /**
+         * The access key used for the AWS KMS provider
+         */
+        accessKeyId: string;
 
-    /**
-     * The secret access key used for the AWS KMS provider
-     */
-    secretAccessKey: string;
+        /**
+         * The secret access key used for the AWS KMS provider
+         */
+        secretAccessKey: string;
 
-    /**
-     * An optional AWS session token that will be used as the
-     * X-Amz-Security-Token header for AWS requests.
-     */
-    sessionToken?: string;
-  };
+        /**
+         * An optional AWS session token that will be used as the
+         * X-Amz-Security-Token header for AWS requests.
+         */
+        sessionToken?: string;
+      }
+    | Record<string, never>;
 
   /**
    * Configuration options for using 'local' as your KMS provider
@@ -147,61 +149,66 @@ export interface KMSProviders {
   /**
    * Configuration options for using 'azure' as your KMS provider
    */
-  azure?: {
-    /**
-     * The tenant ID identifies the organization for the account
-     */
-    tenantId: string;
+  azure?:
+    | {
+        /**
+         * The tenant ID identifies the organization for the account
+         */
+        tenantId: string;
 
-    /**
-     * The client ID to authenticate a registered application
-     */
-    clientId: string;
+        /**
+         * The client ID to authenticate a registered application
+         */
+        clientId: string;
 
-    /**
-     * The client secret to authenticate a registered application
-     */
-    clientSecret: string;
+        /**
+         * The client secret to authenticate a registered application
+         */
+        clientSecret: string;
 
-    /**
-     * If present, a host with optional port. E.g. "example.com" or "example.com:443".
-     * This is optional, and only needed if customer is using a non-commercial Azure instance
-     * (e.g. a government or China account, which use different URLs).
-     * Defaults to "login.microsoftonline.com"
-     */
-    identityPlatformEndpoint?: string | undefined;
-  } | {
-    /**
-     * If present, an access token to authenticate with Azure.
-     */
-    accessToken: string;
-  };
+        /**
+         * If present, a host with optional port. E.g. "example.com" or "example.com:443".
+         * This is optional, and only needed if customer is using a non-commercial Azure instance
+         * (e.g. a government or China account, which use different URLs).
+         * Defaults to "login.microsoftonline.com"
+         */
+        identityPlatformEndpoint?: string | undefined;
+      }
+    | {
+        /**
+         * If present, an access token to authenticate with Azure.
+         */
+        accessToken: string;
+      };
 
   /**
    * Configuration options for using 'gcp' as your KMS provider
    */
-  gcp?: {
-    /**
-     * The service account email to authenticate
-     */
-    email: string;
+  gcp?:
+    | {
+        /**
+         * The service account email to authenticate
+         */
+        email: string;
 
-    /**
-     * A PKCS#8 encrypted key. This can either be a base64 string or a binary representation
-     */
-    privateKey: string | Buffer;
+        /**
+         * A PKCS#8 encrypted key. This can either be a base64 string or a binary representation
+         */
+        privateKey: string | Buffer;
 
-    /**
-     * If present, a host with optional port. E.g. "example.com" or "example.com:443".
-     * Defaults to "oauth2.googleapis.com"
-     */
-    endpoint?: string | undefined;
-  } | {
-    /**
-     * If present, an access token to authenticate with GCP.
-     */
-    accessToken: string;
-  };
+        /**
+         * If present, a host with optional port. E.g. "example.com" or "example.com:443".
+         * Defaults to "oauth2.googleapis.com"
+         */
+        endpoint?: string | undefined;
+      }
+    | {
+        /**
+         * If present, an access token to authenticate with GCP.
+         */
+        accessToken: string;
+      }
+    | Record<string, never>;
 }
 
 /**
@@ -554,11 +561,17 @@ export class ClientEncryption {
    * @throws {MongoCryptCreateDataKeyForEncryptedCollectionError} - If part way through the process a createDataKey invocation fails, an error will be rejected that has the partial `encryptedFields` that were created.
    * @throws {MongoCryptCreateEncryptedCollectionError} - If creating the collection fails, an error will be rejected that has the entire `encryptedFields` that were created.
    */
-  createEncryptedCollection<TSchema extends Document = Document>(db: Db, name: string, options: {
-    provider: ClientEncryptionDataKeyProvider;
-    createCollectionOptions: Omit<CreateCollectionOptions, 'encryptedFields'> & { encryptedFields: Document };
-    masterKey?: AWSEncryptionKeyOptions | AzureEncryptionKeyOptions | GCPEncryptionKeyOptions;
-  }): Promise<{ collection: Collection<TSchema>, encryptedFields: Document }>;
+  createEncryptedCollection<TSchema extends Document = Document>(
+    db: Db,
+    name: string,
+    options: {
+      provider: ClientEncryptionDataKeyProvider;
+      createCollectionOptions: Omit<CreateCollectionOptions, 'encryptedFields'> & {
+        encryptedFields: Document;
+      };
+      masterKey?: AWSEncryptionKeyOptions | AzureEncryptionKeyOptions | GCPEncryptionKeyOptions;
+    }
+  ): Promise<{ collection: Collection<TSchema>; encryptedFields: Document }>;
 
   /**
    * Explicitly encrypt a provided value.

--- a/bindings/node/test/types/index.test-d.ts
+++ b/bindings/node/test/types/index.test-d.ts
@@ -37,16 +37,28 @@ expectAssignable<RequiredCreateEncryptedCollectionSettings>({
 
 {
   // KMSProviders
+  // aws
+  expectAssignable<KMSProviders['aws']>({ accessKeyId: '', secretAccessKey: '' });
+  expectAssignable<KMSProviders['aws']>({ accessKeyId: '', secretAccessKey: '', sessionToken: undefined });
+  expectAssignable<KMSProviders['aws']>({ accessKeyId: '', secretAccessKey: '', sessionToken: '' });
+  // automatic
+  expectAssignable<KMSProviders['aws']>({});
+
   // azure
   expectAssignable<KMSProviders['azure']>({ tenantId: 'a', clientId: 'a', clientSecret: 'a' });
   expectAssignable<KMSProviders['azure']>({ tenantId: 'a', clientId: 'a', clientSecret: 'a' });
   expectAssignable<KMSProviders['azure']>({ tenantId: 'a', clientId: 'a', clientSecret: 'a', identityPlatformEndpoint: undefined });
   expectAssignable<KMSProviders['azure']>({ tenantId: 'a', clientId: 'a', clientSecret: 'a', identityPlatformEndpoint: '' });
   expectAssignable<KMSProviders['azure']>({ accessToken: 'a' });
+  // automatic TODO(NODE-4537): update azure types to accept automatic credentials
+  expectNotAssignable<KMSProviders['azure']>({});
 
   // gcp
   expectAssignable<KMSProviders['gcp']>({ email: 'a', privateKey: 'a' });
   expectAssignable<KMSProviders['gcp']>({ email: 'a', privateKey: 'a', endpoint: undefined });
   expectAssignable<KMSProviders['gcp']>({ email: 'a', privateKey: 'a', endpoint: 'a' });
   expectAssignable<KMSProviders['gcp']>({ accessToken: 'a' });
+  // automatic
+  expectAssignable<KMSProviders['gcp']>({});
+
 }


### PR DESCRIPTION
### Description

#### What is changing?

- Add empty credentials as a viable type for aws/gcp

#### What is the motivation for this change?

currently empty credentials raise a TS error

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
