### PR TITLE
feat(NODE-5417)!: bump minimum Node.js version to v16.20.1

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -146,7 +146,7 @@ functions:
           NODE_GITHUB_TOKEN: ${node_github_token}
           DISTRO_ID: ${distro_id}
           BUILD_VARIANT: ${build_variant}
-          NODE_LTS_VERSION: ${nvm_use_version|16}
+          NODE_LTS_VERSION: ${node_lts_version|16}
 
   "build and test node no peer dependencies":
     - command: "subprocess.exec"
@@ -161,7 +161,7 @@ functions:
           DISTRO_ID: ${distro_id}
           BUILD_VARIANT: ${build_variant}
           OMIT_PEER_DEPS: "true"
-          NODE_NVM_USE_VERSION: ${nvm_use_version|18}
+          NODE_LTS_VERSION: ${node_lts_version|18}
 
   "build and publish node":
     - command: "subprocess.exec"
@@ -175,7 +175,7 @@ functions:
           NODE_GITHUB_TOKEN: ${node_github_token}
           DISTRO_ID: ${distro_id}
           BUILD_VARIANT: ${build_variant}
-          NODE_LTS_VERSION: ${nvm_use_version|16}
+          NODE_LTS_VERSION: ${node_lts_version|16}
 
   "attach node xunit results":
     - command: attach.xunit_results
@@ -927,7 +927,7 @@ tasks:
 - name: rpm-package-build
   tags: [packaging]
   run_on: &docker-distros
-    # * The RHEL76-docker distro runs an old and unsupported version of Docker. 
+    # * The RHEL76-docker distro runs an old and unsupported version of Docker.
     # * (We requires the --mount parameter)
     - ubuntu2004-small
     - ubuntu2004
@@ -998,7 +998,7 @@ buildvariants:
     has_packages: true
     packager_distro: ubuntu1604
     packager_arch: x86_64
-    nvm_use_version: 16
+    node_lts_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1086,7 +1086,7 @@ buildvariants:
     has_packages: true
     packager_distro: amazon
     packager_arch: x86_64
-    nvm_use_version: 16
+    node_lts_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1103,7 +1103,7 @@ buildvariants:
     has_packages: true
     packager_distro: amazon2
     packager_arch: x86_64
-    nvm_use_version: 16
+    node_lts_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1121,7 +1121,7 @@ buildvariants:
     has_packages: true
     packager_distro: amazon2
     packager_arch: arm64
-    nvm_use_version: 16
+    node_lts_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1172,7 +1172,7 @@ buildvariants:
     has_packages: true
     packager_distro: debian92
     packager_arch: x86_64
-    nvm_use_version: 16
+    node_lts_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1204,7 +1204,7 @@ buildvariants:
     has_packages: true
     packager_distro: rhel70
     packager_arch: x86_64
-    nvm_use_version: 16
+    node_lts_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1252,7 +1252,7 @@ buildvariants:
     has_packages: true
     packager_distro: suse12
     packager_arch: x86_64
-    nvm_use_version: 16
+    node_lts_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1270,7 +1270,7 @@ buildvariants:
     has_packages: true
     packager_distro: suse15
     packager_arch: x86_64
-    nvm_use_version: 16
+    node_lts_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1288,7 +1288,7 @@ buildvariants:
     has_packages: true
     packager_distro: ubuntu1604
     packager_arch: arm64
-    nvm_use_version: 16
+    node_lts_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1307,7 +1307,7 @@ buildvariants:
     has_packages: true
     packager_distro: ubuntu1804
     packager_arch: x86_64
-    nvm_use_version: 16
+    node_lts_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1336,7 +1336,7 @@ buildvariants:
     has_packages: true
     packager_distro: ubuntu1804
     packager_arch: arm64
-    nvm_use_version: 16
+    node_lts_version: 16
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
@@ -1354,7 +1354,7 @@ buildvariants:
     has_packages: true
     packager_distro: ubuntu2004
     packager_arch: x86_64
-    nvm_use_version: 20
+    node_lts_version: 20
   tasks:
   - clang-tidy
   - build-and-test-and-upload
@@ -1373,7 +1373,7 @@ buildvariants:
     has_packages: true
     packager_distro: ubuntu2004
     packager_arch: arm64
-    nvm_use_version: 20
+    node_lts_version: 20
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -39,7 +39,7 @@
         "tsd": "^0.28.1"
       },
       "engines": {
-        "node": ">=12.9.0"
+        "node": ">=16.20.1"
       },
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.186.0",

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -76,7 +76,7 @@
     }
   },
   "engines": {
-    "node": ">=12.9.0"
+    "node": ">=16.20.1"
   },
   "binary": {
     "napi_versions": [


### PR DESCRIPTION
### Description

#### What is changing?

- Dropping support for Node.js 14
- Update variable name nvm_use -> node_lts in evg config

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

Removing support for EOL node versions helps us keep our tooling and testing up to date and modern. 

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Minimum Node.js version is now v16.20.1

The minimum supported Node.js  version is now v16.20.1. We strive to keep our minimum supported Node.js version in sync with the runtime's [release cadence](https://nodejs.dev/en/about/releases/) to keep up with the latest security updates and modern language features.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
