### PR TITLE
MONGOCRYPT-566 use setuptools rather than distutils (deprecated) for version calc

### DIFF
--- a/etc/calc_release_version.py
+++ b/etc/calc_release_version.py
@@ -26,7 +26,14 @@ import datetime
 import re
 import subprocess
 import sys
-from distutils.version import LooseVersion
+if sys.version_info < (3, 9):
+    from distutils.version import LooseVersion as Version
+    from distutils.version import LooseVersion as parse_version
+else:
+    # on newer versions of Python use setuptools rather than distutils
+    # (which has been deprecated)
+    from pkg_resources.extern.packaging.version import Version
+    from pkg_resources import parse_version
 
 DEBUG = len(sys.argv) > 1 and '-d' in sys.argv
 if DEBUG:
@@ -70,7 +77,8 @@ def check_head_tag():
     """
 
     found_tag = False
-    version_loose = LooseVersion('0.0.0')
+    version_str = '0.0.0'
+    version_parsed = parse_version(version_str)
 
     # have git tell us if any tags that look like release tags point at HEAD;
     # based on our policy, a commit should never have more than one release tag
@@ -83,17 +91,19 @@ def check_head_tag():
 
     release_tag_match = RELEASE_TAG_RE.match(tag)
     if release_tag_match:
-        new_version_loose = LooseVersion(release_tag_match.group('ver'))
-        if new_version_loose > version_loose:
+        new_version_str = release_tag_match.group('ver')
+        new_version_parsed = parse_version(new_version_str)
+        if new_version_parsed > version_parsed:
             if DEBUG:
-                print('HEAD release tag: ' + release_tag_match.group('ver'))
-            version_loose = new_version_loose
+                print('HEAD release tag: ' + new_version_str)
+            version_str = new_version_str
+            version_parsed = new_version_parsed
             found_tag = True
 
     if found_tag:
         if DEBUG:
-            print('Calculated version: ' + str(version_loose))
-        return str(version_loose)
+            print('Calculated version: ' + version_str)
+        return version_str
 
     return None
 
@@ -106,7 +116,8 @@ def get_next_minor(prerelease_marker):
         - Append a pre-release marker. (e.g. 1.22.0 becomes 1.22.0-20220201+gitf6e6a7025d)
     """
 
-    version_loose = LooseVersion('0.0.0')
+    version_str = '0.0.0'
+    version_parsed = parse_version(version_str)
 
     version_new = {}
     # Use refs (not branches) to get local branches plus remote branches
@@ -119,17 +130,19 @@ def get_next_minor(prerelease_marker):
             version_new['minor'] = int(release_branch_match.group('vermin')) + 1
             version_new['patch'] = 0
             version_new['prerelease'] = prerelease_marker
-            new_version_loose = LooseVersion(str(version_new['major']) + '.' +
-                                             str(version_new['minor']) + '.' +
-                                             str(version_new['patch']) + '-' +
-                                             version_new['prerelease'])
-            if new_version_loose > version_loose:
-                version_loose = new_version_loose
+            new_version_str = str(version_new['major']) + '.' + \
+                              str(version_new['minor']) + '.' + \
+                              str(version_new['patch']) + '-' + \
+                              version_new['prerelease']
+            new_version_parsed = parse_version(new_version_str)
+            if new_version_parsed > version_parsed:
+                version_str = new_version_str
+                version_parsed = new_version_parsed
                 if DEBUG:
-                    print('Found new best version "' + str(version_loose) \
+                    print('Found new best version "' + version_str \
                             + '" based on branch "' \
                             + release_branch_match.group('brname') + '"')
-    return str(version_loose)
+    return version_str
 
 def get_branch_tags(active_branch_name):
     """
@@ -190,7 +203,7 @@ def process_and_sort_tags(tags):
         tag_parts = tag.split('-')
         if len(tag_parts) >= 2 and tag_parts[0] not in processed_and_sorted_tags:
             processed_and_sorted_tags.append(tag)
-    processed_and_sorted_tags.sort(key=LooseVersion)
+    processed_and_sorted_tags.sort(key=Version)
 
     return processed_and_sorted_tags
 
@@ -211,7 +224,8 @@ def main():
            patch version, and append a new pre-release marker
     """
 
-    version_loose = LooseVersion('0.0.0')
+    version_str = '0.0.0'
+    version_parsed = parse_version(version_str)
     head_commit_short = check_output(['git', 'rev-parse', '--revs-only',
                                       '--short=10', 'HEAD^{commit}']).strip()
     prerelease_marker = datetime.date.today().strftime('%Y%m%d') \
@@ -246,17 +260,19 @@ def main():
         version_new['minor'] = int(release_tag_match.group('vermin'))
         version_new['patch'] = int(release_tag_match.group('verpatch')) + 1
         version_new['prerelease'] = prerelease_marker
-        new_version_loose = LooseVersion(str(version_new['major']) + '.' +
-                                         str(version_new['minor']) + '.' +
-                                         str(version_new['patch']) + '-' +
-                                         version_new['prerelease'])
-        if new_version_loose > version_loose:
-            version_loose = new_version_loose
+        new_version_str = str(version_new['major']) + '.' + \
+                          str(version_new['minor']) + '.' + \
+                          str(version_new['patch']) + '-' + \
+                          version_new['prerelease']
+        new_version_parsed = parse_version(new_version_str)
+        if new_version_parsed > version_parsed:
+            version_str = new_version_str
+            version_parsed = new_version_parsed
             if DEBUG:
-                print('Found new best version "' + str(version_loose) \
+                print('Found new best version "' + version_str \
                         + '" from tag "' + release_tag_match.group('ver') + '"')
 
-    return str(version_loose)
+    return version_str
 
 RELEASE_VER = main()
 


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/version/646e43bc7742ae043fe2aa86/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC