### PR TITLE
MONGOCRYPT-540 Define QE v2 token types and implemente token derivation

### DIFF
--- a/src/mc-tokens-private.h
+++ b/src/mc-tokens-private.h
@@ -29,16 +29,19 @@
  * Integers are represented as uint64_t in little-endian.
  *
  * CollectionsLevel1Token = HMAC(RootKey, 1)
+ * ServerTokenDerivationLevel1Token = HMAC(RootKey, 2)  <- new in v2
  * ServerDataEncryptionLevel1Token = HMAC(RootKey, 3)
  *
  * EDCToken = HMAC(CollectionsLevel1Token, 1)
  * ESCToken = HMAC(CollectionsLevel1Token, 2)
- * ECCToken = HMAC(CollectionsLevel1Token, 3)
+ * ECCToken = HMAC(CollectionsLevel1Token, 3)  <- deprecated in v2
  * ECOCToken = HMAC(CollectionsLevel1Token, 4)
  *
  * EDCDerivedFromDataToken = HMAC(EDCToken, v)
  * ESCDerivedFromDataToken = HMAC(ESCToken, v)
- * ECCDerivedFromDataToken = HMAC(ECCToken, v)
+ * ECCDerivedFromDataToken = HMAC(ECCToken, v)  <- deprecated in v2
+ * ServerDerivedFromDataToken = HMAC(ServerDataEncryptionLevel1Token, v) <- new
+ * in v2
  *
  * EDCDerivedFromDataTokenAndCounter = HMAC(EDCDerivedFromDataToken, u)
  * ESCDerivedFromDataTokenAndCounter = HMAC(ESCDerivedFromDataToken, u)
@@ -80,6 +83,8 @@
                                     mongocrypt_status_t * status)
 
 DECL_TOKEN_TYPE (mc_CollectionsLevel1Token, const _mongocrypt_buffer_t *);
