### PR TITLE
Workaround ICE on VS 2022 due to int128.test.cpp

### DIFF
--- a/src/mlib/int128.test.cpp
+++ b/src/mlib/int128.test.cpp
@@ -14,6 +14,11 @@
 // Old GCC and old MSVC have partially-broken constexpr that prevents us from
 // properly using static_assert with from_string()
 #define BROKEN_CONSTEXPR
+#elif (defined(_MSC_VER) && _MSC_VER >= 1930)
+// Avoid internal compiler error on VS 2022 versions 17.0 and newer when
+// evaluating mlib_int128_from_string via operator""_i128. Assumed to be related
+// to: https://developercommunity.visualstudio.com/t/User-defined-literals-cause-ICEs/10259122
+#define BROKEN_CONSTEXPR
 #endif
 
 #ifndef BROKEN_CONSTEXPR


### PR DESCRIPTION
Observed the following internal compiler error when attempting to compile on `windows-vsCurrent` EVG distros (on which new CMake versions use the VS 2022 generator by default):

```
src\mlib\int128.test.cpp(95,21): fatal error C1001: Internal compiler error. [cmake-build\mlib.int128.test.vcxproj]
  (compiler file 'msc1.cpp', line 1691)
[...]
src\mlib\int128.test.cpp(43,12): message : while evaluating constexpr function 'mlib_int128_from_string' [cmake-build\mlib.int128.test.vcxproj]
src\mlib\int128.test.cpp(92,31): message : while evaluating constexpr function 'operator ""_i128' [cmake-build\mlib.int128.test.vcxproj]
[...]
```

Assuming this is related to https://developercommunity.visualstudio.com/t/User-defined-literals-cause-ICEs/10259122 as linked in the corresponding comment. Its resolution status is currently "Pending Release", thus no upper bound on `_MSC_VER`. The reporter lists VS 2022 Version 17.5 Preview 3, but the `windows-vsCurrent` distro used to verify the ICE uses VS 2022 Version 17.1. Therefore, conservatively assuming this issue is present on all VS 2022 versions at this point in time (`_MSC_VER == 1930` corresponds to Visual Studio 2022 RTW (17.0) [per docs](https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170)). Several attempts were made to workaround the ICE by modifying the UDL, `mlib_int128_from_string`, and related helper functions/macros, but no simple workaround could be found.