### PR TITLE
docs(NODE-5264): mark QE equality stable

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -913,8 +913,8 @@ For double and decimal128, min/max/precision must all be set, or all be unset.
 | [keyId] | [<code>ClientEncryptionDataKeyId</code>](#ClientEncryptionDataKeyId) | The id of the Binary dataKey to use for encryption. |
 | [keyAltName] | <code>string</code> | A unique string name corresponding to an already existing dataKey. |
 | [algorithm] | <code>string</code> | The algorithm to use for encryption. Must be either `'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'`, `'AEAD_AES_256_CBC_HMAC_SHA_512-Random'`, `'Indexed'` or `'Unindexed'` |
-| [contentionFactor] | <code>bigint</code> \| <code>number</code> | (experimental) - the contention factor. |
-| queryType | <code>&#x27;equality&#x27;</code> \| <code>&#x27;rangePreview&#x27;</code> | (experimental) - the query type supported. |
+| [contentionFactor] | <code>bigint</code> \| <code>number</code> | the contention factor. |
+| queryType | <code>&#x27;equality&#x27;</code> \| <code>&#x27;rangePreview&#x27;</code> | the query type supported.  only the query type `equality` is stable at this time.  queryType `rangePreview` is experimental. |
 | [rangeOptions] | [<code>RangeOptions</code>](#RangeOptions) | (experimental) The index options for a Queryable Encryption field supporting "rangePreview" queries. |
 
 Options to provide when encrypting data.

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -583,11 +583,6 @@ if (!oldKey) {
 - [<code>MongoCryptCreateDataKeyError</code>](#MongoCryptCreateDataKeyError) - If part way through the process a createDataKey invocation fails, an error will be rejected that has the partial `encryptedFields` that were created.
 - [<code>MongoCryptCreateEncryptedCollectionError</code>](#MongoCryptCreateEncryptedCollectionError) - If creating the collection fails, an error will be rejected that has the entire `encryptedFields` that were created.
 
-**Experimental**: Public Technical Preview
-
-A convenience method for creating an encrypted collection.
-This method will create data keys for any encryptedFields that do not have a `keyId` defined
-and then create a new collection with the full set of encryptedFields.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -597,6 +592,10 @@ and then create a new collection with the full set of encryptedFields.
 | options.provider | <code>string</code> | KMS provider name |
 | [options.masterKey] | [<code>AWSEncryptionKeyOptions</code>](#AWSEncryptionKeyOptions) \| [<code>AzureEncryptionKeyOptions</code>](#AzureEncryptionKeyOptions) \| [<code>GCPEncryptionKeyOptions</code>](#GCPEncryptionKeyOptions) | masterKey to pass to createDataKey |
 | options.createCollectionOptions | <code>CreateCollectionOptions</code> | options to pass to createCollection, must include `encryptedFields` |
+
+A convenience method for creating an encrypted collection.
+This method will create data keys for any encryptedFields that do not have a `keyId` defined
+and then create a new collection with the full set of encryptedFields.
 
 **Returns**: <code>Promise.&lt;{collection: Collection.&lt;TSchema&gt;, encryptedFields: Document}&gt;</code> - - created collection and generated encryptedFields  
 <a name="ClientEncryption+encrypt"></a>
@@ -708,13 +707,11 @@ An error indicating that something went wrong specifically with MongoDB Client E
 <a name="MongoCryptCreateDataKeyError"></a>
 
 ## MongoCryptCreateDataKeyError
-**Experimental**: Public Technical Preview  
 An error indicating that `ClientEncryption.createEncryptedCollection()` failed to create data keys
 
 <a name="MongoCryptCreateEncryptedCollectionError"></a>
 
 ## MongoCryptCreateEncryptedCollectionError
-**Experimental**: Public Technical Preview  
 An error indicating that `ClientEncryption.createEncryptedCollection()` failed to create a collection
 
 <a name="MongoCryptAzureKMSRequestError"></a>

--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -35,12 +35,10 @@ export class MongoCryptError extends Error {
 }
 
 /**
- * @experimental Public Technical Preview
  * An error indicating that `ClientEncryption.createEncryptedCollection()` failed to create a collection
  */
 export class MongoCryptCreateEncryptedCollectionError extends MongoCryptError {
   /**
-   * @experimental Public Technical Preview
    * The entire `encryptedFields` that was completed while attempting createEncryptedCollection
    */
   encryptedFields: Document;
@@ -49,12 +47,10 @@ export class MongoCryptCreateEncryptedCollectionError extends MongoCryptError {
 }
 
 /**
- * @experimental Public Technical Preview
  * An error indicating that `ClientEncryption.createEncryptedCollection()` failed to create data keys
  */
 export class MongoCryptCreateDataKeyError extends MongoCryptError {
   /**
-   * @experimental Public Technical Preview
    * The partial `encryptedFields` that was completed while attempting createEncryptedCollection
    */
   encryptedFields: Document;
@@ -441,10 +437,14 @@ export interface ClientEncryptionEncryptOptions {
    */
   keyAltName?: string;
 
-  /** @experimental Public Technical Preview: The contention factor. */
+  /** The contention factor. */
   contentionFactor?: bigint | number;
 
-  /** @experimental Public Technical Preview: The query type supported */
+  /**
+   * The query type supported.  Only the queryType `equality` is stable.
+   *
+   * @experimental Public Technical Preview: The queryType `rangePreview` is experimental.
+   */
   queryType?: 'equality' | 'rangePreview';
 
   /** @experimental Public Technical Preview: The index options for a Queryable Encryption field supporting "rangePreview" queries.*/
@@ -561,7 +561,6 @@ export class ClientEncryption {
   removeKeyAltName(id: Binary, keyAltName: string): Promise<DataKey | null>;
 
   /**
-   * @experimental Public Technical Preview
    * A convenience method for creating an encrypted collection.
    * This method will create data keys for any encryptedFields that do not have a `keyId` defined
    * and then create a new collection with the full set of encryptedFields.

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -554,8 +554,6 @@ module.exports = function (modules) {
     }
 
     /**
-     * @experimental Public Technical Preview
-     *
      * A convenience method for creating an encrypted collection.
      * This method will create data keys for any encryptedFields that do not have a `keyId` defined
      * and then create a new collection with the full set of encryptedFields.

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -633,8 +633,8 @@ module.exports = function (modules) {
      * @property {ClientEncryptionDataKeyId} [keyId] The id of the Binary dataKey to use for encryption.
      * @property {string} [keyAltName] A unique string name corresponding to an already existing dataKey.
      * @property {string} [algorithm] The algorithm to use for encryption. Must be either `'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'`, `'AEAD_AES_256_CBC_HMAC_SHA_512-Random'`, `'Indexed'` or `'Unindexed'`
-     * @property {bigint | number} [contentionFactor] (experimental) - the contention factor.
-     * @property {'equality' | 'rangePreview'} queryType (experimental) - the query type supported.
+     * @property {bigint | number} [contentionFactor] - the contention factor.
+     * @property {'equality' | 'rangePreview'} queryType - the query type supported.  only the query type `equality` is stable at this time.  queryType `rangePreview` is experimental.
      * @property {RangeOptions} [rangeOptions] (experimental) The index options for a Queryable Encryption field supporting "rangePreview" queries.
      */
 

--- a/bindings/node/lib/errors.js
+++ b/bindings/node/lib/errors.js
@@ -18,7 +18,6 @@ class MongoCryptError extends Error {
 }
 
 /**
- * @experimental Public Technical Preview
  * @class
  * An error indicating that `ClientEncryption.createEncryptedCollection()` failed to create data keys
  */
@@ -34,7 +33,6 @@ class MongoCryptCreateDataKeyError extends MongoCryptError {
 }
 
 /**
- * @experimental Public Technical Preview
  * @class
  * An error indicating that `ClientEncryption.createEncryptedCollection()` failed to create a collection
  */


### PR DESCRIPTION
This PR marks the QE equality API as stable.