### PR TITLE
MONGOCRYPT-568 Avoid calling memcpy with NULL argument in _mongocrypt_buffer_copy_from_data_and_size

### DIFF
--- a/src/mongocrypt-buffer.c
+++ b/src/mongocrypt-buffer.c
@@ -494,9 +494,12 @@ bool _mongocrypt_buffer_copy_from_data_and_size(_mongocrypt_buffer_t *buf, const
     if (!size_to_uint32(len, &buf->len)) {
         return false;
     }
-    buf->data = bson_malloc(len);
-    memcpy(buf->data, data, len);
-    buf->owned = true;
+
+    if ((buf->data = bson_malloc(len))) {
+        memcpy(buf->data, data, len);
+        buf->owned = true;
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Resolves MONGOCRYPT-568. See ticket for details. Verified by [this patch](https://spruce.mongodb.com/version/642f09242a60ed79889f29d9).

For consistency with other `mongocrypt_buffer_t` copy functions such as [_mongocrypt_buffer_copy_to](https://github.com/mongodb/libmongocrypt/blob/9dc3f6cefef442fea41c1f2f186c03a31477ea90/src/mongocrypt-buffer.c#L215), opted to allow `buf->data == NULL` rather than asserting a non-zero length.

Note: `mongocrypt_buffer_t` functions do not seem to be consistent with asserting what the value of `buf->owned` should be given `buf->data == NULL` (e.g. [_make_owned](https://github.com/mongodb/libmongocrypt/blob/9dc3f6cefef442fea41c1f2f186c03a31477ea90/src/mongocrypt-buffer.c#L28) allows `buf->data == NULL && buf->owned`, but [_mongocrypt_buffer_resize](https://github.com/mongodb/libmongocrypt/blob/9dc3f6cefef442fea41c1f2f186c03a31477ea90/src/mongocrypt-buffer.c#L55) asserts `buf->data != NULL` before setting `buf->owned = true`). Nevertheless, opted to leave `buf->owned == false` given `len == 0u`, which I think is preferable.