### PR TITLE
do not build tests if BUILD_TESTING is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,7 @@ if (BUILD_TESTING)
    endif ()
 endif ()
 
+if (BUILD_TESTING)
 set (TEST_MONGOCRYPT_SOURCES
    test/test-gcp-auth.c
    test/test-mc-efc.c
@@ -605,6 +606,7 @@ if (NOT MONGOCRYPT_CRYPTO STREQUAL none)
       target_link_libraries (csfle PRIVATE _mongocrypt::mongoc)
    endif ()
 endif ()
+endif () # BUILD_TESTING
 
 if (ENABLE_STATIC)
    set (TARGETS_TO_INSTALL mongocrypt mongocrypt_static)

--- a/kms-message/CMakeLists.txt
+++ b/kms-message/CMakeLists.txt
@@ -237,6 +237,7 @@ install (
    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )
 
+if (BUILD_TESTING)
 # cannot run tests without crypto
 if (NOT DISABLE_NATIVE_CRYPTO)
    add_executable (
@@ -303,3 +304,4 @@ elseif(ENABLE_ONLINE_TESTS)
       SKIP_RETURN_CODE 2
    )
 endif ()
+endif () # BUILD_TESTING


### PR DESCRIPTION
# Summary

- Do not build test executables if `BUILD_TESTING` is disabled

# Background & Motivation

There is a reported error of installing libmongocrypt with Homebrew:
https://mongodb.slack.com/archives/CDM9QEGUT/p1681457334220079

