### PR TITLE
MONGOCRYPT-586 port in C driver-specific KMS changes

### DIFF
--- a/kms-message/CMakeLists.txt
+++ b/kms-message/CMakeLists.txt
@@ -71,6 +71,14 @@ else()
          "KMS_MESSAGE_ENABLE_CRYPTO_LIBCRYPTO")
 endif()
 
+include (CheckSymbolExists)
+CHECK_SYMBOL_EXISTS (gmtime_r time.h KMS_MESSAGE_HAVE_GMTIME_R)
+if (KMS_MESSAGE_HAVE_GMTIME_R)
+   set (KMS_MESSAGE_DEFINITIONS
+         ${KMS_MESSAGE_DEFINITIONS}
+         "KMS_MESSAGE_HAVE_GMTIME_R")
+endif ()
+
 include (TestBigEndian)
 TEST_BIG_ENDIAN (KMS_BIG_ENDIAN)
 if (KMS_BIG_ENDIAN)
@@ -114,9 +122,9 @@ if (NOT DISABLE_NATIVE_CRYPTO)
    else()
       include (FindOpenSSL)
       target_link_libraries(kms_message "${OPENSSL_LIBRARIES}")
-      target_include_directories(kms_message PRIVATE "${OPENSSL_INCLUDE_DIR}")
+      target_include_directories(kms_message SYSTEM PRIVATE "${OPENSSL_INCLUDE_DIR}")
       target_link_libraries(kms_message_static "${OPENSSL_LIBRARIES}")
-      target_include_directories(kms_message_static PRIVATE "${OPENSSL_INCLUDE_DIR}")
+      target_include_directories(kms_message_static SYSTEM PRIVATE "${OPENSSL_INCLUDE_DIR}")
    endif()
 endif ()
 
@@ -259,7 +267,7 @@ if (NOT DISABLE_NATIVE_CRYPTO)
    else()
       include (FindOpenSSL)
       target_link_libraries(test_kms_request "${OPENSSL_LIBRARIES}")
-      target_include_directories(test_kms_request PRIVATE "${OPENSSL_INCLUDE_DIR}")
+      target_include_directories(test_kms_request SYSTEM PRIVATE "${OPENSSL_INCLUDE_DIR}")
    endif()
 
    add_test (

--- a/kms-message/src/kms_port.c
+++ b/kms-message/src/kms_port.c
@@ -18,7 +18,8 @@
 #if defined(_WIN32)
 #include <stdlib.h>
 #include <string.h>
-char * kms_strndup (const char *src, size_t len)
+char *
+kms_strndup (const char *src, size_t len)
 {
    char *dst = (char *) malloc (len + 1);
    if (!dst) {

--- a/kms-message/src/kms_request.c
+++ b/kms-message/src/kms_request.c
@@ -181,10 +181,12 @@ kms_request_set_date (kms_request_t *request, const struct tm *tm)
       /* use current time */
       time_t t;
       time (&t);
-#ifdef _WIN32
+#if defined(KMS_MESSAGE_HAVE_GMTIME_R)
+      gmtime_r (&t, &tmp_tm);
+#elif defined(_MSC_VER)
       gmtime_s (&tmp_tm, &t);
 #else
-      gmtime_r (&t, &tmp_tm);
+      tmp_tm = *gmtime (&t);
 #endif
       tm = &tmp_tm;
    }

--- a/kms-message/src/kms_request_str.c
+++ b/kms-message/src/kms_request_str.c
@@ -328,7 +328,7 @@ kms_request_str_append_stripped (kms_request_str_t *str,
 
    kms_request_str_reserve (str, appended->len);
 
-   // msvcrt is unhappy when it gets non-ANSI characters in isspace
+   /* msvcrt is unhappy when it gets non-ANSI characters in isspace */
    while (*src >= 0 && isspace (*src)) {
       ++src;
    }


### PR DESCRIPTION
Full Evergreen patch build: https://spruce.mongodb.com/version/64d65ca9850e610b584fe1e8/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC