### PR TITLE
add self-test for calc_release_version.py

### DIFF
--- a/.evergreen/calc_release_version_selftest.sh
+++ b/.evergreen/calc_release_version_selftest.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# calc_release_version_selftest.sh is used to test output of calc_release_version.py.
+# run with:
+# cd etc
+# ./calc_release_version_selftest.sh
+
+set -o errexit
+set -o pipefail
+
+function assert_eq () {
+    a="$1"
+    b="$2"
+    if [[ "$a" != "$b" ]]; then
+        echo "Assertion failed: $a != $b"
+        # Print caller
+        caller
+        exit 1
+    fi
+}
+
+SAVED_REF=$(git rev-parse HEAD)
+
+function cleanup () {
+    rm calc_release_version_test.py
+    git checkout $SAVED_REF --quiet
+}
+
+trap cleanup EXIT
+
+# copy calc_release_version.py to a separate file not tracked by git so it does not change on `git checkout`
+cp calc_release_version.py calc_release_version_test.py
+
+echo "Test a tagged commit ... begin"
+{
+    git checkout 1.8.1 --quiet
+    got=$(python calc_release_version_test.py)
+    assert_eq "$got" "1.8.1"
+    git checkout - --quiet
+}
+echo "Test a tagged commit ... end"
+
+DATE=$(date +%Y%m%d)
+echo "Test an untagged commit ... begin"
+{
+    # b7f8a1f1502d28a5ef440e642fddda8da8f873a1 is commit before 1.8.1
+    git checkout b7f8a1f1502d28a5ef440e642fddda8da8f873a1 --quiet
+    got=$(python calc_release_version_test.py)
+    assert_eq "$got" "1.8.1-$DATE+gitb7f8a1f150"
+    git checkout - --quiet
+}
+echo "Test an untagged commit ... end"
+
+echo "Test next minor version ... begin"
+{
+    CURRENT_SHORTREF=$(git rev-parse --revs-only --short=10 HEAD)
+    got=$(python calc_release_version_test.py --next-minor)
+    # The expected output may need to be updated after a release.
+    assert_eq "$got" "1.9.0-$DATE+git$CURRENT_SHORTREF"
+}
+echo "Test next minor version ... end"
+
+echo "All tests passed"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -386,6 +386,20 @@ tasks:
   - func: "fetch source"
   - func: "run clang-tidy"
 
+- name: calc-release-version-selftest
+  commands:
+  - func: "fetch source"
+  - command: shell.exec
+    type: test
+    params:
+      shell: bash
+      working_dir: "libmongocrypt"
+      script: |-
+        if [ "${is_patch}" != "true" ]; then
+          cd etc
+          bash -x ../.evergreen/calc_release_version_selftest.sh
+        fi
+
 - name: build-and-test-shared-bson
   commands:
   - func: "fetch source"
@@ -1355,6 +1369,7 @@ buildvariants:
     nvm_use_version: 20
   tasks:
   - clang-tidy
+  - calc-release-version-selftest
   - build-and-test-and-upload
   - build-and-test-shared-bson
   - build-and-test-asan
@@ -1392,6 +1407,7 @@ buildvariants:
     clang_env: CC=clang-12 CXX=clang++-12
   tasks:
   - clang-tidy
+  - calc-release-version-selftest
   - build-and-test-and-upload
   - build-and-test-shared-bson
   - build-and-test-asan

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ Do the following when releasing:
 - Update CHANGELOG.md with the version being released.
 - If this is a new minor release (e.g. `x.y.0`):
    - Update the Linux distribution package installation instructions in the below sections to refer to the new version x.y.
-   - Commit these changes (on `master`) so that both the `master` branch and the new branch you are about to create refer to the new branch (note that this means you will commit changes to this file, and `CHANGELOG.md`)
+   - Update `.evergreen/calc_release_version_selftest.sh`, around line 58, to change the expected value of the assertion to the new version x.y.
+   - Commit these changes (on `master`) so that both the `master` branch and the new branch you are about to create refer to the new branch (note that this means you will commit changes to this file, `.evergreen/calc_release_version_selftest.sh`, and `CHANGELOG.md`)
    - Create a branch named `rx.y`.
    - Update the [libmongocrypt-release](https://evergreen.mongodb.com/projects##libmongocrypt-release) Evergreen project (requires auth) to set `Branch Name` to `rx.y`.
 - Commit, create a new git tag, like `1.0.0-rc123` or `1.0.0`, and push.


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/task/libmongocrypt_ubuntu2204_64_calc_release_version_selftest_patch_4ba78c5d59eaa8cd691d59bd760f48801b87d26f_648b86ca9ccd4ed2ea43aad2_23_06_15_21_46_51/logs?execution=0

Note that this implementation is such that it won't run on a patch build. As a result, the patch build above includes these additional changes to simulate the effect of what this task will accomplish when executed on the waterfall:

```
diff --git a/.evergreen/calc_release_version_selftest.sh b/.evergreen/calc_release_version_selftest.sh
index e7cf943..1bfad1b 100644
--- a/.evergreen/calc_release_version_selftest.sh
+++ b/.evergreen/calc_release_version_selftest.sh
@@ -6,6 +6,7 @@
 
 set -o errexit
 set -o pipefail
+git stash
 
 function assert_eq () {
     a="$1"
diff --git a/.evergreen/config.yml b/.evergreen/config.yml
index a1b02ac..001029b 100755
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -399,6 +399,8 @@ tasks:
           cd etc
           bash -x ../.evergreen/calc_release_version_selftest.sh
         fi
+        cd etc
+        bash -x ../.evergreen/calc_release_version_selftest.sh
 
 - name: build-and-test-shared-bson
   commands:
```

