### PR TITLE
test(NODE-5238): set min/max range options when required.

### DIFF
--- a/bindings/node/test/clientEncryption.test.js
+++ b/bindings/node/test/clientEncryption.test.js
@@ -711,6 +711,8 @@ describe('ClientEncryption', function () {
         algorithm: 'RangePreview',
         contentionFactor: 0,
         rangeOptions: {
+          min: new BSON.Long(0),
+          max: new BSON.Long(10),
           sparsity: new BSON.Long(1)
         },
         keyId: dataKey
@@ -763,6 +765,8 @@ describe('ClientEncryption', function () {
         queryType: 'rangePreview',
         contentionFactor: 0,
         rangeOptions: {
+          min: new BSON.Int32(0),
+          max: new BSON.Int32(10),
           sparsity: new BSON.Long(1)
         },
         keyId: dataKey


### PR DESCRIPTION
Patch against this exact commit: https://spruce.mongodb.com/version/6451168856234306eb1923f7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC