### PR TITLE
Remove cryptography pin for PyPy on RHEL 6.2

### DIFF
--- a/bindings/python/test-requirements.txt
+++ b/bindings/python/test-requirements.txt
@@ -5,8 +5,7 @@ cffi>=1.12.0,<2;python_version!="3.4"
 # We test PyPy on RHEL 6.2 which has OpenSSL 1.0.1e
 # Pin to cryptography 2.8.* until we figure our how to
 # install cryptography with PyPy with a newer OpenSSL.
-cryptography>=2,<2.9;platform_python_implementation=='PyPy'
-cryptography>=2;platform_python_implementation!='PyPy'
+cryptography>=2
 mock;python_version=='2.7'
 six>=1.5;python_version=='2.7'
 requests_mock>=1.10


### PR DESCRIPTION
Testing if we can remove this now that we test on RHEL 7.0 instead of RHEL 6.2.