+DECL_TOKEN_TYPE (mc_ServerTokenDerivationLevel1Token,
+                 const _mongocrypt_buffer_t *);
 DECL_TOKEN_TYPE (mc_ServerDataEncryptionLevel1Token,
                  const _mongocrypt_buffer_t *);
 DECL_TOKEN_TYPE (mc_EDCToken,
@@ -93,15 +98,16 @@ DECL_TOKEN_TYPE (mc_ECOCToken,
 DECL_TOKEN_TYPE (mc_EDCDerivedFromDataToken,
                  const mc_EDCToken_t *EDCToken,
                  const _mongocrypt_buffer_t *v);
-DECL_TOKEN_TYPE (mc_ECCDerivedFromDatatoken,
+DECL_TOKEN_TYPE (mc_ECCDerivedFromDataToken,
                  const mc_ECCToken_t *ECCToken,
                  const _mongocrypt_buffer_t *v);
 DECL_TOKEN_TYPE (mc_ESCDerivedFromDataToken,
                  const mc_ESCToken_t *ESCToken,
                  const _mongocrypt_buffer_t *v);
-DECL_TOKEN_TYPE (mc_ECCDerivedFromDataToken,
-                 const mc_ECCToken_t *ECCToken,
-                 const _mongocrypt_buffer_t *v);
+DECL_TOKEN_TYPE (
+   mc_ServerDerivedFromDataToken,
+   const mc_ServerTokenDerivationLevel1Token_t *ServerTokenDerivationToken,
+   const _mongocrypt_buffer_t *v);
 DECL_TOKEN_TYPE (mc_EDCDerivedFromDataTokenAndCounter,
                  const mc_EDCDerivedFromDataToken_t *EDCDerivedFromDataToken,
                  uint64_t u);

--- a/src/mc-tokens-private.h
+++ b/src/mc-tokens-private.h
@@ -40,7 +40,7 @@
  * EDCDerivedFromDataToken = HMAC(EDCToken, v)
  * ESCDerivedFromDataToken = HMAC(ESCToken, v)
  * ECCDerivedFromDataToken = HMAC(ECCToken, v)  <- deprecated in v2
- * ServerDerivedFromDataToken = HMAC(ServerDataEncryptionLevel1Token, v) <- new
+ * ServerDerivedFromDataToken = HMAC(ServerTokenDerivationLevel1Token, v) <- new
  * in v2
  *
  * EDCDerivedFromDataTokenAndCounter = HMAC(EDCDerivedFromDataToken, u)

--- a/src/mc-tokens.c
+++ b/src/mc-tokens.c
@@ -86,6 +86,10 @@
 DEF_TOKEN_TYPE (mc_CollectionsLevel1Token, const _mongocrypt_buffer_t *RootKey)
 IMPL_TOKEN_NEW_CONST (mc_CollectionsLevel1Token, RootKey, 1)
 
+DEF_TOKEN_TYPE (mc_ServerTokenDerivationLevel1Token,
+                const _mongocrypt_buffer_t *RootKey)
+IMPL_TOKEN_NEW_CONST (mc_ServerTokenDerivationLevel1Token, RootKey, 2)
+
 DEF_TOKEN_TYPE (mc_ServerDataEncryptionLevel1Token,
                 const _mongocrypt_buffer_t *RootKey)
 IMPL_TOKEN_NEW_CONST (mc_ServerDataEncryptionLevel1Token, RootKey, 3)
@@ -128,6 +132,15 @@ DEF_TOKEN_TYPE (mc_ECCDerivedFromDataToken,
                 const mc_ECCToken_t *ECCToken,
                 const _mongocrypt_buffer_t *v)
 IMPL_TOKEN_NEW (mc_ECCDerivedFromDataToken, mc_ECCToken_get (ECCToken), v)
+
+DEF_TOKEN_TYPE (
+   mc_ServerDerivedFromDataToken,
+   const mc_ServerTokenDerivationLevel1Token_t *ServerTokenDerivationToken,
+   const _mongocrypt_buffer_t *v)
+IMPL_TOKEN_NEW (
+   mc_ServerDerivedFromDataToken,
+   mc_ServerTokenDerivationLevel1Token_get (ServerTokenDerivationToken),
+   v)
 
 DEF_TOKEN_TYPE (mc_EDCDerivedFromDataTokenAndCounter,
                 const mc_EDCDerivedFromDataToken_t *EDCDerivedFromDataToken,

--- a/test/test-mc-tokens.c
+++ b/test/test-mc-tokens.c
@@ -54,6 +54,17 @@ _test_mc_tokens (_mongocrypt_tester_t *tester)
       *mc_ServerDataEncryptionLevel1Token_get (ServerDataEncryptionLevel1Token),
       expected);
 
+   mc_ServerTokenDerivationLevel1Token_t *ServerTokenDerivationLevel1Token =
+      mc_ServerTokenDerivationLevel1Token_new (crypt->crypto, &RootKey, status);
+   ASSERT_OR_PRINT (ServerTokenDerivationLevel1Token, status);
+   _mongocrypt_buffer_cleanup (&expected);
+   _mongocrypt_buffer_copy_from_hex (
+      &expected,
+      "1adc114b462741e6ac9f52eacf3dcb8cbca19827693c571d9418fda570c29d82");
+   ASSERT_CMPBUF (*mc_ServerTokenDerivationLevel1Token_get (
+                     ServerTokenDerivationLevel1Token),
+                  expected);
+
    mc_EDCToken_t *EDCToken =
       mc_EDCToken_new (crypt->crypto, CollectionsLevel1Token, status);
    ASSERT_OR_PRINT (EDCToken, status);
@@ -120,6 +131,18 @@ _test_mc_tokens (_mongocrypt_tester_t *tester)
    ASSERT_CMPBUF (*mc_ECCDerivedFromDataToken_get (ECCDerivedFromDataToken),
                   expected);
 
+   mc_ServerDerivedFromDataToken_t *ServerDerivedFromDataToken =
+      mc_ServerDerivedFromDataToken_new (
+         crypt->crypto, ServerTokenDerivationLevel1Token, &v, status);
+   ASSERT_OR_PRINT (ServerDerivedFromDataToken, status);
+   _mongocrypt_buffer_cleanup (&expected);
+   _mongocrypt_buffer_copy_from_hex (
+      &expected,
+      "4a671dbf25d68b6c040a077dabb4e63869e03f4d466803609233b16356ec6d66");
+   ASSERT_CMPBUF (
+      *mc_ServerDerivedFromDataToken_get (ServerDerivedFromDataToken),
+      expected);
+
    mc_EDCDerivedFromDataTokenAndCounter_t *EDCDerivedFromDataTokenAndCounter =
       mc_EDCDerivedFromDataTokenAndCounter_new (
          crypt->crypto, EDCDerivedFromDataToken, u, status);
@@ -170,6 +193,8 @@ _test_mc_tokens (_mongocrypt_tester_t *tester)
    mc_ECCToken_destroy (ECCToken);
    mc_ESCToken_destroy (ESCToken);
    mc_EDCToken_destroy (EDCToken);
+   mc_ServerTokenDerivationLevel1Token_destroy (
+      ServerTokenDerivationLevel1Token);
    mc_ServerDataEncryptionLevel1Token_destroy (ServerDataEncryptionLevel1Token);
    mc_CollectionsLevel1Token_destroy (CollectionsLevel1Token);
    _mongocrypt_buffer_cleanup (&v);


### PR DESCRIPTION
This defines and adds derivation functions for the following v2 token types:
* `ServerTokenDerivationLevel1Token = HMAC(indexKey, 2)`
* `ServerDerivedFromDataToken = HMAC(ServerTokenDerivationLevel1Token, value)`

Only `ServerDerivedFromDataToken` will really be used in the v2 payloads. `ServerTokenDerivationLevel1Token` is just an intermediate type used for deriving the `ServerDerivedFromDataToken`.