### PR TITLE
MONGOCRYPT-546 Refactor application crypto interface

### DIFF
--- a/src/mc-fle2-insert-update-payload-v2.c
+++ b/src/mc-fle2-insert-update-payload-v2.c
@@ -302,7 +302,7 @@ mc_FLE2InsertUpdatePayloadV2_decrypt (_mongocrypt_crypto_t *crypto,
                                       const _mongocrypt_buffer_t *user_key,
                                       mongocrypt_status_t *status)
 {
-   const _mongocrypt_value_encryption_algorithm_t *fle2alg =
+   const _mongocrypt_value_encryption_algorithm_t *fle2aead =
       _mcFLE2AEADAlgorithm ();
    BSON_ASSERT_PARAM (crypto);
    BSON_ASSERT_PARAM (iup);
@@ -322,16 +322,16 @@ mc_FLE2InsertUpdatePayloadV2_decrypt (_mongocrypt_crypto_t *crypto,
    }
 
    _mongocrypt_buffer_resize (
-      &iup->plaintext, fle2alg->get_plaintext_len (ciphertext.len, status));
+      &iup->plaintext, fle2aead->get_plaintext_len (ciphertext.len, status));
    uint32_t bytes_written; /* ignored */
 
-   if (!fle2alg->do_decrypt (crypto,
-                             &iup->userKeyId,
-                             user_key,
-                             &ciphertext,
-                             &iup->plaintext,
-                             &bytes_written,
-                             status)) {
+   if (!fle2aead->do_decrypt (crypto,
+                              &iup->userKeyId,
+                              user_key,
+                              &ciphertext,
+                              &iup->plaintext,
+                              &bytes_written,
+                              status)) {
       return NULL;
    }
    return &iup->plaintext;

--- a/src/mc-fle2-insert-update-payload-v2.c
+++ b/src/mc-fle2-insert-update-payload-v2.c
@@ -302,6 +302,8 @@ mc_FLE2InsertUpdatePayloadV2_decrypt (_mongocrypt_crypto_t *crypto,
                                       const _mongocrypt_buffer_t *user_key,
                                       mongocrypt_status_t *status)
 {
+   const _mongocrypt_value_encryption_algorithm_t *fle2alg =
+      _mcFLE2Algorithm ();
    BSON_ASSERT_PARAM (crypto);
    BSON_ASSERT_PARAM (iup);
    BSON_ASSERT_PARAM (user_key);
@@ -319,18 +321,17 @@ mc_FLE2InsertUpdatePayloadV2_decrypt (_mongocrypt_crypto_t *crypto,
       return NULL;
    }
 
-   _mongocrypt_buffer_resize (
-      &iup->plaintext,
-      _mongocrypt_fle2aead_calculate_plaintext_len (ciphertext.len, status));
+   _mongocrypt_buffer_resize (&iup->plaintext,
+                              fle2alg->plaintext_len (ciphertext.len, status));
    uint32_t bytes_written; /* ignored */
 
-   if (!_mongocrypt_fle2aead_do_decryption (crypto,
-                                            &iup->userKeyId,
-                                            user_key,
-                                            &ciphertext,
-                                            &iup->plaintext,
-                                            &bytes_written,
-                                            status)) {
+   if (!fle2alg->decrypt (crypto,
+                          &iup->userKeyId,
+                          user_key,
+                          &ciphertext,
+                          &iup->plaintext,
+                          &bytes_written,
+                          status)) {
       return NULL;
    }
    return &iup->plaintext;

--- a/src/mc-fle2-insert-update-payload-v2.c
+++ b/src/mc-fle2-insert-update-payload-v2.c
@@ -303,7 +303,7 @@ mc_FLE2InsertUpdatePayloadV2_decrypt (_mongocrypt_crypto_t *crypto,
                                       mongocrypt_status_t *status)
 {
    const _mongocrypt_value_encryption_algorithm_t *fle2alg =
-      _mcFLE2Algorithm ();
+      _mcFLE2AEADAlgorithm ();
    BSON_ASSERT_PARAM (crypto);
    BSON_ASSERT_PARAM (iup);
    BSON_ASSERT_PARAM (user_key);
@@ -321,17 +321,17 @@ mc_FLE2InsertUpdatePayloadV2_decrypt (_mongocrypt_crypto_t *crypto,
       return NULL;
    }
 
-   _mongocrypt_buffer_resize (&iup->plaintext,
-                              fle2alg->plaintext_len (ciphertext.len, status));
+   _mongocrypt_buffer_resize (
+      &iup->plaintext, fle2alg->get_plaintext_len (ciphertext.len, status));
    uint32_t bytes_written; /* ignored */
 
-   if (!fle2alg->decrypt (crypto,
-                          &iup->userKeyId,
-                          user_key,
-                          &ciphertext,
-                          &iup->plaintext,
-                          &bytes_written,
-                          status)) {
+   if (!fle2alg->do_decrypt (crypto,
+                             &iup->userKeyId,
+                             user_key,
+                             &ciphertext,
+                             &iup->plaintext,
+                             &bytes_written,
+                             status)) {
       return NULL;
    }
    return &iup->plaintext;

--- a/src/mc-fle2-insert-update-payload.c
+++ b/src/mc-fle2-insert-update-payload.c
@@ -281,7 +281,7 @@ mc_FLE2InsertUpdatePayload_decrypt (_mongocrypt_crypto_t *crypto,
                                     const _mongocrypt_buffer_t *user_key,
                                     mongocrypt_status_t *status)
 {
-   const _mongocrypt_value_encryption_algorithm_t *fle2alg =
+   const _mongocrypt_value_encryption_algorithm_t *fle2aead =
       _mcFLE2AEADAlgorithm ();
    BSON_ASSERT_PARAM (crypto);
    BSON_ASSERT_PARAM (iup);
@@ -301,16 +301,16 @@ mc_FLE2InsertUpdatePayload_decrypt (_mongocrypt_crypto_t *crypto,
    }
 
    _mongocrypt_buffer_resize (
-      &iup->plaintext, fle2alg->get_plaintext_len (ciphertext.len, status));
+      &iup->plaintext, fle2aead->get_plaintext_len (ciphertext.len, status));
    uint32_t bytes_written; /* ignored */
 
-   if (!fle2alg->do_decrypt (crypto,
-                             &iup->userKeyId,
-                             user_key,
-                             &ciphertext,
-                             &iup->plaintext,
-                             &bytes_written,
-                             status)) {
+   if (!fle2aead->do_decrypt (crypto,
+                              &iup->userKeyId,
+                              user_key,
+                              &ciphertext,
+                              &iup->plaintext,
+                              &bytes_written,
+                              status)) {
       return NULL;
    }
    return &iup->plaintext;

--- a/src/mc-fle2-insert-update-payload.c
+++ b/src/mc-fle2-insert-update-payload.c
@@ -281,6 +281,8 @@ mc_FLE2InsertUpdatePayload_decrypt (_mongocrypt_crypto_t *crypto,
                                     const _mongocrypt_buffer_t *user_key,
                                     mongocrypt_status_t *status)
 {
+   const _mongocrypt_value_encryption_algorithm_t *fle2alg =
+      _mcFLE2Algorithm ();
    BSON_ASSERT_PARAM (crypto);
    BSON_ASSERT_PARAM (iup);
    BSON_ASSERT_PARAM (user_key);
@@ -298,18 +300,17 @@ mc_FLE2InsertUpdatePayload_decrypt (_mongocrypt_crypto_t *crypto,
       return NULL;
    }
 
-   _mongocrypt_buffer_resize (
-      &iup->plaintext,
-      _mongocrypt_fle2aead_calculate_plaintext_len (ciphertext.len, status));
+   _mongocrypt_buffer_resize (&iup->plaintext,
+                              fle2alg->plaintext_len (ciphertext.len, status));
    uint32_t bytes_written; /* ignored */
 
-   if (!_mongocrypt_fle2aead_do_decryption (crypto,
-                                            &iup->userKeyId,
-                                            user_key,
-                                            &ciphertext,
-                                            &iup->plaintext,
-                                            &bytes_written,
-                                            status)) {
+   if (!fle2alg->decrypt (crypto,
+                          &iup->userKeyId,
+                          user_key,
+                          &ciphertext,
+                          &iup->plaintext,
+                          &bytes_written,
+                          status)) {
       return NULL;
    }
    return &iup->plaintext;

--- a/src/mc-fle2-insert-update-payload.c
+++ b/src/mc-fle2-insert-update-payload.c
@@ -282,7 +282,7 @@ mc_FLE2InsertUpdatePayload_decrypt (_mongocrypt_crypto_t *crypto,
                                     mongocrypt_status_t *status)
 {
    const _mongocrypt_value_encryption_algorithm_t *fle2alg =
-      _mcFLE2Algorithm ();
+      _mcFLE2AEADAlgorithm ();
    BSON_ASSERT_PARAM (crypto);
    BSON_ASSERT_PARAM (iup);
    BSON_ASSERT_PARAM (user_key);
@@ -300,17 +300,17 @@ mc_FLE2InsertUpdatePayload_decrypt (_mongocrypt_crypto_t *crypto,
       return NULL;
    }
 
-   _mongocrypt_buffer_resize (&iup->plaintext,
-                              fle2alg->plaintext_len (ciphertext.len, status));
+   _mongocrypt_buffer_resize (
+      &iup->plaintext, fle2alg->get_plaintext_len (ciphertext.len, status));
    uint32_t bytes_written; /* ignored */
 
-   if (!fle2alg->decrypt (crypto,
-                          &iup->userKeyId,
-                          user_key,
-                          &ciphertext,
-                          &iup->plaintext,
-                          &bytes_written,
-                          status)) {
+   if (!fle2alg->do_decrypt (crypto,
+                             &iup->userKeyId,
+                             user_key,
+                             &ciphertext,
+                             &iup->plaintext,
+                             &bytes_written,
+                             status)) {
       return NULL;
    }
    return &iup->plaintext;

--- a/src/mc-fle2-payload-iev.c
+++ b/src/mc-fle2-payload-iev.c
@@ -121,7 +121,7 @@ mc_FLE2IndexedEncryptedValue_write (
    }
 
    const _mongocrypt_value_encryption_algorithm_t *fle2iev =
-      _mcFLE2IEVAlgorithm ();
+      _mcFLE2Algorithm ();
    bool ok = false;
 
    BSON_ASSERT_PARAM (crypto);
@@ -161,7 +161,7 @@ mc_FLE2IndexedEncryptedValue_write (
       status));
 
    uint32_t expected_cipher_size =
-      fle2iev->ciphertext_len (expected_plaintext_size, status);
+      fle2iev->get_ciphertext_len (expected_plaintext_size, status);
 
    if (expected_cipher_size == 0) {
       CHECK_AND_GOTO (false);
@@ -224,7 +224,7 @@ mc_fle2IndexedEncryptedValue_encrypt (
    }
 
    const _mongocrypt_value_encryption_algorithm_t *fle2iev =
-      _mcFLE2IEVAlgorithm ();
+      _mcFLE2Algorithm ();
    bool ok = false;
    _mongocrypt_buffer_t in;
    _mongocrypt_buffer_t iv;
@@ -242,7 +242,7 @@ mc_fle2IndexedEncryptedValue_encrypt (
    _mongocrypt_buffer_resize (&in, expected_buf_size);
 
    uint32_t ciphertext_len =
-      fle2iev->ciphertext_len (expected_buf_size, status);
+      fle2iev->get_ciphertext_len (expected_buf_size, status);
 
    if (ciphertext_len == 0) {
       return false;
@@ -279,14 +279,14 @@ mc_fle2IndexedEncryptedValue_encrypt (
 
    CHECK_AND_GOTO (_mongocrypt_random (crypto, &iv, MONGOCRYPT_IV_LEN, status));
 
-   CHECK_AND_GOTO (fle2iev->encrypt (crypto,
-                                     &iv,
-                                     NULL /* aad */,
-                                     token_buf,
-                                     &in,
-                                     out,
-                                     &bytes_written,
-                                     status));
+   CHECK_AND_GOTO (fle2iev->do_encrypt (crypto,
+                                        &iv,
+                                        NULL /* aad */,
+                                        token_buf,
+                                        &in,
+                                        out,
+                                        &bytes_written,
+                                        status));
 
    ok = true;
 
@@ -422,7 +422,7 @@ mc_FLE2IndexedEncryptedValue_decrypt (
    mongocrypt_status_t *status)
 {
    const _mongocrypt_value_encryption_algorithm_t *fle2iev =
-      _mcFLE2IEVAlgorithm ();
+      _mcFLE2Algorithm ();
    BSON_ASSERT_PARAM (crypto);
    BSON_ASSERT_PARAM (iev);
    BSON_ASSERT_PARAM (token);
@@ -444,16 +444,17 @@ mc_FLE2IndexedEncryptedValue_decrypt (
    uint32_t bytes_written;
 
    _mongocrypt_buffer_resize (
-      &iev->Inner, fle2iev->plaintext_len (iev->InnerEncrypted.len, status));
+      &iev->Inner,
+      fle2iev->get_plaintext_len (iev->InnerEncrypted.len, status));
 
    /* Decrypt InnerEncrypted. */
-   if (!fle2iev->decrypt (crypto,
-                          NULL /* aad */,
-                          token_buf,
-                          &iev->InnerEncrypted,
-                          &iev->Inner,
-                          &bytes_written,
-                          status)) {
+   if (!fle2iev->do_decrypt (crypto,
+                             NULL /* aad */,
+                             token_buf,
+                             &iev->InnerEncrypted,
+                             &iev->Inner,
+                             &bytes_written,
+                             status)) {
       return false;
    }
 
@@ -541,7 +542,7 @@ mc_FLE2IndexedEqualityEncryptedValue_add_K_Key (
    mongocrypt_status_t *status)
 {
    const _mongocrypt_value_encryption_algorithm_t *fle2alg =
-      _mcFLE2Algorithm ();
+      _mcFLE2AEADAlgorithm ();
    BSON_ASSERT_PARAM (crypto);
    BSON_ASSERT_PARAM (iev);
    BSON_ASSERT_PARAM (K_Key);
@@ -560,15 +561,15 @@ mc_FLE2IndexedEqualityEncryptedValue_add_K_Key (
    /* Attempt to decrypt ClientEncryptedValue */
    _mongocrypt_buffer_resize (
       &iev->ClientValue,
-      fle2alg->plaintext_len (iev->ClientEncryptedValue.len, status));
+      fle2alg->get_plaintext_len (iev->ClientEncryptedValue.len, status));
    uint32_t bytes_written;
-   if (!fle2alg->decrypt (crypto,
-                          &iev->K_KeyId,
-                          K_Key,
-                          &iev->ClientEncryptedValue,
-                          &iev->ClientValue,
-                          &bytes_written,
-                          status)) {
+   if (!fle2alg->do_decrypt (crypto,
+                             &iev->K_KeyId,
+                             K_Key,
+                             &iev->ClientEncryptedValue,
+                             &iev->ClientValue,
+                             &bytes_written,
+                             status)) {
       return false;
    }
    iev->client_value_decrypted = true;

--- a/src/mc-fle2-payload-uev.c
+++ b/src/mc-fle2-payload-uev.c
@@ -143,6 +143,8 @@ mc_FLE2UnindexedEncryptedValue_decrypt (_mongocrypt_crypto_t *crypto,
                                         const _mongocrypt_buffer_t *key,
                                         mongocrypt_status_t *status)
 {
+   const _mongocrypt_value_encryption_algorithm_t *fle2alg =
+      _mcFLE2Algorithm ();
    BSON_ASSERT_PARAM (crypto);
    BSON_ASSERT_PARAM (uev);
    BSON_ASSERT_PARAM (key);
@@ -169,8 +171,8 @@ mc_FLE2UnindexedEncryptedValue_decrypt (_mongocrypt_crypto_t *crypto,
    AD.data[0] = MC_SUBTYPE_FLE2UnindexedEncryptedValue;
    memcpy (AD.data + 1, uev->key_uuid.data, uev->key_uuid.len);
    AD.data[1 + uev->key_uuid.len] = uev->original_bson_type;
-   const uint32_t plaintext_len = _mongocrypt_fle2aead_calculate_plaintext_len (
-      uev->ciphertext.len, status);
+   const uint32_t plaintext_len =
+      fle2alg->plaintext_len (uev->ciphertext.len, status);
    if (plaintext_len == 0) {
       return NULL;
    }
@@ -178,13 +180,13 @@ mc_FLE2UnindexedEncryptedValue_decrypt (_mongocrypt_crypto_t *crypto,
 
    uint32_t bytes_written;
 
-   if (!_mongocrypt_fle2aead_do_decryption (crypto,
-                                            &AD,
-                                            key,
-                                            &uev->ciphertext,
-                                            &uev->plaintext,
-                                            &bytes_written,
-                                            status)) {
+   if (!fle2alg->decrypt (crypto,
+                          &AD,
+                          key,
+                          &uev->ciphertext,
+                          &uev->plaintext,
+                          &bytes_written,
+                          status)) {
       _mongocrypt_buffer_cleanup (&AD);
       return NULL;
    }
@@ -202,6 +204,8 @@ mc_FLE2UnindexedEncryptedValue_encrypt (_mongocrypt_crypto_t *crypto,
                                         _mongocrypt_buffer_t *out,
                                         mongocrypt_status_t *status)
 {
+   const _mongocrypt_value_encryption_algorithm_t *fle2alg =
+      _mcFLE2Algorithm ();
    _mongocrypt_buffer_t iv = {0};
    _mongocrypt_buffer_t AD = {0};
    bool res = false;
@@ -236,13 +240,13 @@ mc_FLE2UnindexedEncryptedValue_encrypt (_mongocrypt_crypto_t *crypto,
    /* Encrypt. */
    {
       const uint32_t cipherlen =
-         _mongocrypt_fle2aead_calculate_ciphertext_len (plaintext->len, status);
+         fle2alg->ciphertext_len (plaintext->len, status);
       if (cipherlen == 0) {
          goto fail;
       }
       _mongocrypt_buffer_resize (out, cipherlen);
       uint32_t bytes_written; /* unused. */
-      if (!_mongocrypt_fle2aead_do_encryption (
+      if (!fle2alg->encrypt (
              crypto, &iv, &AD, key, plaintext, out, &bytes_written, status)) {
          goto fail;
       }

--- a/src/mc-fle2-payload-uev.c
+++ b/src/mc-fle2-payload-uev.c
@@ -144,7 +144,7 @@ mc_FLE2UnindexedEncryptedValue_decrypt (_mongocrypt_crypto_t *crypto,
                                         mongocrypt_status_t *status)
 {
    const _mongocrypt_value_encryption_algorithm_t *fle2alg =
-      _mcFLE2Algorithm ();
+      _mcFLE2AEADAlgorithm ();
    BSON_ASSERT_PARAM (crypto);
    BSON_ASSERT_PARAM (uev);
    BSON_ASSERT_PARAM (key);
@@ -172,7 +172,7 @@ mc_FLE2UnindexedEncryptedValue_decrypt (_mongocrypt_crypto_t *crypto,
    memcpy (AD.data + 1, uev->key_uuid.data, uev->key_uuid.len);
    AD.data[1 + uev->key_uuid.len] = uev->original_bson_type;
    const uint32_t plaintext_len =
-      fle2alg->plaintext_len (uev->ciphertext.len, status);
+      fle2alg->get_plaintext_len (uev->ciphertext.len, status);
    if (plaintext_len == 0) {
       return NULL;
    }
@@ -180,13 +180,13 @@ mc_FLE2UnindexedEncryptedValue_decrypt (_mongocrypt_crypto_t *crypto,
 
    uint32_t bytes_written;
 
-   if (!fle2alg->decrypt (crypto,
-                          &AD,
-                          key,
-                          &uev->ciphertext,
-                          &uev->plaintext,
-                          &bytes_written,
-                          status)) {
+   if (!fle2alg->do_decrypt (crypto,
+                             &AD,
+                             key,
+                             &uev->ciphertext,
+                             &uev->plaintext,
+                             &bytes_written,
+                             status)) {
       _mongocrypt_buffer_cleanup (&AD);
       return NULL;
    }
@@ -205,7 +205,7 @@ mc_FLE2UnindexedEncryptedValue_encrypt (_mongocrypt_crypto_t *crypto,
                                         mongocrypt_status_t *status)
 {
    const _mongocrypt_value_encryption_algorithm_t *fle2alg =
-      _mcFLE2Algorithm ();
+      _mcFLE2AEADAlgorithm ();
    _mongocrypt_buffer_t iv = {0};
    _mongocrypt_buffer_t AD = {0};
    bool res = false;
@@ -240,13 +240,13 @@ mc_FLE2UnindexedEncryptedValue_encrypt (_mongocrypt_crypto_t *crypto,
    /* Encrypt. */
    {
       const uint32_t cipherlen =
-         fle2alg->ciphertext_len (plaintext->len, status);
+         fle2alg->get_ciphertext_len (plaintext->len, status);
       if (cipherlen == 0) {
          goto fail;
       }
       _mongocrypt_buffer_resize (out, cipherlen);
       uint32_t bytes_written; /* unused. */
-      if (!fle2alg->encrypt (
+      if (!fle2alg->do_encrypt (
              crypto, &iv, &AD, key, plaintext, out, &bytes_written, status)) {
          goto fail;
       }

--- a/src/mongocrypt-crypto-private.h
+++ b/src/mongocrypt-crypto-private.h
@@ -78,10 +78,14 @@ typedef struct {
 } _mongocrypt_value_encryption_algorithm_t;
 
 // FLE1 algorithm: AES-256-CBC HMAC/SHA-512-256 (SHA-512 truncated to 256 bits)
+// Algorithm is documented in [FLE and
+// AEAD](https://docs.google.com/document/d/1D8xTXWo1B1dunO0bDZhPdolKTMbbD5fUIgsERubWRmY)
 const _mongocrypt_value_encryption_algorithm_t *
 _mcFLE1Algorithm ();
 
 // FLE2 general algorithm: AES-256-CTR HMAC/SHA-256
+// Algorithm is documented in [AEAD with
+// CTR](https://docs.google.com/document/d/1eCU7R8Kjr-mdyz6eKvhNIDVmhyYQcAaLtTfHeK7a_vE/).
 const _mongocrypt_value_encryption_algorithm_t *
 _mcFLE2AEADAlgorithm ();
 

--- a/src/mongocrypt-crypto-private.h
+++ b/src/mongocrypt-crypto-private.h
@@ -71,10 +71,10 @@ typedef bool (*_mongocrypt_do_decryption_fn) (
  * encrypting client data values.
  */
 typedef struct {
-   _mongocrypt_ciphertextlen_fn ciphertext_len;
-   _mongocrypt_plaintextlen_fn plaintext_len;
-   _mongocrypt_do_encryption_fn encrypt;
-   _mongocrypt_do_decryption_fn decrypt;
+   _mongocrypt_ciphertextlen_fn get_ciphertext_len;
+   _mongocrypt_plaintextlen_fn get_plaintext_len;
+   _mongocrypt_do_encryption_fn do_encrypt;
+   _mongocrypt_do_decryption_fn do_decrypt;
 } _mongocrypt_value_encryption_algorithm_t;
 
 // FLE1 algorithm: AES-256-CBC HMAC/SHA-512-256 (SHA-512 truncated to 256 bits)
@@ -83,11 +83,11 @@ _mcFLE1Algorithm ();
 
 // FLE2 general algorithm: AES-256-CTR HMAC/SHA-256
 const _mongocrypt_value_encryption_algorithm_t *
-_mcFLE2Algorithm ();
+_mcFLE2AEADAlgorithm ();
 
 // FLE2 used with FLE2IndexedEncryptedValue: AES-256-CTR no HMAC
 const _mongocrypt_value_encryption_algorithm_t *
-_mcFLE2IEVAlgorithm ();
+_mcFLE2Algorithm ();
 
 bool
 _mongocrypt_random (_mongocrypt_crypto_t *crypto,

--- a/src/mongocrypt-crypto-private.h
+++ b/src/mongocrypt-crypto-private.h
@@ -44,116 +44,50 @@ typedef struct {
    void *ctx;
 } _mongocrypt_crypto_t;
 
-uint32_t
-_mongocrypt_calculate_ciphertext_len (uint32_t plaintext_len,
-                                      mongocrypt_status_t *status);
+typedef uint32_t (*_mongocrypt_ciphertextlen_fn) (uint32_t plaintext_len,
+                                                  mongocrypt_status_t *status);
+typedef uint32_t (*_mongocrypt_plaintextlen_fn) (uint32_t plaintext_len,
+                                                 mongocrypt_status_t *status);
+typedef bool (*_mongocrypt_do_encryption_fn) (
+   _mongocrypt_crypto_t *crypto,
+   const _mongocrypt_buffer_t *iv,
+   const _mongocrypt_buffer_t *associated_data,
+   const _mongocrypt_buffer_t *key,
+   const _mongocrypt_buffer_t *plaintext,
+   _mongocrypt_buffer_t *ciphertext,
+   uint32_t *bytes_written,
+   mongocrypt_status_t *status) MONGOCRYPT_WARN_UNUSED_RESULT;
+typedef bool (*_mongocrypt_do_decryption_fn) (
+   _mongocrypt_crypto_t *crypto,
+   const _mongocrypt_buffer_t *associated_data,
+   const _mongocrypt_buffer_t *key,
+   const _mongocrypt_buffer_t *ciphertext,
+   _mongocrypt_buffer_t *plaintext,
+   uint32_t *bytes_written,
+   mongocrypt_status_t *status) MONGOCRYPT_WARN_UNUSED_RESULT;
 
-/* _mongocrypt_fle2aead_calculate_ciphertext_len returns the required length of
- * the ciphertext for _mongocrypt_fle2aead_do_encryption. */
-uint32_t
-_mongocrypt_fle2aead_calculate_ciphertext_len (uint32_t plaintext_len,
-                                               mongocrypt_status_t *status);
-
-/* _mongocrypt_fle2_calculate_ciphertext_len returns the required length of
- * the ciphertext for _mongocrypt_fle2_do_encryption. */
-uint32_t
-_mongocrypt_fle2_calculate_ciphertext_len (uint32_t plaintext_len,
-                                           mongocrypt_status_t *status);
-
-uint32_t
-_mongocrypt_calculate_plaintext_len (uint32_t ciphertext_len,
-                                     mongocrypt_status_t *status);
-
-/* _mongocrypt_fle2aead_calculate_plaintext_len returns the required length of
- * the plaintext for _mongocrypt_fle2aead_do_decryption. */
-uint32_t
-_mongocrypt_fle2aead_calculate_plaintext_len (uint32_t ciphertext_len,
-                                              mongocrypt_status_t *status);
-
-/* _mongocrypt_fle2_calculate_plaintext_len returns the required length of
- * the plaintext for _mongocrypt_fle2_do_decryption. */
-uint32_t
-_mongocrypt_fle2_calculate_plaintext_len (uint32_t ciphertext_len,
-                                          mongocrypt_status_t *status);
-
-bool
-_mongocrypt_do_encryption (_mongocrypt_crypto_t *crypto,
-                           const _mongocrypt_buffer_t *iv,
-                           const _mongocrypt_buffer_t *associated_data,
-                           const _mongocrypt_buffer_t *key,
-                           const _mongocrypt_buffer_t *plaintext,
-                           _mongocrypt_buffer_t *ciphertext,
-                           uint32_t *bytes_written,
-                           mongocrypt_status_t *status)
-   MONGOCRYPT_WARN_UNUSED_RESULT;
-
-bool
-_mongocrypt_do_decryption (_mongocrypt_crypto_t *crypto,
-                           const _mongocrypt_buffer_t *associated_data,
-                           const _mongocrypt_buffer_t *key,
-                           const _mongocrypt_buffer_t *ciphertext,
-                           _mongocrypt_buffer_t *plaintext,
-                           uint32_t *bytes_written,
-                           mongocrypt_status_t *status)
-   MONGOCRYPT_WARN_UNUSED_RESULT;
-
-/* _mongocrypt_fle2aead_do_encryption does AEAD encryption.
- * It follows the construction described in the [AEAD with
- * CTR](https://docs.google.com/document/d/1eCU7R8Kjr-mdyz6eKvhNIDVmhyYQcAaLtTfHeK7a_vE/)
- *
- * Note: The 96 byte key is split differently for FLE 2.
- * - FLE 1 uses first 32 bytes as the mac key, and the second 32 bytes as the
- *   encryption key.
- * - FLE 2 uses first 32 bytes as encryption key, and the
- *   second 32 bytes as the mac key.
- * Note: Attempting to encrypt a 0 length plaintext is an error.
+/**
+ * Defines the application layer protocol to use when
+ * encrypting client data values.
  */
-bool
-_mongocrypt_fle2aead_do_encryption (_mongocrypt_crypto_t *crypto,
-                                    const _mongocrypt_buffer_t *iv,
-                                    const _mongocrypt_buffer_t *associated_data,
-                                    const _mongocrypt_buffer_t *key,
-                                    const _mongocrypt_buffer_t *plaintext,
-                                    _mongocrypt_buffer_t *ciphertext,
-                                    uint32_t *bytes_written,
-                                    mongocrypt_status_t *status)
-   MONGOCRYPT_WARN_UNUSED_RESULT;
+typedef struct {
+   _mongocrypt_ciphertextlen_fn ciphertext_len;
+   _mongocrypt_plaintextlen_fn plaintext_len;
+   _mongocrypt_do_encryption_fn encrypt;
+   _mongocrypt_do_decryption_fn decrypt;
+} _mongocrypt_value_encryption_algorithm_t;
 
-bool
-_mongocrypt_fle2aead_do_decryption (_mongocrypt_crypto_t *crypto,
-                                    const _mongocrypt_buffer_t *associated_data,
-                                    const _mongocrypt_buffer_t *key,
-                                    const _mongocrypt_buffer_t *ciphertext,
-                                    _mongocrypt_buffer_t *plaintext,
-                                    uint32_t *bytes_written,
-                                    mongocrypt_status_t *status)
-   MONGOCRYPT_WARN_UNUSED_RESULT;
+// FLE1 algorithm: AES-256-CBC HMAC/SHA-512-256 (SHA-512 truncated to 256 bits)
+const _mongocrypt_value_encryption_algorithm_t *
+_mcFLE1Algorithm ();
 
-/* _mongocrypt_fle2_do_encryption does non-AEAD encryption.
- * @key is expected to be only an encryption key of size MONGOCRYPT_ENC_KEY_LEN.
- * Note: Attempting to encrypt a 0 length plaintext is an error.
- */
-bool
-_mongocrypt_fle2_do_encryption (_mongocrypt_crypto_t *crypto,
-                                const _mongocrypt_buffer_t *iv,
-                                const _mongocrypt_buffer_t *key,
-                                const _mongocrypt_buffer_t *plaintext,
-                                _mongocrypt_buffer_t *ciphertext,
-                                uint32_t *bytes_written,
-                                mongocrypt_status_t *status)
-   MONGOCRYPT_WARN_UNUSED_RESULT;
+// FLE2 general algorithm: AES-256-CTR HMAC/SHA-256
+const _mongocrypt_value_encryption_algorithm_t *
+_mcFLE2Algorithm ();
 
-/* _mongocrypt_fle2_do_decryption does non-AEAD decryption.
- * @key is expected to be only an encryption key of size MONGOCRYPT_ENC_KEY_LEN.
- */
-bool
-_mongocrypt_fle2_do_decryption (_mongocrypt_crypto_t *crypto,
-                                const _mongocrypt_buffer_t *key,
-                                const _mongocrypt_buffer_t *ciphertext,
-                                _mongocrypt_buffer_t *plaintext,
-                                uint32_t *bytes_written,
-                                mongocrypt_status_t *status)
-   MONGOCRYPT_WARN_UNUSED_RESULT;
+// FLE2 used with FLE2IndexedEncryptedValue: AES-256-CTR no HMAC
+const _mongocrypt_value_encryption_algorithm_t *
+_mcFLE2IEVAlgorithm ();
 
 bool
 _mongocrypt_random (_mongocrypt_crypto_t *crypto,

--- a/src/mongocrypt-crypto-private.h
+++ b/src/mongocrypt-crypto-private.h
@@ -46,7 +46,7 @@ typedef struct {
 
 typedef uint32_t (*_mongocrypt_ciphertextlen_fn) (uint32_t plaintext_len,
                                                   mongocrypt_status_t *status);
-typedef uint32_t (*_mongocrypt_plaintextlen_fn) (uint32_t plaintext_len,
+typedef uint32_t (*_mongocrypt_plaintextlen_fn) (uint32_t ciphertext_len,
                                                  mongocrypt_status_t *status);
 typedef bool (*_mongocrypt_do_encryption_fn) (
    _mongocrypt_crypto_t *crypto,

--- a/src/mongocrypt-crypto.c
+++ b/src/mongocrypt-crypto.c
@@ -847,7 +847,7 @@ _mongocrypt_do_encryption (_mongocrypt_crypto_t *crypto,
       CLIENT_ERR ("unable to create S view from C");
       return false;
    }
-   if (hmac == HMAC_NONE) {
+   if (hmac != HMAC_NONE) {
       S.len -= MONGOCRYPT_HMAC_LEN;
    }
 

--- a/src/mongocrypt-crypto.c
+++ b/src/mongocrypt-crypto.c
@@ -631,10 +631,10 @@ _encrypt_step (_mongocrypt_crypto_t *crypto,
  *    Compute the selected HMAC with a secret key.
  *
  * Parameters:
- *    @mac_key a 32 byte key.
- *    @associated_data associated data to add into the HMAC. This may be
+ *    @Km a 32 byte key.
+ *    @AAD associated data to add into the HMAC. This may be
  *    an empty buffer.
- *    @ciphertext the ciphertext to add into the HMAC.
+ *    @iv_and_ciphertext the IV and S components to add into the HMAC.
  *    @out a location for the resulting HMAC tag.
  *    @status set on error.
  *

--- a/src/mongocrypt-crypto.c
+++ b/src/mongocrypt-crypto.c
@@ -441,9 +441,6 @@ _mongocrypt_calculate_ciphertext_len (uint32_t inlen,
 
    if (mode == MODE_CBC) {
       fill = MONGOCRYPT_BLOCK_SIZE - (inlen % MONGOCRYPT_BLOCK_SIZE);
-      if (fill == 0) {
-         fill += MONGOCRYPT_BLOCK_SIZE;
-      }
    } else {
       BSON_ASSERT (mode == MODE_CTR);
       fill = 0;

--- a/src/mongocrypt-crypto.c
+++ b/src/mongocrypt-crypto.c
@@ -402,7 +402,7 @@ typedef enum {
 } _mongocrypt_key_format_t;
 
 typedef enum {
-   MAC_FORMAT_FLE1,    // HMAC(AAD || S || LEN(AAD) as uint64be)
+   MAC_FORMAT_FLE1,    // HMAC(AAD || IV || S || LEN(AAD) as uint64be)
    MAC_FORMAT_FLE2IEV, // NONE
    MAC_FORMAT_FLE2,    // HMAC(AAD || IV || S)
 } _mongocrypt_mac_format_t;

--- a/src/mongocrypt-crypto.c
+++ b/src/mongocrypt-crypto.c
@@ -308,6 +308,38 @@ _crypto_hmac_sha_512 (_mongocrypt_crypto_t *crypto,
    return _native_crypto_hmac_sha_512 (hmac_key, in, out, status);
 }
 
+bool
+_mongocrypt_hmac_sha_256 (_mongocrypt_crypto_t *crypto,
+                          const _mongocrypt_buffer_t *key,
+                          const _mongocrypt_buffer_t *in,
+                          _mongocrypt_buffer_t *out,
+                          mongocrypt_status_t *status)
+{
+   BSON_ASSERT_PARAM (crypto);
+   BSON_ASSERT_PARAM (key);
+   BSON_ASSERT_PARAM (in);
+   BSON_ASSERT_PARAM (out);
+
+   if (key->len != MONGOCRYPT_MAC_KEY_LEN) {
+      CLIENT_ERR ("invalid hmac_sha_256 key length. Got %" PRIu32
+                  ", expected: %" PRIu32,
+                  key->len,
+                  MONGOCRYPT_MAC_KEY_LEN);
+      return false;
+   }
+
+   if (crypto->hooks_enabled) {
+      mongocrypt_binary_t key_bin, out_bin, in_bin;
+      _mongocrypt_buffer_to_binary (key, &key_bin);
+      _mongocrypt_buffer_to_binary (out, &out_bin);
+      _mongocrypt_buffer_to_binary (in, &in_bin);
+
+      return crypto->hmac_sha_256 (
+         crypto->ctx, &key_bin, &in_bin, &out_bin, status);
+   }
+   return _native_crypto_hmac_sha_256 (key, in, out, status);
+}
+
 
 static bool
 _crypto_random (_mongocrypt_crypto_t *crypto,
@@ -352,114 +384,107 @@ _mongocrypt_memequal (const void *const b1, const void *const b2, size_t len)
    return ret;
 }
 
+typedef enum {
+   MODE_CBC,
+   MODE_CTR,
+} _mongocrypt_encryption_mode_t;
+
+typedef enum {
+   HMAC_NONE,
+   HMAC_SHA_512_256, // sha512 truncated to 256 bits
+   HMAC_SHA_256,
+} _mongocrypt_hmac_type_t;
+
+typedef enum {
+   KEY_FORMAT_FLE1, // 32 octets MAC key, 32 octets DATA key, 32 octets ignored
+   KEY_FORMAT_FLE2IEV, // 32 octets DATA key
+   KEY_FORMAT_FLE2, // 32 octets DATA key, 32 octets MAC key, 32 octets ignored
+} _mongocrypt_key_format_t;
+
+typedef enum {
+   MAC_FORMAT_FLE1,    // HMAC(AAD || S || LEN(AAD) as uint64be)
+   MAC_FORMAT_FLE2IEV, // NONE
+   MAC_FORMAT_FLE2,    // HMAC(AAD || IV || S)
+} _mongocrypt_mac_format_t;
+
 /* ----------------------------------------------------------------------------
  *
- * _mongocrypt_calculate_ciphertext_len --
+ * _mongocrypt_calculate_ciphertext_len
  *
- *    For a given plaintext length, return the length of the ciphertext.
- *    This includes IV and HMAC.
+ * Calculate the space needed for a ciphertext payload of a given size
+ * and using fixed iv/hmac lengths.
  *
- *    To compute that I'm following section 2.3 in [MCGREW]:
- *    L = 16 * ( floor(M / 16) + 2)
- *    This formula includes space for the IV, but not the sha512 HMAC.
- *    Add 32 for the sha512 HMAC.
+ * MODE_CBC: Assumes the ciphertext will be padded according to PKCS#7
+ * wich rounds up to the next block size, adding up to a complete block
+ * for block aligned input payloads.
  *
- * Parameters:
- *    @plaintext_len then length of the plaintext.
- *    @status set on error.
+ * MODE_CTR: Assumes no additional padding since CTR is a streaming cipher.
  *
- * Returns:
- *    The calculated length of the ciphertext.
+ * Assumes all algorithms use identical IV length and blocksizes.
  *
  * ----------------------------------------------------------------------------
  */
-uint32_t
-_mongocrypt_calculate_ciphertext_len (uint32_t plaintext_len,
+static uint32_t
+_mongocrypt_calculate_ciphertext_len (uint32_t inlen,
+                                      _mongocrypt_encryption_mode_t mode,
+                                      _mongocrypt_hmac_type_t hmac,
                                       mongocrypt_status_t *status)
 {
-   if ((plaintext_len / 16u) >
-       ((UINT32_MAX - (uint32_t) MONGOCRYPT_HMAC_LEN) / 16u) - 2u) {
+   const uint32_t hmaclen = (hmac == HMAC_NONE) ? 0 : MONGOCRYPT_HMAC_LEN;
+   const uint32_t maxinlen =
+      UINT32_MAX - (MONGOCRYPT_IV_LEN + MONGOCRYPT_BLOCK_SIZE + hmaclen);
+   uint32_t fill;
+   if (inlen > maxinlen) {
       CLIENT_ERR ("plaintext too long");
       return 0;
    }
-   return 16 * ((plaintext_len / 16) + 2) + MONGOCRYPT_HMAC_LEN;
-}
 
-uint32_t
-_mongocrypt_fle2aead_calculate_ciphertext_len (uint32_t plaintext_len,
-                                               mongocrypt_status_t *status)
-{
-   if (plaintext_len > UINT32_MAX - MONGOCRYPT_IV_LEN - MONGOCRYPT_HMAC_LEN) {
-      CLIENT_ERR ("plaintext too long");
-      return 0;
+   if (mode == MODE_CBC) {
+      fill = MONGOCRYPT_BLOCK_SIZE - (inlen % MONGOCRYPT_BLOCK_SIZE);
+      if (fill == 0) {
+         fill += MONGOCRYPT_BLOCK_SIZE;
+      }
+   } else {
+      BSON_ASSERT (mode == MODE_CTR);
+      fill = 0;
    }
-   /* FLE2 AEAD uses CTR mode. CTR mode does not pad. */
-   return MONGOCRYPT_IV_LEN + plaintext_len + MONGOCRYPT_HMAC_LEN;
-}
 
-uint32_t
-_mongocrypt_fle2_calculate_ciphertext_len (uint32_t plaintext_len,
-                                           mongocrypt_status_t *status)
-{
-   if (plaintext_len > UINT32_MAX - MONGOCRYPT_IV_LEN) {
-      CLIENT_ERR ("plaintext too long");
-      return 0;
-   }
-   /* FLE2 AEAD uses CTR mode. CTR mode does not pad. */
-   return MONGOCRYPT_IV_LEN + plaintext_len;
+   return MONGOCRYPT_IV_LEN + inlen + fill + hmaclen;
 }
-
 
 /* ----------------------------------------------------------------------------
  *
- * _mongocrypt_calculate_plaintext_len --
+ * _mongocrypt_calculate_plaintext_len
  *
- *    For a given ciphertext length, return the length of the plaintext.
- *    This excludes the IV and HMAC, but includes the padding.
+ * Calculate the space needed for a plaintext payload of a given size
+ * and using fixed iv/hmac lengths.
  *
- * Parameters:
- *    @ciphertext_len then length of the ciphertext.
- *    @status set on error.
+ * MODE_CBC: In practice, plaintext will be between 1 and {blocksize} bytes
+ * shorter
+ * than the input ciphertext, but it's easier and safer to assume the
+ * full ciphertext length and waste a few bytes.
  *
- * Returns:
- *    The calculated length of the plaintext.
+ * MODE_CTR: Assumes no additional padding since CTR is a streaming cipher.
+ *
+ * Assumes all algorithms use identical IV length and blocksizes.
  *
  * ----------------------------------------------------------------------------
  */
-uint32_t
-_mongocrypt_calculate_plaintext_len (uint32_t ciphertext_len,
+static uint32_t
+_mongocrypt_calculate_plaintext_len (uint32_t inlen,
+                                     _mongocrypt_encryption_mode_t mode,
+                                     _mongocrypt_hmac_type_t hmac,
                                      mongocrypt_status_t *status)
 {
-   if (ciphertext_len <
-       MONGOCRYPT_HMAC_LEN + MONGOCRYPT_IV_LEN + MONGOCRYPT_BLOCK_SIZE) {
-      CLIENT_ERR ("ciphertext too short");
+   const uint32_t hmaclen = (hmac == HMAC_NONE) ? 0 : MONGOCRYPT_HMAC_LEN;
+   const uint32_t mincipher = (mode == MODE_CTR) ? 0 : MONGOCRYPT_BLOCK_SIZE;
+   if (inlen < (MONGOCRYPT_IV_LEN + mincipher + hmaclen)) {
+      CLIENT_ERR ("input ciphertext too small. Must be more than %" PRIu32
+                  " bytes",
+                  MONGOCRYPT_IV_LEN + mincipher + hmaclen);
       return 0;
    }
-   return ciphertext_len - (MONGOCRYPT_IV_LEN + MONGOCRYPT_HMAC_LEN);
-}
-
-uint32_t
-_mongocrypt_fle2aead_calculate_plaintext_len (uint32_t ciphertext_len,
-                                              mongocrypt_status_t *status)
-{
-   /* FLE2 AEAD uses CTR mode. CTR mode does not pad. */
-   if (ciphertext_len < MONGOCRYPT_IV_LEN + MONGOCRYPT_HMAC_LEN) {
-      CLIENT_ERR ("ciphertext too short");
-      return 0;
-   }
-   return ciphertext_len - MONGOCRYPT_IV_LEN - MONGOCRYPT_HMAC_LEN;
-}
-
-uint32_t
-_mongocrypt_fle2_calculate_plaintext_len (uint32_t ciphertext_len,
-                                          mongocrypt_status_t *status)
-{
-   /* FLE2 AEAD uses CTR mode. CTR mode does not pad. */
-   if (ciphertext_len < MONGOCRYPT_IV_LEN) {
-      CLIENT_ERR ("ciphertext too short");
-      return 0;
-   }
-   return ciphertext_len - MONGOCRYPT_IV_LEN;
+   return inlen - (MONGOCRYPT_IV_LEN + hmaclen);
 }
 
 /* ----------------------------------------------------------------------------
@@ -487,12 +512,13 @@ _mongocrypt_fle2_calculate_plaintext_len (uint32_t ciphertext_len,
  * Postconditions:
  *    1. bytes_written is set to the length of the written ciphertext. This
  *    is the same as
- *    _mongocrypt_calculate_ciphertext_len (plaintext->len, status).
+ *    _mongocrypt_calculate_ciphertext_len (plaintext->len, mode, hmac, status).
  *
  * ----------------------------------------------------------------------------
  */
 static bool
 _encrypt_step (_mongocrypt_crypto_t *crypto,
+               _mongocrypt_encryption_mode_t mode,
                const _mongocrypt_buffer_t *iv,
                const _mongocrypt_buffer_t *enc_key,
                const _mongocrypt_buffer_t *plaintext,
@@ -500,20 +526,11 @@ _encrypt_step (_mongocrypt_crypto_t *crypto,
                uint32_t *bytes_written,
                mongocrypt_status_t *status)
 {
-   uint32_t unaligned;
-   uint32_t padding_byte;
-   _mongocrypt_buffer_t intermediates[2];
-   _mongocrypt_buffer_t to_encrypt;
-   uint8_t final_block_storage[MONGOCRYPT_BLOCK_SIZE];
-   bool ret = false;
-
    BSON_ASSERT_PARAM (crypto);
    BSON_ASSERT_PARAM (iv);
    BSON_ASSERT_PARAM (enc_key);
    BSON_ASSERT_PARAM (plaintext);
    BSON_ASSERT_PARAM (ciphertext);
-
-   _mongocrypt_buffer_init (&to_encrypt);
 
    BSON_ASSERT_PARAM (bytes_written);
    *bytes_written = 0;
@@ -522,18 +539,38 @@ _encrypt_step (_mongocrypt_crypto_t *crypto,
       CLIENT_ERR ("IV should have length %d, but has length %d",
                   MONGOCRYPT_IV_LEN,
                   iv->len);
-      goto done;
+      return false;
    }
 
    if (MONGOCRYPT_ENC_KEY_LEN != enc_key->len) {
       CLIENT_ERR ("Encryption key should have length %d, but has length %d",
                   MONGOCRYPT_ENC_KEY_LEN,
                   enc_key->len);
-      goto done;
+      return false;
    }
 
+   if (mode == MODE_CTR) {
+      // Streaming cipher, no padding required.
+      return _crypto_aes_256_ctr_encrypt (
+         crypto,
+         (aes_256_args_t){.key = enc_key,
+                          .iv = iv,
+                          .in = plaintext,
+                          .out = ciphertext,
+                          .bytes_written = bytes_written,
+                          .status = status});
+   }
+
+   BSON_ASSERT (mode == MODE_CBC);
+
    /* calculate how many extra bytes there are after a block boundary */
-   unaligned = plaintext->len % MONGOCRYPT_BLOCK_SIZE;
+   const uint32_t unaligned = plaintext->len % MONGOCRYPT_BLOCK_SIZE;
+   uint32_t padding_byte = MONGOCRYPT_BLOCK_SIZE - unaligned;
+   _mongocrypt_buffer_t intermediates[2], to_encrypt;
+   uint8_t final_block_storage[MONGOCRYPT_BLOCK_SIZE];
+   bool ret;
+
+   BSON_ASSERT (MONGOCRYPT_BLOCK_SIZE >= unaligned);
 
    /* Some crypto providers disallow variable length inputs, and require
     * the input to be a multiple of the block size. So add everything up
@@ -556,54 +593,45 @@ _encrypt_step (_mongocrypt_crypto_t *crypto,
       memcpy (intermediates[1].data,
               plaintext->data + (plaintext->len - unaligned),
               unaligned);
-      /* Fill the rest with the padding byte. */
-      BSON_ASSERT (MONGOCRYPT_BLOCK_SIZE >= unaligned);
-      padding_byte = MONGOCRYPT_BLOCK_SIZE - unaligned;
-      /* it is certain that padding_byte is in range for a cast to int */
-      memset (
-         intermediates[1].data + unaligned, (int) padding_byte, padding_byte);
-   } else {
-      /* Fill the rest with the padding byte. */
-      padding_byte = MONGOCRYPT_BLOCK_SIZE;
-      memset (intermediates[1].data, (int) padding_byte, padding_byte);
    }
+   /* Fill out block remained or whole block with padding_byte */
+   memset (intermediates[1].data + unaligned, (int) padding_byte, padding_byte);
 
+   _mongocrypt_buffer_init (&to_encrypt);
    if (!_mongocrypt_buffer_concat (&to_encrypt, intermediates, 2)) {
       CLIENT_ERR ("failed to allocate buffer");
-      goto done;
+      _mongocrypt_buffer_cleanup (&to_encrypt);
+      return false;
    }
 
-   if (!_crypto_aes_256_cbc_encrypt (
-          crypto,
-          (aes_256_args_t){.key = enc_key,
-                           .iv = iv,
-                           .in = &to_encrypt,
-                           .out = ciphertext,
-                           .bytes_written = bytes_written,
-                           .status = status})) {
-      goto done;
+   ret = _crypto_aes_256_cbc_encrypt (
+      crypto,
+      (aes_256_args_t){.key = enc_key,
+                       .iv = iv,
+                       .in = &to_encrypt,
+                       .out = ciphertext,
+                       .bytes_written = bytes_written,
+                       .status = status});
+   _mongocrypt_buffer_cleanup (&to_encrypt);
+   if (!ret) {
+      return false;
    }
-
 
    if (*bytes_written % MONGOCRYPT_BLOCK_SIZE != 0) {
       CLIENT_ERR ("encryption failure, wrote %d bytes, not a multiple of %d",
                   *bytes_written,
                   MONGOCRYPT_BLOCK_SIZE);
-      goto done;
+      return false;
    }
 
-   ret = true;
-done:
-   _mongocrypt_buffer_cleanup (&to_encrypt);
-   return ret;
+   return true;
 }
-
 
 /* ----------------------------------------------------------------------------
  *
- * _hmac_sha512 --
+ * _hmac_step --
  *
- *    Compute the SHA512 HMAC with a secret key.
+ *    Compute the selected HMAC with a secret key.
  *
  * Parameters:
  *    @mac_key a 32 byte key.
@@ -626,29 +654,28 @@ done:
  */
 static bool
 _hmac_step (_mongocrypt_crypto_t *crypto,
-            const _mongocrypt_buffer_t *mac_key,
-            const _mongocrypt_buffer_t *associated_data,
-            const _mongocrypt_buffer_t *ciphertext,
+            _mongocrypt_mac_format_t mac_format,
+            _mongocrypt_hmac_type_t hmac,
+            const _mongocrypt_buffer_t *Km,
+            const _mongocrypt_buffer_t *AAD,
+            const _mongocrypt_buffer_t *iv_and_ciphertext,
             _mongocrypt_buffer_t *out,
             mongocrypt_status_t *status)
 {
-   _mongocrypt_buffer_t intermediates[3];
-   _mongocrypt_buffer_t to_hmac;
-   uint64_t associated_data_len_be;
-   uint8_t tag_storage[64];
-   _mongocrypt_buffer_t tag;
+   _mongocrypt_buffer_t to_hmac = {0};
    bool ret = false;
 
+   BSON_ASSERT (hmac != HMAC_NONE);
    BSON_ASSERT_PARAM (crypto);
-   BSON_ASSERT_PARAM (mac_key);
-   BSON_ASSERT_PARAM (associated_data);
-   BSON_ASSERT_PARAM (ciphertext);
+   BSON_ASSERT_PARAM (Km);
+   // AAD may be NULL
+   BSON_ASSERT_PARAM (iv_and_ciphertext);
    BSON_ASSERT_PARAM (out);
 
    _mongocrypt_buffer_init (&to_hmac);
 
-   if (MONGOCRYPT_MAC_KEY_LEN != mac_key->len) {
-      CLIENT_ERR ("HMAC key wrong length: %d", mac_key->len);
+   if (MONGOCRYPT_MAC_KEY_LEN != Km->len) {
+      CLIENT_ERR ("HMAC key wrong length: %d", Km->len);
       goto done;
    }
 
@@ -657,47 +684,56 @@ _hmac_step (_mongocrypt_crypto_t *crypto,
       goto done;
    }
 
-   /* [MCGREW]:
-    * """
-    * 4.  The octet string AL is equal to the number of bits in A expressed as a
-    * 64-bit unsigned integer in network byte order.
-    * 5.  A message authentication tag T is computed by applying HMAC [RFC2104]
-    * to the following data, in order:
-    *      the associated data A,
-    *      the ciphertext S computed in the previous step, and
-    *      the octet string AL defined above.
-    * """
-    */
+   /* Construct the input to the HMAC */
+   uint32_t num_intermediates = 0;
+   _mongocrypt_buffer_t intermediates[3];
+   if (AAD) {
+      intermediates[num_intermediates++] = *AAD;
+   }
+   intermediates[num_intermediates++] = *iv_and_ciphertext;
 
-   /* Add associated data. */
-   _mongocrypt_buffer_init (&intermediates[0]);
-   _mongocrypt_buffer_init (&intermediates[1]);
-   _mongocrypt_buffer_init (&intermediates[2]);
-   intermediates[0].data = associated_data->data;
-   intermediates[0].len = associated_data->len;
-   /* Add ciphertext. */
-   intermediates[1].data = ciphertext->data;
-   intermediates[1].len = ciphertext->len;
-   /* Add associated data length in bits. */
-   /* multiplying a uint32_t by 8 won't bring it anywhere close to UINT64_MAX */
-   associated_data_len_be = 8 * (uint64_t) associated_data->len;
-   associated_data_len_be = BSON_UINT64_TO_BE (associated_data_len_be);
-   intermediates[2].data = (uint8_t *) &associated_data_len_be;
-   intermediates[2].len = sizeof (uint64_t);
-   tag.data = tag_storage;
-   tag.len = sizeof (tag_storage);
+   // Up in this lexical scope because it needs to live until buffer_concat.
+   uint64_t AL;
+   if (mac_format == MAC_FORMAT_FLE1) {
+      /* T := HMAC(AAD || IV || S || AL)
+       * AL is equal to the number of bits in AAD expressed
+       * as a 64bit unsigned big-endian integer.
+       * Multiplying a uint32_t by 8 won't bring it anywhere close to
+       * UINT64_MAX.
+       */
+      AL = AAD ? BSON_UINT64_TO_BE (8 * (uint64_t) AAD->len) : 0;
+      intermediates[num_intermediates].data = (uint8_t *) &AL;
+      intermediates[num_intermediates++].len = sizeof (uint64_t);
 
+   } else {
+      /* T := HMAC(AAD || IV || S) */
+      BSON_ASSERT (mac_format == MAC_FORMAT_FLE2);
+   }
 
-   if (!_mongocrypt_buffer_concat (&to_hmac, intermediates, 3)) {
+   if (!_mongocrypt_buffer_concat (
+          &to_hmac, intermediates, num_intermediates)) {
       CLIENT_ERR ("failed to allocate buffer");
       goto done;
    }
-   if (!_crypto_hmac_sha_512 (crypto, mac_key, &to_hmac, &tag, status)) {
-      goto done;
+
+   if (hmac == HMAC_SHA_512_256) {
+      uint8_t storage[64];
+      _mongocrypt_buffer_t tag = {.data = storage, .len = sizeof (storage)};
+
+      if (!_crypto_hmac_sha_512 (crypto, Km, &to_hmac, &tag, status)) {
+         goto done;
+      }
+
+      // Truncate sha512 to first 256 bits.
+      memcpy (out->data, tag.data, MONGOCRYPT_HMAC_LEN);
+
+   } else {
+      BSON_ASSERT (hmac == HMAC_SHA_256);
+      if (!_mongocrypt_hmac_sha_256 (crypto, Km, &to_hmac, out, status)) {
+         goto done;
+      }
    }
 
-   /* [MCGREW 2.7] "The HMAC-SHA-512 value is truncated to T_LEN=32 octets" */
-   memcpy (out->data, tag.data, MONGOCRYPT_HMAC_LEN);
    ret = true;
 done:
    _mongocrypt_buffer_cleanup (&to_hmac);
@@ -729,12 +765,16 @@ done:
  * Postconditions:
  *    1. bytes_written is set to the length of the written ciphertext. This
  *    is the same as
- *    _mongocrypt_calculate_ciphertext_len (plaintext->len, status).
+ *    _mongocrypt_calculate_ciphertext_len (plaintext->len, mode, hmac, status).
  *
  * ----------------------------------------------------------------------------
  */
-bool
+static bool
 _mongocrypt_do_encryption (_mongocrypt_crypto_t *crypto,
+                           _mongocrypt_key_format_t key_format,
+                           _mongocrypt_mac_format_t mac_format,
+                           _mongocrypt_encryption_mode_t mode,
+                           _mongocrypt_hmac_type_t hmac,
                            const _mongocrypt_buffer_t *iv,
                            const _mongocrypt_buffer_t *associated_data,
                            const _mongocrypt_buffer_t *key,
@@ -743,10 +783,7 @@ _mongocrypt_do_encryption (_mongocrypt_crypto_t *crypto,
                            uint32_t *bytes_written,
                            mongocrypt_status_t *status)
 {
-   _mongocrypt_buffer_t mac_key = {0}, enc_key = {0}, intermediate = {0},
-                        intermediate_hmac = {0}, empty_buffer = {0};
-   uint32_t intermediate_bytes_written = 0;
-
+   _mongocrypt_buffer_t Ke = {0}; // Ke == Key for Encryption
    BSON_ASSERT_PARAM (crypto);
    BSON_ASSERT_PARAM (iv);
    /* associated_data is checked at the point it is used, so it can be NULL */
@@ -754,18 +791,21 @@ _mongocrypt_do_encryption (_mongocrypt_crypto_t *crypto,
    BSON_ASSERT_PARAM (plaintext);
    BSON_ASSERT_PARAM (ciphertext);
 
-   memset (ciphertext->data, 0, ciphertext->len);
-
-   if (ciphertext->len !=
-       _mongocrypt_calculate_ciphertext_len (plaintext->len, status)) {
-      CLIENT_ERR (
-         "output ciphertext should have been allocated with %d bytes",
-         _mongocrypt_calculate_ciphertext_len (plaintext->len, status));
+   if (plaintext->len <= 0) {
+      CLIENT_ERR ("input plaintext too small. Must be more than zero bytes.");
       return false;
    }
 
-   BSON_ASSERT_PARAM (bytes_written);
-   *bytes_written = 0;
+   const uint32_t expect_ciphertext_len =
+      _mongocrypt_calculate_ciphertext_len (plaintext->len, mode, hmac, status);
+   if (mongocrypt_status_type (status) != MONGOCRYPT_STATUS_OK) {
+      return false;
+   }
+   if (expect_ciphertext_len != ciphertext->len) {
+      CLIENT_ERR ("output ciphertext should have been allocated with %d bytes",
+                  expect_ciphertext_len);
+      return false;
+   }
 
    if (MONGOCRYPT_IV_LEN != iv->len) {
       CLIENT_ERR ("IV should have length %d, but has length %d",
@@ -773,73 +813,107 @@ _mongocrypt_do_encryption (_mongocrypt_crypto_t *crypto,
                   iv->len);
       return false;
    }
-   if (MONGOCRYPT_KEY_LEN != key->len) {
+
+   const uint32_t expected_key_len = (key_format == KEY_FORMAT_FLE2IEV)
+                                        ? MONGOCRYPT_ENC_KEY_LEN
+                                        : MONGOCRYPT_KEY_LEN;
+   if (key->len != expected_key_len) {
       CLIENT_ERR ("key should have length %d, but has length %d",
-                  MONGOCRYPT_KEY_LEN,
+                  expected_key_len,
                   key->len);
       return false;
    }
 
-   intermediate.len = ciphertext->len;
-   intermediate.data = ciphertext->data;
+   // Copy IV into the output, and clear remainder.
+   memmove (ciphertext->data, iv->data, MONGOCRYPT_IV_LEN);
+   memset (ciphertext->data + MONGOCRYPT_IV_LEN,
+           0,
+           ciphertext->len - MONGOCRYPT_IV_LEN);
 
-   /* [MCGREW]: Step 1. "MAC_KEY consists of the initial MAC_KEY_LEN octets of
-    * K, in order. ENC_KEY consists of the final ENC_KEY_LEN octets of K, in
-    * order." */
-   mac_key.data = (uint8_t *) key->data;
-   mac_key.len = MONGOCRYPT_MAC_KEY_LEN;
-   enc_key.data = (uint8_t *) key->data + MONGOCRYPT_MAC_KEY_LEN;
-   enc_key.len = MONGOCRYPT_ENC_KEY_LEN;
+   // S is the encryption payload without IV or HMAC
+   _mongocrypt_buffer_t S;
+   if (!_mongocrypt_buffer_from_subrange (&S,
+                                          ciphertext,
+                                          MONGOCRYPT_IV_LEN,
+                                          ciphertext->len -
+                                             MONGOCRYPT_IV_LEN)) {
+      CLIENT_ERR ("unable to create S view from C");
+      return false;
+   }
+   if (hmac == HMAC_NONE) {
+      S.len -= MONGOCRYPT_HMAC_LEN;
+   }
 
-   /* Prepend the IV. */
-   memcpy (intermediate.data, iv->data, iv->len);
-   intermediate.data += iv->len;
-   BSON_ASSERT (intermediate.len >= iv->len);
-   intermediate.len -= iv->len;
-   BSON_ASSERT (*bytes_written <= UINT32_MAX - iv->len);
-   *bytes_written += iv->len;
+   // Ke is the key used for payload encryption
+   const uint32_t Ke_offset =
+      (key_format == KEY_FORMAT_FLE1) ? MONGOCRYPT_MAC_KEY_LEN : 0;
+   if (!_mongocrypt_buffer_from_subrange (
+          &Ke, key, Ke_offset, MONGOCRYPT_ENC_KEY_LEN)) {
+      CLIENT_ERR ("unable to create Ke view from key");
+      return false;
+   }
 
-   /* [MCGREW]: Steps 2 & 3. */
-   if (!_encrypt_step (crypto,
-                       iv,
-                       &enc_key,
-                       plaintext,
-                       &intermediate,
-                       &intermediate_bytes_written,
+   uint32_t S_bytes_written = 0;
+   if (!_encrypt_step (
+          crypto, mode, iv, &Ke, plaintext, &S, &S_bytes_written, status)) {
+      return false;
+   }
+   BSON_ASSERT_PARAM (bytes_written);
+   BSON_ASSERT ((UINT32_MAX - S_bytes_written) > MONGOCRYPT_IV_LEN);
+   *bytes_written = MONGOCRYPT_IV_LEN + S_bytes_written;
+
+   if (hmac != HMAC_NONE) {
+      // Km == Key for MAC
+      const uint32_t Km_offset =
+         (key_format == KEY_FORMAT_FLE1) ? 0 : MONGOCRYPT_ENC_KEY_LEN;
+
+      // Km is the HMAC Key.
+      _mongocrypt_buffer_t Km;
+      if (!_mongocrypt_buffer_from_subrange (
+             &Km, key, Km_offset, MONGOCRYPT_MAC_KEY_LEN)) {
+         CLIENT_ERR ("unable to create Km view from key");
+         return false;
+      }
+
+      /* Primary payload to MAC. */
+      _mongocrypt_buffer_t iv_and_ciphertext;
+      if (!_mongocrypt_buffer_from_subrange (
+             &iv_and_ciphertext, ciphertext, 0, *bytes_written)) {
+         CLIENT_ERR ("unable to create IV || S view from C");
+         return false;
+      }
+
+      // T == HMAC Tag
+      _mongocrypt_buffer_t T;
+      if (!_mongocrypt_buffer_from_subrange (
+             &T, ciphertext, *bytes_written, MONGOCRYPT_HMAC_LEN)) {
+         CLIENT_ERR ("unable to create T view from C");
+         return false;
+      }
+
+      if (!_hmac_step (crypto,
+                       mac_format,
+                       hmac,
+                       &Km,
+                       associated_data,
+                       &iv_and_ciphertext,
+                       &T,
                        status)) {
-      return false;
+         return false;
+      }
+
+      *bytes_written += MONGOCRYPT_HMAC_LEN;
    }
 
-   BSON_ASSERT (*bytes_written <= UINT32_MAX - intermediate_bytes_written);
-   *bytes_written += intermediate_bytes_written;
-
-   /* Append the HMAC tag. */
-   intermediate_hmac.data = ciphertext->data + *bytes_written;
-   intermediate_hmac.len = MONGOCRYPT_HMAC_LEN;
-
-   intermediate.data = ciphertext->data;
-   intermediate.len = *bytes_written;
-
-   /* [MCGREW]: Steps 4 & 5, compute the HMAC. */
-   if (!_hmac_step (crypto,
-                    &mac_key,
-                    associated_data ? associated_data : &empty_buffer,
-                    &intermediate,
-                    &intermediate_hmac,
-                    status)) {
-      return false;
-   }
-
-   *bytes_written += MONGOCRYPT_HMAC_LEN;
    return true;
 }
 
 
 /* ----------------------------------------------------------------------------
  *
- * _aes256_cbc_decrypt --
+ * _decrypt_step --
  *
- *    Decrypts using AES256 CBC using a secret key and a known IV.
+ *    Decrypts using AES256 using a secret key and a known IV.
  *
  * Parameters:
  *    @enc_key a 32 byte key.
@@ -859,12 +933,13 @@ _mongocrypt_do_encryption (_mongocrypt_crypto_t *crypto,
  * Postconditions:
  *    1. bytes_written is set to the length of the written plaintext, excluding
  *    padding. This may be less than
- *    _mongocrypt_calculate_plaintext_len (ciphertext->len, status).
+ *    _mongocrypt_calculate_plaintext_len (ciphertext->len, home, hmac, status).
  *
  * ----------------------------------------------------------------------------
  */
 static bool
 _decrypt_step (_mongocrypt_crypto_t *crypto,
+               _mongocrypt_encryption_mode_t mode,
                const _mongocrypt_buffer_t *iv,
                const _mongocrypt_buffer_t *enc_key,
                const _mongocrypt_buffer_t *ciphertext,
@@ -872,8 +947,6 @@ _decrypt_step (_mongocrypt_crypto_t *crypto,
                uint32_t *bytes_written,
                mongocrypt_status_t *status)
 {
-   uint8_t padding_byte;
-
    BSON_ASSERT_PARAM (crypto);
    BSON_ASSERT_PARAM (iv);
    BSON_ASSERT_PARAM (enc_key);
@@ -897,29 +970,47 @@ _decrypt_step (_mongocrypt_crypto_t *crypto,
    }
 
 
-   if (ciphertext->len % MONGOCRYPT_BLOCK_SIZE > 0) {
-      CLIENT_ERR ("error, ciphertext length is not a multiple of block size");
-      return false;
+   if (mode == MODE_CBC) {
+      if (ciphertext->len % MONGOCRYPT_BLOCK_SIZE > 0) {
+         CLIENT_ERR (
+            "error, ciphertext length is not a multiple of block size");
+         return false;
+      }
+
+      if (!_crypto_aes_256_cbc_decrypt (
+             crypto,
+             (aes_256_args_t){.iv = iv,
+                              .key = enc_key,
+                              .in = ciphertext,
+                              .out = plaintext,
+                              .bytes_written = bytes_written,
+                              .status = status})) {
+         return false;
+      }
+
+      BSON_ASSERT (*bytes_written > 0);
+      uint8_t padding_byte = plaintext->data[*bytes_written - 1];
+      if (padding_byte > 16) {
+         CLIENT_ERR ("error, ciphertext malformed padding");
+         return false;
+      }
+      *bytes_written -= padding_byte;
+
+   } else {
+      BSON_ASSERT (mode == MODE_CTR);
+      if (!_crypto_aes_256_ctr_decrypt (
+             crypto,
+             (aes_256_args_t){.iv = iv,
+                              .key = enc_key,
+                              .in = ciphertext,
+                              .out = plaintext,
+                              .bytes_written = bytes_written,
+                              .status = status})) {
+         return false;
+      }
+      BSON_ASSERT (*bytes_written == plaintext->len);
    }
 
-   if (!_crypto_aes_256_cbc_decrypt (
-          crypto,
-          (aes_256_args_t){.iv = iv,
-                           .key = enc_key,
-                           .in = ciphertext,
-                           .out = plaintext,
-                           .bytes_written = bytes_written,
-                           .status = status})) {
-      return false;
-   }
-
-   BSON_ASSERT (*bytes_written > 0);
-   padding_byte = plaintext->data[*bytes_written - 1];
-   if (padding_byte > 16) {
-      CLIENT_ERR ("error, ciphertext malformed padding");
-      return false;
-   }
-   *bytes_written -= padding_byte;
    return true;
 }
 
@@ -948,12 +1039,16 @@ _decrypt_step (_mongocrypt_crypto_t *crypto,
  *  Postconditions:
  *    1. bytes_written is set to the length of the written plaintext, excluding
  *    padding. This may be less than
- *    _mongocrypt_calculate_plaintext_len (ciphertext->len, status).
+ *    _mongocrypt_calculate_plaintext_len (ciphertext->len, mode, hmac, status).
  *
  * ----------------------------------------------------------------------------
  */
-bool
+static bool
 _mongocrypt_do_decryption (_mongocrypt_crypto_t *crypto,
+                           _mongocrypt_key_format_t key_format,
+                           _mongocrypt_mac_format_t mac_format,
+                           _mongocrypt_encryption_mode_t mode,
+                           _mongocrypt_hmac_type_t hmac,
                            const _mongocrypt_buffer_t *associated_data,
                            const _mongocrypt_buffer_t *key,
                            const _mongocrypt_buffer_t *ciphertext,
@@ -961,11 +1056,6 @@ _mongocrypt_do_decryption (_mongocrypt_crypto_t *crypto,
                            uint32_t *bytes_written,
                            mongocrypt_status_t *status)
 {
-   bool ret = false;
-   _mongocrypt_buffer_t mac_key = {0}, enc_key = {0}, intermediate = {0},
-                        hmac_tag = {0}, iv = {0}, empty_buffer = {0};
-   uint8_t hmac_tag_storage[MONGOCRYPT_HMAC_LEN];
-
    BSON_ASSERT_PARAM (crypto);
    /* associated_data is checked at the point it is used, so it can be NULL */
    BSON_ASSERT_PARAM (key);
@@ -973,83 +1063,215 @@ _mongocrypt_do_decryption (_mongocrypt_crypto_t *crypto,
    BSON_ASSERT_PARAM (plaintext);
    BSON_ASSERT_PARAM (bytes_written);
 
-   if (plaintext->len !=
-       _mongocrypt_calculate_plaintext_len (ciphertext->len, status)) {
+   const uint32_t expect_plaintext_len =
+      _mongocrypt_calculate_plaintext_len (ciphertext->len, mode, hmac, status);
+   if (mongocrypt_status_type (status) != MONGOCRYPT_STATUS_OK) {
+      return false;
+   }
+   if (plaintext->len != expect_plaintext_len) {
       CLIENT_ERR ("output plaintext should have been allocated with %d bytes, "
                   "but has: %d",
-                  _mongocrypt_calculate_plaintext_len (ciphertext->len, status),
+                  expect_plaintext_len,
                   plaintext->len);
       return false;
    }
+   if (expect_plaintext_len == 0) {
+      // While a ciphertext string describing a zero length plaintext is
+      // technically valid,
+      // it's not actually particularly useful in the context of FLE where such
+      // values aren't encoded.
+      CLIENT_ERR ("input ciphertext too small. Must be more than %" PRIu32
+                  " bytes",
+                  _mongocrypt_calculate_ciphertext_len (0, mode, hmac, NULL));
+      return false;
+   }
 
-   if (MONGOCRYPT_KEY_LEN != key->len) {
+   const uint32_t expected_key_len = (key_format == KEY_FORMAT_FLE2IEV)
+                                        ? MONGOCRYPT_ENC_KEY_LEN
+                                        : MONGOCRYPT_KEY_LEN;
+   if (expected_key_len != key->len) {
       CLIENT_ERR ("key should have length %d, but has length %d",
-                  MONGOCRYPT_KEY_LEN,
+                  expected_key_len,
                   key->len);
       return false;
    }
 
-   if (ciphertext->len <
-       MONGOCRYPT_HMAC_LEN + MONGOCRYPT_IV_LEN + MONGOCRYPT_BLOCK_SIZE) {
-      CLIENT_ERR ("corrupt ciphertext - must be > %d bytes",
-                  MONGOCRYPT_HMAC_LEN + MONGOCRYPT_IV_LEN +
-                     MONGOCRYPT_BLOCK_SIZE);
-      goto done;
+   const uint32_t min_cipherlen =
+      _mongocrypt_calculate_ciphertext_len (0, mode, hmac, NULL);
+   if (ciphertext->len < min_cipherlen) {
+      CLIENT_ERR ("corrupt ciphertext - must be > %d bytes", min_cipherlen);
+      return false;
    }
 
-   mac_key.data = (uint8_t *) key->data;
-   mac_key.len = MONGOCRYPT_MAC_KEY_LEN;
-   enc_key.data = (uint8_t *) key->data + MONGOCRYPT_MAC_KEY_LEN;
-   enc_key.len = MONGOCRYPT_ENC_KEY_LEN;
-
-   iv.data = ciphertext->data;
-   iv.len = MONGOCRYPT_IV_LEN;
-
-   intermediate.data = (uint8_t *) ciphertext->data;
-   intermediate.len = ciphertext->len - MONGOCRYPT_HMAC_LEN;
-
-   hmac_tag.data = hmac_tag_storage;
-   hmac_tag.len = MONGOCRYPT_HMAC_LEN;
-
-   /* [MCGREW 2.2]: Step 3: HMAC check. */
-   if (!_hmac_step (crypto,
-                    &mac_key,
-                    associated_data ? associated_data : &empty_buffer,
-                    &intermediate,
-                    &hmac_tag,
-                    status)) {
-      goto done;
+   _mongocrypt_buffer_t Ke;
+   const uint32_t Ke_offset =
+      (key_format == KEY_FORMAT_FLE1) ? MONGOCRYPT_MAC_KEY_LEN : 0;
+   if (!_mongocrypt_buffer_from_subrange (
+          &Ke, key, Ke_offset, MONGOCRYPT_ENC_KEY_LEN)) {
+      CLIENT_ERR ("unable to create Ke view from key");
+      return false;
    }
 
-   /* [MCGREW] "using a comparison routine that takes constant time". */
-   if (0 != _mongocrypt_memequal (hmac_tag.data,
-                                  ciphertext->data +
-                                     (ciphertext->len - MONGOCRYPT_HMAC_LEN),
-                                  MONGOCRYPT_HMAC_LEN)) {
-      CLIENT_ERR ("HMAC validation failure");
-      goto done;
+   _mongocrypt_buffer_t IV;
+   if (!_mongocrypt_buffer_from_subrange (
+          &IV, ciphertext, 0, MONGOCRYPT_IV_LEN)) {
+      CLIENT_ERR ("unable to create IV view from ciphertext");
+      return false;
+   }
+
+   if (hmac == HMAC_NONE) {
+      BSON_ASSERT (key_format == KEY_FORMAT_FLE2IEV);
+
+   } else {
+      BSON_ASSERT (key_format != KEY_FORMAT_FLE2IEV);
+
+      uint8_t hmac_tag_storage[MONGOCRYPT_HMAC_LEN];
+      const uint32_t mac_key_offset =
+         (key_format == KEY_FORMAT_FLE1) ? 0 : MONGOCRYPT_ENC_KEY_LEN;
+      _mongocrypt_buffer_t Km;
+      if (!_mongocrypt_buffer_from_subrange (
+             &Km, key, mac_key_offset, MONGOCRYPT_MAC_KEY_LEN)) {
+         CLIENT_ERR ("unable to create Km view from key");
+         return false;
+      }
+
+      _mongocrypt_buffer_t iv_and_ciphertext;
+      if (!_mongocrypt_buffer_from_subrange (&iv_and_ciphertext,
+                                             ciphertext,
+                                             0,
+                                             ciphertext->len -
+                                                MONGOCRYPT_HMAC_LEN)) {
+         CLIENT_ERR ("unable to create IV || S view from C");
+         return false;
+      }
+
+      _mongocrypt_buffer_t hmac_tag = {.data = hmac_tag_storage,
+                                       .len = MONGOCRYPT_HMAC_LEN};
+
+      if (!_hmac_step (crypto,
+                       mac_format,
+                       hmac,
+                       &Km,
+                       associated_data,
+                       &iv_and_ciphertext,
+                       &hmac_tag,
+                       status)) {
+         return false;
+      }
+
+      /* Constant time compare. */
+      _mongocrypt_buffer_t T;
+      if (!_mongocrypt_buffer_from_subrange (&T,
+                                             ciphertext,
+                                             ciphertext->len -
+                                                MONGOCRYPT_HMAC_LEN,
+                                             MONGOCRYPT_HMAC_LEN)) {
+         CLIENT_ERR ("unable to create T view from C");
+         return false;
+      }
+      if (0 !=
+          _mongocrypt_memequal (hmac_tag.data, T.data, MONGOCRYPT_HMAC_LEN)) {
+         CLIENT_ERR ("HMAC validation failure");
+         return false;
+      }
    }
 
    /* Decrypt data excluding IV + HMAC. */
-   intermediate.data = (uint8_t *) ciphertext->data + MONGOCRYPT_IV_LEN;
-   intermediate.len =
-      ciphertext->len - (MONGOCRYPT_IV_LEN + MONGOCRYPT_HMAC_LEN);
-
-   if (!_decrypt_step (crypto,
-                       &iv,
-                       &enc_key,
-                       &intermediate,
-                       plaintext,
-                       bytes_written,
-                       status)) {
-      goto done;
+   const uint32_t hmac_len = (hmac == HMAC_NONE) ? 0 : MONGOCRYPT_HMAC_LEN;
+   _mongocrypt_buffer_t S;
+   if (!_mongocrypt_buffer_from_subrange (&S,
+                                          ciphertext,
+                                          MONGOCRYPT_IV_LEN,
+                                          ciphertext->len - MONGOCRYPT_IV_LEN -
+                                             hmac_len)) {
+      CLIENT_ERR ("unable to create S view from C");
+      return false;
    }
 
-   ret = true;
-done:
-   return ret;
+   return _decrypt_step (
+      crypto, mode, &IV, &Ke, &S, plaintext, bytes_written, status);
 }
 
+#define DECLARE_ALGORITHM(name, mode, hmac)                                  \
+   static uint32_t _mc_##name##_ciphertext_len (uint32_t plaintext_len,      \
+                                                mongocrypt_status_t *status) \
+   {                                                                         \
+      return _mongocrypt_calculate_ciphertext_len (                          \
+         plaintext_len, MODE_##mode, HMAC_##hmac, status);                   \
+   }                                                                         \
+   static uint32_t _mc_##name##_plaintext_len (uint32_t ciphertext_len,      \
+                                               mongocrypt_status_t *status)  \
+   {                                                                         \
+      return _mongocrypt_calculate_plaintext_len (                           \
+         ciphertext_len, MODE_##mode, HMAC_##hmac, status);                  \
+   }                                                                         \
+   static bool _mc_##name##_do_encryption (                                  \
+      _mongocrypt_crypto_t *crypto,                                          \
+      const _mongocrypt_buffer_t *iv,                                        \
+      const _mongocrypt_buffer_t *aad,                                       \
+      const _mongocrypt_buffer_t *key,                                       \
+      const _mongocrypt_buffer_t *plaintext,                                 \
+      _mongocrypt_buffer_t *ciphertext,                                      \
+      uint32_t *written,                                                     \
+      mongocrypt_status_t *status)                                           \
+   {                                                                         \
+      return _mongocrypt_do_encryption (crypto,                              \
+                                        KEY_FORMAT_##name,                   \
+                                        MAC_FORMAT_##name,                   \
+                                        MODE_##mode,                         \
+                                        HMAC_##hmac,                         \
+                                        iv,                                  \
+                                        aad,                                 \
+                                        key,                                 \
+                                        plaintext,                           \
+                                        ciphertext,                          \
+                                        written,                             \
+                                        status);                             \
+   }                                                                         \
+   static bool _mc_##name##_do_decryption (                                  \
+      _mongocrypt_crypto_t *crypto,                                          \
+      const _mongocrypt_buffer_t *aad,                                       \
+      const _mongocrypt_buffer_t *key,                                       \
+      const _mongocrypt_buffer_t *ciphertext,                                \
+      _mongocrypt_buffer_t *plaintext,                                       \
+      uint32_t *written,                                                     \
+      mongocrypt_status_t *status)                                           \
+   {                                                                         \
+      return _mongocrypt_do_decryption (crypto,                              \
+                                        KEY_FORMAT_##name,                   \
+                                        MAC_FORMAT_##name,                   \
+                                        MODE_##mode,                         \
+                                        HMAC_##hmac,                         \
+                                        aad,                                 \
+                                        key,                                 \
+                                        ciphertext,                          \
+                                        plaintext,                           \
+                                        written,                             \
+                                        status);                             \
+   }                                                                         \
+   static const _mongocrypt_value_encryption_algorithm_t                     \
+      _mc##name##Algorithm_definition = {                                    \
+         _mc_##name##_ciphertext_len,                                        \
+         _mc_##name##_plaintext_len,                                         \
+         _mc_##name##_do_encryption,                                         \
+         _mc_##name##_do_decryption,                                         \
+   };                                                                        \
+   const _mongocrypt_value_encryption_algorithm_t *_mc##name##Algorithm ()   \
+   {                                                                         \
+      return &_mc##name##Algorithm_definition;                               \
+   }
+
+
+// FLE1 algorithm: AES-256-CBC HMAC/SHA-512-256 (SHA-512 truncated to 256 bits)
+DECLARE_ALGORITHM (FLE1, CBC, SHA_512_256)
+
+// FLE2 general algorithm: AES-256-CTR HMAC/SHA-256
+DECLARE_ALGORITHM (FLE2, CTR, SHA_256)
+
+// FLE2 used with FLE2IndexedEncryptedValue: AES-256-CTR no HMAC
+DECLARE_ALGORITHM (FLE2IEV, CTR, NONE)
+
+#undef DECLARE_ALGORITHM
 
 /* ----------------------------------------------------------------------------
  *
@@ -1197,6 +1419,8 @@ _mongocrypt_wrap_key (_mongocrypt_crypto_t *crypto,
                       _mongocrypt_buffer_t *encrypted_dek,
                       mongocrypt_status_t *status)
 {
+   const _mongocrypt_value_encryption_algorithm_t *fle1alg =
+      _mcFLE1Algorithm ();
    uint32_t bytes_written;
    _mongocrypt_buffer_t iv = {0};
    bool ret = false;
@@ -1216,22 +1440,23 @@ _mongocrypt_wrap_key (_mongocrypt_crypto_t *crypto,
       goto done;
    }
 
-   _mongocrypt_buffer_resize (
-      encrypted_dek, _mongocrypt_calculate_ciphertext_len (dek->len, status));
+   // _mongocrypt_wrap_key() uses FLE1 algorithm parameters.
+   _mongocrypt_buffer_resize (encrypted_dek,
+                              fle1alg->ciphertext_len (dek->len, status));
    _mongocrypt_buffer_resize (&iv, MONGOCRYPT_IV_LEN);
 
    if (!_mongocrypt_random (crypto, &iv, MONGOCRYPT_IV_LEN, status)) {
       goto done;
    }
 
-   if (!_mongocrypt_do_encryption (crypto,
-                                   &iv,
-                                   NULL /* associated data. */,
-                                   kek,
-                                   dek,
-                                   encrypted_dek,
-                                   &bytes_written,
-                                   status)) {
+   if (!fle1alg->encrypt (crypto,
+                          &iv,
+                          NULL /* associated data. */,
+                          kek,
+                          dek,
+                          encrypted_dek,
+                          &bytes_written,
+                          status)) {
       goto done;
    }
 
@@ -1248,6 +1473,8 @@ _mongocrypt_unwrap_key (_mongocrypt_crypto_t *crypto,
                         _mongocrypt_buffer_t *dek,
                         mongocrypt_status_t *status)
 {
+   const _mongocrypt_value_encryption_algorithm_t *fle1alg =
+      _mcFLE1Algorithm ();
    uint32_t bytes_written;
 
    BSON_ASSERT_PARAM (crypto);
@@ -1255,17 +1482,18 @@ _mongocrypt_unwrap_key (_mongocrypt_crypto_t *crypto,
    BSON_ASSERT_PARAM (dek);
    BSON_ASSERT_PARAM (encrypted_dek);
 
+   // _mongocrypt_wrap_key() uses FLE1 algorithm parameters.
    _mongocrypt_buffer_init (dek);
    _mongocrypt_buffer_resize (
-      dek, _mongocrypt_calculate_plaintext_len (encrypted_dek->len, status));
+      dek, fle1alg->plaintext_len (encrypted_dek->len, status));
 
-   if (!_mongocrypt_do_decryption (crypto,
-                                   NULL /* associated data. */,
-                                   kek,
-                                   encrypted_dek,
-                                   dek,
-                                   &bytes_written,
-                                   status)) {
+   if (!fle1alg->decrypt (crypto,
+                          NULL /* associated data. */,
+                          kek,
+                          encrypted_dek,
+                          dek,
+                          &bytes_written,
+                          status)) {
       return false;
    }
    dek->len = bytes_written;
@@ -1277,500 +1505,6 @@ _mongocrypt_unwrap_key (_mongocrypt_crypto_t *crypto,
                   dek->len);
       return false;
    }
-   return true;
-}
-
-bool
-_mongocrypt_hmac_sha_256 (_mongocrypt_crypto_t *crypto,
-                          const _mongocrypt_buffer_t *key,
-                          const _mongocrypt_buffer_t *in,
-                          _mongocrypt_buffer_t *out,
-                          mongocrypt_status_t *status)
-{
-   BSON_ASSERT_PARAM (crypto);
-   BSON_ASSERT_PARAM (key);
-   BSON_ASSERT_PARAM (in);
-   BSON_ASSERT_PARAM (out);
-
-   if (key->len != MONGOCRYPT_MAC_KEY_LEN) {
-      CLIENT_ERR ("invalid hmac_sha_256 key length. Got %" PRIu32
-                  ", expected: %" PRIu32,
-                  key->len,
-                  MONGOCRYPT_MAC_KEY_LEN);
-      return false;
-   }
-
-   if (crypto->hooks_enabled) {
-      mongocrypt_binary_t key_bin, out_bin, in_bin;
-      _mongocrypt_buffer_to_binary (key, &key_bin);
-      _mongocrypt_buffer_to_binary (out, &out_bin);
-      _mongocrypt_buffer_to_binary (in, &in_bin);
-
-      return crypto->hmac_sha_256 (
-         crypto->ctx, &key_bin, &in_bin, &out_bin, status);
-   }
-   return _native_crypto_hmac_sha_256 (key, in, out, status);
-}
-
-bool
-_mongocrypt_fle2aead_do_encryption (_mongocrypt_crypto_t *crypto,
-                                    const _mongocrypt_buffer_t *iv,
-                                    const _mongocrypt_buffer_t *associated_data,
-                                    const _mongocrypt_buffer_t *key,
-                                    const _mongocrypt_buffer_t *plaintext,
-                                    _mongocrypt_buffer_t *ciphertext,
-                                    uint32_t *bytes_written,
-                                    mongocrypt_status_t *status)
-{
-   BSON_ASSERT_PARAM (crypto);
-   BSON_ASSERT_PARAM (iv);
-   BSON_ASSERT_PARAM (associated_data);
-   BSON_ASSERT_PARAM (key);
-   BSON_ASSERT_PARAM (plaintext);
-   BSON_ASSERT_PARAM (ciphertext);
-   BSON_ASSERT_PARAM (bytes_written);
-
-   if (ciphertext->len !=
-       _mongocrypt_fle2aead_calculate_ciphertext_len (plaintext->len, status)) {
-      CLIENT_ERR ("output ciphertext must be allocated with %" PRIu32 " bytes",
-                  _mongocrypt_fle2aead_calculate_ciphertext_len (plaintext->len,
-                                                                 status));
-      return false;
-   }
-
-   if (plaintext->len <= 0) {
-      CLIENT_ERR ("input plaintext too small. Must be more than zero bytes.");
-      return false;
-   }
-
-   if (MONGOCRYPT_IV_LEN != iv->len) {
-      CLIENT_ERR ("IV must be length %d, but is length %" PRIu32,
-                  MONGOCRYPT_IV_LEN,
-                  iv->len);
-      return false;
-   }
-   if (MONGOCRYPT_KEY_LEN != key->len) {
-      CLIENT_ERR ("key must be length %d, but is length %" PRIu32,
-                  MONGOCRYPT_KEY_LEN,
-                  key->len);
-      return false;
-   }
-
-   memset (ciphertext->data, 0, ciphertext->len);
-   *bytes_written = 0;
-
-   /* Declare variable names matching [AEAD with
-    * CTR](https://docs.google.com/document/d/1eCU7R8Kjr-mdyz6eKvhNIDVmhyYQcAaLtTfHeK7a_vE/).
-    */
-   /* M is the input plaintext. */
-   _mongocrypt_buffer_t M;
-   if (!_mongocrypt_buffer_from_subrange (&M, plaintext, 0, plaintext->len)) {
-      CLIENT_ERR ("unable to create M view from plaintext");
-      return false;
-   }
-   /* Ke is 32 byte Key for encryption. */
-   _mongocrypt_buffer_t Ke;
-   if (!_mongocrypt_buffer_from_subrange (
-          &Ke, key, 0, MONGOCRYPT_ENC_KEY_LEN)) {
-      CLIENT_ERR ("unable to create Ke view from key");
-      return false;
-   }
-   /* IV is 16 byte IV. */
-   _mongocrypt_buffer_t IV;
-   if (!_mongocrypt_buffer_from_subrange (&IV, iv, 0, iv->len)) {
-      CLIENT_ERR ("unable to create IV view from iv");
-      return false;
-   }
-   /* Km is 32 byte Key for HMAC. */
-   _mongocrypt_buffer_t Km;
-   if (!_mongocrypt_buffer_from_subrange (
-          &Km, key, MONGOCRYPT_ENC_KEY_LEN, MONGOCRYPT_MAC_KEY_LEN)) {
-      CLIENT_ERR ("unable to create Km view from key");
-      return false;
-   }
-   /* AD is Associated Data. */
-   _mongocrypt_buffer_t AD;
-   if (!_mongocrypt_buffer_from_subrange (
-          &AD, associated_data, 0, associated_data->len)) {
-      CLIENT_ERR ("unable to create AD view from associated_data");
-      return false;
-   }
-   /* C is the output ciphertext. */
-   _mongocrypt_buffer_t C;
-   if (!_mongocrypt_buffer_from_subrange (&C, ciphertext, 0, ciphertext->len)) {
-      CLIENT_ERR ("unable to create C view from ciphertext");
-      return false;
-   }
-   /* S is the output of the symmetric cipher. It is appended after IV in C. */
-   _mongocrypt_buffer_t S;
-   BSON_ASSERT (C.len >= MONGOCRYPT_IV_LEN + MONGOCRYPT_HMAC_LEN);
-   if (!_mongocrypt_buffer_from_subrange (&S,
-                                          &C,
-                                          MONGOCRYPT_IV_LEN,
-                                          C.len - MONGOCRYPT_IV_LEN -
-                                             MONGOCRYPT_HMAC_LEN)) {
-      CLIENT_ERR ("unable to create S view from C");
-      return false;
-   }
-   uint32_t S_bytes_written = 0;
-   /* T is the output of the HMAC tag. It is appended after S in C. */
-   _mongocrypt_buffer_t T;
-   if (!_mongocrypt_buffer_from_subrange (
-          &T, &C, C.len - MONGOCRYPT_HMAC_LEN, MONGOCRYPT_HMAC_LEN)) {
-      CLIENT_ERR ("unable to create T view from C");
-      return false;
-   }
-
-   /* Compute S = AES-CTR.Enc(Ke, IV, M). */
-   if (!_crypto_aes_256_ctr_encrypt (
-          crypto,
-          (aes_256_args_t){.key = &Ke,
-                           .iv = &IV,
-                           .in = &M,
-                           .out = &S,
-                           .bytes_written = &S_bytes_written,
-                           .status = status})) {
-      return false;
-   }
-
-   /* Compute T = HMAC-SHA256(Km, AD || IV || S). */
-   {
-      _mongocrypt_buffer_t hmac_inputs[] = {AD, IV, S};
-      _mongocrypt_buffer_t hmac_input = {0};
-      _mongocrypt_buffer_concat (&hmac_input, hmac_inputs, 3);
-      if (!_mongocrypt_hmac_sha_256 (crypto, &Km, &hmac_input, &T, status)) {
-         _mongocrypt_buffer_cleanup (&hmac_input);
-         return false;
-      }
-      _mongocrypt_buffer_cleanup (&hmac_input);
-   }
-
-   /* Output C = IV || S || T. */
-   /* S and T are already in C. Prepend IV. */
-   memmove (C.data, IV.data, MONGOCRYPT_IV_LEN);
-
-   *bytes_written = MONGOCRYPT_IV_LEN + S_bytes_written + MONGOCRYPT_HMAC_LEN;
-   return true;
-}
-
-bool
-_mongocrypt_fle2aead_do_decryption (_mongocrypt_crypto_t *crypto,
-                                    const _mongocrypt_buffer_t *associated_data,
-                                    const _mongocrypt_buffer_t *key,
-                                    const _mongocrypt_buffer_t *ciphertext,
-                                    _mongocrypt_buffer_t *plaintext,
-                                    uint32_t *bytes_written,
-                                    mongocrypt_status_t *status)
-{
-   BSON_ASSERT_PARAM (crypto);
-   BSON_ASSERT_PARAM (associated_data);
-   BSON_ASSERT_PARAM (key);
-   BSON_ASSERT_PARAM (ciphertext);
-   BSON_ASSERT_PARAM (plaintext);
-   BSON_ASSERT_PARAM (bytes_written);
-
-   if (ciphertext->len <= MONGOCRYPT_IV_LEN + MONGOCRYPT_HMAC_LEN) {
-      CLIENT_ERR ("input ciphertext too small. Must be more than %" PRIu32
-                  " bytes",
-                  MONGOCRYPT_IV_LEN + MONGOCRYPT_HMAC_LEN);
-      return false;
-   }
-
-   if (plaintext->len !=
-       _mongocrypt_fle2aead_calculate_plaintext_len (ciphertext->len, status)) {
-      CLIENT_ERR ("output plaintext must be allocated with %" PRIu32 " bytes",
-                  _mongocrypt_fle2aead_calculate_plaintext_len (ciphertext->len,
-                                                                status));
-      return false;
-   }
-
-   if (MONGOCRYPT_KEY_LEN != key->len) {
-      CLIENT_ERR ("key must be length %d, but is length %" PRIu32,
-                  MONGOCRYPT_KEY_LEN,
-                  key->len);
-      return false;
-   }
-
-   memset (plaintext->data, 0, plaintext->len);
-   *bytes_written = 0;
-
-   /* Declare variable names matching [AEAD with
-    * CTR](https://docs.google.com/document/d/1eCU7R8Kjr-mdyz6eKvhNIDVmhyYQcAaLtTfHeK7a_vE/).
-    */
-   /* C is the input ciphertext. */
-   _mongocrypt_buffer_t C;
-   if (!_mongocrypt_buffer_from_subrange (&C, ciphertext, 0, ciphertext->len)) {
-      CLIENT_ERR ("unable to create C view from ciphertext");
-      return false;
-   }
-   /* IV is 16 byte IV. It is the first part of C. */
-   _mongocrypt_buffer_t IV;
-   if (!_mongocrypt_buffer_from_subrange (
-          &IV, ciphertext, 0, MONGOCRYPT_IV_LEN)) {
-      CLIENT_ERR ("unable to create IV view from ciphertext");
-      return false;
-   }
-   /* S is the symmetric cipher output from C. It is after the IV in C. */
-   _mongocrypt_buffer_t S;
-   if (!_mongocrypt_buffer_from_subrange (&S,
-                                          ciphertext,
-                                          MONGOCRYPT_IV_LEN,
-                                          C.len - MONGOCRYPT_IV_LEN -
-                                             MONGOCRYPT_HMAC_LEN)) {
-      CLIENT_ERR ("unable to create S view from C");
-      return false;
-   }
-   /* T is the HMAC tag from C. It is after S in C. */
-   _mongocrypt_buffer_t T;
-   if (!_mongocrypt_buffer_from_subrange (
-          &T, &C, C.len - MONGOCRYPT_HMAC_LEN, MONGOCRYPT_HMAC_LEN)) {
-      CLIENT_ERR ("unable to create T view from C");
-      return false;
-   }
-   /* Tp is the computed HMAC of the input. */
-   _mongocrypt_buffer_t Tp = {0};
-   /* M is the output plaintext. */
-   _mongocrypt_buffer_t M;
-   if (!_mongocrypt_buffer_from_subrange (&M, plaintext, 0, plaintext->len)) {
-      CLIENT_ERR ("unable to create M view from plaintext");
-      return false;
-   }
-   /* Ke is 32 byte Key for encryption. */
-   _mongocrypt_buffer_t Ke;
-   if (!_mongocrypt_buffer_from_subrange (
-          &Ke, key, 0, MONGOCRYPT_ENC_KEY_LEN)) {
-      CLIENT_ERR ("unable to create Ke view from key");
-      return false;
-   }
-   /* Km is 32 byte Key for HMAC. */
-   _mongocrypt_buffer_t Km;
-   if (!_mongocrypt_buffer_from_subrange (
-          &Km, key, MONGOCRYPT_ENC_KEY_LEN, MONGOCRYPT_MAC_KEY_LEN)) {
-      CLIENT_ERR ("unable to create Km view from key");
-      return false;
-   }
-   /* AD is Associated Data. */
-   _mongocrypt_buffer_t AD;
-   if (!_mongocrypt_buffer_from_subrange (
-          &AD, associated_data, 0, associated_data->len)) {
-      CLIENT_ERR ("unable to create AD view from associated_data");
-      return false;
-   }
-
-   /* Compute Tp = HMAC-SHA256(Km, AD || IV || S). Check that it matches input
-    * ciphertext T. */
-   {
-      _mongocrypt_buffer_t hmac_inputs[] = {AD, IV, S};
-      _mongocrypt_buffer_t hmac_input = {0};
-      _mongocrypt_buffer_concat (&hmac_input, hmac_inputs, 3);
-      _mongocrypt_buffer_resize (&Tp, MONGOCRYPT_HMAC_LEN);
-      if (!_mongocrypt_hmac_sha_256 (crypto, &Km, &hmac_input, &Tp, status)) {
-         _mongocrypt_buffer_cleanup (&hmac_input);
-         _mongocrypt_buffer_cleanup (&Tp);
-         return false;
-      }
-      if (0 != _mongocrypt_buffer_cmp (&T, &Tp)) {
-         CLIENT_ERR ("decryption error");
-         _mongocrypt_buffer_cleanup (&hmac_input);
-         _mongocrypt_buffer_cleanup (&Tp);
-         return false;
-      }
-      _mongocrypt_buffer_cleanup (&hmac_input);
-      _mongocrypt_buffer_cleanup (&Tp);
-   }
-
-   /* Compute and output M = AES-CTR.Dec(Ke, S) */
-   if (!_crypto_aes_256_ctr_decrypt (
-          crypto,
-          (aes_256_args_t){.key = &Ke,
-                           .iv = &IV,
-                           .in = &S,
-                           .out = &M,
-                           .bytes_written = bytes_written,
-                           .status = status})) {
-      return false;
-   }
-
-   return true;
-}
-
-bool
-_mongocrypt_fle2_do_encryption (_mongocrypt_crypto_t *crypto,
-                                const _mongocrypt_buffer_t *iv,
-                                const _mongocrypt_buffer_t *key,
-                                const _mongocrypt_buffer_t *plaintext,
-                                _mongocrypt_buffer_t *ciphertext,
-                                uint32_t *bytes_written,
-                                mongocrypt_status_t *status)
-{
-   BSON_ASSERT_PARAM (crypto);
-   BSON_ASSERT_PARAM (iv);
-   BSON_ASSERT_PARAM (key);
-   BSON_ASSERT_PARAM (plaintext);
-   BSON_ASSERT_PARAM (ciphertext);
-   BSON_ASSERT_PARAM (bytes_written);
-
-   if (ciphertext->len !=
-       _mongocrypt_fle2_calculate_ciphertext_len (plaintext->len, status)) {
-      CLIENT_ERR (
-         "output ciphertext must be allocated with %" PRIu32 " bytes",
-         _mongocrypt_fle2_calculate_ciphertext_len (plaintext->len, status));
-      return false;
-   }
-
-   if (plaintext->len <= 0) {
-      CLIENT_ERR ("input plaintext too small. Must be more than zero bytes.");
-      return false;
-   }
-
-   if (MONGOCRYPT_IV_LEN != iv->len) {
-      CLIENT_ERR ("IV must be length %d, but is length %" PRIu32,
-                  MONGOCRYPT_IV_LEN,
-                  iv->len);
-      return false;
-   }
-   if (MONGOCRYPT_ENC_KEY_LEN != key->len) {
-      CLIENT_ERR ("key must be length %d, but is length %" PRIu32,
-                  MONGOCRYPT_ENC_KEY_LEN,
-                  key->len);
-      return false;
-   }
-
-   BSON_ASSERT (ciphertext->len >= MONGOCRYPT_IV_LEN);
-   memset (ciphertext->data + MONGOCRYPT_IV_LEN,
-           0,
-           ciphertext->len - MONGOCRYPT_IV_LEN);
-   *bytes_written = 0;
-
-   /* Declare variable names matching [AEAD with
-    * CTR](https://docs.google.com/document/d/1eCU7R8Kjr-mdyz6eKvhNIDVmhyYQcAaLtTfHeK7a_vE/).
-    */
-   /* M is the input plaintext. */
-   _mongocrypt_buffer_t M = *plaintext;
-   /* Ke is 32 byte Key for encryption. */
-   _mongocrypt_buffer_t Ke = *key;
-   /* IV is 16 byte IV. */
-   _mongocrypt_buffer_t IV = *iv;
-   /* C is the output ciphertext. */
-   _mongocrypt_buffer_t C = *ciphertext;
-   /* S is the output of the symmetric cipher. It is appended after IV in C. */
-   _mongocrypt_buffer_t S;
-   if (!_mongocrypt_buffer_from_subrange (
-          &S, &C, MONGOCRYPT_IV_LEN, C.len - MONGOCRYPT_IV_LEN)) {
-      CLIENT_ERR ("unable to create S view from C");
-      return false;
-   }
-   uint32_t S_bytes_written = 0;
-
-   /* Compute S = AES-CTR.Enc(Ke, IV, M). */
-   if (!_crypto_aes_256_ctr_encrypt (
-          crypto,
-          (aes_256_args_t){.key = &Ke,
-                           .iv = &IV,
-                           .in = &M,
-                           .out = &S,
-                           .bytes_written = &S_bytes_written,
-                           .status = status})) {
-      return false;
-   }
-
-   if (S_bytes_written != M.len) {
-      CLIENT_ERR ("expected S_bytes_written=%" PRIu32 " got %" PRIu32,
-                  M.len,
-                  S_bytes_written);
-      return false;
-   }
-
-   /* Output C = IV || S. */
-   /* S is already in C. Prepend IV. */
-   memmove (C.data, IV.data, MONGOCRYPT_IV_LEN);
-
-   *bytes_written = MONGOCRYPT_IV_LEN + S_bytes_written;
-   return true;
-}
-
-bool
-_mongocrypt_fle2_do_decryption (_mongocrypt_crypto_t *crypto,
-                                const _mongocrypt_buffer_t *key,
-                                const _mongocrypt_buffer_t *ciphertext,
-                                _mongocrypt_buffer_t *plaintext,
-                                uint32_t *bytes_written,
-                                mongocrypt_status_t *status)
-{
-   BSON_ASSERT_PARAM (crypto);
-   BSON_ASSERT_PARAM (key);
-   BSON_ASSERT_PARAM (ciphertext);
-   BSON_ASSERT_PARAM (plaintext);
-   BSON_ASSERT_PARAM (bytes_written);
-
-   if (ciphertext->len <= MONGOCRYPT_IV_LEN) {
-      CLIENT_ERR ("input ciphertext too small. Must be more than %" PRIu32
-                  " bytes",
-                  MONGOCRYPT_IV_LEN);
-      return false;
-   }
-
-   if (plaintext->len !=
-       _mongocrypt_fle2_calculate_plaintext_len (ciphertext->len, status)) {
-      CLIENT_ERR (
-         "output plaintext must be allocated with %" PRIu32 " bytes",
-         _mongocrypt_fle2_calculate_plaintext_len (ciphertext->len, status));
-      return false;
-   }
-
-   if (MONGOCRYPT_ENC_KEY_LEN != key->len) {
-      CLIENT_ERR ("key must be length %d, but is length %" PRIu32,
-                  MONGOCRYPT_ENC_KEY_LEN,
-                  key->len);
-      return false;
-   }
-
-   memset (plaintext->data, 0, plaintext->len);
-   *bytes_written = 0;
-
-   /* Declare variable names matching [AEAD with
-    * CTR](https://docs.google.com/document/d/1eCU7R8Kjr-mdyz6eKvhNIDVmhyYQcAaLtTfHeK7a_vE/).
-    */
-   /* C is the input ciphertext. */
-   _mongocrypt_buffer_t C = *ciphertext;
-   /* IV is 16 byte IV. It is the first part of C. */
-   _mongocrypt_buffer_t IV;
-   if (!_mongocrypt_buffer_from_subrange (
-          &IV, ciphertext, 0, MONGOCRYPT_IV_LEN)) {
-      CLIENT_ERR ("unable to create IV view from ciphertext");
-      return false;
-   }
-   /* S is the symmetric cipher output from C. It is after the IV in C. */
-   _mongocrypt_buffer_t S;
-   if (!_mongocrypt_buffer_from_subrange (
-          &S, ciphertext, MONGOCRYPT_IV_LEN, C.len - MONGOCRYPT_IV_LEN)) {
-      CLIENT_ERR ("unable to create S view from C");
-      return false;
-   }
-   /* M is the output plaintext. */
-   _mongocrypt_buffer_t M = *plaintext;
-   /* Ke is 32 byte Key for encryption. */
-   _mongocrypt_buffer_t Ke = *key;
-
-   /* Compute and output M = AES-CTR.Dec(Ke, S) */
-   if (!_crypto_aes_256_ctr_decrypt (
-          crypto,
-          (aes_256_args_t){.key = &Ke,
-                           .iv = &IV,
-                           .in = &S,
-                           .out = &M,
-                           .bytes_written = bytes_written,
-                           .status = status})) {
-      return false;
-   }
-
-   if (*bytes_written != S.len) {
-      CLIENT_ERR ("expected bytes_written=%" PRIu32 " got %" PRIu32,
-                  S.len,
-                  *bytes_written);
-      return false;
-   }
-
    return true;
 }
 

--- a/src/mongocrypt-ctx-decrypt.c
+++ b/src/mongocrypt-ctx-decrypt.c
@@ -218,6 +218,8 @@ _replace_ciphertext_with_plaintext (void *ctx,
                                     bson_value_t *out,
                                     mongocrypt_status_t *status)
 {
+   const _mongocrypt_value_encryption_algorithm_t *fle1alg =
+      _mcFLE1Algorithm ();
    _mongocrypt_key_broker_t *kb;
    _mongocrypt_ciphertext_t ciphertext;
    _mongocrypt_buffer_t plaintext;
@@ -263,8 +265,7 @@ _replace_ciphertext_with_plaintext (void *ctx,
       goto fail;
    }
 
-   plaintext.len =
-      _mongocrypt_calculate_plaintext_len (ciphertext.data.len, status);
+   plaintext.len = fle1alg->plaintext_len (ciphertext.data.len, status);
    if (plaintext.len == 0) {
       goto fail;
    }
@@ -279,13 +280,13 @@ _replace_ciphertext_with_plaintext (void *ctx,
       goto fail;
    }
 
-   if (!_mongocrypt_do_decryption (kb->crypt->crypto,
-                                   &associated_data,
-                                   &key_material,
-                                   &ciphertext.data,
-                                   &plaintext,
-                                   &bytes_written,
-                                   status)) {
+   if (!fle1alg->decrypt (kb->crypt->crypto,
+                          &associated_data,
+                          &key_material,
+                          &ciphertext.data,
+                          &plaintext,
+                          &bytes_written,
+                          status)) {
       goto fail;
    }
 

--- a/src/mongocrypt-ctx-decrypt.c
+++ b/src/mongocrypt-ctx-decrypt.c
@@ -265,7 +265,7 @@ _replace_ciphertext_with_plaintext (void *ctx,
       goto fail;
    }
 
-   plaintext.len = fle1alg->plaintext_len (ciphertext.data.len, status);
+   plaintext.len = fle1alg->get_plaintext_len (ciphertext.data.len, status);
    if (plaintext.len == 0) {
       goto fail;
    }
@@ -280,13 +280,13 @@ _replace_ciphertext_with_plaintext (void *ctx,
       goto fail;
    }
 
-   if (!fle1alg->decrypt (kb->crypt->crypto,
-                          &associated_data,
-                          &key_material,
-                          &ciphertext.data,
-                          &plaintext,
-                          &bytes_written,
-                          status)) {
+   if (!fle1alg->do_decrypt (kb->crypt->crypto,
+                             &associated_data,
+                             &key_material,
+                             &ciphertext.data,
+                             &plaintext,
+                             &bytes_written,
+                             status)) {
       goto fail;
    }
 

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -291,7 +291,7 @@ _fle2_placeholder_aes_ctr_encrypt (_mongocrypt_key_broker_t *kb,
                                    mongocrypt_status_t *status)
 {
    const _mongocrypt_value_encryption_algorithm_t *fle2iev =
-      _mcFLE2IEVAlgorithm ();
+      _mcFLE2Algorithm ();
    BSON_ASSERT_PARAM (kb);
    BSON_ASSERT_PARAM (key);
    BSON_ASSERT_PARAM (in);
@@ -300,7 +300,7 @@ _fle2_placeholder_aes_ctr_encrypt (_mongocrypt_key_broker_t *kb,
 
    _mongocrypt_crypto_t *crypto = kb->crypt->crypto;
    _mongocrypt_buffer_t iv;
-   const uint32_t cipherlen = fle2iev->ciphertext_len (in->len, status);
+   const uint32_t cipherlen = fle2iev->get_ciphertext_len (in->len, status);
    if (cipherlen == 0) {
       return false;
    }
@@ -314,7 +314,7 @@ _fle2_placeholder_aes_ctr_encrypt (_mongocrypt_key_broker_t *kb,
       return false;
    }
 
-   if (!fle2iev->encrypt (
+   if (!fle2iev->do_encrypt (
           crypto, &iv, NULL /* aad */, key, in, out, &written, status)) {
       _mongocrypt_buffer_cleanup (out);
       _mongocrypt_buffer_init (out);
@@ -332,7 +332,8 @@ _fle2_placeholder_aead_encrypt (_mongocrypt_key_broker_t *kb,
                                 _mongocrypt_buffer_t *out,
                                 mongocrypt_status_t *status)
 {
-   const _mongocrypt_value_encryption_algorithm_t *fle2 = _mcFLE2Algorithm ();
+   const _mongocrypt_value_encryption_algorithm_t *fle2 =
+      _mcFLE2AEADAlgorithm ();
    BSON_ASSERT_PARAM (kb);
    BSON_ASSERT_PARAM (keyId);
    BSON_ASSERT_PARAM (in);
@@ -341,7 +342,7 @@ _fle2_placeholder_aead_encrypt (_mongocrypt_key_broker_t *kb,
 
    _mongocrypt_crypto_t *crypto = kb->crypt->crypto;
    _mongocrypt_buffer_t iv, key;
-   const uint32_t cipherlen = fle2->ciphertext_len (in->len, status);
+   const uint32_t cipherlen = fle2->get_ciphertext_len (in->len, status);
    if (cipherlen == 0) {
       return false;
    }
@@ -360,7 +361,7 @@ _fle2_placeholder_aead_encrypt (_mongocrypt_key_broker_t *kb,
    }
 
    _mongocrypt_buffer_init_size (out, cipherlen);
-   res = fle2->encrypt (crypto, &iv, keyId, &key, in, out, &written, status);
+   res = fle2->do_encrypt (crypto, &iv, keyId, &key, in, out, &written, status);
    _mongocrypt_buffer_cleanup (&key);
    _mongocrypt_buffer_cleanup (&iv);
 
@@ -1492,7 +1493,7 @@ _mongocrypt_fle1_marking_to_ciphertext (_mongocrypt_key_broker_t *kb,
    }
 
    _mongocrypt_buffer_from_iter (&plaintext, &marking->v_iter);
-   ciphertext->data.len = fle1->ciphertext_len (plaintext.len, status);
+   ciphertext->data.len = fle1->get_ciphertext_len (plaintext.len, status);
    if (ciphertext->data.len == 0) {
       goto fail;
    }
@@ -1516,14 +1517,14 @@ _mongocrypt_fle1_marking_to_ciphertext (_mongocrypt_key_broker_t *kb,
          goto fail;
       }
 
-      ret = fle1->encrypt (kb->crypt->crypto,
-                           &iv,
-                           &associated_data,
-                           &key_material,
-                           &plaintext,
-                           &ciphertext->data,
-                           &bytes_written,
-                           status);
+      ret = fle1->do_encrypt (kb->crypt->crypto,
+                              &iv,
+                              &associated_data,
+                              &key_material,
+                              &plaintext,
+                              &ciphertext->data,
+                              &bytes_written,
+                              status);
       break;
    case MONGOCRYPT_ENCRYPTION_ALGORITHM_RANDOM:
       /* Use randomized encryption.
@@ -1533,14 +1534,14 @@ _mongocrypt_fle1_marking_to_ciphertext (_mongocrypt_key_broker_t *kb,
              kb->crypt->crypto, &iv, MONGOCRYPT_IV_LEN, status)) {
          goto fail;
       }
-      ret = fle1->encrypt (kb->crypt->crypto,
-                           &iv,
-                           &associated_data,
-                           &key_material,
-                           &plaintext,
-                           &ciphertext->data,
-                           &bytes_written,
-                           status);
+      ret = fle1->do_encrypt (kb->crypt->crypto,
+                              &iv,
+                              &associated_data,
+                              &key_material,
+                              &plaintext,
+                              &ciphertext->data,
+                              &bytes_written,
+                              status);
       break;
    case MONGOCRYPT_ENCRYPTION_ALGORITHM_NONE:
    default:

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -290,6 +290,8 @@ _fle2_placeholder_aes_ctr_encrypt (_mongocrypt_key_broker_t *kb,
                                    _mongocrypt_buffer_t *out,
                                    mongocrypt_status_t *status)
 {
+   const _mongocrypt_value_encryption_algorithm_t *fle2iev =
+      _mcFLE2IEVAlgorithm ();
    BSON_ASSERT_PARAM (kb);
    BSON_ASSERT_PARAM (key);
    BSON_ASSERT_PARAM (in);
@@ -298,8 +300,7 @@ _fle2_placeholder_aes_ctr_encrypt (_mongocrypt_key_broker_t *kb,
 
    _mongocrypt_crypto_t *crypto = kb->crypt->crypto;
    _mongocrypt_buffer_t iv;
-   const uint32_t cipherlen =
-      _mongocrypt_fle2_calculate_ciphertext_len (in->len, status);
+   const uint32_t cipherlen = fle2iev->ciphertext_len (in->len, status);
    if (cipherlen == 0) {
       return false;
    }
@@ -313,8 +314,8 @@ _fle2_placeholder_aes_ctr_encrypt (_mongocrypt_key_broker_t *kb,
       return false;
    }
 
-   if (!_mongocrypt_fle2_do_encryption (
-          crypto, &iv, key, in, out, &written, status)) {
+   if (!fle2iev->encrypt (
+          crypto, &iv, NULL /* aad */, key, in, out, &written, status)) {
       _mongocrypt_buffer_cleanup (out);
       _mongocrypt_buffer_init (out);
       return false;
@@ -331,6 +332,7 @@ _fle2_placeholder_aead_encrypt (_mongocrypt_key_broker_t *kb,
                                 _mongocrypt_buffer_t *out,
                                 mongocrypt_status_t *status)
 {
+   const _mongocrypt_value_encryption_algorithm_t *fle2 = _mcFLE2Algorithm ();
    BSON_ASSERT_PARAM (kb);
    BSON_ASSERT_PARAM (keyId);
    BSON_ASSERT_PARAM (in);
@@ -339,8 +341,7 @@ _fle2_placeholder_aead_encrypt (_mongocrypt_key_broker_t *kb,
 
    _mongocrypt_crypto_t *crypto = kb->crypt->crypto;
    _mongocrypt_buffer_t iv, key;
-   const uint32_t cipherlen =
-      _mongocrypt_fle2aead_calculate_ciphertext_len (in->len, status);
+   const uint32_t cipherlen = fle2->ciphertext_len (in->len, status);
    if (cipherlen == 0) {
       return false;
    }
@@ -359,8 +360,7 @@ _fle2_placeholder_aead_encrypt (_mongocrypt_key_broker_t *kb,
    }
 
    _mongocrypt_buffer_init_size (out, cipherlen);
-   res = _mongocrypt_fle2aead_do_encryption (
-      crypto, &iv, keyId, &key, in, out, &written, status);
+   res = fle2->encrypt (crypto, &iv, keyId, &key, in, out, &written, status);
    _mongocrypt_buffer_cleanup (&key);
    _mongocrypt_buffer_cleanup (&iv);
 
@@ -705,8 +705,7 @@ get_edges (mc_FLE2RangeInsertSpec_t *insertSpec,
 #if MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
       const mc_dec128 value = mc_dec128_from_bson_iter (&insertSpec->v);
       mc_getEdgesDecimal128_args_t args = {
-         .value = value,
-         .sparsity = sparsity,
+         .value = value, .sparsity = sparsity,
       };
       if (insertSpec->precision.set) {
          const mc_dec128 min = mc_dec128_from_bson_iter (&insertSpec->min);
@@ -1435,6 +1434,7 @@ _mongocrypt_fle1_marking_to_ciphertext (_mongocrypt_key_broker_t *kb,
                                         _mongocrypt_ciphertext_t *ciphertext,
                                         mongocrypt_status_t *status)
 {
+   const _mongocrypt_value_encryption_algorithm_t *fle1 = _mcFLE1Algorithm ();
    _mongocrypt_buffer_t plaintext;
    _mongocrypt_buffer_t iv;
    _mongocrypt_buffer_t associated_data;
@@ -1492,8 +1492,7 @@ _mongocrypt_fle1_marking_to_ciphertext (_mongocrypt_key_broker_t *kb,
    }
 
    _mongocrypt_buffer_from_iter (&plaintext, &marking->v_iter);
-   ciphertext->data.len =
-      _mongocrypt_calculate_ciphertext_len (plaintext.len, status);
+   ciphertext->data.len = fle1->ciphertext_len (plaintext.len, status);
    if (ciphertext->data.len == 0) {
       goto fail;
    }
@@ -1517,14 +1516,14 @@ _mongocrypt_fle1_marking_to_ciphertext (_mongocrypt_key_broker_t *kb,
          goto fail;
       }
 
-      ret = _mongocrypt_do_encryption (kb->crypt->crypto,
-                                       &iv,
-                                       &associated_data,
-                                       &key_material,
-                                       &plaintext,
-                                       &ciphertext->data,
-                                       &bytes_written,
-                                       status);
+      ret = fle1->encrypt (kb->crypt->crypto,
+                           &iv,
+                           &associated_data,
+                           &key_material,
+                           &plaintext,
+                           &ciphertext->data,
+                           &bytes_written,
+                           status);
       break;
    case MONGOCRYPT_ENCRYPTION_ALGORITHM_RANDOM:
       /* Use randomized encryption.
@@ -1534,14 +1533,14 @@ _mongocrypt_fle1_marking_to_ciphertext (_mongocrypt_key_broker_t *kb,
              kb->crypt->crypto, &iv, MONGOCRYPT_IV_LEN, status)) {
          goto fail;
       }
-      ret = _mongocrypt_do_encryption (kb->crypt->crypto,
-                                       &iv,
-                                       &associated_data,
-                                       &key_material,
-                                       &plaintext,
-                                       &ciphertext->data,
-                                       &bytes_written,
-                                       status);
+      ret = fle1->encrypt (kb->crypt->crypto,
+                           &iv,
+                           &associated_data,
+                           &key_material,
+                           &plaintext,
+                           &ciphertext->data,
+                           &bytes_written,
+                           status);
       break;
    case MONGOCRYPT_ENCRYPTION_ALGORITHM_NONE:
    default:

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -290,7 +290,7 @@ _fle2_placeholder_aes_ctr_encrypt (_mongocrypt_key_broker_t *kb,
                                    _mongocrypt_buffer_t *out,
                                    mongocrypt_status_t *status)
 {
-   const _mongocrypt_value_encryption_algorithm_t *fle2iev =
+   const _mongocrypt_value_encryption_algorithm_t *fle2alg =
       _mcFLE2Algorithm ();
    BSON_ASSERT_PARAM (kb);
    BSON_ASSERT_PARAM (key);
@@ -300,7 +300,7 @@ _fle2_placeholder_aes_ctr_encrypt (_mongocrypt_key_broker_t *kb,
 
    _mongocrypt_crypto_t *crypto = kb->crypt->crypto;
    _mongocrypt_buffer_t iv;
-   const uint32_t cipherlen = fle2iev->get_ciphertext_len (in->len, status);
+   const uint32_t cipherlen = fle2alg->get_ciphertext_len (in->len, status);
    if (cipherlen == 0) {
       return false;
    }
@@ -314,7 +314,7 @@ _fle2_placeholder_aes_ctr_encrypt (_mongocrypt_key_broker_t *kb,
       return false;
    }
 
-   if (!fle2iev->do_encrypt (
+   if (!fle2alg->do_encrypt (
           crypto, &iv, NULL /* aad */, key, in, out, &written, status)) {
       _mongocrypt_buffer_cleanup (out);
       _mongocrypt_buffer_init (out);

--- a/test/test-mc-fle2-payload-iev.c
+++ b/test/test-mc-fle2-payload-iev.c
@@ -130,7 +130,8 @@ test_FLE2IndexedEqualityEncryptedValue_parse (_mongocrypt_tester_t *tester)
 }
 
 static void
-test_FLE2IndexedEqualityEncryptedValueTokens_init_from_buf (_mongocrypt_tester_t *tester)
+test_FLE2IndexedEqualityEncryptedValueTokens_init_from_buf (
+   _mongocrypt_tester_t *tester)
 {
    uint64_t counter = 45;
    _mongocrypt_buffer_t expected_edc_token;
@@ -160,16 +161,19 @@ test_FLE2IndexedEqualityEncryptedValueTokens_init_from_buf (_mongocrypt_tester_t
       "EBB22F74BE0FA4AD863188D3F33AF0B95CB4CA4ED0091E1A43513DB20E9D59AE"
       "A1DF0BB04C977BD4BC0B487FFFD2E3BBB96078354DE9F204EE5872BB10F01971");
 
-   /* Test function mc_FLE2IndexedEqualityEncryptedValueTokens_init_from_buffer. */
+   /* Test function mc_FLE2IndexedEqualityEncryptedValueTokens_init_from_buffer.
+    */
    {
       mongocrypt_status_t *status = mongocrypt_status_new ();
-      mc_FLE2IndexedEqualityEncryptedValueTokens *tokens = mc_FLE2IndexedEqualityEncryptedValueTokens_new ();
-      
-      ASSERT (mc_FLE2IndexedEqualityEncryptedValueTokens_init_from_buffer(tokens, &input_token_set, status));
+      mc_FLE2IndexedEqualityEncryptedValueTokens *tokens =
+         mc_FLE2IndexedEqualityEncryptedValueTokens_new ();
+
+      ASSERT (mc_FLE2IndexedEqualityEncryptedValueTokens_init_from_buffer (
+         tokens, &input_token_set, status));
       ASSERT_CMPUINT64 (counter, ==, tokens->counter);
-      ASSERT_CMPBUF(expected_edc_token, tokens->edc);
-      ASSERT_CMPBUF(expected_esc_token, tokens->esc);
-      ASSERT_CMPBUF(expected_ecc_token, tokens->ecc);
+      ASSERT_CMPBUF (expected_edc_token, tokens->edc);
+      ASSERT_CMPBUF (expected_esc_token, tokens->esc);
+      ASSERT_CMPBUF (expected_ecc_token, tokens->ecc);
 
       mc_FLE2IndexedEqualityEncryptedValueTokens_destroy (tokens);
       mongocrypt_status_destroy (status);
@@ -290,30 +294,34 @@ test_FLE2IndexedEqualityEncryptedValue_decrypt (_mongocrypt_tester_t *tester)
    {
       mongocrypt_status_t *status = mongocrypt_status_new ();
       iev = mc_FLE2IndexedEncryptedValue_new ();
-      mc_FLE2IndexedEqualityEncryptedValueTokens *tokens = mc_FLE2IndexedEqualityEncryptedValueTokens_new ();
+      mc_FLE2IndexedEqualityEncryptedValueTokens *tokens =
+         mc_FLE2IndexedEqualityEncryptedValueTokens_new ();
 
       ASSERT_OK_STATUS (
-         mc_FLE2IndexedEncryptedValue_parse (iev, &input_with_tokens, status), status);
+         mc_FLE2IndexedEncryptedValue_parse (iev, &input_with_tokens, status),
+         status);
 
       _mongocrypt_buffer_t TokenKey;
       ASSERT (_mongocrypt_buffer_from_subrange (&TokenKey,
                                                 &correct_S_Key,
-                                                correct_S_Key.len - MONGOCRYPT_TOKEN_KEY_LEN,
+                                                correct_S_Key.len -
+                                                   MONGOCRYPT_TOKEN_KEY_LEN,
                                                 MONGOCRYPT_TOKEN_KEY_LEN));
 
       mc_ServerDataEncryptionLevel1Token_t *token =
-         mc_ServerDataEncryptionLevel1Token_new (crypt->crypto, &TokenKey, status);
+         mc_ServerDataEncryptionLevel1Token_new (
+            crypt->crypto, &TokenKey, status);
 
       ASSERT (token);
 
-      ASSERT_OK_STATUS (mc_FLE2IndexedEncryptedValue_decrypt_equality(
-                           crypt->crypto, iev, token, tokens, status), 
+      ASSERT_OK_STATUS (mc_FLE2IndexedEncryptedValue_decrypt_equality (
+                           crypt->crypto, iev, token, tokens, status),
                         status);
 
-      ASSERT_CMPUINT64(123456, ==, tokens->counter);
-      ASSERT_CMPBUF(expected_edc_token, tokens->edc);
-      ASSERT_CMPBUF(expected_esc_token, tokens->esc);
-      ASSERT_CMPBUF(expected_ecc_token, tokens->ecc);
+      ASSERT_CMPUINT64 (123456, ==, tokens->counter);
+      ASSERT_CMPBUF (expected_edc_token, tokens->edc);
+      ASSERT_CMPBUF (expected_esc_token, tokens->esc);
+      ASSERT_CMPBUF (expected_ecc_token, tokens->ecc);
 
       mc_ServerDataEncryptionLevel1Token_destroy (token);
       mc_FLE2IndexedEqualityEncryptedValueTokens_destroy (tokens);
@@ -325,52 +333,61 @@ test_FLE2IndexedEqualityEncryptedValue_decrypt (_mongocrypt_tester_t *tester)
    {
       mongocrypt_status_t *status = mongocrypt_status_new ();
       iev = mc_FLE2IndexedEncryptedValue_new ();
-      mc_FLE2IndexedEqualityEncryptedValueTokens *tokens = mc_FLE2IndexedEqualityEncryptedValueTokens_new ();
+      mc_FLE2IndexedEqualityEncryptedValueTokens *tokens =
+         mc_FLE2IndexedEqualityEncryptedValueTokens_new ();
 
       ASSERT_OK_STATUS (
-         mc_FLE2IndexedEncryptedValue_parse (iev, &input_with_tokens, status), status);
+         mc_FLE2IndexedEncryptedValue_parse (iev, &input_with_tokens, status),
+         status);
 
       _mongocrypt_buffer_t TokenKey;
       ASSERT (_mongocrypt_buffer_from_subrange (&TokenKey,
                                                 &correct_S_Key,
-                                                correct_S_Key.len - MONGOCRYPT_TOKEN_KEY_LEN,
+                                                correct_S_Key.len -
+                                                   MONGOCRYPT_TOKEN_KEY_LEN,
                                                 MONGOCRYPT_TOKEN_KEY_LEN));
 
       mc_ServerDataEncryptionLevel1Token_t *token =
-         mc_ServerDataEncryptionLevel1Token_new (crypt->crypto, &TokenKey, status);
+         mc_ServerDataEncryptionLevel1Token_new (
+            crypt->crypto, &TokenKey, status);
 
       ASSERT (token);
 
-      ASSERT_OK_STATUS (mc_FLE2IndexedEncryptedValue_decrypt_equality(
-                           crypt->crypto, iev, token, tokens, status), 
+      ASSERT_OK_STATUS (mc_FLE2IndexedEncryptedValue_decrypt_equality (
+                           crypt->crypto, iev, token, tokens, status),
                         status);
 
       _mongocrypt_buffer_t write_buffer;
       _mongocrypt_buffer_init_size (&write_buffer, input_with_tokens.len);
 
-      const bson_type_t bson_type = mc_FLE2IndexedEncryptedValue_get_original_bson_type(iev, status);
-      const _mongocrypt_buffer_t *S_KeyId = mc_FLE2IndexedEncryptedValue_get_S_KeyId(iev, status);
-      const _mongocrypt_buffer_t *ClientEncryptedValue = mc_FLE2IndexedEncryptedValue_get_ClientEncryptedValue(iev, status);
+      const bson_type_t bson_type =
+         mc_FLE2IndexedEncryptedValue_get_original_bson_type (iev, status);
+      const _mongocrypt_buffer_t *S_KeyId =
+         mc_FLE2IndexedEncryptedValue_get_S_KeyId (iev, status);
+      const _mongocrypt_buffer_t *ClientEncryptedValue =
+         mc_FLE2IndexedEncryptedValue_get_ClientEncryptedValue (iev, status);
 
-      ASSERT (mc_FLE2IndexedEncryptedValue_write(crypt->crypto,
-                                                 bson_type,
-                                                 S_KeyId,
-                                                 ClientEncryptedValue,
-                                                 token,
-                                                 tokens,
-                                                 &write_buffer,
-                                                 status));
+      ASSERT (mc_FLE2IndexedEncryptedValue_write (crypt->crypto,
+                                                  bson_type,
+                                                  S_KeyId,
+                                                  ClientEncryptedValue,
+                                                  token,
+                                                  tokens,
+                                                  &write_buffer,
+                                                  status));
 
       mc_FLE2IndexedEncryptedValue_t *iev2;
       iev2 = mc_FLE2IndexedEncryptedValue_new ();
-      
+
       ASSERT_OK_STATUS (
-         mc_FLE2IndexedEncryptedValue_parse (iev2, &write_buffer, status), status);
+         mc_FLE2IndexedEncryptedValue_parse (iev2, &write_buffer, status),
+         status);
 
-      mc_FLE2IndexedEqualityEncryptedValueTokens *tokens2 = mc_FLE2IndexedEqualityEncryptedValueTokens_new ();
+      mc_FLE2IndexedEqualityEncryptedValueTokens *tokens2 =
+         mc_FLE2IndexedEqualityEncryptedValueTokens_new ();
 
-      ASSERT_OK_STATUS (mc_FLE2IndexedEncryptedValue_decrypt_equality(
-                           crypt->crypto, iev2, token, tokens2, status), 
+      ASSERT_OK_STATUS (mc_FLE2IndexedEncryptedValue_decrypt_equality (
+                           crypt->crypto, iev2, token, tokens2, status),
                         status);
 
       ASSERT_CMPUINT64 (tokens->counter, ==, tokens2->counter);
@@ -378,7 +395,7 @@ test_FLE2IndexedEqualityEncryptedValue_decrypt (_mongocrypt_tester_t *tester)
       ASSERT_CMPBUF (tokens->esc, tokens2->esc);
       ASSERT_CMPBUF (tokens->ecc, tokens2->ecc);
 
-      _mongocrypt_buffer_cleanup(&write_buffer);
+      _mongocrypt_buffer_cleanup (&write_buffer);
       mc_ServerDataEncryptionLevel1Token_destroy (token);
       mc_FLE2IndexedEqualityEncryptedValueTokens_destroy (tokens);
       mc_FLE2IndexedEqualityEncryptedValueTokens_destroy (tokens2);
@@ -432,7 +449,7 @@ test_FLE2IndexedEqualityEncryptedValue_decrypt (_mongocrypt_tester_t *tester)
       ASSERT_FAILS_STATUS (mc_FLE2IndexedEqualityEncryptedValue_add_K_Key (
                               crypt->crypto, iev, &incorrect_K_Key, status),
                            status,
-                           "decryption error");
+                           "HMAC validation failure");
       mc_FLE2IndexedEncryptedValue_destroy (iev);
       _mongocrypt_buffer_cleanup (&incorrect_K_Key);
       mongocrypt_status_destroy (status);

--- a/test/test-mc-fle2-payload-iup.c
+++ b/test/test-mc-fle2-payload-iup.c
@@ -161,7 +161,7 @@ test_FLE2InsertUpdatePayload_decrypt (_mongocrypt_tester_t *tester)
                         status);
       const _mongocrypt_buffer_t *got = mc_FLE2InsertUpdatePayload_decrypt (
          crypt->crypto, &iup, &incorrect_key, status);
-      ASSERT_FAILS_STATUS (got != NULL, status, "decryption error");
+      ASSERT_FAILS_STATUS (got != NULL, status, "HMAC validation failure");
 
       mc_FLE2InsertUpdatePayload_cleanup (&iup);
       _mongocrypt_buffer_cleanup (&input);

--- a/test/test-mc-fle2-payload-uev.c
+++ b/test/test-mc-fle2-payload-uev.c
@@ -177,7 +177,7 @@ test_FLE2UnindexedEncryptedValue_decrypt (_mongocrypt_tester_t *tester)
          mc_FLE2UnindexedEncryptedValue_parse (uev, &input, status), status);
       const _mongocrypt_buffer_t *got = mc_FLE2UnindexedEncryptedValue_decrypt (
          crypt->crypto, uev, &incorrect_key, status);
-      ASSERT_FAILS_STATUS (got != NULL, status, "decryption error");
+      ASSERT_FAILS_STATUS (got != NULL, status, "HMAC validation failure");
       mc_FLE2UnindexedEncryptedValue_destroy (uev);
       _mongocrypt_buffer_cleanup (&incorrect_key);
       mongocrypt_status_destroy (status);

--- a/test/test-mc-tokens.c
+++ b/test/test-mc-tokens.c
@@ -193,6 +193,7 @@ _test_mc_tokens (_mongocrypt_tester_t *tester)
    mc_ECCToken_destroy (ECCToken);
    mc_ESCToken_destroy (ESCToken);
    mc_EDCToken_destroy (EDCToken);
+   mc_ServerDerivedFromDataToken_destroy (ServerDerivedFromDataToken);
    mc_ServerTokenDerivationLevel1Token_destroy (
       ServerTokenDerivationLevel1Token);
    mc_ServerDataEncryptionLevel1Token_destroy (ServerDataEncryptionLevel1Token);

--- a/test/test-mongocrypt-crypto-hooks.c
+++ b/test/test-mongocrypt-crypto-hooks.c
@@ -333,34 +333,34 @@ _test_crypto_hooks_encryption_helper (_mongocrypt_tester_t *tester,
 
    if (ctr_hook || ecb_hook) {
       const _mongocrypt_value_encryption_algorithm_t *fle2iev =
-         _mcFLE2IEVAlgorithm ();
+         _mcFLE2Algorithm ();
       _mongocrypt_buffer_copy_from_hex (&key, ENCRYPTION_KEY_HEX);
       _mongocrypt_buffer_init (&ciphertext);
       _mongocrypt_buffer_resize (
-         &ciphertext, fle2iev->ciphertext_len (plaintext.len, status));
-      ret = fle2iev->encrypt (crypt->crypto,
-                              &iv,
-                              NULL /* aad */,
-                              &key,
-                              &plaintext,
-                              &ciphertext,
-                              &bytes_written,
-                              status);
+         &ciphertext, fle2iev->get_ciphertext_len (plaintext.len, status));
+      ret = fle2iev->do_encrypt (crypt->crypto,
+                                 &iv,
+                                 NULL /* aad */,
+                                 &key,
+                                 &plaintext,
+                                 &ciphertext,
+                                 &bytes_written,
+                                 status);
    } else {
       const _mongocrypt_value_encryption_algorithm_t *fle1alg =
          _mcFLE1Algorithm ();
       _mongocrypt_buffer_copy_from_hex (&key, KEY_HEX);
       _mongocrypt_buffer_init (&ciphertext);
       _mongocrypt_buffer_resize (
-         &ciphertext, fle1alg->ciphertext_len (plaintext.len, status));
-      ret = fle1alg->encrypt (crypt->crypto,
-                              &iv,
-                              &associated_data,
-                              &key,
-                              &plaintext,
-                              &ciphertext,
-                              &bytes_written,
-                              status);
+         &ciphertext, fle1alg->get_ciphertext_len (plaintext.len, status));
+      ret = fle1alg->do_encrypt (crypt->crypto,
+                                 &iv,
+                                 &associated_data,
+                                 &key,
+                                 &plaintext,
+                                 &ciphertext,
+                                 &bytes_written,
+                                 status);
    }
 
    if (0 == strcmp (error_on, "error_on:none")) {
@@ -443,34 +443,34 @@ _test_crypto_hooks_decryption_helper (_mongocrypt_tester_t *tester,
 
    if (ctr_hook || ecb_hook) {
       const _mongocrypt_value_encryption_algorithm_t *fle2iev =
-         _mcFLE2IEVAlgorithm ();
+         _mcFLE2Algorithm ();
       _mongocrypt_buffer_copy_from_hex (&key, ENCRYPTION_KEY_HEX);
       _mongocrypt_buffer_init (&plaintext);
       _mongocrypt_buffer_resize (
-         &plaintext, fle2iev->plaintext_len (ciphertext.len, status));
+         &plaintext, fle2iev->get_plaintext_len (ciphertext.len, status));
 
-      ret = fle2iev->decrypt (crypt->crypto,
-                              NULL /* aad */,
-                              &key,
-                              &ciphertext,
-                              &plaintext,
-                              &bytes_written,
-                              status);
+      ret = fle2iev->do_decrypt (crypt->crypto,
+                                 NULL /* aad */,
+                                 &key,
+                                 &ciphertext,
+                                 &plaintext,
+                                 &bytes_written,
+                                 status);
    } else {
       const _mongocrypt_value_encryption_algorithm_t *fle1alg =
          _mcFLE1Algorithm ();
       _mongocrypt_buffer_copy_from_hex (&key, KEY_HEX);
       _mongocrypt_buffer_init (&plaintext);
       _mongocrypt_buffer_resize (
-         &plaintext, fle1alg->plaintext_len (ciphertext.len, status));
+         &plaintext, fle1alg->get_plaintext_len (ciphertext.len, status));
 
-      ret = fle1alg->decrypt (crypt->crypto,
-                              &associated_data,
-                              &key,
-                              &ciphertext,
-                              &plaintext,
-                              &bytes_written,
-                              status);
+      ret = fle1alg->do_decrypt (crypt->crypto,
+                                 &associated_data,
+                                 &key,
+                                 &ciphertext,
+                                 &plaintext,
+                                 &bytes_written,
+                                 status);
    }
 
    if (0 == strcmp (error_on, "error_on:none")) {
@@ -830,7 +830,7 @@ void
 _test_fle2_crypto_via_ecb_hook (_mongocrypt_tester_t *tester)
 {
    const _mongocrypt_value_encryption_algorithm_t *fle2iev =
-      _mcFLE2IEVAlgorithm ();
+      _mcFLE2Algorithm ();
    bool ret;
    _mongocrypt_buffer_t key;
    _mongocrypt_buffer_t iv;
@@ -851,32 +851,32 @@ _test_fle2_crypto_via_ecb_hook (_mongocrypt_tester_t *tester)
 
    mongocrypt_t *crypt_reg = mongocrypt_new ();
    _mongocrypt_buffer_init (&ciphertext_reg);
-   _mongocrypt_buffer_resize (&ciphertext_reg,
-                              fle2iev->ciphertext_len (plaintext.len, status));
-   ret = fle2iev->encrypt (crypt_reg->crypto,
-                           &iv,
-                           NULL /* aad */,
-                           &key,
-                           &plaintext,
-                           &ciphertext_reg,
-                           &bytes_written,
-                           status);
+   _mongocrypt_buffer_resize (
+      &ciphertext_reg, fle2iev->get_ciphertext_len (plaintext.len, status));
+   ret = fle2iev->do_encrypt (crypt_reg->crypto,
+                              &iv,
+                              NULL /* aad */,
+                              &key,
+                              &plaintext,
+                              &ciphertext_reg,
+                              &bytes_written,
+                              status);
    ASSERT_OK (ret, crypt_reg);
 
    mongocrypt_t *crypt_ecb = mongocrypt_new ();
    ret = mongocrypt_setopt_aes_256_ecb (crypt_ecb, _aes_256_ecb_encrypt, NULL);
    ASSERT_OK (ret, crypt_ecb);
    _mongocrypt_buffer_init (&ciphertext_ecb);
-   _mongocrypt_buffer_resize (&ciphertext_ecb,
-                              fle2iev->ciphertext_len (plaintext.len, status));
-   ret = fle2iev->encrypt (crypt_ecb->crypto,
-                           &iv,
-                           NULL /* aad */,
-                           &key,
-                           &plaintext,
-                           &ciphertext_ecb,
-                           &bytes_written,
-                           status);
+   _mongocrypt_buffer_resize (
+      &ciphertext_ecb, fle2iev->get_ciphertext_len (plaintext.len, status));
+   ret = fle2iev->do_encrypt (crypt_ecb->crypto,
+                              &iv,
+                              NULL /* aad */,
+                              &key,
+                              &plaintext,
+                              &ciphertext_ecb,
+                              &bytes_written,
+                              status);
    ASSERT_OK (ret, crypt_ecb);
 
    ASSERT (0 == _mongocrypt_buffer_cmp (&ciphertext_reg, &ciphertext_ecb));
@@ -885,14 +885,14 @@ _test_fle2_crypto_via_ecb_hook (_mongocrypt_tester_t *tester)
 
    _mongocrypt_buffer_init (&plaintext_ecb);
    _mongocrypt_buffer_resize (
-      &plaintext_ecb, fle2iev->plaintext_len (ciphertext_ecb.len, status));
-   ret = fle2iev->decrypt (crypt_ecb->crypto,
-                           NULL /* aad */,
-                           &key,
-                           &ciphertext_ecb,
-                           &plaintext_ecb,
-                           &bytes_written,
-                           status);
+      &plaintext_ecb, fle2iev->get_plaintext_len (ciphertext_ecb.len, status));
+   ret = fle2iev->do_decrypt (crypt_ecb->crypto,
+                              NULL /* aad */,
+                              &key,
+                              &ciphertext_ecb,
+                              &plaintext_ecb,
+                              &bytes_written,
+                              status);
    ASSERT_OK (ret, crypt_ecb);
 
    ASSERT (0 == _mongocrypt_buffer_cmp (&plaintext, &plaintext_ecb));

--- a/test/test-mongocrypt-crypto-hooks.c
+++ b/test/test-mongocrypt-crypto-hooks.c
@@ -332,13 +332,13 @@ _test_crypto_hooks_encryption_helper (_mongocrypt_tester_t *tester,
    call_history = bson_string_new (NULL);
 
    if (ctr_hook || ecb_hook) {
-      const _mongocrypt_value_encryption_algorithm_t *fle2iev =
+      const _mongocrypt_value_encryption_algorithm_t *fle2alg =
          _mcFLE2Algorithm ();
       _mongocrypt_buffer_copy_from_hex (&key, ENCRYPTION_KEY_HEX);
       _mongocrypt_buffer_init (&ciphertext);
       _mongocrypt_buffer_resize (
-         &ciphertext, fle2iev->get_ciphertext_len (plaintext.len, status));
-      ret = fle2iev->do_encrypt (crypt->crypto,
+         &ciphertext, fle2alg->get_ciphertext_len (plaintext.len, status));
+      ret = fle2alg->do_encrypt (crypt->crypto,
                                  &iv,
                                  NULL /* aad */,
                                  &key,
@@ -442,14 +442,14 @@ _test_crypto_hooks_decryption_helper (_mongocrypt_tester_t *tester,
    call_history = bson_string_new (NULL);
 
    if (ctr_hook || ecb_hook) {
-      const _mongocrypt_value_encryption_algorithm_t *fle2iev =
+      const _mongocrypt_value_encryption_algorithm_t *fle2alg =
          _mcFLE2Algorithm ();
       _mongocrypt_buffer_copy_from_hex (&key, ENCRYPTION_KEY_HEX);
       _mongocrypt_buffer_init (&plaintext);
       _mongocrypt_buffer_resize (
-         &plaintext, fle2iev->get_plaintext_len (ciphertext.len, status));
+         &plaintext, fle2alg->get_plaintext_len (ciphertext.len, status));
 
-      ret = fle2iev->do_decrypt (crypt->crypto,
+      ret = fle2alg->do_decrypt (crypt->crypto,
                                  NULL /* aad */,
                                  &key,
                                  &ciphertext,
@@ -829,7 +829,7 @@ _aes_256_ecb_encrypt (void *ctx,
 void
 _test_fle2_crypto_via_ecb_hook (_mongocrypt_tester_t *tester)
 {
-   const _mongocrypt_value_encryption_algorithm_t *fle2iev =
+   const _mongocrypt_value_encryption_algorithm_t *fle2alg =
       _mcFLE2Algorithm ();
    bool ret;
    _mongocrypt_buffer_t key;
@@ -852,8 +852,8 @@ _test_fle2_crypto_via_ecb_hook (_mongocrypt_tester_t *tester)
    mongocrypt_t *crypt_reg = mongocrypt_new ();
    _mongocrypt_buffer_init (&ciphertext_reg);
    _mongocrypt_buffer_resize (
-      &ciphertext_reg, fle2iev->get_ciphertext_len (plaintext.len, status));
-   ret = fle2iev->do_encrypt (crypt_reg->crypto,
+      &ciphertext_reg, fle2alg->get_ciphertext_len (plaintext.len, status));
+   ret = fle2alg->do_encrypt (crypt_reg->crypto,
                               &iv,
                               NULL /* aad */,
                               &key,
@@ -868,8 +868,8 @@ _test_fle2_crypto_via_ecb_hook (_mongocrypt_tester_t *tester)
    ASSERT_OK (ret, crypt_ecb);
    _mongocrypt_buffer_init (&ciphertext_ecb);
    _mongocrypt_buffer_resize (
-      &ciphertext_ecb, fle2iev->get_ciphertext_len (plaintext.len, status));
-   ret = fle2iev->do_encrypt (crypt_ecb->crypto,
+      &ciphertext_ecb, fle2alg->get_ciphertext_len (plaintext.len, status));
+   ret = fle2alg->do_encrypt (crypt_ecb->crypto,
                               &iv,
                               NULL /* aad */,
                               &key,
@@ -885,8 +885,8 @@ _test_fle2_crypto_via_ecb_hook (_mongocrypt_tester_t *tester)
 
    _mongocrypt_buffer_init (&plaintext_ecb);
    _mongocrypt_buffer_resize (
-      &plaintext_ecb, fle2iev->get_plaintext_len (ciphertext_ecb.len, status));
-   ret = fle2iev->do_decrypt (crypt_ecb->crypto,
+      &plaintext_ecb, fle2alg->get_plaintext_len (ciphertext_ecb.len, status));
+   ret = fle2alg->do_decrypt (crypt_ecb->crypto,
                               NULL /* aad */,
                               &key,
                               &ciphertext_ecb,

--- a/test/test-mongocrypt-crypto.c
+++ b/test/test-mongocrypt-crypto.c
@@ -752,7 +752,7 @@ typedef struct {
 void
 _test_fle2_roundtrip (_mongocrypt_tester_t *tester)
 {
-   const _mongocrypt_value_encryption_algorithm_t *fle2iev =
+   const _mongocrypt_value_encryption_algorithm_t *fle2alg =
       _mcFLE2Algorithm ();
    mongocrypt_t *crypt;
    fle2_aead_roundtrip_test_t tests[] = {
@@ -797,10 +797,10 @@ _test_fle2_roundtrip (_mongocrypt_tester_t *tester)
       }
       _mongocrypt_buffer_init (&ciphertext_got);
       _mongocrypt_buffer_resize (
-         &ciphertext_got, fle2iev->get_ciphertext_len (plaintext.len, status));
+         &ciphertext_got, fle2alg->get_ciphertext_len (plaintext.len, status));
 
       /* Test encrypt. */
-      ret = fle2iev->do_encrypt (crypt->crypto,
+      ret = fle2alg->do_encrypt (crypt->crypto,
                                  &iv,
                                  NULL, /* aad */
                                  &key,
@@ -818,7 +818,7 @@ _test_fle2_roundtrip (_mongocrypt_tester_t *tester)
          ASSERT_CMPINT ((int) bytes_written, ==, (int) ciphertext.len);
 
          /* Test decrypt. */
-         ret = fle2iev->do_decrypt (crypt->crypto,
+         ret = fle2alg->do_decrypt (crypt->crypto,
                                     NULL, /* aad */
                                     &key,
                                     &ciphertext,

--- a/test/test-mongocrypt-crypto.c
+++ b/test/test-mongocrypt-crypto.c
@@ -22,6 +22,8 @@
 static void
 _test_roundtrip (_mongocrypt_tester_t *tester)
 {
+   const _mongocrypt_value_encryption_algorithm_t *fle1alg =
+      _mcFLE1Algorithm ();
    mongocrypt_t *crypt;
    mongocrypt_status_t *const status = mongocrypt_status_new ();
    _mongocrypt_buffer_t key = {0}, iv = {0}, associated_data = {0},
@@ -33,13 +35,13 @@ _test_roundtrip (_mongocrypt_tester_t *tester)
    plaintext.data = (uint8_t *) "test";
    plaintext.len = 5; /* include NULL. */
 
-   ciphertext.len = _mongocrypt_calculate_ciphertext_len (5, status);
+   ciphertext.len = fle1alg->ciphertext_len (5, status);
    ciphertext.data = bson_malloc (ciphertext.len);
    BSON_ASSERT (ciphertext.data);
 
    ciphertext.owned = true;
 
-   decrypted.len = _mongocrypt_calculate_plaintext_len (ciphertext.len, status);
+   decrypted.len = fle1alg->plaintext_len (ciphertext.len, status);
    decrypted.data = bson_malloc (decrypted.len);
    BSON_ASSERT (decrypted.data);
 
@@ -53,25 +55,25 @@ _test_roundtrip (_mongocrypt_tester_t *tester)
    iv.len = MONGOCRYPT_IV_LEN;
    iv.owned = true;
 
-   ret = _mongocrypt_do_encryption (crypt->crypto,
-                                    &iv,
-                                    &associated_data,
-                                    &key,
-                                    &plaintext,
-                                    &ciphertext,
-                                    &bytes_written,
-                                    status);
+   ret = fle1alg->encrypt (crypt->crypto,
+                           &iv,
+                           &associated_data,
+                           &key,
+                           &plaintext,
+                           &ciphertext,
+                           &bytes_written,
+                           status);
    BSON_ASSERT (ret);
 
    BSON_ASSERT (bytes_written == ciphertext.len);
 
-   ret = _mongocrypt_do_decryption (crypt->crypto,
-                                    &associated_data,
-                                    &key,
-                                    &ciphertext,
-                                    &decrypted,
-                                    &bytes_written,
-                                    status);
+   ret = fle1alg->decrypt (crypt->crypto,
+                           &associated_data,
+                           &key,
+                           &ciphertext,
+                           &decrypted,
+                           &bytes_written,
+                           status);
    BSON_ASSERT (ret);
 
 
@@ -83,19 +85,19 @@ _test_roundtrip (_mongocrypt_tester_t *tester)
    ciphertext.data[ciphertext.len - 1] ^= 1;
 
    _mongocrypt_buffer_cleanup (&decrypted);
-   decrypted.len = _mongocrypt_calculate_plaintext_len (ciphertext.len, status);
+   decrypted.len = fle1alg->plaintext_len (ciphertext.len, status);
    decrypted.data = bson_malloc (decrypted.len);
    BSON_ASSERT (decrypted.data);
 
    decrypted.owned = true;
 
-   ret = _mongocrypt_do_decryption (crypt->crypto,
-                                    &associated_data,
-                                    &key,
-                                    &ciphertext,
-                                    &decrypted,
-                                    &bytes_written,
-                                    status);
+   ret = fle1alg->decrypt (crypt->crypto,
+                           &associated_data,
+                           &key,
+                           &ciphertext,
+                           &decrypted,
+                           &bytes_written,
+                           status);
    BSON_ASSERT (!ret);
    BSON_ASSERT (0 == strcmp (mongocrypt_status_message (status, NULL),
                              "HMAC validation failure"));
@@ -103,24 +105,24 @@ _test_roundtrip (_mongocrypt_tester_t *tester)
     * again. */
    ciphertext.data[ciphertext.len - 1] ^= 1;
    _mongocrypt_status_reset (status);
-   ret = _mongocrypt_do_decryption (crypt->crypto,
-                                    &associated_data,
-                                    &key,
-                                    &ciphertext,
-                                    &decrypted,
-                                    &bytes_written,
-                                    status);
+   ret = fle1alg->decrypt (crypt->crypto,
+                           &associated_data,
+                           &key,
+                           &ciphertext,
+                           &decrypted,
+                           &bytes_written,
+                           status);
    BSON_ASSERT (ret);
 
    /* Modify parts of the key. */
    key.data[0] ^= 1; /* part of the mac key */
-   ret = _mongocrypt_do_decryption (crypt->crypto,
-                                    &associated_data,
-                                    &key,
-                                    &ciphertext,
-                                    &decrypted,
-                                    &bytes_written,
-                                    status);
+   ret = fle1alg->decrypt (crypt->crypto,
+                           &associated_data,
+                           &key,
+                           &ciphertext,
+                           &decrypted,
+                           &bytes_written,
+                           status);
    BSON_ASSERT (!ret);
    BSON_ASSERT (0 == strcmp (mongocrypt_status_message (status, NULL),
                              "HMAC validation failure"));
@@ -130,13 +132,13 @@ _test_roundtrip (_mongocrypt_tester_t *tester)
 
    /* Modify the portion of the key responsible for encryption/decryption */
    key.data[MONGOCRYPT_MAC_KEY_LEN + 1] ^= 1; /* part of the encryption key */
-   ret = _mongocrypt_do_decryption (crypt->crypto,
-                                    &associated_data,
-                                    &key,
-                                    &ciphertext,
-                                    &decrypted,
-                                    &bytes_written,
-                                    status);
+   ret = fle1alg->decrypt (crypt->crypto,
+                           &associated_data,
+                           &key,
+                           &ciphertext,
+                           &decrypted,
+                           &bytes_written,
+                           status);
    BSON_ASSERT (!ret);
    BSON_ASSERT (0 == strcmp (mongocrypt_status_message (status, NULL),
                              "error, ciphertext malformed padding"));
@@ -154,6 +156,8 @@ _test_roundtrip (_mongocrypt_tester_t *tester)
 static void
 _test_mcgrew (_mongocrypt_tester_t *tester)
 {
+   const _mongocrypt_value_encryption_algorithm_t *fle1alg =
+      _mcFLE1Algorithm ();
    mongocrypt_t *crypt;
    mongocrypt_status_t *const status = mongocrypt_status_new ();
    _mongocrypt_buffer_t key, iv, associated_data, plaintext,
@@ -191,8 +195,7 @@ _test_mcgrew (_mongocrypt_tester_t *tester)
       "930806d0703b1f64dd3b4c088a7f45c216839645b2012bf2e6269a8c56a81"
       "6dbc1b267761955bc5");
 
-   ciphertext_actual.len =
-      _mongocrypt_calculate_ciphertext_len (plaintext.len, status);
+   ciphertext_actual.len = fle1alg->ciphertext_len (plaintext.len, status);
    ciphertext_actual.data = bson_malloc (ciphertext_actual.len);
    BSON_ASSERT (ciphertext_actual.data);
 
@@ -200,16 +203,20 @@ _test_mcgrew (_mongocrypt_tester_t *tester)
 
    /* Force the crypto stack to initialize with mongocrypt_new */
    crypt = _mongocrypt_tester_mongocrypt (TESTER_MONGOCRYPT_DEFAULT);
-   ret = _mongocrypt_do_encryption (crypt->crypto,
-                                    &iv,
-                                    &associated_data,
-                                    &key,
-                                    &plaintext,
-                                    &ciphertext_actual,
-                                    &bytes_written,
-                                    status);
-   BSON_ASSERT (ret);
+   ret = fle1alg->encrypt (crypt->crypto,
+                           &iv,
+                           &associated_data,
+                           &key,
+                           &plaintext,
+                           &ciphertext_actual,
+                           &bytes_written,
+                           status);
+   ASSERT_OR_PRINT (ret, status);
    BSON_ASSERT (ciphertext_actual.len == ciphertext_expected.len);
+   ASSERT_CMPBYTES (ciphertext_expected.data,
+                    ciphertext_expected.len,
+                    ciphertext_actual.data,
+                    ciphertext_actual.len);
    BSON_ASSERT (0 == memcmp (ciphertext_actual.data,
                              ciphertext_expected.data,
                              ciphertext_actual.len));
@@ -488,6 +495,8 @@ typedef struct {
 void
 _test_fle2_aead_roundtrip (_mongocrypt_tester_t *tester)
 {
+   const _mongocrypt_value_encryption_algorithm_t *fle2aead =
+      _mcFLE2Algorithm ();
    mongocrypt_t *crypt;
    fle2_aead_roundtrip_test_t tests[] = {
       {.testname = "Plaintext is 'test1'",
@@ -561,18 +570,17 @@ _test_fle2_aead_roundtrip (_mongocrypt_tester_t *tester)
       _mongocrypt_buffer_init (&ciphertext_got);
       status = mongocrypt_status_new ();
       _mongocrypt_buffer_resize (
-         &ciphertext_got,
-         _mongocrypt_fle2aead_calculate_ciphertext_len (plaintext.len, status));
+         &ciphertext_got, fle2aead->ciphertext_len (plaintext.len, status));
 
       /* Test encrypt. */
-      ret = _mongocrypt_fle2aead_do_encryption (crypt->crypto,
-                                                &iv,
-                                                &associated_data,
-                                                &key,
-                                                &plaintext,
-                                                &ciphertext_got,
-                                                &bytes_written,
-                                                status);
+      ret = fle2aead->encrypt (crypt->crypto,
+                               &iv,
+                               &associated_data,
+                               &key,
+                               &plaintext,
+                               &ciphertext_got,
+                               &bytes_written,
+                               status);
 
       if (NULL == test->expect_encrypt_error) {
          ASSERT_OR_PRINT (ret, status);
@@ -583,13 +591,13 @@ _test_fle2_aead_roundtrip (_mongocrypt_tester_t *tester)
          ASSERT_CMPINT ((int) bytes_written, ==, (int) ciphertext.len);
 
          /* Test decrypt. */
-         ret = _mongocrypt_fle2aead_do_decryption (crypt->crypto,
-                                                   &associated_data,
-                                                   &key,
-                                                   &ciphertext,
-                                                   &plaintext_got,
-                                                   &bytes_written,
-                                                   status);
+         ret = fle2aead->decrypt (crypt->crypto,
+                                  &associated_data,
+                                  &key,
+                                  &ciphertext,
+                                  &plaintext_got,
+                                  &bytes_written,
+                                  status);
          ASSERT_OR_PRINT (ret, status);
          ASSERT_CMPBYTES (plaintext.data,
                           plaintext.len,
@@ -633,6 +641,8 @@ typedef struct {
 void
 _test_fle2_aead_decrypt (_mongocrypt_tester_t *tester)
 {
+   const _mongocrypt_value_encryption_algorithm_t *fle2aead =
+      _mcFLE2Algorithm ();
    mongocrypt_t *crypt;
    fle2_aead_decrypt_test_t tests[] = {
       {.testname = "Mismatched HMAC",
@@ -644,7 +654,7 @@ _test_fle2_aead_decrypt (_mongocrypt_tester_t *tester)
        .plaintext = "74657374310a",
        .ciphertext = "918ab83c8966995dfb528a0020d9bb1070cead40b081ee0cbfe7265dd"
                      "57a84f6c331421b7fe6a9c8375748b46acbed1ec7a1b9983800",
-       .expect_error = "decryption error"},
+       .expect_error = "HMAC validation failure"},
       {.testname = "Ciphertext too small",
        .associated_data = "99f05406f40d1af74cc737a96c1932fdec90",
        .key =
@@ -697,13 +707,13 @@ _test_fle2_aead_decrypt (_mongocrypt_tester_t *tester)
       }
       status = mongocrypt_status_new ();
 
-      ret = _mongocrypt_fle2aead_do_decryption (crypt->crypto,
-                                                &associated_data,
-                                                &key,
-                                                &ciphertext,
-                                                &plaintext,
-                                                &bytes_written,
-                                                status);
+      ret = fle2aead->decrypt (crypt->crypto,
+                               &associated_data,
+                               &key,
+                               &ciphertext,
+                               &plaintext,
+                               &bytes_written,
+                               status);
       if (test->expect_error == NULL) {
          ASSERT_OR_PRINT (ret, status);
          ASSERT_CMPBYTES (plaintext.data,
@@ -742,6 +752,8 @@ typedef struct {
 void
 _test_fle2_roundtrip (_mongocrypt_tester_t *tester)
 {
+   const _mongocrypt_value_encryption_algorithm_t *fle2iev =
+      _mcFLE2IEVAlgorithm ();
    mongocrypt_t *crypt;
    fle2_aead_roundtrip_test_t tests[] = {
       {.testname = "Plaintext is 'test1'",
@@ -785,17 +797,17 @@ _test_fle2_roundtrip (_mongocrypt_tester_t *tester)
       }
       _mongocrypt_buffer_init (&ciphertext_got);
       _mongocrypt_buffer_resize (
-         &ciphertext_got,
-         _mongocrypt_fle2_calculate_ciphertext_len (plaintext.len, status));
+         &ciphertext_got, fle2iev->ciphertext_len (plaintext.len, status));
 
       /* Test encrypt. */
-      ret = _mongocrypt_fle2_do_encryption (crypt->crypto,
-                                            &iv,
-                                            &key,
-                                            &plaintext,
-                                            &ciphertext_got,
-                                            &bytes_written,
-                                            status);
+      ret = fle2iev->encrypt (crypt->crypto,
+                              &iv,
+                              NULL, /* aad */
+                              &key,
+                              &plaintext,
+                              &ciphertext_got,
+                              &bytes_written,
+                              status);
 
       if (NULL == test->expect_encrypt_error) {
          ASSERT_OR_PRINT (ret, status);
@@ -806,12 +818,13 @@ _test_fle2_roundtrip (_mongocrypt_tester_t *tester)
          ASSERT_CMPINT ((int) bytes_written, ==, (int) ciphertext.len);
 
          /* Test decrypt. */
-         ret = _mongocrypt_fle2_do_decryption (crypt->crypto,
-                                               &key,
-                                               &ciphertext,
-                                               &plaintext_got,
-                                               &bytes_written,
-                                               status);
+         ret = fle2iev->decrypt (crypt->crypto,
+                                 NULL, /* aad */
+                                 &key,
+                                 &ciphertext,
+                                 &plaintext_got,
+                                 &bytes_written,
+                                 status);
          ASSERT_OR_PRINT (ret, status);
          ASSERT_CMPBYTES (plaintext.data,
                           plaintext.len,


### PR DESCRIPTION
Lotta code motion here, but I endeavored to match the original code as well as possible.

Goals:
* Reduce the number of protocol implementations to:
  * Reduce surface area of bugs
  * Improve opportunities for optimiztions
  * Simplify adding new protocols (Example: FLE2v2 will be implemented with just: `DECLARE_ALGORITHM(FLE2v2, CBC, SHA_256)` and the rest auto-fills like a budget template.  Note that this has the handy side-effect of describing what primitives are used in the algorithm.
* Make the intent of the API more recognizably associated with the protocol version.  e.g. `_mcFLE1Algorithm->encrypt()` vs `mongocrypt_do_encryption`.
* Unify local variable naming conventions.  FLE2 algos have standardized names like `Km`, `Ke`, `T`, `S`, `C`, `IV`, `AD`.  The state I'm in now can probably be improved upon, but this generally is part of the "make this more readable" goal.

Some interesting finds (which others probably already know):
* FLE1 and FLE2AEAD both use 96 bit keys, but only the first 64 bits of them. FLE2 non-AEAD uses 32 bit keys.
* FLE1 keys put the HMAC key first, then the Data key, FLE2 reverses this.  The non-AEAD has no HMAC key because it doesn't need it.
* Only FLE1 includes the AAD length in the HMAC signature.

Unrelated changes:
* `clang-format` tidied up more than what I touched.  Is it possible this isn't run on this codebase reliably? Or am I perhaps just using a different version of `clang-format`?
* The change in `test/test-mc-tokens.c` is to fix a recently introduced leak.