### PR TITLE
test(NODE-5268): use node 20 in ci

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -146,7 +146,7 @@ functions:
           NODE_GITHUB_TOKEN: ${node_github_token}
           DISTRO_ID: ${distro_id}
           BUILD_VARIANT: ${build_variant}
-          NODE_NVM_USE_VERSION: ${nvm_use_version|18}
+          NODE_LTS_VERSION: ${nvm_use_version|16}
 
   "build and test node no peer dependencies":
     - command: "subprocess.exec"
@@ -1329,6 +1329,7 @@ buildvariants:
     has_packages: true
     packager_distro: ubuntu2004
     packager_arch: x86_64
+    nvm_use_version: 20
   tasks:
   - clang-tidy
   - build-and-test-and-upload
@@ -1347,6 +1348,7 @@ buildvariants:
     has_packages: true
     packager_distro: ubuntu2004
     packager_arch: arm64
+    nvm_use_version: 20
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1334,7 +1334,7 @@ buildvariants:
     has_packages: true
     packager_distro: ubuntu1804
     packager_arch: arm64
-    nvm_use_version: 18
+    nvm_use_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1305,7 +1305,7 @@ buildvariants:
     has_packages: true
     packager_distro: ubuntu1804
     packager_arch: x86_64
-    nvm_use_version: 18
+    nvm_use_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1282,7 +1282,7 @@ buildvariants:
     has_packages: true
     packager_distro: ubuntu1804
     packager_arch: x86_64
-    nvm_use_version: 16
+    nvm_use_version: 18
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1311,7 +1311,7 @@ buildvariants:
     has_packages: true
     packager_distro: ubuntu1804
     packager_arch: arm64
-    nvm_use_version: 16
+    nvm_use_version: 18
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -163,6 +163,20 @@ functions:
           OMIT_PEER_DEPS: "true"
           NODE_NVM_USE_VERSION: ${nvm_use_version|18}
 
+  "build and publish node":
+    - command: "subprocess.exec"
+      params:
+        binary: bash
+        working_dir: "./libmongocrypt/bindings/node"
+        args:
+          - "./.evergreen/prebuild.sh"
+        env:
+          PROJECT_DIRECTORY: ${project_directory}
+          NODE_GITHUB_TOKEN: ${node_github_token}
+          DISTRO_ID: ${distro_id}
+          BUILD_VARIANT: ${build_variant}
+          NODE_LTS_VERSION: ${nvm_use_version|16}
+
   "attach node xunit results":
     - command: attach.xunit_results
       params:
@@ -501,6 +515,11 @@ tasks:
     - func: "fetch source"
     - func: "build and test node"
     - func: "attach node xunit results"
+
+- name: build-and-publish-node
+  commands:
+    - func: "fetch source"
+    - func: "build and publish node"
 
 - name: build-and-test-node-no-peer-dependencies
   commands:
@@ -984,6 +1003,7 @@ buildvariants:
   - build-and-test-asan
   - build-and-test-node
   - build-and-test-node-no-peer-dependencies
+  - build-and-publish-node
   - test-java
   - name: publish-packages
     distros:
@@ -997,6 +1017,7 @@ buildvariants:
   - build-and-test-asan-mac
   - build-and-test-node
   - build-and-test-node-no-peer-dependencies
+  - build-and-publish-node
   - build-and-test-csharp
   - test-python
   - test-java
@@ -1042,6 +1063,7 @@ buildvariants:
   - build-and-test-csharp
   - build-and-test-node
   - build-and-test-node-no-peer-dependencies
+  - build-and-publish-node
   - test-java
   - windows-upload-check
 - name: windows-test-python
@@ -1271,6 +1293,7 @@ buildvariants:
   - build-and-test-asan
   - build-and-test-node
   - build-and-test-node-no-peer-dependencies
+  - build-and-publish-node
   - test-java
   - name: publish-packages
     distros:
@@ -1424,6 +1447,7 @@ buildvariants:
   - build-and-test-and-upload
   - build-and-test-node
   - build-and-test-node-no-peer-dependencies
+  - build-and-publish-node
   - test-python
   - test-java
 - name: windows-vs2017-32bit

--- a/bindings/node/.evergreen/install-dependencies.sh
+++ b/bindings/node/.evergreen/install-dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -o errexit  # Exit the script with error if any of the commands fail
 
-NODE_LTS_NAME=${NODE_LTS_NAME:-fermium}
+NODE_LTS_VERSION=${NODE_LTS_VERSION:-14}
 NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY:-$(pwd)}/node-artifacts"
 if [[ "$OS" = "Windows_NT" ]]; then NODE_ARTIFACTS_PATH=$(cygpath --unix "$NODE_ARTIFACTS_PATH"); fi
 
@@ -28,11 +28,12 @@ curl "${CURL_FLAGS[@]}" "https://nodejs.org/dist/index.tab" --output node_index.
 
 while IFS=$'\t' read -r -a row; do
   node_index_version="${row[0]}"
