### PR TITLE
Define a mongocrypt::platform target for platform requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,13 +78,13 @@ if (ENABLE_MORE_WARNINGS_AS_ERRORS)
       )
 endif ()
 
-find_package (Threads REQUIRED)
-
 add_subdirectory (bindings/cs)
 
 include (GenerateExportHeader)
 
 include (CTest)
+include (Platform)
+
 
 set (MONGOCRYPT_PUBLIC_HEADERS
    src/mongocrypt-compat.h
@@ -277,26 +277,15 @@ target_include_directories (
    PUBLIC
       "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>"
    )
-include (TestBigEndian)
-TEST_BIG_ENDIAN (MONGOCRYPT_BIG_ENDIAN)
-if (MONGOCRYPT_BIG_ENDIAN)
-   message ("Detected byte order: big endian")
-   list (APPEND MONGOCRYPT_DEFINITIONS MONGOCRYPT_BIG_ENDIAN)
-else ()
-   message ("Detected byte order: little endian")
-   list (APPEND MONGOCRYPT_DEFINITIONS MONGOCRYPT_LITTLE_ENDIAN)
-endif ()
-target_compile_definitions (mongocrypt PRIVATE ${MONGOCRYPT_DEFINITIONS})
 target_link_libraries (
    mongocrypt
    PRIVATE
       _mongocrypt::libbson_for_shared
-      Threads::Threads
       kms_message_static
       $<BUILD_INTERFACE:mongo::mlib>
    PUBLIC
+      mongocrypt::platform
       ${maybe_dfp_library}
-      ${CMAKE_DL_LIBS}
    )
 
 if (NOT USE_SHARED_LIBBSON)
@@ -353,9 +342,8 @@ target_link_libraries (
       kms_message_static
       $<BUILD_INTERFACE:mongo::mlib>
    PUBLIC
+      mongocrypt::platform
       ${maybe_dfp_library}
-      ${CMAKE_THREAD_LIBS_INIT}
-      ${CMAKE_DL_LIBS}
    )
 set (PKG_CONFIG_STATIC_LIBS "\${prefix}/${CMAKE_INSTALL_LIBDIR}/libmongocrypt-static.a")
 set (PKG_CONFIG_STATIC_LIBS "${PKG_CONFIG_STATIC_LIBS} ${CMAKE_THREAD_LIBS_INIT}")
@@ -401,8 +389,6 @@ endif ()
 if (NOT APPLE)
    find_library (M_LIBRARY m)
    if (M_LIBRARY)
-      target_link_libraries (mongocrypt PRIVATE ${M_LIBRARY})
-      target_link_libraries (mongocrypt_static PRIVATE ${M_LIBRARY})
       set (PKG_CONFIG_STATIC_LIBS "${PKG_CONFIG_STATIC_LIBS} -lm")
    endif ()
 endif ()
@@ -560,7 +546,6 @@ if ("cxx_relaxed_constexpr" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
          mongocrypt
          mongo::mlib
          ${maybe_dfp_library}
-         Threads::Threads
          _mongocrypt::libbson_for_static
          )
       add_test ("${test_name}" "${exe_name}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,8 +329,6 @@ target_include_directories (
    )
 target_compile_definitions (
    mongocrypt_static
-   PRIVATE
-      ${MONGOCRYPT_DEFINITIONS}
    PUBLIC
       MONGOCRYPT_STATIC_DEFINE
       KMS_MSG_STATIC
@@ -509,8 +507,6 @@ target_include_directories (test-mongocrypt PRIVATE ./src "${CMAKE_CURRENT_SOURC
 target_link_libraries (test-mongocrypt PRIVATE _mongocrypt::libbson_for_static mongocrypt_static mongo::mlib)
 target_include_directories (test-mongocrypt PRIVATE "${CMAKE_CURRENT_LIST_DIR}/test")
 target_compile_definitions (test-mongocrypt PRIVATE
-   ${BSON_DEFINITIONS}
-   ${MONGOCRYPT_DEFINITIONS}
    # Set a definition so that testcases can know where test-mongocrypt.exe was written to
    "TEST_MONGOCRYPT_OUTPUT_PATH=\"$<TARGET_FILE:test-mongocrypt>\""
    # Tell test-mongocrypt whether we have a real csfle library for testing

--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -1,0 +1,50 @@
+#[[
+    Defines a platform-support target _mongocrypt::platform.
+
+    This target sets certain internal-only compile definitions, and defines
+    usage requirements on certain platform features required by libmongocrypt
+    (Threads, dlopen(), math)
+]]
+
+add_library (lmc-platform INTERFACE)
+add_library (mongocrypt::platform ALIAS lmc-platform)
+install (TARGETS lmc-platform EXPORT mongocrypt_targets)
+set_property (
+    TARGET lmc-platform
+    PROPERTY EXPORT_NAME mongocrypt::platform
+    )
+
+# Threads:
+find_package (Threads REQUIRED)
+
+# Special math:
+if (NOT APPLE)
+    find_library (M_LIBRARY m)
+endif ()
+
+# Special runtime:
+find_library (RT_LIBRARY rt)
+
+# Endian detection:
+if (DEFINED CMAKE_C_BYTE_ORDER)
+    # Newer CMake knows this immediately:
+    set (MONGOCRYPT_ENDIAN_DEF "MONGOCRYPT_${CMAKE_C_BYTE_ORDER}")
+else ()
+    include (TestBigEndian)
+    test_big_endian (_is_big)
+    set (MONGOCRYPT_ENDIAN_DEF "MONGOCRYPT_$<IF:${_is_big},BIG,LITTLE>_ENDIAN")
+endif ()
+
+target_compile_definitions (lmc-platform INTERFACE
+    "$<BUILD_INTERFACE:${MONGOCRYPT_ENDIAN_DEF}>"
+    )
+target_link_libraries (lmc-platform INTERFACE
+    Threads::Threads
+    # These are build-interface libs, but still required. These will be added
+    # to the platform library in mongocrypt-config.cmake using the same
+    # find_library() calls:
+    $<BUILD_INTERFACE:${CMAKE_DL_LIBS}>
+    $<BUILD_INTERFACE:$<$<BOOL:${M_LIBRARY}>:${M_LIBRARY}>>
+    $<BUILD_INTERFACE:$<$<BOOL:${RT_LIBRARY}>:${RT_LIBRARY}>>
+    )
+

--- a/cmake/mongocrypt-config.cmake
+++ b/cmake/mongocrypt-config.cmake
@@ -1,6 +1,25 @@
 include(CMakeFindDependencyMacro)
 find_dependency(kms_message 0.0.1)
+find_dependency(Threads)
+
 include("${CMAKE_CURRENT_LIST_DIR}/mongocrypt_targets.cmake")
+
+# Link for dlopen():
+set_property(TARGET mongo::mongocrypt::platform APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS})
+
+# Link for special math functions:
+if (NOT APPLE)
+    find_library (_MONGOCRYPT_M_LIBRARY m)
+    if (_MONGOCRYPT_M_LIBRARY)
+        set_property(TARGET mongo::mongocrypt::platform APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${_MONGOCRYPT_M_LIBRARY}")
+    endif ()
+endif ()
+
+# Special runtime:
+find_library (_MONGOCRYPT_RT_LIBRARY rt)
+if (_MONGOCRYPT_RT_LIBRARY)
+    set_property (TARGET mongo::mongocrypt::platform APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${_MONGOCRYPT_RT_LIBRARY}")
+endif ()
 
 if (DEFINED MONGOCRYPT_LIBBSON_STATIC_USE)
     # The user has named a library that should be linked as the static libbson library

--- a/cmake/mongocrypt-config.cmake
+++ b/cmake/mongocrypt-config.cmake
@@ -49,6 +49,7 @@ set_property (TARGET mongo::mongocrypt::platform APPEND PROPERTY INTERFACE_LINK_
 # Link for special math functions:
 if (NOT APPLE)
     find_library (_MONGOCRYPT_M_LIBRARY m)
+    mark_as_advanced (_MONGOCRYPT_M_LIBRARY)
     if (_MONGOCRYPT_M_LIBRARY)
         set_property (TARGET mongo::mongocrypt::platform APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${_MONGOCRYPT_M_LIBRARY}")
     endif ()
@@ -56,6 +57,7 @@ endif ()
 
 # Special runtime:
 find_library (_MONGOCRYPT_RT_LIBRARY rt)
+mark_as_advanced (_MONGOCRYPT_RT_LIBRARY)
 if (_MONGOCRYPT_RT_LIBRARY)
     set_property (TARGET mongo::mongocrypt::platform APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${_MONGOCRYPT_RT_LIBRARY}")
 endif ()

--- a/cmake/mongocrypt-config.cmake
+++ b/cmake/mongocrypt-config.cmake
@@ -1,25 +1,6 @@
 include(CMakeFindDependencyMacro)
 find_dependency(kms_message 0.0.1)
-find_dependency(Threads)
-
 include("${CMAKE_CURRENT_LIST_DIR}/mongocrypt_targets.cmake")
-
-# Link for dlopen():
-set_property(TARGET mongo::mongocrypt::platform APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS})
-
-# Link for special math functions:
-if (NOT APPLE)
-    find_library (_MONGOCRYPT_M_LIBRARY m)
-    if (_MONGOCRYPT_M_LIBRARY)
-        set_property(TARGET mongo::mongocrypt::platform APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${_MONGOCRYPT_M_LIBRARY}")
-    endif ()
-endif ()
-
-# Special runtime:
-find_library (_MONGOCRYPT_RT_LIBRARY rt)
-if (_MONGOCRYPT_RT_LIBRARY)
-    set_property (TARGET mongo::mongocrypt::platform APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${_MONGOCRYPT_RT_LIBRARY}")
-endif ()
 
 if (DEFINED MONGOCRYPT_LIBBSON_STATIC_USE)
     # The user has named a library that should be linked as the static libbson library
@@ -58,4 +39,23 @@ if (_using_system_intel_dfp)
       TARGET mongo::_mongocrypt-intel_dfp
       PROPERTY IMPORTED_LOCATION "${_MONGOCRYPT_SYSTEM_INTEL_DFP_STATIC}"
       )
+endif ()
+
+find_dependency(Threads)
+
+# Link for dlopen():
+set_property(TARGET mongo::mongocrypt::platform APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS})
+
+# Link for special math functions:
+if (NOT APPLE)
+    find_library (_MONGOCRYPT_M_LIBRARY m)
+    if (_MONGOCRYPT_M_LIBRARY)
+        set_property(TARGET mongo::mongocrypt::platform APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${_MONGOCRYPT_M_LIBRARY}")
+    endif ()
+endif ()
+
+# Special runtime:
+find_library (_MONGOCRYPT_RT_LIBRARY rt)
+if (_MONGOCRYPT_RT_LIBRARY)
+    set_property (TARGET mongo::mongocrypt::platform APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${_MONGOCRYPT_RT_LIBRARY}")
 endif ()

--- a/cmake/mongocrypt-config.cmake
+++ b/cmake/mongocrypt-config.cmake
@@ -44,13 +44,13 @@ endif ()
 find_dependency(Threads)
 
 # Link for dlopen():
-set_property(TARGET mongo::mongocrypt::platform APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS})
+set_property (TARGET mongo::mongocrypt::platform APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS})
 
 # Link for special math functions:
 if (NOT APPLE)
     find_library (_MONGOCRYPT_M_LIBRARY m)
     if (_MONGOCRYPT_M_LIBRARY)
-        set_property(TARGET mongo::mongocrypt::platform APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${_MONGOCRYPT_M_LIBRARY}")
+        set_property (TARGET mongo::mongocrypt::platform APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${_MONGOCRYPT_M_LIBRARY}")
     endif ()
 endif ()
 


### PR DESCRIPTION
`mongocrypt::platform` is an `INTERFACE` library that defines usage requirements related to platform features and dependencies on system libraries. When a library links to a libmongocrypt library, it will transitively link to `mongocrypt::platform`, which will propagate usage requirements required for consuming libmongocrypt (e.g. runtime support libraries)