### PR TITLE
MONGOCRYPT-589 Add bulk decrypt benchmark with Java bindings

### DIFF
--- a/.evergreen/benchmark-java.sh
+++ b/.evergreen/benchmark-java.sh
@@ -17,8 +17,8 @@ run_cmake \
     -B"$build_dir"
 run_cmake --build "$build_dir" --target install
 
-# Run Java benchmarks.
-export JAVA_HOME=/opt/java/jdk8
+# Run Java benchmarks. Do not use JDK 8 to avoid hang in gradle observed in MONGOCRYPT-590.
+export JAVA_HOME=/opt/java/jdk17
 # Include path to installed libmongocrypt.so
 export LD_LIBRARY_PATH="$MONGOCRYPT_INSTALL_PREFIX/lib64"
 cd bindings/java/mongocrypt

--- a/.evergreen/benchmark-java.sh
+++ b/.evergreen/benchmark-java.sh
@@ -23,4 +23,5 @@ export JAVA_HOME=/opt/java/jdk8
 export LD_LIBRARY_PATH="$MONGOCRYPT_INSTALL_PREFIX/lib64"
 cd bindings/java/mongocrypt
 ./gradlew --version
-./gradlew clean benchmarks:run --info
+# `-DgitRevision=${GIT_REVISION}` is set to work around an observed hang noted in MONGOCRYPT-590.
+./gradlew clean benchmarks:run --info -DgitRevision=${GIT_REVISION}

--- a/.evergreen/benchmark-java.sh
+++ b/.evergreen/benchmark-java.sh
@@ -23,5 +23,4 @@ export JAVA_HOME=/opt/java/jdk8
 export LD_LIBRARY_PATH="$MONGOCRYPT_INSTALL_PREFIX/lib64"
 cd bindings/java/mongocrypt
 ./gradlew --version
-# `-DgitRevision=${GIT_REVISION}` is set to work around an observed hang noted in MONGOCRYPT-590.
-./gradlew clean benchmarks:run --info -DgitRevision=${GIT_REVISION}
+./gradlew clean benchmarks:run --info

--- a/.evergreen/benchmark-java.sh
+++ b/.evergreen/benchmark-java.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+. "$(dirname "${BASH_SOURCE[0]}")/init.sh"
+
+if test "$OS_NAME" != "linux"; then
+    log "Warning: Script is expected only to run on distro: rhel90-dbx-perf-large"
+    log "More changes may be needed to run on other distros.";
+fi
+
+MONGOCRYPT_INSTALL_PREFIX=$LIBMONGOCRYPT_DIR/.install
+
+# Install libmongocrypt.
+build_dir="$LIBMONGOCRYPT_DIR/cmake-build"
+run_cmake \
+    -DCMAKE_INSTALL_PREFIX="$MONGOCRYPT_INSTALL_PREFIX" \
+    -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
+    -B"$build_dir"
+run_cmake --build "$build_dir" --target install
+
+# Run Java benchmarks.
+export JAVA_HOME=/opt/java/jdk8
+# Include path to installed libmongocrypt.so
+export LD_LIBRARY_PATH="$MONGOCRYPT_INSTALL_PREFIX/lib64"
+cd bindings/java/mongocrypt
+./gradlew --version
+./gradlew clean benchmarks:run --info

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -970,6 +970,19 @@ tasks:
     - func: fetch source
     - func: lint-node-typescript
 
+- name: benchmark-java
+  commands:
+    - func: "fetch source"
+    - command: "subprocess.exec"
+      params:
+        binary: bash
+        working_dir: "./libmongocrypt"
+        args:
+          - "./.evergreen/benchmark-java.sh"
+    - command: "perf.send"
+      params:
+        file: libmongocrypt/bindings/java/mongocrypt/benchmarks/results.json
+
 pre:
   # Update the evergreen expansion to dynamically set the ${libmongocrypt_s3_suffix} and ${libmongocrypt_s3_suffix_copy} expansions.
   - command: "shell.exec"
@@ -1546,3 +1559,10 @@ buildvariants:
     vs_target_arch: x86
   tasks:
   - build-and-test-and-upload
+
+- name: benchmark
+  display_name: "Benchmark"
+  # rhel90-dbx-perf-large is the dedicated performance distro referenced in DRIVERS-2666.
+  run_on: rhel90-dbx-perf-large
+  tasks:
+  - benchmark-java

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -977,6 +977,8 @@ tasks:
       params:
         binary: bash
         working_dir: "./libmongocrypt"