+  node_index_major_version=$(echo $node_index_version | sed -E 's/^v([0-9]+).*$/\1/')
   node_index_date="${row[1]}"
   node_index_lts="${row[9]}"
   [[ "$node_index_version" = "version" ]] && continue # skip tsv header
-  [[ "$NODE_LTS_NAME" = "latest" ]] && break # first line is latest
-  [[ "$NODE_LTS_NAME" = "$node_index_lts" ]] && break # case insensitive compare
+  [[ "$NODE_LTS_VERSION" = "latest" ]] && break # first line is latest
+  [[ "$NODE_LTS_VERSION" = "$node_index_major_version" ]] && break # case insensitive compare
 done < node_index.tab
 
 if [[ "$OS" = "Windows_NT" ]]; then

--- a/bindings/node/.evergreen/install-dependencies.sh
+++ b/bindings/node/.evergreen/install-dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -o errexit  # Exit the script with error if any of the commands fail
 
-NODE_LTS_VERSION=${NODE_LTS_VERSION:-14}
+NODE_LTS_VERSION=${NODE_LTS_VERSION:-16}
 NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY:-$(pwd)}/node-artifacts"
 if [[ "$OS" = "Windows_NT" ]]; then NODE_ARTIFACTS_PATH=$(cygpath --unix "$NODE_ARTIFACTS_PATH"); fi
 

--- a/bindings/node/.evergreen/prebuild.sh
+++ b/bindings/node/.evergreen/prebuild.sh
@@ -80,27 +80,6 @@ if [[ -n $NODE_FORCE_PUBLISH ]]; then
 elif [[ "$VERSION_AT_HEAD" != "$VERSION_AT_HEAD_1" ]]; then
   echo "Difference is package version ($VERSION_AT_HEAD_1 -> $VERSION_AT_HEAD)"
   echo "Beginning prebuild"
-
-  if [[ "$OS" == "linux" ]]; then
-    # Handle limiting which linux gets to publish prebuild
-    ARCH=$(uname -m)
-
-    if [[ $DISTRO_ID == "rhel70-small" ]]; then
-      # only publish x86_64 linux prebuilds from RHEL 7
-      run_prebuild
-    elif [[ "$ARCH" != "x86_64" ]]; then
-      # Non-x86 linux variants should just publish
-      run_prebuild
-    else
-      # Non RHEL 7 linux variants should just test the prebuild task
-      echo "Will prebuild without submit ($OS - $ARCH - $DISTRO_ID)"
-      npm run prebuild
-    fi
-
-    exit 0
-  fi
-
-  # Windows and MacOS
   run_prebuild
 else
   echo "No difference is package version ($VERSION_AT_HEAD_1 -> $VERSION_AT_HEAD)"

--- a/bindings/node/.evergreen/prebuild.sh
+++ b/bindings/node/.evergreen/prebuild.sh
@@ -18,13 +18,12 @@ source ./.evergreen/install-dependencies.sh
 echo "Installing package dependencies (includes a static build)"
 bash ./etc/build-static.sh
 
-# FLE platform matrix (as of Feb 8th 2022)
+# FLE platform matrix (as of 22 May 2023)
 # macos   arm64  (compiled on 11.00)
 # macos   x86_64 (compiled on 10.14)
-# windows x86_64 (compiled on vs2017)
-# linux   x86_64 (releases on RHEL7)
-# linux   s390x
-# linux   arm64
+# windows x86_64 (compiled on vs2019)
+# linux   x86_64 (compiled on Ubuntu 16.04)
+# linux   arm64  (compiled on Ubuntu 16.04)
 
 # Determines the OS name through uname results
 # Returns 'windows' 'linux' 'macos' or 'unknown'

--- a/bindings/node/.evergreen/prebuild.sh
+++ b/bindings/node/.evergreen/prebuild.sh
@@ -5,6 +5,19 @@ if [ -z ${DISTRO_ID+omitted} ]; then echo "DISTRO_ID is unset" && exit 1; fi
 set -o errexit
 set +o xtrace
 
+echo "Setting up environment"
+
+export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
+hash -r
+
+NODE_LTS_VERSION=${NODE_LTS_VERSION:-16}
+export NODE_LTS_VERSION=${NODE_LTS_VERSION}
+source ./.evergreen/install-dependencies.sh
+
+# install node dependencies
+echo "Installing package dependencies (includes a static build)"
+bash ./etc/build-static.sh
+
 # FLE platform matrix (as of Feb 8th 2022)
 # macos   arm64  (compiled on 11.00)
 # macos   x86_64 (compiled on 10.14)

--- a/bindings/node/.evergreen/test.sh
+++ b/bindings/node/.evergreen/test.sh
@@ -8,7 +8,8 @@ echo "Setting up environment"
 export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
 hash -r
 
