### PR TITLE
fix(NODE-4896): do not pass explicit session into state machine helpers

### DIFF
--- a/bindings/node/CHANGELOG.md
+++ b/bindings/node/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.8.0-alpha.1](https://github.com/mongodb/libmongocrypt/compare/node-v2.8.0-alpha.0...node-v2.8.0-alpha.1) (2023-04-27)
+
 ## [2.8.0-alpha.0](https://github.com/mongodb/libmongocrypt/compare/node-v2.7.1...node-v2.8.0-alpha.0) (2023-04-04)
 
 ### [2.7.1](https://github.com/mongodb/libmongocrypt/compare/node-v2.7.0...node-v2.7.1) (2023-03-20)

--- a/bindings/node/lib/stateMachine.js
+++ b/bindings/node/lib/stateMachine.js
@@ -413,8 +413,7 @@ module.exports = function (modules) {
         .db(dbName)
         .listCollections(filter, {
           promoteLongs: false,
-          promoteValues: false,
-          session: this.options.session
+          promoteValues: false
         })
         .toArray()
         .then(
@@ -476,7 +475,7 @@ module.exports = function (modules) {
       client
         .db(dbName)
         .collection(collectionName, { readConcern: { level: 'majority' } })
-        .find(filter, { session: this.options.session })
+        .find(filter)
         .toArray()
         .then(
           keys => {

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongodb-client-encryption",
-  "version": "2.8.0-alpha.0",
+  "version": "2.8.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongodb-client-encryption",
-      "version": "2.8.0-alpha.0",
+      "version": "2.8.0-alpha.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-client-encryption",
-  "version": "2.8.0-alpha.0",
+  "version": "2.8.0-alpha.1",
   "description": "Official client encryption module for the MongoDB Node.js driver",
   "main": "lib/index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
This PR fixes a bug in the driver's auto encryption.  The full details of the bug are listed in NODE-4896.

patch w/ driver: https://spruce.mongodb.com/version/644ac2897742aef2bc3b0cc4/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

No drivers changes needed here, because CI pulls in `mongodb-client-encryption@alpha`.  Our custom csfle tests don't run in load balanced mode, so they were unaffected and we can wait to update the pinned commit until after the official 2.8.0 release.