+        env:
+          GIT_REVISION: ${revision}
         args:
           - "./.evergreen/benchmark-java.sh"
     - command: "perf.send"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -977,8 +977,6 @@ tasks:
       params:
         binary: bash
         working_dir: "./libmongocrypt"
-        env:
-          GIT_REVISION: ${revision}
         args:
           - "./.evergreen/benchmark-java.sh"
     - command: "perf.send"

--- a/bindings/java/mongocrypt/benchmarks/build.gradle.kts
+++ b/bindings/java/mongocrypt/benchmarks/build.gradle.kts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+plugins {
+    id("application")
+}
+
+application {
+    mainClass.set("com.mongodb.crypt.benchmark.BenchmarkRunner")
+}
+
+dependencies {
+    implementation(project(":")) // Reference to the parent project
+}

--- a/bindings/java/mongocrypt/benchmarks/src/main/java/com/mongodb/crypt/benchmark/BenchmarkRunner.java
+++ b/bindings/java/mongocrypt/benchmarks/src/main/java/com/mongodb/crypt/benchmark/BenchmarkRunner.java
@@ -117,13 +117,13 @@ public class BenchmarkRunner {
                 }
             }
 
-            String created_at = ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
+            String createdAt = ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
             // Warm up benchmark and discard the result.
             measureMedianOpsPerSecOfDecrypt(mongoCrypt, encrypted, NUM_WARMUP_SECS);
             // Decrypt `encrypted` and measure ops/sec.
             long medianOpsPerSec = measureMedianOpsPerSecOfDecrypt(mongoCrypt, encrypted, NUM_SECS);
             System.out.printf("Decrypting 1500 fields median ops/sec : %d%n", medianOpsPerSec);
-            String completed_at = ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
+            String completedAt = ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
 
             // Print the results in JSON that can be accepted by the `perf.send` command.
             // See https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Project-Commands#perfsend for the expected `perf.send` input.
