### PR TITLE
Fix Race Condition

### DIFF
--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -628,7 +628,6 @@ static void _csfle_drop_global_ref(void) {
             mstr_free(old_state.dll.error_string);
         }
     }
-
 }
 
 /**

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -611,12 +611,7 @@ static void _csfle_drop_global_ref(void) {
                         g_csfle_state.vtable.status_get_code(status));
             }
             g_csfle_state.vtable.status_destroy(status);
-#ifndef __linux__
             mcr_dll_close(g_csfle_state.dll);
-#endif
-            /// NOTE: On Linux, skip closing the CSFLE library itself, since a bug in
-            /// the way ld-linux and GCC interact causes static destructors to not run
-            /// during dlclose(). Still, free the error string:
             mstr_free(g_csfle_state.dll.error_string);
         }
     }

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -597,35 +597,27 @@ static bool _validate_csfle_singleton(mongocrypt_t *crypt, _loaded_csfle found) 
 static void _csfle_drop_global_ref(void) {
     mlib_call_once(&g_csfle_init_flag, init_csfle_state);
 
-    bool dropped_last_ref = false;
-    csfle_global_lib_state old_state = {.refcount = 0};
     MONGOCRYPT_WITH_MUTEX(g_csfle_state.mtx) {
         assert(g_csfle_state.refcount > 0);
         int new_rc = --g_csfle_state.refcount;
         if (new_rc == 0) {
-            old_state = g_csfle_state;
-            dropped_last_ref = true;
-        }
-
-        if (dropped_last_ref) {
-            mongo_crypt_v1_status *status = old_state.vtable.status_create();
-            const int destroy_rc = old_state.vtable.lib_destroy(old_state.csfle_lib, status);
+            mongo_crypt_v1_status *status = g_csfle_state.vtable.status_create();
+            const int destroy_rc = g_csfle_state.vtable.lib_destroy(g_csfle_state.csfle_lib, status);
             if (destroy_rc != MONGO_CRYPT_V1_SUCCESS && status) {
                 fprintf(stderr,
                         "csfle lib_destroy() failed: %s [Error %d, code %d]\n",
-                        old_state.vtable.status_get_explanation(status),
-                        old_state.vtable.status_get_error(status),
-                        old_state.vtable.status_get_code(status));
+                        g_csfle_state.vtable.status_get_explanation(status),
+                        g_csfle_state.vtable.status_get_error(status),
+                        g_csfle_state.vtable.status_get_code(status));
             }
-            old_state.vtable.status_destroy(status);
-
+            g_csfle_state.vtable.status_destroy(status);
 #ifndef __linux__
-            mcr_dll_close(old_state.dll);
+            mcr_dll_close(g_csfle_state.dll);
 #endif
             /// NOTE: On Linux, skip closing the CSFLE library itself, since a bug in
             /// the way ld-linux and GCC interact causes static destructors to not run
             /// during dlclose(). Still, free the error string:
-            mstr_free(old_state.dll.error_string);
+            mstr_free(g_csfle_state.dll.error_string);
         }
     }
 }

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -606,28 +606,29 @@ static void _csfle_drop_global_ref(void) {
             old_state = g_csfle_state;
             dropped_last_ref = true;
         }
-    }
 
-    if (dropped_last_ref) {
-        mongo_crypt_v1_status *status = old_state.vtable.status_create();
-        const int destroy_rc = old_state.vtable.lib_destroy(old_state.csfle_lib, status);
-        if (destroy_rc != MONGO_CRYPT_V1_SUCCESS && status) {
-            fprintf(stderr,
-                    "csfle lib_destroy() failed: %s [Error %d, code %d]\n",
-                    old_state.vtable.status_get_explanation(status),
-                    old_state.vtable.status_get_error(status),
-                    old_state.vtable.status_get_code(status));
-        }
-        old_state.vtable.status_destroy(status);
+        if (dropped_last_ref) {
+            mongo_crypt_v1_status *status = old_state.vtable.status_create();
+            const int destroy_rc = old_state.vtable.lib_destroy(old_state.csfle_lib, status);
+            if (destroy_rc != MONGO_CRYPT_V1_SUCCESS && status) {
+                fprintf(stderr,
+                        "csfle lib_destroy() failed: %s [Error %d, code %d]\n",
+                        old_state.vtable.status_get_explanation(status),
+                        old_state.vtable.status_get_error(status),
+                        old_state.vtable.status_get_code(status));
+            }
+            old_state.vtable.status_destroy(status);
 
 #ifndef __linux__
-        mcr_dll_close(old_state.dll);
+            mcr_dll_close(old_state.dll);
 #endif
-        /// NOTE: On Linux, skip closing the CSFLE library itself, since a bug in
-        /// the way ld-linux and GCC interact causes static destructors to not run
-        /// during dlclose(). Still, free the error string:
-        mstr_free(old_state.dll.error_string);
+            /// NOTE: On Linux, skip closing the CSFLE library itself, since a bug in
+            /// the way ld-linux and GCC interact causes static destructors to not run
+            /// during dlclose(). Still, free the error string:
+            mstr_free(old_state.dll.error_string);
+        }
     }
+
 }
 
 /**

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -617,6 +617,8 @@ static void _csfle_drop_global_ref(void) {
             /// NOTE: On Linux, skip closing the CSFLE library itself, since a bug in
             /// the way ld-linux and GCC interact causes static destructors to not run
             /// during dlclose(). Still, free the error string:
+            ///
+            /// Please see: https://jira.mongodb.org/browse/SERVER-63710
             mstr_free(g_csfle_state.dll.error_string);
         }
     }

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -613,13 +613,14 @@ static void _csfle_drop_global_ref(void) {
             g_csfle_state.vtable.status_destroy(status);
 #ifndef __linux__
             mcr_dll_close(g_csfle_state.dll);
-#endif
+#else
             /// NOTE: On Linux, skip closing the CSFLE library itself, since a bug in
             /// the way ld-linux and GCC interact causes static destructors to not run
             /// during dlclose(). Still, free the error string:
             ///
             /// Please see: https://jira.mongodb.org/browse/SERVER-63710
             mstr_free(g_csfle_state.dll.error_string);
+#endif
         }
     }
 }

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -611,7 +611,12 @@ static void _csfle_drop_global_ref(void) {
                         g_csfle_state.vtable.status_get_code(status));
             }
             g_csfle_state.vtable.status_destroy(status);
+#ifndef __linux__
             mcr_dll_close(g_csfle_state.dll);
+#endif
+            /// NOTE: On Linux, skip closing the CSFLE library itself, since a bug in
+            /// the way ld-linux and GCC interact causes static destructors to not run
+            /// during dlclose(). Still, free the error string:
             mstr_free(g_csfle_state.dll.error_string);
         }
     }


### PR DESCRIPTION
Related: MONGOCRYPT-526

Fix race condition by moving critical section into the mutex protected scope.

See the following repo for a tool to test the race condition fixed in this PR: https://github.com/kkloberdanz/libmongocrypt_stresstest