### PR TITLE
MONGOCRYPT-542 Derive and use serverDataDerivedToken

### DIFF
--- a/src/mc-fle2-insert-update-payload-private-v2.h
+++ b/src/mc-fle2-insert-update-payload-private-v2.h
@@ -31,7 +31,7 @@
  * FLE2InsertUpdatePayloadV2 has the following data layout:
  *
  * struct {
- *   uint8_t fle_blob_subtype = 4;
+ *   uint8_t fle_blob_subtype = 11;
  *   uint8_t bson[];
  * } FLE2InsertUpdatePayloadV2;
  *

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -285,6 +285,34 @@ DERIVE_TOKEN_IMPL (ECC)
 
 
 static bool
+_fle2_derive_serverDerivedFromDataToken (
+   _mongocrypt_crypto_t *crypto,
+   _mongocrypt_buffer_t *out,
+   const mc_ServerTokenDerivationLevel1Token_t *level1Token,
+   const _mongocrypt_buffer_t *value,
+   mongocrypt_status_t *status)
+{
+   BSON_ASSERT_PARAM (crypto);
+   BSON_ASSERT_PARAM (out);
+   BSON_ASSERT_PARAM (level1Token);
+   BSON_ASSERT_PARAM (value);
+   BSON_ASSERT_PARAM (status);
+
+   _mongocrypt_buffer_init (out);
+
+   mc_ServerDerivedFromDataToken_t *token =
+      mc_ServerDerivedFromDataToken_new (crypto, level1Token, value, status);
+   if (!token) {
+      return false;
+   }
+
+   _mongocrypt_buffer_copy_to (mc_ServerDerivedFromDataToken_get (token), out);
+   mc_ServerDerivedFromDataToken_destroy (token);
+   return true;
+}
+
+
+static bool
 _fle2_placeholder_aes_ctr_encrypt (_mongocrypt_crypto_t *crypto,
                                    const _mongocrypt_buffer_t *key,
                                    const _mongocrypt_buffer_t *in,
@@ -408,9 +436,12 @@ typedef struct {
    _mongocrypt_buffer_t tokenKey;
    mc_CollectionsLevel1Token_t *collectionsLevel1Token;
    mc_ServerDataEncryptionLevel1Token_t *serverDataEncryptionLevel1Token;
+   mc_ServerTokenDerivationLevel1Token_t
+      *serverTokenDerivationLevel1Token; // v2
    _mongocrypt_buffer_t edcDerivedToken;
    _mongocrypt_buffer_t escDerivedToken;
-   _mongocrypt_buffer_t eccDerivedToken;
+   _mongocrypt_buffer_t eccDerivedToken;            // v1
+   _mongocrypt_buffer_t serverDerivedFromDataToken; // v2
 } _FLE2EncryptedPayloadCommon_t;
 
 static void
@@ -424,9 +455,12 @@ _FLE2EncryptedPayloadCommon_cleanup (_FLE2EncryptedPayloadCommon_t *common)
    mc_CollectionsLevel1Token_destroy (common->collectionsLevel1Token);
    mc_ServerDataEncryptionLevel1Token_destroy (
       common->serverDataEncryptionLevel1Token);
+   mc_ServerTokenDerivationLevel1Token_destroy (
+      common->serverTokenDerivationLevel1Token);
    _mongocrypt_buffer_cleanup (&common->edcDerivedToken);
    _mongocrypt_buffer_cleanup (&common->escDerivedToken);
    _mongocrypt_buffer_cleanup (&common->eccDerivedToken);
+   _mongocrypt_buffer_cleanup (&common->serverDerivedFromDataToken);
    memset (common, 0, sizeof (*common));
 }
 
@@ -530,14 +564,35 @@ _mongocrypt_fle2_placeholder_common (_mongocrypt_key_broker_t *kb,
       goto fail;
    }
 
-   if (!_fle2_derive_ECC_token (crypto,
-                                &ret->eccDerivedToken,
-                                ret->collectionsLevel1Token,
-                                value,
-                                useCounter,
-                                maxContentionCounter,
-                                status)) {
-      goto fail;
+   if (kb->crypt->opts.use_fle2_v2) {
+      /* FLE2v2 */
+      ret->serverTokenDerivationLevel1Token =
+         mc_ServerTokenDerivationLevel1Token_new (
+            crypto, &ret->tokenKey, status);
+      if (!ret->serverTokenDerivationLevel1Token) {
+         CLIENT_ERR ("unablet to derive serverTokenDerivationLevel1Token");
+         goto fail;
+      }
+
+      if (!_fle2_derive_serverDerivedFromDataToken (
+             crypto,
+             &ret->serverDerivedFromDataToken,
+             ret->serverTokenDerivationLevel1Token,
+             value,
+             status)) {
+         goto fail;
+      }
+   } else {
+      /* FLE2v1 */
+      if (!_fle2_derive_ECC_token (crypto,
+                                   &ret->eccDerivedToken,
+                                   ret->collectionsLevel1Token,
+                                   value,
+                                   useCounter,
+                                   maxContentionCounter,
+                                   status)) {
+         goto fail;
+      }
    }
 
    _mongocrypt_buffer_cleanup (&indexKey);
@@ -550,9 +605,9 @@ fail:
 }
 
 
-// Shared implementation for insert/update and insert/update ForRange
+// Shared implementation for insert/update and insert/update ForRange (v1)
 static bool