@@ -131,8 +131,8 @@ public class BenchmarkRunner {
                     Arrays.asList(
                             new BsonDocument()
                                     .append("info", new BsonDocument().append("test_name", new BsonString("java_decrypt_1500")))
-                                    .append("created_at", new BsonString(created_at))
-                                    .append("completed_at", new BsonString(completed_at))
+                                    .append("created_at", new BsonString(createdAt))
+                                    .append("completed_at", new BsonString(completedAt))
                                     .append("artifacts", new BsonArray())
                                     .append("metrics", new BsonArray(Arrays.asList(
                                             new BsonDocument()

--- a/bindings/java/mongocrypt/benchmarks/src/main/java/com/mongodb/crypt/benchmark/BenchmarkRunner.java
+++ b/bindings/java/mongocrypt/benchmarks/src/main/java/com/mongodb/crypt/benchmark/BenchmarkRunner.java
@@ -89,10 +89,6 @@ public class BenchmarkRunner {
     }
 
     public static void main(String[] args) throws IOException {
-        if (System.getenv("QUICK") != null && System.getenv("QUICK").equals("ON")) {
-            System.out.printf("QUICK=ON is set. Using NUM_SECS=3%n");
-            NUM_SECS = 3;
-        }
         System.out.printf("BenchmarkRunner is using libmongocrypt version=%s, NUM_WARMUP_SECS=%d, NUM_SECS=%d%n", CAPI.mongocrypt_version(null).toString(), NUM_WARMUP_SECS, NUM_SECS);
         // `keyDocument` is a Data Encryption Key (DEK) encrypted with the Key Encryption Key (KEK) `LOCAL_MASTER_KEY`.
         BsonDocument keyDocument = getResourceAsDocument("keyDocument.json");

--- a/bindings/java/mongocrypt/benchmarks/src/main/java/com/mongodb/crypt/benchmark/BenchmarkRunner.java
+++ b/bindings/java/mongocrypt/benchmarks/src/main/java/com/mongodb/crypt/benchmark/BenchmarkRunner.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2023-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.crypt.benchmark;
+
+import com.mongodb.crypt.capi.*;
+import org.bson.*;
+
+import java.io.*;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+public class BenchmarkRunner {
+    static final int NUM_FIELDS = 1500;
+    static int NUM_WARMUP_SECS = 2;
+    static int NUM_SECS = 10;
+    static final byte[] LOCAL_MASTER_KEY = new byte[]{
+            -99, -108, 75, 13, -109, -48, -59, 68, -91, 114, -3, 50, 27, -108, 48, -112, 35, 53,
+            115, 124, -16, -10, -62, -12, -38, 35, 86, -25, -113, 4, -52, -6, -34, 117, -76, 81,
+            -121, -13, -117, -105, -41, 75, 68, 59, -84, 57, -94, -58, 77, -111, 0, 62, -47, -6, 74,
+            48, -63, -46, -58, 94, -5, -84, 65, -14, 72, 19, 60, -101, 80, -4, -89, 36, 122, 46, 2,
+            99, -93, -58, 22, 37, 81, 80, 120, 62, 15, -40, 110, -124, -90, -20, -115, 45, 36, 71,
+            -27, -81
+    };
+
+    private static String getFileAsString(final String fileName, String lineSeparator) {
+        try {
+            URL resource = BenchmarkRunner.class.getResource("/" + fileName);
+            if (resource == null) {
+                throw new RuntimeException("Could not find file " + fileName);
+            }
+            File file = new File(resource.toURI());
+            StringBuilder stringBuilder = new StringBuilder();
+            String line;
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(Files.newInputStream(file.toPath()), StandardCharsets.UTF_8))) {
+                boolean first = true;
+                while ((line = reader.readLine()) != null) {
+                    if (!first) {
+                        stringBuilder.append(lineSeparator);
+                    }
+                    first = false;
+                    stringBuilder.append(line);
+                }
+            }
+            return stringBuilder.toString();
+        } catch (Throwable t) {
+            throw new RuntimeException("Could not parse file " + fileName, t);
+        }
+    }
+
+    private static BsonDocument getResourceAsDocument(final String fileName) {
+        return BsonDocument.parse(getFileAsString(fileName, System.getProperty("line.separator")));
+    }
+
+    private static MongoCrypt createMongoCrypt() {
+        return MongoCrypts.create(MongoCryptOptions
+                .builder()
+                .localKmsProviderOptions(MongoLocalKmsProviderOptions.builder()
+                        .localMasterKey(ByteBuffer.wrap(LOCAL_MASTER_KEY))
+                        .build())
+                .build());
+    }
+
+    private static long measureMedianOpsPerSecOfDecrypt(MongoCrypt mongoCrypt, BsonDocument toDecrypt) {
+        ArrayList<Long> opsPerSecs = new ArrayList<Long>(NUM_SECS);
+        for (int i = 0; i < NUM_WARMUP_SECS + NUM_SECS; i++) {
+            long opsPerSec = 0;
+            long start = System.nanoTime();
+            // Run for one second.
+            while (System.nanoTime() - start < 1_000_000_000) {
+                try (MongoCryptContext ctx = mongoCrypt.createDecryptionContext(toDecrypt)) {
+                    assert ctx.getState() == MongoCryptContext.State.READY;
+                    RawBsonDocument result = ctx.finish();
+                    int gotSize = result.size();
+                    if (gotSize != NUM_FIELDS) {
+                        throw new RuntimeException("Expected size: " + NUM_FIELDS + ", got " + gotSize);
+                    }
+                    opsPerSec++;
+                }
+            }
+            if (i > NUM_WARMUP_SECS) {
+                opsPerSecs.add(opsPerSec);
+            }
+        }
+        Collections.sort(opsPerSecs);
+        return opsPerSecs.get(NUM_SECS / 2);
+    }
+
+    public static void main(String[] args) throws IOException {
+        if (System.getenv("QUICK") != null && System.getenv("QUICK").equals("ON")) {
+            System.out.printf("QUICK=ON is set. Using NUM_SECS=3%n");
+            NUM_SECS = 3;
+        }
+        System.out.printf("BenchmarkRunner is using libmongocrypt version=%s, NUM_WARMUP_SECS=%d, NUM_SECS=%d%n", CAPI.mongocrypt_version(null).toString(), NUM_WARMUP_SECS, NUM_SECS);
+        // `keyDocument` is a Data Encryption Key (DEK) encrypted with the Key Encryption Key (KEK) `LOCAL_MASTER_KEY`.
+        BsonDocument keyDocument = getResourceAsDocument("keyDocument.json");
+        try (MongoCrypt mongoCrypt = createMongoCrypt()) {
+            // `encrypted` will contain encrypted fields.
+            BsonDocument encrypted = new BsonDocument();
+            {
+                for (int i = 0; i < NUM_FIELDS; i++) {
+                    MongoExplicitEncryptOptions options = MongoExplicitEncryptOptions.builder()
+                            .keyId(new BsonBinary(BsonBinarySubType.UUID_STANDARD, Base64.getDecoder().decode("YWFhYWFhYWFhYWFhYWFhYQ==")))
+                            .algorithm("AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic")
+                            .build();
+                    BsonDocument toEncrypt = new BsonDocument("v", new BsonString(String.format("value %04d", i)));
+                    try (MongoCryptContext ctx = mongoCrypt.createExplicitEncryptionContext(toEncrypt, options)) {
+                        // If mongocrypt_t has not yet cached the DEK, supply it.
+                        if (MongoCryptContext.State.NEED_MONGO_KEYS == ctx.getState()) {
+                            ctx.addMongoOperationResult(keyDocument);
+                            ctx.completeMongoOperation();
+                        }
+                        assert ctx.getState() == MongoCryptContext.State.READY;
+                        RawBsonDocument result = ctx.finish();
+                        BsonValue encryptedValue = result.get("v");
+                        String key = String.format("key%04d", i);
+                        encrypted.append(key, encryptedValue);
+                    }
+                }
+            }
+
+            String created_at = ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
+            // Decrypt `encrypted` and measure ops/sec.
+            long medianOpsPerSec = measureMedianOpsPerSecOfDecrypt(mongoCrypt, encrypted);
+            System.out.printf("Decrypting 1500 fields median ops/sec : %d%n", medianOpsPerSec);
+            String completed_at = ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
+
+            // Print the results in JSON that can be accepted by the `perf.send` command.
+            // See https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Project-Commands#perfsend for the expected `perf.send` input.
+            BsonDocument results = new BsonDocument().append("results", new BsonArray(
+                    Arrays.asList(
+                            new BsonDocument()
+                                    .append("info", new BsonDocument().append("test_name", new BsonString("java_decrypt_1500")))
+                                    .append("created_at", new BsonString(created_at))
+                                    .append("completed_at", new BsonString(completed_at))
+                                    .append("artifacts", new BsonArray())
+                                    .append("metrics", new BsonArray(Arrays.asList(
+                                            new BsonDocument()
+                                                    .append("name", new BsonString("medianOpsPerSec"))
+                                                    .append("type", new BsonString("THROUGHPUT"))
+                                                    .append("value", new BsonInt64(medianOpsPerSec))
+                                    )))
+                                    .append("sub_tests", new BsonArray())
+                    )
+            ));
+            String resultsString = results.toJson();
+            // Remove the prefix and suffix when writing to a file so only the [ ... ] array is included.
+            resultsString = resultsString.substring("{\"results\": ".length(), resultsString.length() - 1);
+
+            String resultsFilePath = "results.json";
+            try (OutputStreamWriter fileWriter = new OutputStreamWriter(new FileOutputStream(resultsFilePath), StandardCharsets.UTF_8)) {
+                fileWriter.write(resultsString);
+            }
+            System.out.println("Results written to file: " + resultsFilePath);
+        }
+    }
+}

--- a/bindings/java/mongocrypt/benchmarks/src/main/java/com/mongodb/crypt/benchmark/BenchmarkRunner.java
+++ b/bindings/java/mongocrypt/benchmarks/src/main/java/com/mongodb/crypt/benchmark/BenchmarkRunner.java
@@ -33,8 +33,8 @@ import java.util.*;
 
 public class BenchmarkRunner {
     static final int NUM_FIELDS = 1500;
-    static int NUM_WARMUP_SECS = 2;
-    static int NUM_SECS = 10;
+    static final int NUM_WARMUP_SECS = 2;
+    static final int NUM_SECS = 10;
     static final byte[] LOCAL_MASTER_KEY = new byte[]{
             -99, -108, 75, 13, -109, -48, -59, 68, -91, 114, -3, 50, 27, -108, 48, -112, 35, 53,
             115, 124, -16, -10, -62, -12, -38, 35, 86, -25, -113, 4, -52, -6, -34, 117, -76, 81,

--- a/bindings/java/mongocrypt/benchmarks/src/main/java/com/mongodb/crypt/benchmark/BenchmarkRunner.java
+++ b/bindings/java/mongocrypt/benchmarks/src/main/java/com/mongodb/crypt/benchmark/BenchmarkRunner.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -43,34 +44,20 @@ public class BenchmarkRunner {
             -27, -81
     };
 
-    private static String getFileAsString(final String fileName, String lineSeparator) {
+    private static String getFileAsString(final String fileName) {
         try {
             URL resource = BenchmarkRunner.class.getResource("/" + fileName);
             if (resource == null) {
                 throw new RuntimeException("Could not find file " + fileName);
             }
-            File file = new File(resource.toURI());
-            StringBuilder stringBuilder = new StringBuilder();
-            String line;
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(Files.newInputStream(file.toPath()), StandardCharsets.UTF_8))) {
-                boolean first = true;
-                while ((line = reader.readLine()) != null) {
-                    if (!first) {
-                        stringBuilder.append(lineSeparator);
-                    }
-                    first = false;
-                    stringBuilder.append(line);
-                }
-            }
-            return stringBuilder.toString();
+            return Files.readString(Path.of(resource.toURI()));
         } catch (Throwable t) {
             throw new RuntimeException("Could not parse file " + fileName, t);
         }
     }
 
     private static BsonDocument getResourceAsDocument(final String fileName) {
-        return BsonDocument.parse(getFileAsString(fileName, System.getProperty("line.separator")));
+        return BsonDocument.parse(getFileAsString(fileName));
     }
 
     private static MongoCrypt createMongoCrypt() {

--- a/bindings/java/mongocrypt/benchmarks/src/main/java/com/mongodb/crypt/benchmark/BenchmarkRunner.java
+++ b/bindings/java/mongocrypt/benchmarks/src/main/java/com/mongodb/crypt/benchmark/BenchmarkRunner.java
@@ -78,11 +78,7 @@ public class BenchmarkRunner {
             while (System.nanoTime() - start < 1_000_000_000) {
                 try (MongoCryptContext ctx = mongoCrypt.createDecryptionContext(toDecrypt)) {
                     assert ctx.getState() == MongoCryptContext.State.READY;
-                    RawBsonDocument result = ctx.finish();
-                    int gotSize = result.size();
-                    if (gotSize != NUM_FIELDS) {
-                        throw new RuntimeException("Expected size: " + NUM_FIELDS + ", got " + gotSize);
-                    }
+                    ctx.finish();
                     opsPerSec++;
                 }
             }

--- a/bindings/java/mongocrypt/benchmarks/src/main/java/com/mongodb/crypt/benchmark/BenchmarkRunner.java
+++ b/bindings/java/mongocrypt/benchmarks/src/main/java/com/mongodb/crypt/benchmark/BenchmarkRunner.java
@@ -69,9 +69,9 @@ public class BenchmarkRunner {
                 .build());
     }
 
-    private static long measureMedianOpsPerSecOfDecrypt(MongoCrypt mongoCrypt, BsonDocument toDecrypt) {
-        ArrayList<Long> opsPerSecs = new ArrayList<Long>(NUM_SECS);
-        for (int i = 0; i < NUM_WARMUP_SECS + NUM_SECS; i++) {
+    private static long measureMedianOpsPerSecOfDecrypt(MongoCrypt mongoCrypt, BsonDocument toDecrypt, int numSecs) {
+        ArrayList<Long> opsPerSecs = new ArrayList<Long>(numSecs);
+        for (int i = 0; i < numSecs; i++) {
             long opsPerSec = 0;
             long start = System.nanoTime();
             // Run for one second.
@@ -86,12 +86,10 @@ public class BenchmarkRunner {
                     opsPerSec++;
                 }
             }
-            if (i > NUM_WARMUP_SECS) {
-                opsPerSecs.add(opsPerSec);
-            }
+            opsPerSecs.add(opsPerSec);
         }
         Collections.sort(opsPerSecs);
-        return opsPerSecs.get(NUM_SECS / 2);
+        return opsPerSecs.get(numSecs / 2);
     }
 
     public static void main(String[] args) throws IOException {
@@ -128,8 +126,10 @@ public class BenchmarkRunner {
             }
 
             String created_at = ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
+            // Warm up benchmark and discard the result.
+            measureMedianOpsPerSecOfDecrypt(mongoCrypt, encrypted, NUM_WARMUP_SECS);
             // Decrypt `encrypted` and measure ops/sec.
-            long medianOpsPerSec = measureMedianOpsPerSecOfDecrypt(mongoCrypt, encrypted);
+            long medianOpsPerSec = measureMedianOpsPerSecOfDecrypt(mongoCrypt, encrypted, NUM_SECS);
             System.out.printf("Decrypting 1500 fields median ops/sec : %d%n", medianOpsPerSec);
             String completed_at = ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
 

--- a/bindings/java/mongocrypt/benchmarks/src/main/java/com/mongodb/crypt/benchmark/BenchmarkRunner.java
+++ b/bindings/java/mongocrypt/benchmarks/src/main/java/com/mongodb/crypt/benchmark/BenchmarkRunner.java
@@ -25,7 +25,7 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -50,7 +50,7 @@ public class BenchmarkRunner {
             if (resource == null) {
                 throw new RuntimeException("Could not find file " + fileName);
             }
-            return Files.readString(Path.of(resource.toURI()));
+            return new String(Files.readAllBytes(Paths.get(resource.toURI())));
         } catch (Throwable t) {
             throw new RuntimeException("Could not parse file " + fileName, t);
         }

--- a/bindings/java/mongocrypt/benchmarks/src/main/resources/keyDocument.json
+++ b/bindings/java/mongocrypt/benchmarks/src/main/resources/keyDocument.json
@@ -1,0 +1,24 @@
+{
+  "_id": {
+    "$binary": {
+      "base64": "YWFhYWFhYWFhYWFhYWFhYQ==",
+      "subType": "04"
+    }
+  },
+  "keyMaterial": {
+    "$binary": {
+      "base64": "ACR7Hm33dDOAAD7l2ubZhSpSUWK8BkALUY+qW3UgBAEcTV8sBwZnaAWnzDsmrX55dgmYHWfynDlJogC/e33u6pbhyXvFTs5ow9OLCuCWBJ39T/Ivm3kMaZJybkejY0V+uc4UEdHvVVz/SbitVnzs2WXdMGmo1/HmDRrxGYZjewFslquv8wtUHF5pyB+QDlQBd/al9M444/8bJZFbMSmtIg==",
+      "subType": "00"
+    }
+  },
+  "creationDate": {
+    "$date": "2023-08-21T14:28:20.875Z"
+  },
+  "updateDate": {
+    "$date": "2023-08-21T14:28:20.875Z"
+  },
+  "status": 0,
+  "masterKey": {
+    "provider": "local"
+  }
+}

--- a/bindings/java/mongocrypt/build.gradle.kts
+++ b/bindings/java/mongocrypt/build.gradle.kts
@@ -37,9 +37,11 @@ plugins {
     id("biz.aQute.bnd.builder") version "6.2.0"
 }
 
-repositories {
-    mavenCentral()
-    google()
+allprojects {
+    repositories {
+        mavenCentral()
+        google()
+    }
 }
 
 group = "org.mongodb"

--- a/bindings/java/mongocrypt/settings.gradle.kts
+++ b/bindings/java/mongocrypt/settings.gradle.kts
@@ -1,0 +1,1 @@
+include("benchmarks")


### PR DESCRIPTION
# Summary

Add a benchmark in the Java bindings to measure throughput of decrypting documents with many encrypted values.

This PR partially resolves MONGOCRYPT-589. A following PR is planned to export the struct definition of `mongocrypt_binary_t` and update bindings to avoid calls to `mongocrypt_binary_data` and `mongocrypt_binary_len`.

# Background & Motivation

The benchmark is intended to measure the workload identified in DRIVERS-2581 and compare future changes.

The benchmark uses the `rhel90-dbx-perf-large` distro suggested in DRIVERS-2666. The results appears stable: [10 executions](https://spruce.mongodb.com/task/libmongocrypt_benchmark_benchmark_java_patch_f6817fa54b4913d42b8f8718577f4884133530fb_64eca5d2a4cf47658d19ef8d_23_08_28_13_49_06/logs?execution=9) produced the same `Decrypting median ops/sec` of `31`.

[Java Microbenchmarking Harness (JMH)](https://github.com/openjdk/jmh) was briefly considered but decidedly not used. JMH does not have native Gradle support. 

The task uses JDK 8. I am not sure if JDK 8 is needed or wanted. JDK 8 was used for consistency with the existing `test-java` task. Use of JDK 8 resulted in an observed hang in Gradle configure documented in MONGOCRYPT-590. A work around was applied in https://github.com/mongodb/libmongocrypt/pull/690/commits/2cb869ae3f963d021cfcc31e370344973aad8727.