### PR TITLE
Improve bson_t initialization behavior

### DIFF
--- a/src/mc-fle2-rfds-private.h
+++ b/src/mc-fle2-rfds-private.h
@@ -48,6 +48,8 @@ bool mc_FLE2RangeFindDriverSpec_parse(mc_FLE2RangeFindDriverSpec_t *spec,
 
 // mc_FLE2RangeFindDriverSpec_to_placeholders creates a new document with
 // placeholders to encrypt.
+//
+// ACHTUNG: `out` MUST be initialized!
 bool mc_FLE2RangeFindDriverSpec_to_placeholders(mc_FLE2RangeFindDriverSpec_t *spec,
                                                 const mc_RangeOpts_t *range_opts,
                                                 int64_t maxContentionCounter,

--- a/src/mc-fle2-rfds-private.h
+++ b/src/mc-fle2-rfds-private.h
@@ -49,7 +49,7 @@ bool mc_FLE2RangeFindDriverSpec_parse(mc_FLE2RangeFindDriverSpec_t *spec,
 // mc_FLE2RangeFindDriverSpec_to_placeholders creates a new document with
 // placeholders to encrypt.
 //
-// ACHTUNG: `out` MUST be initialized!
+// `out` must be initialized by caller.
 bool mc_FLE2RangeFindDriverSpec_to_placeholders(mc_FLE2RangeFindDriverSpec_t *spec,
                                                 const mc_RangeOpts_t *range_opts,
                                                 int64_t maxContentionCounter,

--- a/src/mc-fle2-rfds.c
+++ b/src/mc-fle2-rfds.c
@@ -456,8 +456,6 @@ bool mc_FLE2RangeFindDriverSpec_to_placeholders(mc_FLE2RangeFindDriverSpec_t *sp
         TRY(bson_iter_init_find(&indexMax, &minMaxDoc, "indexMax"));
     }
 
-    bson_init(out);
-
     mc_makeRangeFindPlaceholder_args_t args = {.isStub = false,
                                                .user_key_id = user_key_id,
                                                .index_key_id = index_key_id,

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -219,6 +219,7 @@ static bool _fle2_insert_encryptionInformation(const mongocrypt_ctx_t *ctx,
         if (!_fle2_append_encryptionInformation(ctx, cmd, ns, encryptedFieldConfig, deleteTokens, coll_name, status)) {
             goto fail;
         }
+        bson_destroy(&out);
         goto success;
     }
 
@@ -248,6 +249,7 @@ static bool _fle2_insert_encryptionInformation(const mongocrypt_ctx_t *ctx,
         if (!mc_iter_document_as_bson(&iter, &tmp, status)) {
             goto fail;
         }
+        bson_destroy(&explain);
         bson_copy_to(&tmp, &explain);
     }
 

--- a/test/test-mc-fle2-payload-iev-v2.c
+++ b/test/test-mc-fle2-payload-iev-v2.c
@@ -199,6 +199,7 @@ static void _mc_fle2_iev_v2_test_explicit_ctx(_mongocrypt_tester_t *tester, _mc_
         ASSERT(bson_compare(&out_bson, &expect_bson) == 0);
         bson_value_destroy(&expect_value);
         mongocrypt_binary_destroy(out);
+        bson_destroy(&expect_bson);
     }
 
     mongocrypt_ctx_destroy(ctx);

--- a/test/test-mc-fle2-payload-uev-v2.c
+++ b/test/test-mc-fle2-payload-uev-v2.c
@@ -271,6 +271,7 @@ static void test_FLE2UnindexedEncryptedValueV2_ctx_decrypt(_mongocrypt_tester_t 
         ASSERT(bson_compare(&out_bson, &expect_bson) == 0);
         bson_value_destroy(&expect_value);
         mongocrypt_binary_destroy(out);
+        bson_destroy(&expect_bson);
     }
 
     mongocrypt_ctx_destroy(ctx);

--- a/test/test-mc-fle2-rfds.c
+++ b/test/test-mc-fle2-rfds.c
@@ -383,7 +383,7 @@ static void test_mc_FLE2RangeFindDriverSpec_to_placeholders(_mongocrypt_tester_t
             _mongocrypt_buffer_cleanup(&p1);
         }
 
-        bson_t out;
+        bson_t out = BSON_INITIALIZER;
         bool ok = mc_FLE2RangeFindDriverSpec_to_placeholders(&spec,
                                                              &range_opts,
                                                              maxContentionCounter,


### PR DESCRIPTION
MONGOCRYPT-558
MONGOCRYPT-559
MONGOCRYPT-560

This addresses the issues brought up in the above tickets. We will not be removing calls to `BSON_INITIALIZER`, but we are addressing the other issues uncovered in these tickets.