### PR TITLE
remove trailing newline in `compile_env`

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -387,7 +387,8 @@ tasks:
       compile_env: >-
         ${compile_env|}
         LIBMONGOCRYPT_EXTRA_CFLAGS="-fsanitize=address -pthread"
-        ASAN_OPTIONS="detect_leaks=1"
+        # Add detect_odr_violation=0 to ASAN_OPTIONS to ignore odr-violation in IntelDFP symbol: __dpml_bid_globals_table
+        ASAN_OPTIONS="detect_leaks=1 detect_odr_violation=0"
 
 - name: build-and-test-asan-mac
   commands:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -384,7 +384,7 @@ tasks:
   - func: "fetch source"
   - func: "build and test"
     vars:
-      compile_env: >
+      compile_env: >-
         ${compile_env|}
         LIBMONGOCRYPT_EXTRA_CFLAGS="-fsanitize=address -pthread"
         ASAN_OPTIONS="detect_leaks=1"

--- a/.lsan-suppressions
+++ b/.lsan-suppressions
@@ -1,3 +1,5 @@
 leak:ccrng_cryptographic_init_once
 leak:ccrng_cryptographic_generate
 leak:CRYPTO_zalloc
+# Ignore leak reported in dlopen error.
+leak:_dlerror_run


### PR DESCRIPTION
# Summary
- remove trailing newline in `compile_env` to fix leak detection

# Background & Motivation

The trailing newline in `compile_env` results in the `env` command run separately in the [`build and test` function](https://github.com/mongodb/libmongocrypt/blob/master/.evergreen/config.yml#L76-L78). This results in the [environment variables being printed](https://parsley.mongodb.com/evergreen/libmongocrypt_ubuntu1804_64_build_and_test_asan_50eaa4b9da767d817710d7e8612b15f1b1b9f2d4_23_04_17_21_26_57/0/task?bookmarks=0,5271&shareLine=59) instead of applying the `compile_env` to the environment.

This patch includes a leak to verify leak detection is working: https://spruce.mongodb.com/version/644045600ae6068d54cab675


After enabling, ASAN reported two errors.

1. An [odr-violation from IntelDFP](https://spruce.mongodb.com/task/libmongocrypt_debian11_build_and_test_asan_patch_50eaa4b9da767d817710d7e8612b15f1b1b9f2d4_644046fa1e2d17ce26f0eb81_23_04_19_19_54_35/logs?execution=0):

```
==9000==ERROR: AddressSanitizer: odr-violation (0x561b06a4c5e0):
  [1] size=416 '__dpml_bid_globals_table' /data/mci/1beb5ae10e290ed026a01bbd2654c81f/libmongocrypt/cmake-build/_deps/intel_dfp-src/LIBRARY/float128/dpml_globals.h:40:24
  [2] size=416 '__dpml_bid_globals_table' /data/mci/1beb5ae10e290ed026a01bbd2654c81f/libmongocrypt/cmake-build/_deps/intel_dfp-src/LIBRARY/float128/dpml_globals.h:40:24
These globals were registered at these points:
  [1]:
    #0 0x7f4bcbf1df40 in __asan_register_globals ../../../../src/libsanitizer/asan/asan_globals.cpp:341
    #1 0x561b06a4b814 in __libc_csu_init (/data/mci/1beb5ae10e290ed026a01bbd2654c81f/libmongocrypt/cmake-build/example-state-machine+0x14e814)
  [2]:
    #0 0x7f4bcbf1df40 in __asan_register_globals ../../../../src/libsanitizer/asan/asan_globals.cpp:341
    #1 0x7f4bcc8cbfe1 in call_init elf/dl-init.c:72
==9000==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
SUMMARY: AddressSanitizer: odr-violation: global '__dpml_bid_globals_table' at /data/mci/1beb5ae10e290ed026a01bbd2654c81f/libmongocrypt/cmake-build/_deps/intel_dfp-src/LIBRARY/float128/dpml_globals.==9000==ABORTING
```

`__dpml_bid_globals_table` appears to be read-only. I chose to use `ASAN_OPTIONS=odr-violation=0` rather than investigate patching IntelDFP.

2. A [leak in `_dlerror_run`](https://spruce.mongodb.com/task/libmongocrypt_ubuntu2204_arm64_build_and_test_asan_patch_50eaa4b9da767d817710d7e8612b15f1b1b9f2d4_644046fa1e2d17ce26f0eb81_23_04_19_19_54_35/logs?execution=0)

```
==7723==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0xffff8240a2f4 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0xffff81cd91e0 in _dlerror_run dlfcn/dlerror.c:168
    #2 0xffff81cd9780 in dlopen_implementation dlfcn/dlopen.c:71
    #3 0xffff81cd9780 in ___dlopen dlfcn/dlopen.c:81
    #4 0xffff823abb80 in __interceptor_dlopen ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:6251
    #5 0xaaaacb010014 in mcr_dll_open /data/mci/e5629f86cd6569e4093087262baed3b9/libmongocrypt/src/os_posix/os_dll.c:28
    #6 0xaaaacaf77238 in _test_load_nonesuch /data/mci/e5629f86cd6569e4093087262baed3b9/libmongocrypt/test/test-mongocrypt-dll.c:32
    #7 0xaaaacaccb66c in main /data/mci/e5629f86cd6569e4093087262baed3b9/libmongocrypt/test/test-mongocrypt.c:900
    #8 0xffff81c873f8 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #9 0xffff81c874c8 in __libc_start_main_impl ../csu/libc-start.c:392
    #10 0xaaaacaccc7ec in _start (/data/mci/e5629f86cd6569e4093087262baed3b9/libmongocrypt/cmake-build/test-mongocrypt+0x1dc7ec)
Indirect leak of 93 byte(s) in 1 object(s) allocated from:
    #0 0xffff8240a69c in __interceptor_realloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:164
    #1 0xffff81cd2154 in __vasprintf_internal libio/vasprintf.c:79
    #2 0xffff81cb0c7c in ___asprintf stdio-common/asprintf.c:31
    #3 0xffff81cd8fb4 in __dlerror dlfcn/dlerror.c:81
    #4 0xaaaacb010034 in mcr_dll_open /data/mci/e5629f86cd6569e4093087262baed3b9/libmongocrypt/src/os_posix/os_dll.c:33
    #5 0xaaaacaf77238 in _test_load_nonesuch /data/mci/e5629f86cd6569e4093087262baed3b9/libmongocrypt/test/test-mongocrypt-dll.c:32
    #6 0xaaaacaccb66c in main /data/mci/e5629f86cd6569e4093087262baed3b9/libmongocrypt/test/test-mongocrypt.c:900
    #7 0xffff81c873f8 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #8 0xffff81c874c8 in __libc_start_main_impl ../csu/libc-start.c:392
    #9 0xaaaacaccc7ec in _start (/data/mci/e5629f86cd6569e4093087262baed3b9/libmongocrypt/cmake-build/test-mongocrypt+0x1dc7ec)
SUMMARY: AddressSanitizer: 117 byte(s) leaked in 2 allocation(s).
```

This does not appear to be a bug in libmongocrypt. `.lsan-suppressions` was updated to ignore the leak in `_dlerror_run`.
