### PR TITLE
ci(NODE-5604): use npm 9 on eol node versions

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -147,6 +147,7 @@ functions:
           DISTRO_ID: ${distro_id}
           BUILD_VARIANT: ${build_variant}
           NODE_LTS_VERSION: ${node_lts_version|16}
+          NPM_VERSION: "9"
 
 
   "build and publish node":
@@ -162,6 +163,7 @@ functions:
           DISTRO_ID: ${distro_id}
           BUILD_VARIANT: ${build_variant}
           NODE_LTS_VERSION: ${node_lts_version|16}
+          NPM_VERSION: "9"
 
   "attach node xunit results":
     - command: attach.xunit_results
@@ -371,6 +373,7 @@ functions:
         env:
           PROJECT_DIRECTORY: ${project_directory}
           NODE_LTS_VERSION: ${node_lts_version|16}
+          NPM_VERSION: "9"
           LINT_TARGET: cpp
 
   lint-node-typescript:
@@ -383,6 +386,7 @@ functions:
         env:
           PROJECT_DIRECTORY: ${project_directory}
           NODE_LTS_VERSION: ${node_lts_version|16}
+          NPM_VERSION: "9"
           LINT_TARGET: typescript
 
 tasks:

--- a/bindings/node/.evergreen/install-dependencies.sh
+++ b/bindings/node/.evergreen/install-dependencies.sh
@@ -2,7 +2,9 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 NODE_LTS_VERSION=${NODE_LTS_VERSION:-16}
-NODE_LOWEST_LTS=18
+# npm version can be defined in the environment for cases where we need to install
+# a version lower than latest to support EOL Node versions.
+NPM_VERSION=${NPM_VERSION:-latest}
 
 source "${PROJECT_DIRECTORY}/libmongocrypt/bindings/node/.evergreen/init-node-and-npm-env.sh"
 
@@ -95,12 +97,7 @@ else
 fi
 
 if [[ $operating_system != "win" ]]; then
-  # Update npm to latest when we can
-  if [[ $NODE_LTS_VERSION -lt $NODE_LOWEST_LTS ]]; then
-    npm install --global npm@9
-  else
-    npm install --global npm@latest
-  fi
+  npm install --global npm@$NPM_VERSION
   hash -r
 fi
 

--- a/bindings/node/.evergreen/install-dependencies.sh
+++ b/bindings/node/.evergreen/install-dependencies.sh
@@ -2,6 +2,7 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 NODE_LTS_VERSION=${NODE_LTS_VERSION:-16}
+NODE_LOWEST_LTS=18
 
 source "${PROJECT_DIRECTORY}/libmongocrypt/bindings/node/.evergreen/init-node-and-npm-env.sh"
 
@@ -95,7 +96,11 @@ fi
 
 if [[ $operating_system != "win" ]]; then
   # Update npm to latest when we can
-  npm install --global npm@latest
+  if [[ $NODE_LTS_VERSION -lt $NODE_LOWEST_LTS ]]; then
+    npm install --global npm@9
+  else
+    npm install --global npm@latest
+  fi
   hash -r
 fi
 


### PR DESCRIPTION
Fixes Node 16 failures on npm latest.