-export NODE_LTS_VERSION=16
+NODE_LTS_VERSION=${NODE_LTS_VERSION:-16}
+export NODE_LTS_VERSION=${NODE_LTS_VERSION}
 source ./.evergreen/install-dependencies.sh
 
 # Handle the circular dependency when testing with a real client.

--- a/bindings/node/.evergreen/test.sh
+++ b/bindings/node/.evergreen/test.sh
@@ -8,10 +8,8 @@ echo "Setting up environment"
 export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
 hash -r
 
-export NODE_LTS_NAME="gallium"
+export NODE_LTS_VERSION=20
 source ./.evergreen/install-dependencies.sh
-
-
 
 # Handle the circular dependency when testing with a real client.
 MONGODB_CLIENT_ENCRYPTION_OVERRIDE="$(pwd)"

--- a/bindings/node/.evergreen/test.sh
+++ b/bindings/node/.evergreen/test.sh
@@ -29,7 +29,3 @@ fi
 echo "Running tests"
 npm run check:lint
 MONGODB_NODE_SKIP_LIVE_TESTS=true npm test
-
-# Run prebuild and deploy
-echo "Running prebuild and deploy"
-bash ./.evergreen/prebuild.sh

--- a/bindings/node/.evergreen/test.sh
+++ b/bindings/node/.evergreen/test.sh
@@ -8,7 +8,7 @@ echo "Setting up environment"
 export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
 hash -r
 
-export NODE_LTS_VERSION=20
+export NODE_LTS_VERSION=16
 source ./.evergreen/install-dependencies.sh
 
 # Handle the circular dependency when testing with a real client.
@@ -20,8 +20,8 @@ echo "Installing package dependencies (includes a static build)"
 bash ./etc/build-static.sh
 
 if [[ $OMIT_PEER_DEPS != "true" ]]; then
-    npm install '@aws-sdk/credential-providers'
-    npm install 'gcp-metadata'
+  npm install '@aws-sdk/credential-providers'
+  npm install 'gcp-metadata'
 fi
 
 # Run tests

--- a/bindings/node/test/providers/credentialsProvider.test.js
+++ b/bindings/node/test/providers/credentialsProvider.test.js
@@ -169,12 +169,10 @@ describe('#loadCredentials', function () {
         httpServer = http
           .createServer((_, res) => {
             if (status === 200) {
-              res.writeHead(200, { 'Content-Type': 'application/json' });
-              res.writeHead(200, { 'Metadata-Flavor': 'Google' });
+              res.writeHead(200, { 'Content-Type': 'application/json', 'Metadata-Flavor': 'Google' });
               res.end(JSON.stringify({ access_token: 'abc' }));
             } else {
-              res.writeHead(401, { 'Content-Type': 'application/json' });
-              res.writeHead(401, { 'Metadata-Flavor': 'Google' });
+              res.writeHead(200, { 'Content-Type': 'application/json', 'Metadata-Flavor': 'Google' });
               res.end('{}');
             }
           })

--- a/bindings/node/test/providers/credentialsProvider.test.js
+++ b/bindings/node/test/providers/credentialsProvider.test.js
@@ -175,7 +175,7 @@ describe('#loadCredentials', function () {
               });
               res.end(JSON.stringify({ access_token: 'abc' }));
             } else {
-              res.writeHead(200, {
+              res.writeHead(401, {
                 'Content-Type': 'application/json',
                 'Metadata-Flavor': 'Google'
               });

--- a/bindings/node/test/providers/credentialsProvider.test.js
+++ b/bindings/node/test/providers/credentialsProvider.test.js
@@ -169,10 +169,16 @@ describe('#loadCredentials', function () {
         httpServer = http
           .createServer((_, res) => {
             if (status === 200) {
-              res.writeHead(200, { 'Content-Type': 'application/json', 'Metadata-Flavor': 'Google' });
+              res.writeHead(200, {
+                'Content-Type': 'application/json',
+                'Metadata-Flavor': 'Google'
+              });
               res.end(JSON.stringify({ access_token: 'abc' }));
             } else {
-              res.writeHead(200, { 'Content-Type': 'application/json', 'Metadata-Flavor': 'Google' });
+              res.writeHead(200, {
+                'Content-Type': 'application/json',
+                'Metadata-Flavor': 'Google'
+              });
               res.end('{}');
             }
           })


### PR DESCRIPTION
- Breaks out the prebuild script in the Node bindings to its own task.
- Adds Node 20 to bindings and tests it on Ubuntu 20 distros.
- Only prebuilds and publishes Node bindings on specific distros with Node 16.
- Fixes HTTP header errors on Node 20 tests.

Distros Node publishes from now:
- MacOS M1 arm64 11.00
- MacOS x64 10.14
- Ubuntu 16 arm64
- Ubuntu 16 x64
- Windows x64