### PR TITLE
[MONGOCRYPT-583] cmake/bson: allow shared-only system lib

### DIFF
--- a/cmake/ImportBSON.cmake
+++ b/cmake/ImportBSON.cmake
@@ -134,10 +134,13 @@ function (_import_system_libbson target library_type library_name)
 endfunction ()
 
 function (_import_bson)
-   if (MONGOCRYPT_MONGOC_DIR STREQUAL "USE-SYSTEM" AND USE_SHARED_LIBBSON)
+   if (MONGOCRYPT_MONGOC_DIR STREQUAL "USE-SYSTEM")
       message (STATUS "NOTE: Using system-wide libbson library. This is intended only for package maintainers.")
-      _import_system_libbson(bson_shared SHARED "${CMAKE_SHARED_LIBRARY_PREFIX}bson-1.0${CMAKE_SHARED_LIBRARY_SUFFIX}")
-      _import_system_libbson(bson_static STATIC "${CMAKE_STATIC_LIBRARY_PREFIX}bson-static-1.0${CMAKE_STATIC_LIBRARY_SUFFIX}")
+      if (USE_SHARED_LIBBSON)
+         _import_system_libbson (bson_shared SHARED "${CMAKE_SHARED_LIBRARY_PREFIX}bson-1.0${CMAKE_SHARED_LIBRARY_SUFFIX}")
+      else ()
+         _import_system_libbson (bson_static STATIC "${CMAKE_STATIC_LIBRARY_PREFIX}bson-static-1.0${CMAKE_STATIC_LIBRARY_SUFFIX}")
+      endif ()
    else ()
       message (STATUS "Using [${MONGOCRYPT_MONGOC_DIR}] as a sub-project for libbson")
       # Disable AWS_AUTH, to prevent it from building the kms-message symbols, which we build ourselves
@@ -211,11 +214,11 @@ install (
 # users during find_package()
 if (USE_SHARED_LIBBSON)
    target_link_libraries (_mongocrypt-libbson_for_shared INTERFACE $<BUILD_INTERFACE:bson_shared>)
+   target_link_libraries (_mongocrypt-libbson_for_static INTERFACE $<BUILD_INTERFACE:bson_shared>)
 else ()
    target_link_libraries (_mongocrypt-libbson_for_shared INTERFACE $<BUILD_INTERFACE:bson_static>)
+   target_link_libraries (_mongocrypt-libbson_for_static INTERFACE $<BUILD_INTERFACE:bson_static>)
 endif ()
-# libbson_for_static always links to the static libbson:
-target_link_libraries (_mongocrypt-libbson_for_static INTERFACE $<BUILD_INTERFACE:bson_static>)
 
 if (TARGET mongoc_static)
    # And an alias to the mongoc target for use in some test cases

--- a/cmake/ImportBSON.cmake
+++ b/cmake/ImportBSON.cmake
@@ -105,9 +105,12 @@ if (NOT DEFINED MONGOCRYPT_MONGOC_DIR)
    include (FetchMongoC)
    # The FetchMongoC module defines a MONGOCRYPT_MONGOC_DIR for us to use
 endif ()
+if (ENABLE_ONLINE_TESTS AND (MONGOCRYPT_MONGOC_DIR STREQUAL "USE-SYSTEM" OR USE_SHARED_LIBBSON))
+   message (FATAL_ERROR "Online tests requires static local build of libbson")
+endif ()
 
 function (_import_bson)
-   if (MONGOCRYPT_MONGOC_DIR STREQUAL "USE-SYSTEM" AND USE_SHARED_LIBBSON AND NOT ENABLE_ONLINE_TESTS)
+   if (MONGOCRYPT_MONGOC_DIR STREQUAL "USE-SYSTEM" AND USE_SHARED_LIBBSON)
       message (STATUS "NOTE: Using system-wide libbson library. This is intended only for package maintainers.")
       find_library (_MONGOCRYPT_SYSTEM_LIBBSON_SHARED "${CMAKE_SHARED_LIBRARY_PREFIX}bson-1.0${CMAKE_SHARED_LIBRARY_SUFFIX}")
       find_library (_MONGOCRYPT_SYSTEM_LIBBSON_STATIC "${CMAKE_STATIC_LIBRARY_PREFIX}bson-static-1.0${CMAKE_STATIC_LIBRARY_SUFFIX}")


### PR DESCRIPTION
see [jira's issue](https://jira.mongodb.org/projects/MONGOCRYPT/issues/MONGOCRYPT-583) for general intro. some comments now

* when loading system, only load the wanted library, so it creates target `bson_shared` if `USE_SHARED_LIBBSON` else `bson_shared`; that allows to have {shared,static}-only system library
* extract a function to actually perform the system library load that can be used by both shared and static; also fail early if lib not found
* now, `_mongocrypt-libbson_for_{shared,static}` links to shared only iff `USE_SHARED_LIBBSON` else to static
  * fun info: one can craft a static mongocrypt with a dynamic libbson (dunno why one would want that)
* move around some code
  * install static lib iff we localy built it
  * set runtime output of shared iff we localy built it
* for enforcing the local build for test, I wasn't really sure of the check you wanted to make, I took a broad one (fails if `test && (system || shared)`) but really depend on your use cases