-_mongocrypt_fle2_placeholder_to_insert_update_common (
+_mongocrypt_fle2_placeholder_to_insert_update_common_v1 (
    _mongocrypt_key_broker_t *kb,
    mc_FLE2InsertUpdatePayload_t *out,
    int64_t *contentionFactor,
@@ -567,6 +622,7 @@ _mongocrypt_fle2_placeholder_to_insert_update_common (
    BSON_ASSERT_PARAM (placeholder);
    BSON_ASSERT_PARAM (value_iter);
    BSON_ASSERT (kb->crypt);
+   BSON_ASSERT (kb->crypt->opts.use_fle2_v2 == false);
    BSON_ASSERT (placeholder->type == MONGOCRYPT_FLE2_PLACEHOLDER_TYPE_INSERT);
 
    _mongocrypt_crypto_t *crypto = kb->crypt->crypto;
@@ -653,7 +709,7 @@ fail:
  *  v: value, e: serverToken}
  */
 static bool
-_mongocrypt_fle2_placeholder_to_insert_update_ciphertext (
+_mongocrypt_fle2_placeholder_to_insert_update_ciphertext_v1 (
    _mongocrypt_key_broker_t *kb,
    _mongocrypt_marking_t *marking,
    _mongocrypt_ciphertext_t *ciphertext,
@@ -663,6 +719,8 @@ _mongocrypt_fle2_placeholder_to_insert_update_ciphertext (
    BSON_ASSERT_PARAM (marking);
    BSON_ASSERT_PARAM (ciphertext);
    BSON_ASSERT_PARAM (status);
+   BSON_ASSERT (kb->crypt);
+   BSON_ASSERT (kb->crypt->opts.use_fle2_v2 == false);
    BSON_ASSERT (marking->type == MONGOCRYPT_MARKING_FLE2_ENCRYPTION);
    BSON_ASSERT (marking->fle2.algorithm == MONGOCRYPT_FLE2_ALGORITHM_EQUALITY);
 
@@ -673,7 +731,7 @@ _mongocrypt_fle2_placeholder_to_insert_update_ciphertext (
    bool res = false;
 
    int64_t contentionFactor = 0; /* ignored */
-   if (!_mongocrypt_fle2_placeholder_to_insert_update_common (
+   if (!_mongocrypt_fle2_placeholder_to_insert_update_common_v1 (
           kb,
           &payload,
           &contentionFactor,
@@ -700,6 +758,34 @@ fail:
    _FLE2EncryptedPayloadCommon_cleanup (&common);
 
    return res;
+}
+
+
+/**
+ * Payload subtype 11: FLE2InsertUpdatePayloadV2
+ * Delegates to ..._insert_update_ciphertext_v1 for subtype 4
+ *   when crypt.opts.use_fle2_v2 == false
+ *
+ * {d: EDC, s: ESC, p: encToken, v: value,
+ *  e: serverToken, l: derivedFromDataToken}
+ */
+static bool
+_mongocrypt_fle2_placeholder_to_insert_update_ciphertext (
+   _mongocrypt_key_broker_t *kb,
+   _mongocrypt_marking_t *marking,
+   _mongocrypt_ciphertext_t *ciphertext,
+   mongocrypt_status_t *status)
+{
+   BSON_ASSERT (marking->type == MONGOCRYPT_MARKING_FLE2_ENCRYPTION);
+
+   if (!kb->crypt->opts.use_fle2_v2) {
+      return _mongocrypt_fle2_placeholder_to_insert_update_ciphertext_v1 (
+         kb, marking, ciphertext, status);
+   }
+
+   // TODO (MONGOCRYPT-543): InsertUpdatePayloadV2
+   CLIENT_ERR ("FLE2InsertUpdatePayloadV2 not implemented");
+   return false;
 }
 
 
@@ -798,7 +884,7 @@ get_edges (mc_FLE2RangeInsertSpec_t *insertSpec,
  *      ...]}
  */
 static bool
-_mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange (
+_mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange_v1 (
    _mongocrypt_key_broker_t *kb,
    _mongocrypt_marking_t *marking,
    _mongocrypt_ciphertext_t *ciphertext,
@@ -827,13 +913,14 @@ _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange (
    }
 
    int64_t contentionFactor = 0;
-   if (!_mongocrypt_fle2_placeholder_to_insert_update_common (kb,
-                                                              &payload,
-                                                              &contentionFactor,
-                                                              &common,
-                                                              &marking->fle2,
-                                                              &insertSpec.v,
-                                                              status)) {
+   if (!_mongocrypt_fle2_placeholder_to_insert_update_common_v1 (
+          kb,
+          &payload,
+          &contentionFactor,
+          &common,
+          &marking->fle2,
+          &insertSpec.v,
+          status)) {
       goto fail;
    }
 
@@ -925,8 +1012,43 @@ fail:
 }
 
 
+/**
+ * Payload subtype 11: FLE2InsertUpdatePayloadV2 for range updates
+ * Delegates to ..._insert_update_ciphertext_v1 for subtype 4
+ *   when crypt.opts.use_fle2_v2 == false
+ *
+ * {d: EDC, s: ESC, p: encToken, v: value,
+ *  e: serverToken, l: derivedFromDataToken,
+ *  g: [{d: EDC, s: ESC, c: ECC, p: encToken},
+ *      {d: EDC, s: ESC, c: ECC, p: encToken},
+ *      ...]}
+ */
 static bool
-_mongocrypt_fle2_placeholder_to_find_ciphertext (
+_mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange (
+   _mongocrypt_key_broker_t *kb,
+   _mongocrypt_marking_t *marking,
+   _mongocrypt_ciphertext_t *ciphertext,
+   mongocrypt_status_t *status)
+{
+   BSON_ASSERT (marking->type == MONGOCRYPT_MARKING_FLE2_ENCRYPTION);
+
+   if (!kb->crypt->opts.use_fle2_v2) {
+      return _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange_v1 (
+         kb, marking, ciphertext, status);
+   }
+
+   // TODO (MONGOCRYPT-543): InsertUpdatePayloadV2
+   CLIENT_ERR ("FLE2InsertUpdatePayloadV2 not implemented");
+   return false;
+}
+
+/**
+ * Payload subtype 5: FLE2FindEqualityPayload
+ *
+ * {d: EDC, s: ESC, c: ECC, e: serverToken, cm: contentionCounter}
+ */
+static bool
+_mongocrypt_fle2_placeholder_to_find_ciphertext_v1 (
    _mongocrypt_key_broker_t *kb,
    _mongocrypt_marking_t *marking,
    _mongocrypt_ciphertext_t *ciphertext,
@@ -942,6 +1064,7 @@ _mongocrypt_fle2_placeholder_to_find_ciphertext (
    mc_FLE2FindEqualityPayload_t payload;
    bool res = false;
 
+   BSON_ASSERT (kb->crypt->opts.use_fle2_v2 == false);
    BSON_ASSERT (marking->type == MONGOCRYPT_MARKING_FLE2_ENCRYPTION);
    BSON_ASSERT (placeholder->type == MONGOCRYPT_FLE2_PLACEHOLDER_TYPE_FIND);
    _mongocrypt_buffer_init (&value);
@@ -992,6 +1115,34 @@ fail:
 
    return res;
 }
+
+/**
+ * Payload subtype 12: FLE2FindEqualityPayload
+ * Delegates to ..._find_ciphertext_v1 when crypt->opts.use_fle2_v2 == false.
+ *
+ * {d: EDC, s: ESC, l: serverToken, cm: contentionCounter}
+ */
+static bool
+_mongocrypt_fle2_placeholder_to_find_ciphertext (
+   _mongocrypt_key_broker_t *kb,
+   _mongocrypt_marking_t *marking,
+   _mongocrypt_ciphertext_t *ciphertext,
+   mongocrypt_status_t *status)
+{
+   BSON_ASSERT_PARAM (kb);
+   BSON_ASSERT_PARAM (marking);
+   BSON_ASSERT_PARAM (ciphertext);
+
+   if (kb->crypt->opts.use_fle2_v2 == false) {
+      return _mongocrypt_fle2_placeholder_to_find_ciphertext_v1 (
+         kb, marking, ciphertext, status);
+   }
+
+   // TODO:(MONGOCRYPT-544) FindEqualityPayloadV2
+   CLIENT_ERR ("FLE2FindEqualityPayloadV2 not implemented");
+   return false;
+}
+
 
 static bool
 isInfinite (bson_iter_t *iter)
@@ -1194,8 +1345,14 @@ mc_get_mincover_from_FLE2RangeFindSpec (mc_FLE2RangeFindSpec_t *findSpec,
    }
 }
 
+/**
+ * Payload subtype 10: FLE2FindRangePayload
+ *
+ * {e: serverToken, cm: contentionCounter,
+ *  g: [{d: EDC, s: ESC, c: ECC}, ...]}
+ */
 static bool
-_mongocrypt_fle2_placeholder_to_find_ciphertextForRange (
+_mongocrypt_fle2_placeholder_to_find_ciphertextForRange_v1 (
    _mongocrypt_key_broker_t *kb,
    _mongocrypt_marking_t *marking,
    _mongocrypt_ciphertext_t *ciphertext,
@@ -1213,6 +1370,7 @@ _mongocrypt_fle2_placeholder_to_find_ciphertextForRange (
    mc_mincover_t *mincover = NULL;
    _mongocrypt_buffer_t tokenKey = {0};
 
+   BSON_ASSERT (kb->crypt->opts.use_fle2_v2 == false);
    BSON_ASSERT (marking->type == MONGOCRYPT_MARKING_FLE2_ENCRYPTION);
    BSON_ASSERT (placeholder);
    BSON_ASSERT (placeholder->type == MONGOCRYPT_FLE2_PLACEHOLDER_TYPE_FIND);
@@ -1332,6 +1490,37 @@ fail:
 
    return res;
 }
+
+
+/**
+ * Payload subtype 13: FLE2FindRangePayloadV2
+ * Delegates to ..._find_ciphertextForRange_v1
+ *   when crypt->opts.use_fle2_v2 is false
+ *
+ * {e: serverToken, cm: contentionCounter,
+ *  g: [{d: EDC, s: ESC, c: ECC}, ...]}
+ */
+static bool
+_mongocrypt_fle2_placeholder_to_find_ciphertextForRange (
+   _mongocrypt_key_broker_t *kb,
+   _mongocrypt_marking_t *marking,
+   _mongocrypt_ciphertext_t *ciphertext,
+   mongocrypt_status_t *status)
+{
+   BSON_ASSERT_PARAM (kb);
+   BSON_ASSERT_PARAM (marking);
+   BSON_ASSERT_PARAM (ciphertext);
+
+   if (kb->crypt->opts.use_fle2_v2 == false) {
+      return _mongocrypt_fle2_placeholder_to_find_ciphertextForRange_v1 (
+         kb, marking, ciphertext, status);
+   }
+
+   // TODO:(MONGOCRYPT-545) FindRangePayloadV2
+   CLIENT_ERR ("FLE2FindRangePayloadV2 not implemented");
+   return false;
+}
+
 
 static bool
 _mongocrypt_fle2_placeholder_to_FLE2UnindexedEncryptedValue (

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -1020,7 +1020,7 @@ fail:
 
 /**
  * Payload subtype 11: FLE2InsertUpdatePayloadV2 for range updates
- * Delegates to ..._insert_update_ciphertext_v1 for subtype 4
+ * Delegates to ..._insert_update_ciphertextForRange_v1 for subtype 4
  *   when crypt.opts.use_fle2_v2 == false
  *
  * {d: EDC, s: ESC, p: encToken,
@@ -1544,6 +1544,12 @@ _mongocrypt_fle2_placeholder_to_FLE2UnindexedEncryptedValue (
    BSON_ASSERT_PARAM (kb);
    BSON_ASSERT_PARAM (marking);
    BSON_ASSERT_PARAM (ciphertext);
+
+   if (kb->crypt->opts.use_fle2_v2) {
+      // TODO (MONGOCRYPT-551): UnindexedEncryptedValueV2
+      CLIENT_ERR ("FLE2UnindexedEncryptedValueV2 not implemented");
+      return false;
+   }
 
    _mongocrypt_buffer_t plaintext = {0};
    mc_FLE2EncryptionPlaceholder_t *placeholder = &marking->fle2;

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -570,7 +570,7 @@ _mongocrypt_fle2_placeholder_common (_mongocrypt_key_broker_t *kb,
          mc_ServerTokenDerivationLevel1Token_new (
             crypto, &ret->tokenKey, status);
       if (!ret->serverTokenDerivationLevel1Token) {
-         CLIENT_ERR ("unablet to derive serverTokenDerivationLevel1Token");
+         CLIENT_ERR ("unable to derive serverTokenDerivationLevel1Token");
          goto fail;
       }
 
@@ -766,8 +766,10 @@ fail:
  * Delegates to ..._insert_update_ciphertext_v1 for subtype 4
  *   when crypt.opts.use_fle2_v2 == false
  *
- * {d: EDC, s: ESC, p: encToken, v: value,
- *  e: serverToken, l: derivedFromDataToken}
+ * {d: EDC, s: ESC, p: encToken,
+ *  u: indexKeyId, t: valueType, v: value,
+ *  e: serverToken, l: serverDerivedFromDataToken,
+ *  k: contentionFactor}
  */
 static bool
 _mongocrypt_fle2_placeholder_to_insert_update_ciphertext (
@@ -776,6 +778,10 @@ _mongocrypt_fle2_placeholder_to_insert_update_ciphertext (
    _mongocrypt_ciphertext_t *ciphertext,
    mongocrypt_status_t *status)
 {
+   BSON_ASSERT_PARAM (kb);
+   BSON_ASSERT_PARAM (marking);
+   BSON_ASSERT_PARAM (ciphertext);
+   BSON_ASSERT (kb->crypt);
    BSON_ASSERT (marking->type == MONGOCRYPT_MARKING_FLE2_ENCRYPTION);
 
    if (!kb->crypt->opts.use_fle2_v2) {
@@ -1017,10 +1023,12 @@ fail:
  * Delegates to ..._insert_update_ciphertext_v1 for subtype 4
  *   when crypt.opts.use_fle2_v2 == false
  *
- * {d: EDC, s: ESC, p: encToken, v: value,
- *  e: serverToken, l: derivedFromDataToken,
- *  g: [{d: EDC, s: ESC, c: ECC, p: encToken},
- *      {d: EDC, s: ESC, c: ECC, p: encToken},
+ * {d: EDC, s: ESC, p: encToken,
+ *  u: indexKeyId, t: valueType, v: value,
+ *  e: serverToken, l: serverDerivedFromDataToken,
+ *  k: contentionFactor,
+ *  g: [{d: EDC, s: ESC, l: serverDerivedFromDataToken, p: encToken},
+ *      {d: EDC, s: ESC, l: serverDerivedFromDataToken, p: encToken},
  *      ...]}
  */
 static bool
@@ -1030,6 +1038,10 @@ _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange (
    _mongocrypt_ciphertext_t *ciphertext,
    mongocrypt_status_t *status)
 {
+   BSON_ASSERT_PARAM (kb);
+   BSON_ASSERT_PARAM (marking);
+   BSON_ASSERT_PARAM (ciphertext);
+   BSON_ASSERT (kb->crypt);
    BSON_ASSERT (marking->type == MONGOCRYPT_MARKING_FLE2_ENCRYPTION);
 
    if (!kb->crypt->opts.use_fle2_v2) {
@@ -1117,10 +1129,10 @@ fail:
 }
 
 /**
- * Payload subtype 12: FLE2FindEqualityPayload
+ * Payload subtype 12: FLE2FindEqualityPayloadV2
  * Delegates to ..._find_ciphertext_v1 when crypt->opts.use_fle2_v2 == false.
  *
- * {d: EDC, s: ESC, l: serverToken, cm: contentionCounter}
+ * {d: EDC, s: ESC, l: serverDerivedFromDataToken, cm: contentionCounter}
  */
 static bool
 _mongocrypt_fle2_placeholder_to_find_ciphertext (
@@ -1497,8 +1509,8 @@ fail:
  * Delegates to ..._find_ciphertextForRange_v1
  *   when crypt->opts.use_fle2_v2 is false
  *
- * {e: serverToken, cm: contentionCounter,
- *  g: [{d: EDC, s: ESC, c: ECC}, ...]}
+ * {cm: contentionCounter,
+ *  g: [{d: EDC, s: ESC, l: serverDerivedFromDataToken}, ...]}
  */
 static bool
 _mongocrypt_fle2_placeholder_to_find_ciphertextForRange (

--- a/src/mongocrypt-opts-private.h
+++ b/src/mongocrypt-opts-private.h
@@ -87,6 +87,10 @@ typedef struct {
 
    bool use_need_kms_credentials_state;
    bool bypass_query_analysis;
+
+   // When creating new encrypted payloads,
+   // use V2 variants of the FLE2 datatypes.
+   bool use_fle2_v2;
 } _mongocrypt_opts_t;
 
 

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -319,7 +319,7 @@ mongocrypt_new (void);
  * @param[in] crypt The @ref mongocrypt_t object.
  * @param[in] enable Whether to enable use of FLE2v2 payloads.
  *
- * @returns A boolean indicating success. If false, and error status is set.
+ * @returns A boolean indicating success. If false, an error status is set.
  * Retrieve it with @ref mongocrypt_ctx_status
  */
 MONGOCRYPT_EXPORT

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -320,7 +320,7 @@ mongocrypt_new (void);
  * @param[in] enable Whether to enable use of FLE2v2 payloads.
  *
  * @returns A boolean indicating success. If false, an error status is set.
- * Retrieve it with @ref mongocrypt_ctx_status
+ * Retrieve it with @ref mongocrypt_status
  */
 MONGOCRYPT_EXPORT
 bool

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -314,6 +314,20 @@ mongocrypt_new (void);
 
 
 /**
+ * Enable/disable the use of FLE2v2 payload types for write.
+ *
+ * @param[in] crypt The @ref mongocrypt_t object.
+ * @param[in] enable Whether to enable use of FLE2v2 payloads.
+ *
+ * @returns A boolean indicating success. If false, and error status is set.
+ * Retrieve it with @ref mongocrypt_ctx_status
+ */
+MONGOCRYPT_EXPORT
+bool
+mongocrypt_setopt_fle2v2 (mongocrypt_t *crypt, bool enable);
+
+
+/**
  * Set a handler on the @ref mongocrypt_t object to get called on every log
  * message.
  *

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -2607,8 +2607,8 @@ _test_encrypt_fle2_unindexed_encrypted_payload (_mongocrypt_tester_t *tester)
    _test_rng_data_source source = {
       .buf = {.data = rng_data, .len = sizeof (rng_data) - 1u}};
 
-   // TODO (SERVER-74139): Implement InsertUpdatePlacePayloadV2 transform
-   // Test kFLE2v2Enable when MONGOCRYPT work done folllowing SERVER work.
+   // TODO (MONGOCRYPT-551): Implement UnindexedEncryptedValueV2 transform
+   // Add kFLE2v2Enable case (or use macro) when the above work complete.
    source.pos = 0;
    _test_encrypt_fle2_encryption_placeholder (tester,
                                               "fle2-insert-unindexed",

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -2417,18 +2417,56 @@ _test_rng_source (void *ctx,
    return true;
 }
 
+typedef enum {
+   kFLE2v2Default,
+   kFLE2v2Disable,
+   kFLE2v2Enable,
+} _test_fle2v2_option;
+
+#define TEST_ENCRYPT_FLE2_ENCRYPTION_PLACEHOLDER(                             \
+   tester, data_path, rng_source, v2_failure)                                 \
+   {                                                                          \
+      (rng_source)->pos = 0;                                                  \
+      _test_encrypt_fle2_encryption_placeholder (tester,                      \
+                                                 data_path,                   \
+                                                 rng_source,                  \
+                                                 kFLE2v2Default,              \
+                                                 "encrypted-payload.json",    \
+                                                 NULL);                       \
+      (rng_source)->pos = 0;                                                  \
+      _test_encrypt_fle2_encryption_placeholder (tester,                      \
+                                                 data_path,                   \
+                                                 rng_source,                  \
+                                                 kFLE2v2Disable,              \
+                                                 "encrypted-payload.json",    \
+                                                 NULL);                       \
+      (rng_source)->pos = 0;                                                  \
+      _test_encrypt_fle2_encryption_placeholder (tester,                      \
+                                                 data_path,                   \
+                                                 rng_source,                  \
+                                                 kFLE2v2Enable,               \
+                                                 "encrypted-payload-v2.json", \
+                                                 v2_failure);                 \
+   }
+
+
 static void
-_test_encrypt_fle2_encryption_placeholder (_mongocrypt_tester_t *tester,
-                                           const char *data_path,
-                                           _test_rng_data_source *rng_source)
+_test_encrypt_fle2_encryption_placeholder (
+   _mongocrypt_tester_t *tester,
+   const char *data_path,
+   _test_rng_data_source *rng_source,
+   _test_fle2v2_option test_fle2v2_option,
+   const char *output_path,
+   const char *finalize_failure)
 {
    mongocrypt_t *crypt;
    char pathbuf[2048];
 
-#define MAKE_PATH(path)                                                       \
-   ASSERT (snprintf (                                                         \
-              pathbuf, sizeof (pathbuf), "./test/data/%s/" path, data_path) < \
-           sizeof (pathbuf))
+#define MAKE_PATH(mypath)                                                     \
+   ASSERT (                                                                   \
+      snprintf (                                                              \
+         pathbuf, sizeof (pathbuf), "./test/data/%s/%s", data_path, mypath) < \
+      sizeof (pathbuf))
 
    if (!_aes_ctr_is_supported_by_os) {
       printf ("Common Crypto with no CTR support detected. Skipping.");
@@ -2443,6 +2481,10 @@ _test_encrypt_fle2_encryption_placeholder (_mongocrypt_tester_t *tester,
       mongocrypt_binary_t *localkey;
 
       crypt = mongocrypt_new ();
+      if (test_fle2v2_option != kFLE2v2Default) {
+         ASSERT (mongocrypt_setopt_fle2v2 (
+            crypt, test_fle2v2_option == kFLE2v2Enable));
+      }
       mongocrypt_setopt_log_handler (crypt, _mongocrypt_stdout_log_fn, NULL);
       localkey = mongocrypt_binary_new_from_data ((uint8_t *) localkey_data,
                                                   sizeof localkey_data);
@@ -2502,12 +2544,15 @@ _test_encrypt_fle2_encryption_placeholder (_mongocrypt_tester_t *tester,
 
    ASSERT_STATE_EQUAL (mongocrypt_ctx_state (ctx), MONGOCRYPT_CTX_READY);
    {
-      mongocrypt_binary_t *out;
-
-      out = mongocrypt_binary_new ();
-      ASSERT_OK (mongocrypt_ctx_finalize (ctx, out), ctx);
-      MAKE_PATH ("encrypted-payload.json");
-      ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (TEST_FILE (pathbuf), out);
+      mongocrypt_binary_t *out = mongocrypt_binary_new ();
+      bool ok = mongocrypt_ctx_finalize (ctx, out);
+      if (finalize_failure) {
+         ASSERT_FAILS_STATUS (ok, ctx->status, finalize_failure);
+      } else {
+         ASSERT_OK (ok, ctx);
+         MAKE_PATH (output_path);
+         ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON (TEST_FILE (pathbuf), out);
+      }
       mongocrypt_binary_destroy (out);
    }
 #undef MAKE_PATH
@@ -2526,9 +2571,15 @@ static void
 _test_encrypt_fle2_insert_payload (_mongocrypt_tester_t *tester)
 {
    uint8_t rng_data[] = RNG_DATA;
+
    _test_rng_data_source source = {
       .buf = {.data = rng_data, .len = sizeof (rng_data) - 1u}};
-   _test_encrypt_fle2_encryption_placeholder (tester, "fle2-insert", &source);
+   // TODO (MONGOCRYPT-543): Implement InsertUpdatePayloadV2 transform
+   TEST_ENCRYPT_FLE2_ENCRYPTION_PLACEHOLDER (
+      tester,
+      "fle2-insert",
+      &source,
+      "FLE2InsertUpdatePayloadV2 not implemented")
 }
 #undef RNG_DATA
 
@@ -2537,8 +2588,12 @@ static void
 _test_encrypt_fle2_find_payload (_mongocrypt_tester_t *tester)
 {
    _test_rng_data_source source = {{0}};
-   _test_encrypt_fle2_encryption_placeholder (
-      tester, "fle2-find-equality", &source);
+   // TODO (MONGOCRYPT-544): Implement FindEqualityPayloadV2 transform
+   TEST_ENCRYPT_FLE2_ENCRYPTION_PLACEHOLDER (
+      tester,
+      "fle2-find-equality",
+      &source,
+      "FLE2FindEqualityPayloadV2 not implemented")
 }
 
 /* 16 bytes of random data are used for IV. This IV produces the expected test
@@ -2551,8 +2606,24 @@ _test_encrypt_fle2_unindexed_encrypted_payload (_mongocrypt_tester_t *tester)
    uint8_t rng_data[] = RNG_DATA;
    _test_rng_data_source source = {
       .buf = {.data = rng_data, .len = sizeof (rng_data) - 1u}};
-   _test_encrypt_fle2_encryption_placeholder (
-      tester, "fle2-insert-unindexed", &source);
+
+   // TODO (SERVER-74139): Implement InsertUpdatePlacePayloadV2 transform
+   // Test kFLE2v2Enable when MONGOCRYPT work done folllowing SERVER work.
+   source.pos = 0;
+   _test_encrypt_fle2_encryption_placeholder (tester,
+                                              "fle2-insert-unindexed",
+                                              &source,
+                                              kFLE2v2Default,
+                                              "encrypted-payload.json",
+                                              NULL);
+
+   source.pos = 0;
+   _test_encrypt_fle2_encryption_placeholder (tester,
+                                              "fle2-insert-unindexed",
+                                              &source,
+                                              kFLE2v2Disable,
+                                              "encrypted-payload.json",
+                                              NULL);
 }
 #undef RNG_DATA
 
@@ -2563,8 +2634,12 @@ _test_encrypt_fle2_insert_range_payload_int32 (_mongocrypt_tester_t *tester)
    uint8_t rng_data[] = RNG_DATA;
    _test_rng_data_source source = {
       .buf = {.data = rng_data, .len = sizeof (rng_data) - 1u}};
-   _test_encrypt_fle2_encryption_placeholder (
-      tester, "fle2-insert-range/int32", &source);
+   // TODO (MONGOCRYPT-543): Implement InsertUpdatePayloadV2 transform
+   TEST_ENCRYPT_FLE2_ENCRYPTION_PLACEHOLDER (
+      tester,
+      "fle2-insert-range/int32",
+      &source,
+      "FLE2InsertUpdatePayloadV2 not implemented")
 }
 #undef RNG_DATA
 
@@ -2575,8 +2650,12 @@ _test_encrypt_fle2_insert_range_payload_int64 (_mongocrypt_tester_t *tester)
    uint8_t rng_data[] = RNG_DATA;
    _test_rng_data_source source = {
       .buf = {.data = rng_data, .len = sizeof (rng_data) - 1u}};
-   _test_encrypt_fle2_encryption_placeholder (
-      tester, "fle2-insert-range/int64", &source);
+   // TODO (MONGOCRYPT-543): Implement InsertUpdatePayloadV2 transform
+   TEST_ENCRYPT_FLE2_ENCRYPTION_PLACEHOLDER (
+      tester,
+      "fle2-insert-range/int64",
+      &source,
+      "FLE2InsertUpdatePayloadV2 not implemented")
 }
 #undef RNG_DATA
 
@@ -2587,8 +2666,12 @@ _test_encrypt_fle2_insert_range_payload_date (_mongocrypt_tester_t *tester)
    uint8_t rng_data[] = RNG_DATA;
    _test_rng_data_source source = {
       .buf = {.data = rng_data, .len = sizeof (rng_data) - 1u}};
-   _test_encrypt_fle2_encryption_placeholder (
-      tester, "fle2-insert-range/date", &source);
+   // TODO (MONGOCRYPT-543): Implement InsertUpdatePayloadV2 transform
+   TEST_ENCRYPT_FLE2_ENCRYPTION_PLACEHOLDER (
+      tester,
+      "fle2-insert-range/date",
+      &source,
+      "FLE2InsertUpdatePayloadV2 not implemented")
 }
 #undef RNG_DATA
 
@@ -2599,8 +2682,12 @@ _test_encrypt_fle2_insert_range_payload_double (_mongocrypt_tester_t *tester)
    uint8_t rng_data[] = RNG_DATA;
    _test_rng_data_source source = {
       .buf = {.data = rng_data, .len = sizeof (rng_data) - 1u}};
-   _test_encrypt_fle2_encryption_placeholder (
-      tester, "fle2-insert-range/double", &source);
+   // TODO (MONGOCRYPT-543): Implement InsertUpdatePayloadV2 transform
+   TEST_ENCRYPT_FLE2_ENCRYPTION_PLACEHOLDER (
+      tester,
+      "fle2-insert-range/double",
+      &source,
+      "FLE2InsertUpdatePayloadV2 not implemented")
 }
 #undef RNG_DATA
 
@@ -2612,8 +2699,12 @@ _test_encrypt_fle2_insert_range_payload_double_precision (
    uint8_t rng_data[] = RNG_DATA;
    _test_rng_data_source source = {
       .buf = {.data = rng_data, .len = sizeof (rng_data) - 1u}};
-   _test_encrypt_fle2_encryption_placeholder (
-      tester, "fle2-insert-range/double-precision", &source);
+   // TODO (MONGOCRYPT-543): Implement InsertUpdatePayloadV2 transform
+   TEST_ENCRYPT_FLE2_ENCRYPTION_PLACEHOLDER (
+      tester,
+      "fle2-insert-range/double-precision",
+      &source,
+      "FLE2InsertUpdatePayloadV2 not implemented")
 }
 #undef RNG_DATA
 
@@ -2626,8 +2717,12 @@ _test_encrypt_fle2_insert_range_payload_decimal128 (
    uint8_t rng_data[] = RNG_DATA;
    _test_rng_data_source source = {
       .buf = {.data = rng_data, .len = sizeof (rng_data) - 1u}};
-   _test_encrypt_fle2_encryption_placeholder (
-      tester, "fle2-insert-range/decimal128", &source);
+   // TODO (MONGOCRYPT-543): Implement InsertUpdatePayloadV2 transform
+   TEST_ENCRYPT_FLE2_ENCRYPTION_PLACEHOLDER (
+      tester,
+      "fle2-insert-range/decimal128",
+      &source,
+      "FLE2InsertUpdatePayloadV2 not implemented")
 }
 #undef RNG_DATA
 
@@ -2639,8 +2734,12 @@ _test_encrypt_fle2_insert_range_payload_decimal128_precision (
    uint8_t rng_data[] = RNG_DATA;
    _test_rng_data_source source = {
       .buf = {.data = rng_data, .len = sizeof (rng_data) - 1u}};
-   _test_encrypt_fle2_encryption_placeholder (
-      tester, "fle2-insert-range/decimal128-precision", &source);
+   // TODO (MONGOCRYPT-543): Implement InsertUpdatePayloadV2 transform
+   TEST_ENCRYPT_FLE2_ENCRYPTION_PLACEHOLDER (
+      tester,
+      "fle2-insert-range/decimal128-precision",
+      &source,
+      "FLE2InsertUpdatePayloadV2 not implemented")
 }
 #undef RNG_DATA
 #endif // MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
@@ -2650,8 +2749,12 @@ static void
 _test_encrypt_fle2_find_range_payload_int32 (_mongocrypt_tester_t *tester)
 {
    _test_rng_data_source source = {{0}};
-   _test_encrypt_fle2_encryption_placeholder (
-      tester, "fle2-find-range/int32", &source);
+   // TODO (MONGOCRYPT-545): Implement FindRangePayloadV2 transform
+   TEST_ENCRYPT_FLE2_ENCRYPTION_PLACEHOLDER (
+      tester,
+      "fle2-find-range/int32",
+      &source,
+      "FLE2FindRangePayloadV2 not implemented")
 }
 
 // FLE2FindRangePayload only uses deterministic token generation.
@@ -2659,8 +2762,12 @@ static void
 _test_encrypt_fle2_find_range_payload_int64 (_mongocrypt_tester_t *tester)
 {
    _test_rng_data_source source = {{0}};
-   _test_encrypt_fle2_encryption_placeholder (
-      tester, "fle2-find-range/int64", &source);
+   // TODO (MONGOCRYPT-545): Implement FindRangePayloadV2 transform
+   TEST_ENCRYPT_FLE2_ENCRYPTION_PLACEHOLDER (
+      tester,
+      "fle2-find-range/int64",
+      &source,
+      "FLE2FindRangePayloadV2 not implemented")
 }
 
 // FLE2FindRangePayload only uses deterministic token generation.
@@ -2668,8 +2775,12 @@ static void
 _test_encrypt_fle2_find_range_payload_date (_mongocrypt_tester_t *tester)
 {
    _test_rng_data_source source = {{0}};
-   _test_encrypt_fle2_encryption_placeholder (
-      tester, "fle2-find-range/date", &source);
+   // TODO (MONGOCRYPT-545): Implement FindRangePayloadV2 transform
+   TEST_ENCRYPT_FLE2_ENCRYPTION_PLACEHOLDER (
+      tester,
+      "fle2-find-range/date",
+      &source,
+      "FLE2FindRangePayloadV2 not implemented")
 }
 
 // FLE2FindRangePayload only uses deterministic token generation.
@@ -2677,8 +2788,12 @@ static void
 _test_encrypt_fle2_find_range_payload_double (_mongocrypt_tester_t *tester)
 {
    _test_rng_data_source source = {{0}};
-   _test_encrypt_fle2_encryption_placeholder (
-      tester, "fle2-find-range/double", &source);
+   // TODO (MONGOCRYPT-545): Implement FindRangePayloadV2 transform
+   TEST_ENCRYPT_FLE2_ENCRYPTION_PLACEHOLDER (
+      tester,
+      "fle2-find-range/double",
+      &source,
+      "FLE2FindRangePayloadV2 not implemented")
 }
 
 // FLE2FindRangePayload only uses deterministic token generation.
@@ -2687,8 +2802,12 @@ _test_encrypt_fle2_find_range_payload_double_precision (
    _mongocrypt_tester_t *tester)
 {
    _test_rng_data_source source = {{0}};
-   _test_encrypt_fle2_encryption_placeholder (
-      tester, "fle2-find-range/double-precision", &source);
+   // TODO (MONGOCRYPT-545): Implement FindRangePayloadV2 transform
+   TEST_ENCRYPT_FLE2_ENCRYPTION_PLACEHOLDER (
+      tester,
+      "fle2-find-range/double-precision",
+      &source,
+      "FLE2FindRangePayloadV2 not implemented")
 }
 
 #if MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
@@ -2697,8 +2816,12 @@ static void
 _test_encrypt_fle2_find_range_payload_decimal128 (_mongocrypt_tester_t *tester)
 {
    _test_rng_data_source source = {{0}};
-   _test_encrypt_fle2_encryption_placeholder (
-      tester, "fle2-find-range/decimal128", &source);
+   // TODO (MONGOCRYPT-545): Implement FindRangePayloadV2 transform
+   TEST_ENCRYPT_FLE2_ENCRYPTION_PLACEHOLDER (
+      tester,
+      "fle2-find-range/decimal128",
+      &source,
+      "FLE2FindRangePayloadV2 not implemented")
 }
 
 // FLE2FindRangePayload only uses deterministic token generation.
@@ -2707,8 +2830,12 @@ _test_encrypt_fle2_find_range_payload_decimal128_precision (
    _mongocrypt_tester_t *tester)
 {
    _test_rng_data_source source = {{0}};
-   _test_encrypt_fle2_encryption_placeholder (
-      tester, "fle2-find-range/decimal128-precision", &source);
+   // TODO (MONGOCRYPT-545): Implement FindRangePayloadV2 transform
+   TEST_ENCRYPT_FLE2_ENCRYPTION_PLACEHOLDER (
+      tester,
+      "fle2-find-range/decimal128-precision",
+      &source,
+      "FLE2FindRangePayloadV2 not implemented")
 }
 #endif // MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
 

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -2608,22 +2608,11 @@ _test_encrypt_fle2_unindexed_encrypted_payload (_mongocrypt_tester_t *tester)
       .buf = {.data = rng_data, .len = sizeof (rng_data) - 1u}};
 
    // TODO (MONGOCRYPT-551): Implement UnindexedEncryptedValueV2 transform
-   // Add kFLE2v2Enable case (or use macro) when the above work complete.
-   source.pos = 0;
-   _test_encrypt_fle2_encryption_placeholder (tester,
-                                              "fle2-insert-unindexed",
-                                              &source,
-                                              kFLE2v2Default,
-                                              "encrypted-payload.json",
-                                              NULL);
-
-   source.pos = 0;
-   _test_encrypt_fle2_encryption_placeholder (tester,
-                                              "fle2-insert-unindexed",
-                                              &source,
-                                              kFLE2v2Disable,
-                                              "encrypted-payload.json",
-                                              NULL);
+   TEST_ENCRYPT_FLE2_ENCRYPTION_PLACEHOLDER (
+      tester,
+      "fle2-insert-unindexed",
+      &source,
+      "FLE2UnindexedEncryptedValueV2 not implemented");
 }
 #undef RNG_DATA
 


### PR DESCRIPTION
This ended up including leaking into some other tickets in the process:

- MONGOCRYPT-548 Add a global feature flag to toggle usage of FLE2 protocol version 2
- MONGOCRYPT-538 Integrate the v2 payload types to the mongocrypt state machine. This fell out of having the feature flag.

This also lays out the framework for implementing MONGOCRYPT-543/MONGOCRYPT-544/MONGOCRYPT-545/MONGOCRYPT-551 as implementations and test vectors which should speed their course.
