### PR TITLE
MONGOCRYPT-549 Unify payload derivations in mongocrypt-marking.c

### DIFF
--- a/src/mongocrypt-marking-private.h
+++ b/src/mongocrypt-marking-private.h
@@ -58,6 +58,9 @@ _mongocrypt_marking_parse_unowned (const _mongocrypt_buffer_t *in,
                                    mongocrypt_status_t *status)
    MONGOCRYPT_WARN_UNUSED_RESULT;
 
+// Callers are expected to initialize `ciphertext` with
+// `_mongocrypt_ciphertext_init before calling,
+// and eventually free it using `_mongocrypt_ciphertext_cleanup`.
 bool
 _mongocrypt_marking_to_ciphertext (void *ctx,
                                    _mongocrypt_marking_t *marking,

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -283,8 +283,9 @@ DERIVE_TOKEN_IMPL (ECC)
 
 #undef DERIVE_TOKEN_IMPL
 
+
 static bool
-_fle2_placeholder_aes_ctr_encrypt (_mongocrypt_key_broker_t *kb,
+_fle2_placeholder_aes_ctr_encrypt (_mongocrypt_crypto_t *crypto,
                                    const _mongocrypt_buffer_t *key,
                                    const _mongocrypt_buffer_t *in,
                                    _mongocrypt_buffer_t *out,
@@ -292,13 +293,11 @@ _fle2_placeholder_aes_ctr_encrypt (_mongocrypt_key_broker_t *kb,
 {
    const _mongocrypt_value_encryption_algorithm_t *fle2alg =
       _mcFLE2Algorithm ();
-   BSON_ASSERT_PARAM (kb);
+   BSON_ASSERT_PARAM (crypto);
    BSON_ASSERT_PARAM (key);
    BSON_ASSERT_PARAM (in);
    BSON_ASSERT_PARAM (out);
-   BSON_ASSERT (kb->crypt);
 
-   _mongocrypt_crypto_t *crypto = kb->crypt->crypto;
    _mongocrypt_buffer_t iv;
    const uint32_t cipherlen = fle2alg->get_ciphertext_len (in->len, status);
    if (cipherlen == 0) {
@@ -326,11 +325,11 @@ _fle2_placeholder_aes_ctr_encrypt (_mongocrypt_key_broker_t *kb,
 
 
 static bool
-_fle2_placeholder_aead_encrypt (_mongocrypt_key_broker_t *kb,
-                                const _mongocrypt_buffer_t *keyId,
-                                const _mongocrypt_buffer_t *in,
-                                _mongocrypt_buffer_t *out,
-                                mongocrypt_status_t *status)
+_fle2_placeholder_aes_ctr_aead_encrypt (_mongocrypt_key_broker_t *kb,
+                                        _mongocrypt_buffer_t *out,
+                                        const _mongocrypt_buffer_t *keyId,
+                                        const _mongocrypt_buffer_t *in,
+                                        mongocrypt_status_t *status)
 {
    const _mongocrypt_value_encryption_algorithm_t *fle2 =
       _mcFLE2AEADAlgorithm ();
@@ -375,10 +374,40 @@ _fle2_placeholder_aead_encrypt (_mongocrypt_key_broker_t *kb,
 }
 
 
+// p := EncryptCTR(ECOCToken, ESCDerivedFromDataTokenAndCounter ||
+//                            ECCDerivedFromDataTokenAndCounter)
+static bool
+_fle2_derive_encrypted_token (
+   _mongocrypt_crypto_t *crypto,
+   _mongocrypt_buffer_t *out,
+   const mc_CollectionsLevel1Token_t *collectionsLevel1Token,
+   const _mongocrypt_buffer_t *escDerivedToken,
+   const _mongocrypt_buffer_t *eccDerivedToken,
+   mongocrypt_status_t *status)
+{
+   mc_ECOCToken_t *ecocToken =
+      mc_ECOCToken_new (crypto, collectionsLevel1Token, status);
+   if (!ecocToken) {
+      return false;
+   }
+
+   const _mongocrypt_buffer_t tokens[] = {*escDerivedToken, *eccDerivedToken};
+   _mongocrypt_buffer_t p;
+   _mongocrypt_buffer_concat (&p, tokens, 2);
+
+   const bool ok = _fle2_placeholder_aes_ctr_encrypt (
+      crypto, mc_ECOCToken_get (ecocToken), &p, out, status);
+   _mongocrypt_buffer_cleanup (&p);
+   mc_ECOCToken_destroy (ecocToken);
+   return ok;
+}
+
+
 // Field derivations shared by both INSERT and FIND payloads.
 typedef struct {
    _mongocrypt_buffer_t tokenKey;
    mc_CollectionsLevel1Token_t *collectionsLevel1Token;
+   mc_ServerDataEncryptionLevel1Token_t *serverDataEncryptionLevel1Token;
    _mongocrypt_buffer_t edcDerivedToken;
    _mongocrypt_buffer_t escDerivedToken;
    _mongocrypt_buffer_t eccDerivedToken;
@@ -393,6 +422,8 @@ _FLE2EncryptedPayloadCommon_cleanup (_FLE2EncryptedPayloadCommon_t *common)
 
    _mongocrypt_buffer_cleanup (&common->tokenKey);
    mc_CollectionsLevel1Token_destroy (common->collectionsLevel1Token);
+   mc_ServerDataEncryptionLevel1Token_destroy (
+      common->serverDataEncryptionLevel1Token);
    _mongocrypt_buffer_cleanup (&common->edcDerivedToken);
    _mongocrypt_buffer_cleanup (&common->escDerivedToken);
    _mongocrypt_buffer_cleanup (&common->eccDerivedToken);
@@ -472,6 +503,13 @@ _mongocrypt_fle2_placeholder_common (_mongocrypt_key_broker_t *kb,
       goto fail;
    }
 
+   ret->serverDataEncryptionLevel1Token =
+      mc_ServerDataEncryptionLevel1Token_new (crypto, &ret->tokenKey, status);
+   if (!ret->serverDataEncryptionLevel1Token) {
+      CLIENT_ERR ("unable to derive serverDataEncryptionLevel1Token");
+      goto fail;
+   }
+
    if (!_fle2_derive_EDC_token (crypto,
                                 &ret->edcDerivedToken,
                                 ret->collectionsLevel1Token,
@@ -512,6 +550,106 @@ fail:
 }
 
 
+// Shared implementation for insert/update and insert/update ForRange
+static bool
+_mongocrypt_fle2_placeholder_to_insert_update_common (
+   _mongocrypt_key_broker_t *kb,
+   mc_FLE2InsertUpdatePayload_t *out,
+   int64_t *contentionFactor,
+   _FLE2EncryptedPayloadCommon_t *common,
+   const mc_FLE2EncryptionPlaceholder_t *placeholder,
+   bson_iter_t *value_iter,
+   mongocrypt_status_t *status)
+{
+   BSON_ASSERT_PARAM (kb);
+   BSON_ASSERT_PARAM (out);
+   BSON_ASSERT_PARAM (common);
+   BSON_ASSERT_PARAM (placeholder);
+   BSON_ASSERT_PARAM (value_iter);
+   BSON_ASSERT (kb->crypt);
+   BSON_ASSERT (placeholder->type == MONGOCRYPT_FLE2_PLACEHOLDER_TYPE_INSERT);
+
+   _mongocrypt_crypto_t *crypto = kb->crypt->crypto;
+   _mongocrypt_buffer_t value = {0};
+   bool res = false;
+
+   *contentionFactor = 0;
+   if (placeholder->maxContentionCounter > 0) {
+      /* Choose a random contentionFactor in the inclusive range [0,
+       * placeholder->maxContentionCounter] */
+      if (!_mongocrypt_random_int64 (crypto,
+                                     placeholder->maxContentionCounter + 1,
+                                     contentionFactor,
+                                     status)) {
+         goto fail;
+      }
+   }
+
+   _mongocrypt_buffer_from_iter (&value, value_iter);
+   if (!_mongocrypt_fle2_placeholder_common (
+          kb,
+          common,
+          &placeholder->index_key_id,
+          &value,
+          true, /* derive tokens using counter */
+          *contentionFactor,
+          status)) {
+      goto fail;
+   }
+
+   // d := EDCDerivedToken
+   _mongocrypt_buffer_steal (&out->edcDerivedToken, &common->edcDerivedToken);
+   // s := ESCDerivedToken
+   _mongocrypt_buffer_steal (&out->escDerivedToken, &common->escDerivedToken);
+   // c := ECCDerivedToken
+   _mongocrypt_buffer_steal (&out->eccDerivedToken, &common->eccDerivedToken);
+
+   // p := EncryptCTR(ECOCToken, ESCDerivedFromDataTokenAndCounter ||
+   // ECCDerivedFromDataTokenAndCounter)
+   if (!_fle2_derive_encrypted_token (crypto,
+                                      &out->encryptedTokens,
+                                      common->collectionsLevel1Token,
+                                      &out->escDerivedToken,
+                                      &out->eccDerivedToken,
+                                      status)) {
+      goto fail;
+   }
+
+   _mongocrypt_buffer_copy_to (&placeholder->index_key_id,
+                               &out->indexKeyId); // u
+   out->valueType = bson_iter_type (value_iter);  // t
+
+   // v := UserKeyId + EncryptCTRAEAD(UserKey, value)
+   {
+      _mongocrypt_buffer_t ciphertext = {0};
+      if (!_fle2_placeholder_aes_ctr_aead_encrypt (
+             kb, &ciphertext, &placeholder->user_key_id, &value, status)) {
+         goto fail;
+      }
+      const _mongocrypt_buffer_t v[2] = {placeholder->user_key_id, ciphertext};
+      const bool ok = _mongocrypt_buffer_concat (&out->value, v, 2);
+      _mongocrypt_buffer_cleanup (&ciphertext);
+      if (!ok) {
+         goto fail;
+      }
+   }
+
+   // e := ServerDataEncryptionLevel1Token
+   _mongocrypt_buffer_copy_to (mc_ServerDataEncryptionLevel1Token_get (
+                                  common->serverDataEncryptionLevel1Token),
+                               &out->serverEncryptionToken);
+
+   res = true;
+fail:
+   _mongocrypt_buffer_cleanup (&value);
+   return res;
+}
+
+/**
+ * Payload subtype 4: FLE2InsertUpdatePayload
+ *
+ * {d: EDC, s: ESC, c: ECC, p: encToken, v: value, e: serverToken}
+ */
 static bool
 _mongocrypt_fle2_placeholder_to_insert_update_ciphertext (
    _mongocrypt_key_broker_t *kb,
@@ -519,113 +657,27 @@ _mongocrypt_fle2_placeholder_to_insert_update_ciphertext (
    _mongocrypt_ciphertext_t *ciphertext,
    mongocrypt_status_t *status)
 {
-   BSON_ASSERT_PARAM (kb);
-   BSON_ASSERT_PARAM (marking);
-   BSON_ASSERT_PARAM (ciphertext);
-   BSON_ASSERT (kb->crypt);
-
-   _mongocrypt_crypto_t *crypto = kb->crypt->crypto;
-   _FLE2EncryptedPayloadCommon_t common = {{0}};
-   _mongocrypt_buffer_t value = {0};
    mc_FLE2EncryptionPlaceholder_t *placeholder = &marking->fle2;
+   _FLE2EncryptedPayloadCommon_t common = {{0}};
    mc_FLE2InsertUpdatePayload_t payload;
+   mc_FLE2InsertUpdatePayload_init (&payload);
    bool res = false;
 
    BSON_ASSERT (marking->type == MONGOCRYPT_MARKING_FLE2_ENCRYPTION);
-   BSON_ASSERT (placeholder->type == MONGOCRYPT_FLE2_PLACEHOLDER_TYPE_INSERT);
-   _mongocrypt_ciphertext_init (ciphertext);
-   _mongocrypt_buffer_init (&value);
-   mc_FLE2InsertUpdatePayload_init (&payload);
-
-   _mongocrypt_buffer_from_iter (&value, &placeholder->v_iter);
 
    int64_t contentionFactor = 0;
-   if (placeholder->maxContentionCounter > 0) {
-      /* Choose a random contentionFactor in the inclusive range [0,
-       * placeholder->maxContentionCounter] */
-      if (!_mongocrypt_random_int64 (crypto,
-                                     placeholder->maxContentionCounter + 1,
-                                     &contentionFactor,
-                                     status)) {
-         goto fail;
-      }
-   }
-
-   if (!_mongocrypt_fle2_placeholder_common (
+   if (!_mongocrypt_fle2_placeholder_to_insert_update_common (
           kb,
+          &payload,
+          &contentionFactor,
           &common,
-          &placeholder->index_key_id,
-          &value,
-          true, /* derive tokens using counter */
-          contentionFactor,
+          placeholder,
+          &placeholder->v_iter,
           status)) {
       goto fail;
    }
 
-   // d := EDCDerivedToken
-   _mongocrypt_buffer_steal (&payload.edcDerivedToken, &common.edcDerivedToken);
-   // s := ESCDerivedToken
-   _mongocrypt_buffer_steal (&payload.escDerivedToken, &common.escDerivedToken);
-   // c := ECCDerivedToken
-   _mongocrypt_buffer_steal (&payload.eccDerivedToken, &common.eccDerivedToken);
-
-   // p := EncryptCTR(ECOCToken, ESCDerivedFromDataTokenAndCounter ||
-   // ECCDerivedFromDataTokenAndCounter)
-   {
-      _mongocrypt_buffer_t tokens[] = {payload.escDerivedToken,
-                                       payload.eccDerivedToken};
-      _mongocrypt_buffer_t p;
-      _mongocrypt_buffer_concat (&p, tokens, 2);
-      mc_ECOCToken_t *ecocToken =
-         mc_ECOCToken_new (crypto, common.collectionsLevel1Token, status);
-      if (!ecocToken) {
-         _mongocrypt_buffer_cleanup (&p);
-         goto fail;
-      }
-      bool ok = _fle2_placeholder_aes_ctr_encrypt (kb,
-                                                   mc_ECOCToken_get (ecocToken),
-                                                   &p,
-                                                   &payload.encryptedTokens,
-                                                   status);
-      _mongocrypt_buffer_cleanup (&p);
-      mc_ECOCToken_destroy (ecocToken);
-      if (!ok) {
-         goto fail;
-      }
-   }
-
-   _mongocrypt_buffer_copy_to (&placeholder->index_key_id,
-                               &payload.indexKeyId);          // u
-   payload.valueType = bson_iter_type (&placeholder->v_iter); // t
-
-   // v := UserKeyId + EncryptAEAD(UserKey, value)
-   {
-      _mongocrypt_buffer_t tmp[2] = {placeholder->user_key_id, {0}};
-      if (!_fle2_placeholder_aead_encrypt (
-             kb, &placeholder->user_key_id, &value, &tmp[1], status)) {
-         goto fail;
-      }
-      bool ok = _mongocrypt_buffer_concat (&payload.value, tmp, 2);
-      _mongocrypt_buffer_cleanup (&tmp[1]);
-      if (!ok) {
-         goto fail;
-      }
-   }
-
-   // e := ServerDataEncryptionLevel1Token
-   {
-      mc_ServerDataEncryptionLevel1Token_t *serverToken =
-         mc_ServerDataEncryptionLevel1Token_new (
-            crypto, &common.tokenKey, status);
-      if (!serverToken) {
-         goto fail;
-      }
-      _mongocrypt_buffer_copy_to (
-         mc_ServerDataEncryptionLevel1Token_get (serverToken),
-         &payload.serverEncryptionToken);
-      mc_ServerDataEncryptionLevel1Token_destroy (serverToken);
-   }
-
+   _mongocrypt_ciphertext_init (ciphertext);
    {
       bson_t out;
       bson_init (&out);
@@ -639,11 +691,11 @@ _mongocrypt_fle2_placeholder_to_insert_update_ciphertext (
    res = true;
 fail:
    mc_FLE2InsertUpdatePayload_cleanup (&payload);
-   _mongocrypt_buffer_cleanup (&value);
    _FLE2EncryptedPayloadCommon_cleanup (&common);
 
    return res;
 }
+
 
 // get_edges creates and returns edges from an FLE2RangeInsertSpec. Returns NULL
 // on error.
@@ -729,9 +781,14 @@ get_edges (mc_FLE2RangeInsertSpec_t *insertSpec,
    return NULL;
 }
 
-// _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange transforms a
-// FLE2EncryptedPlaceholder to an FLE2InsertUpdatePayload for the range
-// algorithm.
+/**
+ * Payload subtype 4: FLE2InsertUpdatePayload for range updates
+ *
+ * {d: EDC, s: ESC, c: ECC, p: encToken, v: value, e: serverToken,
+ *  g: [{d: EDC, s: ESC, c: ECC, p: encToken},
+ *      {d: EDC, s: ESC, c: ECC, p: encToken},
+ *      ...]}
+ */
 static bool
 _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange (
    _mongocrypt_key_broker_t *kb,
@@ -739,24 +796,15 @@ _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange (
    _mongocrypt_ciphertext_t *ciphertext,
    mongocrypt_status_t *status)
 {
-   BSON_ASSERT_PARAM (kb);
-   BSON_ASSERT_PARAM (marking);
-   BSON_ASSERT_PARAM (ciphertext);
-   BSON_ASSERT (kb->crypt);
-
-   _mongocrypt_crypto_t *crypto = kb->crypt->crypto;
-   _FLE2EncryptedPayloadCommon_t common = {{0}};
-   _mongocrypt_buffer_t value = {0};
    mc_FLE2EncryptionPlaceholder_t *placeholder = &marking->fle2;
+   _FLE2EncryptedPayloadCommon_t common = {{0}};
    mc_FLE2InsertUpdatePayload_t payload;
+   mc_FLE2InsertUpdatePayload_init (&payload);
    bool res = false;
    mc_edges_t *edges = NULL;
 
    BSON_ASSERT (marking->type == MONGOCRYPT_MARKING_FLE2_ENCRYPTION);
-   BSON_ASSERT (placeholder->type == MONGOCRYPT_FLE2_PLACEHOLDER_TYPE_INSERT);
    BSON_ASSERT (placeholder->algorithm == MONGOCRYPT_FLE2_ALGORITHM_RANGE);
-   _mongocrypt_ciphertext_init (ciphertext);
-   mc_FLE2InsertUpdatePayload_init (&payload);
 
    // Parse the value ("v"), min ("min"), and max ("max") from
    // FLE2EncryptionPlaceholder for range insert.
@@ -766,93 +814,15 @@ _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange (
       goto fail;
    }
 
-   _mongocrypt_buffer_from_iter (&value, &insertSpec.v);
-
    int64_t contentionFactor = 0;
-   if (placeholder->maxContentionCounter > 0) {
-      /* Choose a random contentionFactor in the inclusive range [0,
-       * placeholder->maxContentionCounter] */
-      if (!_mongocrypt_random_int64 (crypto,
-                                     placeholder->maxContentionCounter + 1,
-                                     &contentionFactor,
-                                     status)) {
-         goto fail;
-      }
-   }
-
-   if (!_mongocrypt_fle2_placeholder_common (
-          kb,
-          &common,
-          &placeholder->index_key_id,
-          &value,
-          true, /* derive tokens using counter */
-          contentionFactor,
-          status)) {
+   if (!_mongocrypt_fle2_placeholder_to_insert_update_common (kb,
+                                                              &payload,
+                                                              &contentionFactor,
+                                                              &common,
+                                                              &marking->fle2,
+                                                              &insertSpec.v,
+                                                              status)) {
       goto fail;
-   }
-
-   // d := EDCDerivedToken
-   _mongocrypt_buffer_steal (&payload.edcDerivedToken, &common.edcDerivedToken);
-   // s := ESCDerivedToken
-   _mongocrypt_buffer_steal (&payload.escDerivedToken, &common.escDerivedToken);
-   // c := ECCDerivedToken
-   _mongocrypt_buffer_steal (&payload.eccDerivedToken, &common.eccDerivedToken);
-
-   // p := EncryptCTR(ECOCToken, ESCDerivedFromDataTokenAndCounter ||
-   // ECCDerivedFromDataTokenAndCounter)
-   {
-      _mongocrypt_buffer_t tokens[] = {payload.escDerivedToken,
-                                       payload.eccDerivedToken};
-      _mongocrypt_buffer_t p;
-      _mongocrypt_buffer_concat (&p, tokens, 2);
-      mc_ECOCToken_t *ecocToken =
-         mc_ECOCToken_new (crypto, common.collectionsLevel1Token, status);
-      if (!ecocToken) {
-         _mongocrypt_buffer_cleanup (&p);
-         goto fail;
-      }
-      bool ok = _fle2_placeholder_aes_ctr_encrypt (kb,
-                                                   mc_ECOCToken_get (ecocToken),
-                                                   &p,
-                                                   &payload.encryptedTokens,
-                                                   status);
-      _mongocrypt_buffer_cleanup (&p);
-      mc_ECOCToken_destroy (ecocToken);
-      if (!ok) {
-         goto fail;
-      }
-   }
-
-   _mongocrypt_buffer_copy_to (&placeholder->index_key_id,
-                               &payload.indexKeyId);   // u
-   payload.valueType = bson_iter_type (&insertSpec.v); // t
-
-   // v := UserKeyId + EncryptAEAD(UserKey, value)
-   {
-      _mongocrypt_buffer_t tmp[2] = {placeholder->user_key_id, {0}};
-      if (!_fle2_placeholder_aead_encrypt (
-             kb, &placeholder->user_key_id, &value, &tmp[1], status)) {
-         goto fail;
-      }
-      bool ok = _mongocrypt_buffer_concat (&payload.value, tmp, 2);
-      _mongocrypt_buffer_cleanup (&tmp[1]);
-      if (!ok) {
-         goto fail;
-      }
-   }
-
-   // e := ServerDataEncryptionLevel1Token
-   {
-      mc_ServerDataEncryptionLevel1Token_t *serverToken =
-         mc_ServerDataEncryptionLevel1Token_new (
-            crypto, &common.tokenKey, status);
-      if (!serverToken) {
-         goto fail;
-      }
-      _mongocrypt_buffer_copy_to (
-         mc_ServerDataEncryptionLevel1Token_get (serverToken),
-         &payload.serverEncryptionToken);
-      mc_ServerDataEncryptionLevel1Token_destroy (serverToken);
    }
 
    // g:= array<EdgeTokenSet>
@@ -864,7 +834,7 @@ _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange (
          goto fail;
       }
 
-      for (size_t i = 0; i < mc_edges_len (edges); i++) {
+      for (size_t i = 0; i < mc_edges_len (edges); ++i) {
          // Create an EdgeTokenSet from each edge.
          bool loop_ok = false;
          const char *edge = mc_edges_get (edges, i);
@@ -889,28 +859,6 @@ _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange (
             goto fail_loop;
          }
 
-         // p := EncryptCTR(ECOCToken, ESCDerivedFromDataTokenAndCounter ||
-         // ECCDerivedFromDataTokenAndCounter)
-         {
-            _mongocrypt_buffer_t tokens[] = {edge_tokens.escDerivedToken,
-                                             edge_tokens.eccDerivedToken};
-            _mongocrypt_buffer_t p;
-            _mongocrypt_buffer_concat (&p, tokens, 2);
-            mc_ECOCToken_t *ecocToken = mc_ECOCToken_new (
-               crypto, edge_tokens.collectionsLevel1Token, status);
-            if (!ecocToken) {
-               _mongocrypt_buffer_cleanup (&p);
-               goto fail_loop;
-            }
-            bool ok = _fle2_placeholder_aes_ctr_encrypt (
-               kb, mc_ECOCToken_get (ecocToken), &p, &encryptedTokens, status);
-            _mongocrypt_buffer_cleanup (&p);
-            mc_ECOCToken_destroy (ecocToken);
-            if (!ok) {
-               goto fail_loop;
-            }
-         }
-
          // d := EDCDerivedToken
          _mongocrypt_buffer_steal (&etc.edcDerivedToken,
                                    &edge_tokens.edcDerivedToken);
@@ -921,7 +869,17 @@ _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange (
          _mongocrypt_buffer_steal (&etc.eccDerivedToken,
                                    &edge_tokens.eccDerivedToken);
 
-         _mongocrypt_buffer_steal (&etc.encryptedTokens, &encryptedTokens);
+         // p := EncryptCTR(ECOCToken, ESCDerivedFromDataTokenAndCounter ||
+         // ECCDerivedFromDataTokenAndCounter)
+         if (!_fle2_derive_encrypted_token (kb->crypt->crypto,
+                                            &etc.encryptedTokens,
+                                            edge_tokens.collectionsLevel1Token,
+                                            &etc.escDerivedToken,
+                                            &etc.eccDerivedToken,
+                                            status)) {
+            goto fail_loop;
+         }
+
          _mc_array_append_val (&payload.edgeTokenSetArray, etc);
 
          loop_ok = true;
@@ -935,7 +893,7 @@ _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange (
       }
    }
 
-   // Serialize.
+   _mongocrypt_ciphertext_init (ciphertext);
    {
       bson_t out;
       bson_init (&out);
@@ -950,7 +908,6 @@ _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange (
 fail:
    mc_edges_destroy (edges);
    mc_FLE2InsertUpdatePayload_cleanup (&payload);
-   _mongocrypt_buffer_cleanup (&value);
    _FLE2EncryptedPayloadCommon_cleanup (&common);
 
    return res;
@@ -1001,19 +958,9 @@ _mongocrypt_fle2_placeholder_to_find_ciphertext (
    _mongocrypt_buffer_steal (&payload.eccDerivedToken, &common.eccDerivedToken);
 
    // e := ServerDataEncryptionLevel1Token
-   BSON_ASSERT (kb->crypt);
-   {
-      mc_ServerDataEncryptionLevel1Token_t *serverToken =
-         mc_ServerDataEncryptionLevel1Token_new (
-            kb->crypt->crypto, &common.tokenKey, status);
-      if (!serverToken) {
-         goto fail;
-      }
-      _mongocrypt_buffer_copy_to (
-         mc_ServerDataEncryptionLevel1Token_get (serverToken),
-         &payload.serverEncryptionToken);
-      mc_ServerDataEncryptionLevel1Token_destroy (serverToken);
-   }
+   _mongocrypt_buffer_copy_to (mc_ServerDataEncryptionLevel1Token_get (
+                                  common.serverDataEncryptionLevel1Token),
+                               &payload.serverEncryptionToken);
 
    payload.maxContentionCounter = placeholder->maxContentionCounter;
 


### PR DESCRIPTION
Removing more copypasta from a series of methods that do the same thing with minor differences.  In fact, insert_updateForRange is a superset of insert_update.

I wanted to merge the find variants as well, but they diverge too much to make it worth it.

This is in support of having yet more variants come into this file and wanting to keep it as tidy as possible.