### PR TITLE
assert return of `EVP_CIPHER_CTX_new`

### DIFF
--- a/src/crypto/libcrypto.c
+++ b/src/crypto/libcrypto.c
@@ -120,6 +120,7 @@ static bool _decrypt_with_cipher(const EVP_CIPHER *cipher, aes_256_args_t args) 
     mongocrypt_status_t *status = args.status;
 
     ctx = EVP_CIPHER_CTX_new();
+    BSON_ASSERT(ctx);
 
     BSON_ASSERT_PARAM(cipher);
     BSON_ASSERT(args.iv);


### PR DESCRIPTION
# Background & Motivation
Intends to resolve Coverity reported issue with CID 121624.

`man EVP_CIPHER_CTX_new` on macOS documents:

> EVP_CIPHER_CTX_new() returns a pointer to a newly created EVP_CIPHER_CTX for success and NULL for failure.