### PR TITLE
feat(NODE-5431): add node bindings v6 deprecations

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -11,8 +11,8 @@ You can install `mongodb-client-encryption` with the following:
 npm install mongodb-client-encryption
 ```
 
-### Development 
-#### Setup 
+### Development
+#### Setup
 
 Run the following command to build libmongocrypt and setup the node bindings for development:
 
@@ -23,10 +23,10 @@ bash ./etc/build-static.sh
 
 #### Testing
 
-Some tests require a standalone server to be running with authentication enabled.  Set up a single 
+Some tests require a standalone server to be running with authentication enabled.  Set up a single
 server running with the following conditions:
 
-| param     | value     | 
+| param     | value     |
 |-----------|-----------|
 | host      | localhost |
 | port      | 27017     |
@@ -40,6 +40,12 @@ npm test
 ```
 
 # Documentation
+
+## Deprecation Notice
+
+There are breaking changes planned for this package.  In the next major version, callbacks will be removed
+from the public API on all asynchronous functions.  Additionally, the classes documented here will be
+moved into [node-mongodb-native](https://github.com/mongodb/node-mongodb-native).
 
 ## Classes
 

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -48,21 +48,22 @@ npm test
 <dd><p>An internal class to be used by the driver for auto encryption
 <strong>NOTE</strong>: Not meant to be instantiated directly, this is for internal use only.</p>
 </dd>
-<dt><a href="#ClientEncryption">ClientEncryption</a></dt>
-<dd><p>The public interface for explicit in-use encryption</p>
-</dd>
-<dt><a href="#MongoCryptError">MongoCryptError</a></dt>
+<dt><del><a href="#ClientEncryption">ClientEncryption</a></del></dt>
+<dd></dd>
+<dt><del><a href="#MongoCryptError">MongoCryptError</a></del></dt>
 <dd><p>An error indicating that something went wrong specifically with MongoDB Client Encryption</p>
 </dd>
-<dt><a href="#MongoCryptCreateDataKeyError">MongoCryptCreateDataKeyError</a></dt>
+<dt><del><a href="#MongoCryptCreateDataKeyError">MongoCryptCreateDataKeyError</a></del></dt>
 <dd><p>An error indicating that <code>ClientEncryption.createEncryptedCollection()</code> failed to create data keys</p>
 </dd>
-<dt><a href="#MongoCryptCreateEncryptedCollectionError">MongoCryptCreateEncryptedCollectionError</a></dt>
+<dt><del><a href="#MongoCryptCreateEncryptedCollectionError">MongoCryptCreateEncryptedCollectionError</a></del></dt>
 <dd><p>An error indicating that <code>ClientEncryption.createEncryptedCollection()</code> failed to create a collection</p>
 </dd>
-<dt><a href="#MongoCryptAzureKMSRequestError">MongoCryptAzureKMSRequestError</a></dt>
+<dt><del><a href="#MongoCryptAzureKMSRequestError">MongoCryptAzureKMSRequestError</a></del></dt>
 <dd><p>An error indicating that mongodb-client-encryption failed to auto-refresh Azure KMS credentials.</p>
 </dd>
+<dt><del><a href="#MongoCryptKMSRequestNetworkTimeoutError">MongoCryptKMSRequestNetworkTimeoutError</a></del></dt>
+<dd></dd>
 </dl>
 
 ## Typedefs
@@ -100,7 +101,7 @@ npm test
 Can be used for <a href="ClientEncryption.encrypt">ClientEncryption.encrypt</a>, and can be used to directly
 query for the data key itself against the key vault namespace.</p>
 </dd>
-<dt><a href="#ClientEncryptionCreateDataKeyCallback">ClientEncryptionCreateDataKeyCallback</a> : <code>function</code></dt>
+<dt><del><a href="#ClientEncryptionCreateDataKeyCallback">ClientEncryptionCreateDataKeyCallback</a> : <code>function</code></del></dt>
 <dd></dd>
 <dt><a href="#AWSEncryptionKeyOptions">AWSEncryptionKeyOptions</a> : <code>object</code></dt>
 <dd><p>Configuration options for making an AWS encryption key</p>
@@ -113,7 +114,7 @@ query for the data key itself against the key vault namespace.</p>
 </dd>
 <dt><a href="#RewrapManyDataKeyResult">RewrapManyDataKeyResult</a> : <code>object</code></dt>
 <dd></dd>
-<dt><a href="#ClientEncryptionEncryptCallback">ClientEncryptionEncryptCallback</a> : <code>function</code></dt>
+<dt><del><a href="#ClientEncryptionEncryptCallback">ClientEncryptionEncryptCallback</a> : <code>function</code></del></dt>
 <dd></dd>
 <dt><a href="#RangeOptions">RangeOptions</a> : <code>object</code></dt>
 <dd><p>min, max, sparsity, and range must match the values set in the encryptedFields of the destination collection.
@@ -282,12 +283,12 @@ the underlying C++ Bindings.
 
 <a name="ClientEncryption"></a>
 
-## ClientEncryption
-The public interface for explicit in-use encryption
+## ~~ClientEncryption~~
+***Deprecated***
 
 
-* [ClientEncryption](#ClientEncryption)
-
+* ~~[ClientEncryption](#ClientEncryption)
+~~
     * [new ClientEncryption(client, options)](#new_ClientEncryption_new)
 
     * _instance_
@@ -318,8 +319,8 @@ The public interface for explicit in-use encryption
         * [.askForKMSCredentials()](#ClientEncryption+askForKMSCredentials)
 
     * _inner_
-        * [~decryptCallback](#ClientEncryption..decryptCallback)
-
+        * ~~[~decryptCallback](#ClientEncryption..decryptCallback)
+~~
 
 <a name="new_ClientEncryption_new"></a>
 
@@ -369,7 +370,7 @@ new ClientEncryption(mongoClient, {
 | [options] | <code>object</code> | Options for creating the data key |
 | [options.masterKey] | [<code>AWSEncryptionKeyOptions</code>](#AWSEncryptionKeyOptions) \| [<code>AzureEncryptionKeyOptions</code>](#AzureEncryptionKeyOptions) \| [<code>GCPEncryptionKeyOptions</code>](#GCPEncryptionKeyOptions) | Idenfities a new KMS-specific key used to encrypt the new data key |
 | [options.keyAltNames] | <code>Array.&lt;string&gt;</code> | An optional list of string alternate names used to reference a key. If a key is created with alternate names, then encryption may refer to the key by the unique alternate name instead of by _id. |
-| [callback] | [<code>ClientEncryptionCreateDataKeyCallback</code>](#ClientEncryptionCreateDataKeyCallback) | Optional callback to invoke when key is created |
+| [callback] | [<code>ClientEncryptionCreateDataKeyCallback</code>](#ClientEncryptionCreateDataKeyCallback) | DEPRECATED - Callbacks will be removed in the next major version.  Optional callback to invoke when key is created |
 
 Creates a data key used for explicit encryption and inserts it into the key vault namespace
 
@@ -606,7 +607,7 @@ and then create a new collection with the full set of encryptedFields.
 | --- | --- | --- |
 | value | <code>\*</code> | The value that you wish to serialize. Must be of a type that can be serialized into BSON |
 | options | [<code>EncryptOptions</code>](#EncryptOptions) |  |
-| [callback] | [<code>ClientEncryptionEncryptCallback</code>](#ClientEncryptionEncryptCallback) | Optional callback to invoke when value is encrypted |
+| [callback] | [<code>ClientEncryptionEncryptCallback</code>](#ClientEncryptionEncryptCallback) | DEPRECATED: Callbacks will be removed in the next major version.  Optional callback to invoke when value is encrypted |
 
 Explicitly encrypt a provided value. Note that either `options.keyId` or `options.keyAltName` must
 be specified. Specifying both `options.keyId` and `options.keyAltName` is considered an error.
@@ -662,7 +663,7 @@ Only supported when queryType is "rangePreview" and algorithm is "RangePreview".
 | Param | Type | Description |
 | --- | --- | --- |
 | value | <code>Buffer</code> \| <code>Binary</code> | An encrypted value |
-| callback | [<code>decryptCallback</code>](#ClientEncryption..decryptCallback) | Optional callback to invoke when value is decrypted |
+| callback | [<code>decryptCallback</code>](#ClientEncryption..decryptCallback) | DEPRECATED - Callbacks will be removed in the next major version.  Optional callback to invoke when value is decrypted |
 
 Explicitly decrypt a provided encrypted value
 
@@ -692,7 +693,9 @@ the original ones.
 
 <a name="ClientEncryption..decryptCallback"></a>
 
-### *ClientEncryption*~decryptCallback
+### ~~*ClientEncryption*~decryptCallback~~
+***Deprecated***
+
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -701,22 +704,30 @@ the original ones.
 
 <a name="MongoCryptError"></a>
 
-## MongoCryptError
+## ~~MongoCryptError~~
+***Deprecated***
+
 An error indicating that something went wrong specifically with MongoDB Client Encryption
 
 <a name="MongoCryptCreateDataKeyError"></a>
 
-## MongoCryptCreateDataKeyError
+## ~~MongoCryptCreateDataKeyError~~
+***Deprecated***
+
 An error indicating that `ClientEncryption.createEncryptedCollection()` failed to create data keys
 
 <a name="MongoCryptCreateEncryptedCollectionError"></a>
 
-## MongoCryptCreateEncryptedCollectionError
+## ~~MongoCryptCreateEncryptedCollectionError~~
+***Deprecated***
+
 An error indicating that `ClientEncryption.createEncryptedCollection()` failed to create a collection
 
 <a name="MongoCryptAzureKMSRequestError"></a>
 
-## MongoCryptAzureKMSRequestError
+## ~~MongoCryptAzureKMSRequestError~~
+***Deprecated***
+
 An error indicating that mongodb-client-encryption failed to auto-refresh Azure KMS credentials.
 
 <a name="new_MongoCryptAzureKMSRequestError_new"></a>
@@ -727,6 +738,11 @@ An error indicating that mongodb-client-encryption failed to auto-refresh Azure 
 | --- | --- |
 | message | <code>string</code> | 
 | body | <code>object</code> \| <code>undefined</code> | 
+
+<a name="MongoCryptKMSRequestNetworkTimeoutError"></a>
+
+## ~~MongoCryptKMSRequestNetworkTimeoutError~~
+***Deprecated***
 
 <a name="BSONValue"></a>
 
@@ -821,7 +837,9 @@ query for the data key itself against the key vault namespace.
 
 <a name="ClientEncryptionCreateDataKeyCallback"></a>
 
-## ClientEncryptionCreateDataKeyCallback
+## ~~ClientEncryptionCreateDataKeyCallback~~
+***Deprecated***
+
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -881,7 +899,9 @@ Configuration options for making an Azure encryption key
 
 <a name="ClientEncryptionEncryptCallback"></a>
 
-## ClientEncryptionEncryptCallback
+## ~~ClientEncryptionEncryptCallback~~
+***Deprecated***
+
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/bindings/node/etc/README.hbs
+++ b/bindings/node/etc/README.hbs
@@ -11,8 +11,8 @@ You can install `mongodb-client-encryption` with the following:
 npm install mongodb-client-encryption
 ```
 
-### Development 
-#### Setup 
+### Development
+#### Setup
 
 Run the following command to build libmongocrypt and setup the node bindings for development:
 
@@ -23,10 +23,10 @@ bash ./etc/build-static.sh
 
 #### Testing
 
-Some tests require a standalone server to be running with authentication enabled.  Set up a single 
+Some tests require a standalone server to be running with authentication enabled.  Set up a single
 server running with the following conditions:
 
-| param     | value     | 
+| param     | value     |
 |-----------|-----------|
 | host      | localhost |
 | port      | 27017     |
@@ -40,5 +40,11 @@ npm test
 ```
 
 # Documentation
+
+## Deprecation Notice
+
+There are breaking changes planned for this package.  In the next major version, callbacks will be removed
+from the public API on all asynchronous functions.  Additionally, the classes documented here will be
+moved into [node-mongodb-native](https://github.com/mongodb/node-mongodb-native).
 
 {{>main}}

--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -29,7 +29,7 @@ export interface DataKey {
 
 /**
  * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
- * in the next major version and in the next major version must be imported from the driver.
+ * in the next major version and must be imported from the driver.
  *
  * An error indicating that something went wrong specifically with MongoDB Client Encryption
  */
@@ -39,7 +39,7 @@ export class MongoCryptError extends Error {
 
 /**
  * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
- * in the next major version and in the next major version must be imported from the driver.
+ * in the next major version and must be imported from the driver.
  *
  * An error indicating that `ClientEncryption.createEncryptedCollection()` failed to create a collection
  */
@@ -54,7 +54,7 @@ export class MongoCryptCreateEncryptedCollectionError extends MongoCryptError {
 
 /**
  * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
- * in the next major version and in the next major version must be imported from the driver.
+ * in the next major version and must be imported from the driver.
  *
  * An error indicating that `ClientEncryption.createEncryptedCollection()` failed to create data keys
  */
@@ -69,7 +69,7 @@ export class MongoCryptCreateDataKeyError extends MongoCryptError {
 
 /**
  * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
- * in the next major version and in the next major version must be imported from the driver.
+ * in the next major version and must be imported from the driver.
  *
  * An error indicating that mongodb-client-encryption failed to auto-refresh Azure KMS credentials.
  */
@@ -80,7 +80,7 @@ export class MongoCryptAzureKMSRequestError extends MongoCryptError {
 
 /**
  * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
- * in the next major version and in the next major version must be imported from the driver.
+ * in the next major version and must be imported from the driver.
  *
  */
 export class MongoCryptKMSRequestNetworkTimeoutError extends MongoCryptError {}

--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -28,6 +28,9 @@ export interface DataKey {
 }
 
 /**
+ * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
+ * in the next major version and in the next major version must be imported from the driver.
+ *
  * An error indicating that something went wrong specifically with MongoDB Client Encryption
  */
 export class MongoCryptError extends Error {
@@ -35,6 +38,9 @@ export class MongoCryptError extends Error {
 }
 
 /**
+ * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
+ * in the next major version and in the next major version must be imported from the driver.
+ *
  * An error indicating that `ClientEncryption.createEncryptedCollection()` failed to create a collection
  */
 export class MongoCryptCreateEncryptedCollectionError extends MongoCryptError {
@@ -47,6 +53,9 @@ export class MongoCryptCreateEncryptedCollectionError extends MongoCryptError {
 }
 
 /**
+ * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
+ * in the next major version and in the next major version must be imported from the driver.
+ *
  * An error indicating that `ClientEncryption.createEncryptedCollection()` failed to create data keys
  */
 export class MongoCryptCreateDataKeyError extends MongoCryptError {
@@ -59,6 +68,9 @@ export class MongoCryptCreateDataKeyError extends MongoCryptError {
 }
 
 /**
+ * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
+ * in the next major version and in the next major version must be imported from the driver.
+ *
  * An error indicating that mongodb-client-encryption failed to auto-refresh Azure KMS credentials.
  */
 export class MongoCryptAzureKMSRequestError extends MongoCryptError {
@@ -66,6 +78,11 @@ export class MongoCryptAzureKMSRequestError extends MongoCryptError {
   body?: Document ;
 }
 
+/**
+ * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
+ * in the next major version and in the next major version must be imported from the driver.
+ *
+ */
 export class MongoCryptKMSRequestNetworkTimeoutError extends MongoCryptError {}
 
 /**
@@ -78,6 +95,10 @@ export interface ProxyOptions {
   proxyPassword?: string;
 }
 
+/**
+ * @deprecated Callback overloads are deprecated and will be removed in the next major version.  Please
+ * use the Promise overloads instead.
+ */
 export interface ClientEncryptionCreateDataKeyCallback {
   /**
    * @param error If present, indicates an error that occurred in the creation of the data key
@@ -86,6 +107,10 @@ export interface ClientEncryptionCreateDataKeyCallback {
   (error?: Error, dataKeyId?: Binary): void;
 }
 
+/**
+ * @deprecated Callback overloads are deprecated and will be removed in the next major version.  Please
+ * use the Promise overloads instead.
+ */
 export interface ClientEncryptionEncryptCallback {
   /**
    * @param error If present, indicates an error that occurred in the process of encryption
@@ -94,6 +119,10 @@ export interface ClientEncryptionEncryptCallback {
   (error?: Error, result?: Binary): void;
 }
 
+/**
+ * @deprecated Callback overloads are deprecated and will be removed in the next major version.  Please
+ * use the Promise overloads instead.
+ */
 export interface ClientEncryptionDecryptCallback {
   /**
    * @param error If present, indicates an error that occurred in the process of decryption
@@ -479,6 +508,9 @@ export class ClientEncryption {
   ): Promise<Binary>;
 
   /**
+   * @deprecated Callback overloads are deprecated and will be removed in the next major version.  Please
+   * use the Promise overloads instead.
+   *
    * Creates a data key used for explicit encryption and inserts it into the key vault namespace
    * @param provider The KMS provider used for this data key. Must be `'aws'`, `'azure'`, `'gcp'`, or `'local'`
    * @param callback Callback to invoke when key is created
@@ -489,6 +521,9 @@ export class ClientEncryption {
   ): void;
 
   /**
+   * @deprecated Callback overloads are deprecated and will be removed in the next major version.  Please
+   * use the Promise overloads instead.
+   *
    * Creates a data key used for explicit encryption and inserts it into the key vault namespace
    * @param provider The KMS provider used for this data key. Must be `'aws'`, `'azure'`, `'gcp'`, or `'local'`
    * @param options Options for creating the data key
@@ -593,6 +628,9 @@ export class ClientEncryption {
   encrypt(value: any, options: ClientEncryptionEncryptOptions): Promise<Binary>;
 
   /**
+   * @deprecated Callback overloads are deprecated and will be removed in the next major version.  Please
+   * use the Promise overloads instead.
+   *
    * Explicitly encrypt a provided value.
    * Note that either options.keyId or options.keyAltName must be specified.
    * Specifying both options.keyId and options.keyAltName is considered an error.
@@ -630,6 +668,9 @@ export class ClientEncryption {
   decrypt(value: Buffer | Binary): Promise<any>;
 
   /**
+   * @deprecated Callback overloads are deprecated and will be removed in the next major version.  Please
+   * use the Promise overloads instead.
+   *
    * Explicitly decrypt a provided encrypted value
    * @param value An encrypted value
    * @param callback Callback to invoke when value is decrypted

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -74,7 +74,7 @@ module.exports = function (modules) {
 
   /**
    * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
-   * in the next major version and in the next major version must be imported from the driver.
+   * in the next major version and must be imported from the driver.
    *
    * The public interface for explicit in-use encryption
    */

--- a/bindings/node/lib/clientEncryption.js
+++ b/bindings/node/lib/clientEncryption.js
@@ -73,6 +73,9 @@ module.exports = function (modules) {
    */
 
   /**
+   * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
+   * in the next major version and in the next major version must be imported from the driver.
+   *
    * The public interface for explicit in-use encryption
    */
   class ClientEncryption {
@@ -138,6 +141,8 @@ module.exports = function (modules) {
      */
 
     /**
+     * @deprecated Callback overloads are deprecated and will be removed in the next major version.  Please
+     * use the Promise overloads instead.
      * @callback ClientEncryptionCreateDataKeyCallback
      * @param {Error} [error] If present, indicates an error that occurred in the creation of the data key
      * @param {ClientEncryption~dataKeyId} [dataKeyId] If present, returns the id of the created data key
@@ -174,7 +179,7 @@ module.exports = function (modules) {
      * @param {object} [options] Options for creating the data key
      * @param {AWSEncryptionKeyOptions|AzureEncryptionKeyOptions|GCPEncryptionKeyOptions} [options.masterKey] Idenfities a new KMS-specific key used to encrypt the new data key
      * @param {string[]} [options.keyAltNames] An optional list of string alternate names used to reference a key. If a key is created with alternate names, then encryption may refer to the key by the unique alternate name instead of by _id.
-     * @param {ClientEncryptionCreateDataKeyCallback} [callback] Optional callback to invoke when key is created
+     * @param {ClientEncryptionCreateDataKeyCallback} [callback] DEPRECATED - Callbacks will be removed in the next major version.  Optional callback to invoke when key is created
      * @returns {Promise|void} If no callback is provided, returns a Promise that either resolves with {@link ClientEncryption~dataKeyId the id of the created data key}, or rejects with an error. If a callback is provided, returns nothing.
      * @example
      * // Using callbacks to create a local key
@@ -613,6 +618,9 @@ module.exports = function (modules) {
     }
 
     /**
+     * @deprecated Callback overloads are deprecated and will be removed in the next major version.  Please
+     * use the Promise overloads instead.
+     *
      * @callback ClientEncryptionEncryptCallback
      * @param {Error} [err] If present, indicates an error that occurred in the process of encryption
      * @param {Buffer} [result] If present, is the encrypted result
@@ -644,7 +652,7 @@ module.exports = function (modules) {
      *
      * @param {*} value The value that you wish to serialize. Must be of a type that can be serialized into BSON
      * @param {EncryptOptions} options
-     * @param {ClientEncryptionEncryptCallback} [callback] Optional callback to invoke when value is encrypted
+     * @param {ClientEncryptionEncryptCallback} [callback] DEPRECATED: Callbacks will be removed in the next major version.  Optional callback to invoke when value is encrypted
      * @returns {Promise|void} If no callback is provided, returns a Promise that either resolves with the encrypted value, or rejects with an error. If a callback is provided, returns nothing.
      *
      * @example
@@ -699,6 +707,9 @@ module.exports = function (modules) {
     }
 
     /**
+     * @deprecated Callback overloads are deprecated and will be removed in the next major version.  Please
+     * use the Promise overloads instead.
+     *
      * @callback ClientEncryption~decryptCallback
      * @param {Error} [err] If present, indicates an error that occurred in the process of decryption
      * @param {object} [result] If present, is the decrypted result
@@ -708,7 +719,7 @@ module.exports = function (modules) {
      * Explicitly decrypt a provided encrypted value
      *
      * @param {Buffer | Binary} value An encrypted value
-     * @param {ClientEncryption~decryptCallback} callback Optional callback to invoke when value is decrypted
+     * @param {ClientEncryption~decryptCallback} callback DEPRECATED - Callbacks will be removed in the next major version.  Optional callback to invoke when value is decrypted
      * @returns {Promise|void} If no callback is provided, returns a Promise that either resolves with the decrypted value, or rejects with an error. If a callback is provided, returns nothing.
      *
      * @example

--- a/bindings/node/lib/errors.js
+++ b/bindings/node/lib/errors.js
@@ -2,7 +2,7 @@
 
 /**
  * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
- * in the next major version and in the next major version must be imported from the driver.
+ * in the next major version and must be imported from the driver.
  * @class
  * An error indicating that something went wrong specifically with MongoDB Client Encryption
  */
@@ -21,7 +21,7 @@ class MongoCryptError extends Error {
 
 /**
  * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
- * in the next major version and in the next major version must be imported from the driver.
+ * in the next major version and must be imported from the driver.
  * @class
  * An error indicating that `ClientEncryption.createEncryptedCollection()` failed to create data keys
  */
@@ -38,7 +38,7 @@ class MongoCryptCreateDataKeyError extends MongoCryptError {
 
 /**
  * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
- * in the next major version and in the next major version must be imported from the driver.
+ * in the next major version and must be imported from the driver.
  * @class
  * An error indicating that `ClientEncryption.createEncryptedCollection()` failed to create a collection
  */
@@ -55,7 +55,7 @@ class MongoCryptCreateEncryptedCollectionError extends MongoCryptError {
 
 /**
  * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
- * in the next major version and in the next major version must be imported from the driver.
+ * in the next major version and must be imported from the driver.
  * @class
  * An error indicating that mongodb-client-encryption failed to auto-refresh Azure KMS credentials.
  */
@@ -72,7 +72,7 @@ class MongoCryptAzureKMSRequestError extends MongoCryptError {
 
 /**
  * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
- * in the next major version and in the next major version must be imported from the driver.
+ * in the next major version and must be imported from the driver.
  */
 class MongoCryptKMSRequestNetworkTimeoutError extends MongoCryptError {}
 

--- a/bindings/node/lib/errors.js
+++ b/bindings/node/lib/errors.js
@@ -1,6 +1,8 @@
 'use strict';
 
 /**
+ * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
+ * in the next major version and in the next major version must be imported from the driver.
  * @class
  * An error indicating that something went wrong specifically with MongoDB Client Encryption
  */
@@ -18,6 +20,8 @@ class MongoCryptError extends Error {
 }
 
 /**
+ * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
+ * in the next major version and in the next major version must be imported from the driver.
  * @class
  * An error indicating that `ClientEncryption.createEncryptedCollection()` failed to create data keys
  */
@@ -33,6 +37,8 @@ class MongoCryptCreateDataKeyError extends MongoCryptError {
 }
 
 /**
+ * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
+ * in the next major version and in the next major version must be imported from the driver.
  * @class
  * An error indicating that `ClientEncryption.createEncryptedCollection()` failed to create a collection
  */
@@ -48,6 +54,8 @@ class MongoCryptCreateEncryptedCollectionError extends MongoCryptError {
 }
 
 /**
+ * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
+ * in the next major version and in the next major version must be imported from the driver.
  * @class
  * An error indicating that mongodb-client-encryption failed to auto-refresh Azure KMS credentials.
  */
@@ -62,6 +70,10 @@ class MongoCryptAzureKMSRequestError extends MongoCryptError {
   }
 }
 
+/**
+ * @deprecated This class will be moved into the [Node driver](https://github.com/mongodb/node-mongodb-native)
+ * in the next major version and in the next major version must be imported from the driver.
+ */
 class MongoCryptKMSRequestNetworkTimeoutError extends MongoCryptError {}
 
 module.exports = {


### PR DESCRIPTION
This PR deprecates any public callback types and overloads of public async functions that take callbacks.  Additionally, this PR notes on any publicly exported classes that the classes will be moved into the driver in the coming major release.