### PR TITLE
MONGOCRYPT-582 fix leaks on errors

### DIFF
--- a/src/mc-fle2-payload-iev-v2.c
+++ b/src/mc-fle2-payload-iev-v2.c
@@ -180,7 +180,7 @@ bool mc_FLE2IndexedEncryptedValueV2_add_S_Key(_mongocrypt_crypto_t *crypto,
         CLIENT_ERR("Invalid ServerEncryptedValue length, got %" PRIu32 ", expected more than %d",
                    DecryptedServerEncryptedValueLen,
                    UUID_LEN);
-        return false;
+        goto fail;
     }
     _mongocrypt_buffer_resize(&iev->DecryptedServerEncryptedValue, DecryptedServerEncryptedValueLen);
     uint32_t bytes_written = 0;

--- a/src/mc-fle2-payload-iev.c
+++ b/src/mc-fle2-payload-iev.c
@@ -207,7 +207,7 @@ static bool mc_fle2IndexedEncryptedValue_encrypt(_mongocrypt_crypto_t *crypto,
     uint32_t ciphertext_len = fle2alg->get_ciphertext_len(expected_buf_size, status);
 
     if (ciphertext_len == 0) {
-        return false;
+        goto cleanup;
     }
 
     _mongocrypt_buffer_resize(out, ciphertext_len);


### PR DESCRIPTION
I expect these are low impact leaks that could only appear on encrypting or decrypting malformed data.