### PR TITLE
Fix memory leak

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -219,6 +219,7 @@ static bool _fle2_insert_encryptionInformation(const mongocrypt_ctx_t *ctx,
         if (!_fle2_append_encryptionInformation(ctx, cmd, ns, encryptedFieldConfig, deleteTokens, coll_name, status)) {
             goto fail;
         }
+        bson_destroy(&out);
         goto success;
     }
 
@@ -248,6 +249,7 @@ static bool _fle2_insert_encryptionInformation(const mongocrypt_ctx_t *ctx,
         if (!mc_iter_document_as_bson(&iter, &tmp, status)) {
             goto fail;
         }
+        bson_destroy(&explain);
         bson_copy_to(&tmp, &explain);
     }
 


### PR DESCRIPTION
_fle2_insert_encryptionInformation leaks memory when BSON_MEMCHECK is enabled. The fix is to destroy the initialized objects before overwritting them or before returning from the function.