### PR TITLE
MONGOCRYPT-512 fix warnings from -Wsign-compare

### DIFF
--- a/cmake/ImportBSON.cmake
+++ b/cmake/ImportBSON.cmake
@@ -144,15 +144,11 @@ function (_import_bson)
       set (ENABLE_CLIENT_SIDE_ENCRYPTION OFF CACHE BOOL "Disable client-side encryption for the libmongoc subproject")
       # Add the subdirectory as a project. EXCLUDE_FROM_ALL to inhibit building and installing of components unless requested
       # SYSTEM (on applicable CMake versions) to prevent warnings (particularly from -Wconversion/-Wsign-conversion) from the C driver code
-      # It is also necessary to prune -Werror, in the event it is present, regardless of CMake version
-      set(OLD_CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
-      string(REPLACE "-Werror" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
       if (CMAKE_VERSION VERSION_GREATER 3.25)
          add_subdirectory ("${MONGOCRYPT_MONGOC_DIR}" _mongo-c-driver EXCLUDE_FROM_ALL SYSTEM)
       else ()
          add_subdirectory ("${MONGOCRYPT_MONGOC_DIR}" _mongo-c-driver EXCLUDE_FROM_ALL)
       endif ()
-      set(CMAKE_C_FLAGS ${OLD_CMAKE_C_FLAGS})
       if (TARGET mongoc_static)
          # Workaround: Embedded mongoc_static does not set its INCLUDE_DIRECTORIES for user targets
          target_include_directories (mongoc_static

--- a/cmake/ImportBSON.cmake
+++ b/cmake/ImportBSON.cmake
@@ -144,11 +144,15 @@ function (_import_bson)
       set (ENABLE_CLIENT_SIDE_ENCRYPTION OFF CACHE BOOL "Disable client-side encryption for the libmongoc subproject")
       # Add the subdirectory as a project. EXCLUDE_FROM_ALL to inhibit building and installing of components unless requested
       # SYSTEM (on applicable CMake versions) to prevent warnings (particularly from -Wconversion/-Wsign-conversion) from the C driver code
+      # It is also necessary to prune -Werror, in the event it is present, regardless of CMake version
+      set(OLD_CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
+      string(REPLACE "-Werror" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
       if (CMAKE_VERSION VERSION_GREATER 3.25)
          add_subdirectory ("${MONGOCRYPT_MONGOC_DIR}" _mongo-c-driver EXCLUDE_FROM_ALL SYSTEM)
       else ()
          add_subdirectory ("${MONGOCRYPT_MONGOC_DIR}" _mongo-c-driver EXCLUDE_FROM_ALL)
       endif ()
+      set(CMAKE_C_FLAGS ${OLD_CMAKE_C_FLAGS})
       if (TARGET mongoc_static)
          # Workaround: Embedded mongoc_static does not set its INCLUDE_DIRECTORIES for user targets
          target_include_directories (mongoc_static

--- a/src/crypto/libcrypto.c
+++ b/src/crypto/libcrypto.c
@@ -71,8 +71,8 @@ static bool _encrypt_with_cipher(const EVP_CIPHER *cipher, aes_256_args_t args) 
     BSON_ASSERT(args.out);
     BSON_ASSERT(ctx);
     BSON_ASSERT(cipher);
-    BSON_ASSERT(NULL == args.iv || EVP_CIPHER_iv_length(cipher) == args.iv->len);
-    BSON_ASSERT(EVP_CIPHER_key_length(cipher) == args.key->len);
+    BSON_ASSERT(NULL == args.iv || (uint32_t)EVP_CIPHER_iv_length(cipher) == args.iv->len);
+    BSON_ASSERT((uint32_t)EVP_CIPHER_key_length(cipher) == args.key->len);
     BSON_ASSERT(args.in->len <= INT_MAX);
 
     if (!EVP_EncryptInit_ex(ctx, cipher, NULL /* engine */, args.key->data, NULL == args.iv ? NULL : args.iv->data)) {
@@ -97,7 +97,7 @@ static bool _encrypt_with_cipher(const EVP_CIPHER *cipher, aes_256_args_t args) 
         goto done;
     }
 
-    BSON_ASSERT(UINT32_MAX - *args.bytes_written >= intermediate_bytes_written);
+    BSON_ASSERT(UINT32_MAX - *args.bytes_written >= (uint32_t)intermediate_bytes_written);
     *args.bytes_written += (uint32_t)intermediate_bytes_written;
 
     ret = true;
@@ -127,8 +127,8 @@ static bool _decrypt_with_cipher(const EVP_CIPHER *cipher, aes_256_args_t args) 
     BSON_ASSERT(args.key);
     BSON_ASSERT(args.in);
     BSON_ASSERT(args.out);
-    BSON_ASSERT(EVP_CIPHER_iv_length(cipher) == args.iv->len);
-    BSON_ASSERT(EVP_CIPHER_key_length(cipher) == args.key->len);
+    BSON_ASSERT((uint32_t)EVP_CIPHER_iv_length(cipher) == args.iv->len);
+    BSON_ASSERT((uint32_t)EVP_CIPHER_key_length(cipher) == args.key->len);
     BSON_ASSERT(args.in->len <= INT_MAX);
 
     if (!EVP_DecryptInit_ex(ctx, cipher, NULL /* engine */, args.key->data, args.iv->data)) {
@@ -154,7 +154,7 @@ static bool _decrypt_with_cipher(const EVP_CIPHER *cipher, aes_256_args_t args) 
         goto done;
     }
 
-    BSON_ASSERT(UINT32_MAX - *args.bytes_written >= intermediate_bytes_written);
+    BSON_ASSERT(UINT32_MAX - *args.bytes_written >= (uint32_t)intermediate_bytes_written);
     *args.bytes_written += (uint32_t)intermediate_bytes_written;
 
     ret = true;

--- a/src/mc-fle2-encryption-placeholder.c
+++ b/src/mc-fle2-encryption-placeholder.c
@@ -186,7 +186,7 @@ bool mc_validate_sparsity(int64_t sparsity, mongocrypt_status_t *status) {
         return false;
     }
     // mc_getEdgesInt expects a size_t sparsity.
-    if (sparsity >= SIZE_MAX) {
+    if ((uint64_t)sparsity >= SIZE_MAX) {
         CLIENT_ERR("sparsity must be < %zu, got: %" PRId64, SIZE_MAX, sparsity);
         return false;
     }

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1927,7 +1927,10 @@ static void _test_encrypt_fle2_encryption_placeholder(_mongocrypt_tester_t *test
     char pathbuf[2048];
 
 #define MAKE_PATH(mypath)                                                                                              \
-    ASSERT(snprintf(pathbuf, sizeof(pathbuf), "./test/data/%s/%s", data_path, mypath) < sizeof(pathbuf))
+    {                                                                                                                  \
+        int pathbuf_ret = snprintf(pathbuf, sizeof(pathbuf), "./test/data/%s/%s", data_path, mypath);                  \
+        ASSERT(pathbuf_ret >= 0 && (size_t)pathbuf_ret < sizeof(pathbuf));                                             \
+    }
 
     if (!_aes_ctr_is_supported_by_os) {
         printf("Common Crypto with no CTR support detected. Skipping.");

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1927,10 +1927,11 @@ static void _test_encrypt_fle2_encryption_placeholder(_mongocrypt_tester_t *test
     char pathbuf[2048];
 
 #define MAKE_PATH(mypath)                                                                                              \
-    {                                                                                                                  \
+    if (1) {                                                                                                           \
         int pathbuf_ret = snprintf(pathbuf, sizeof(pathbuf), "./test/data/%s/%s", data_path, mypath);                  \
         ASSERT(pathbuf_ret >= 0 && (size_t)pathbuf_ret < sizeof(pathbuf));                                             \
-    }
+    } else                                                                                                             \
+        ((void)0)
 
     if (!_aes_ctr_is_supported_by_os) {
         printf("Common Crypto with no CTR support detected. Skipping.");


### PR DESCRIPTION
Some simple tweaks.

It would be helpful if we ran all our CI builds with `-Wall -Werror`, but when I tried to enable that it quickly became apparent that there are multiple moving parts that need to be sorted out. As a result, I am going to write a separate ticket for that work.