### PR TITLE
MONGOCRYPT-589 export `mongocrypt_binary_t`

### DIFF
--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
@@ -92,7 +92,7 @@ public class CAPI {
             // Representing `uint32_t` values greater than INT32_MAX is represented as a negative `int`.
             // Throw an exception. mongocrypt_binary_t is not expected to use lengths greater than INT32_MAX.
             if (len < 0) {
-                throw new IllegalArgumentException(
+                throw new AssertionError(
                         String.format("Expected mongocrypt_binary_t length to be non-negative, got: %d", len));
             }
             return len;

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
@@ -87,7 +87,16 @@ public class CAPI {
             return this.getPointer().getPointer(0);
         }
         public int len() {
-            return this.getPointer().getInt(Native.POINTER_SIZE);
+            int len = this.getPointer().getInt(Native.POINTER_SIZE);
+            // mongocrypt_binary_t represents length as an unsigned `uint32_t`.
+            // Representing `uint32_t` values greater than INT32_MAX is represented as a negative `int`.
+            // Throw an exception. mongocrypt_binary_t is not expected to use lengths greater than INT32_MAX.
+            if (len < 0) {
+                throw new IllegalArgumentException(
+                        String.format("Expected mongocrypt_binary_t length to be non-negative, got: %d", len));
+            }
+            return len;
+
         }
     }
 

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
@@ -75,7 +75,7 @@ public class CAPI {
     public static class mongocrypt_binary_t extends PointerType {
         // The `mongocrypt_binary_t` struct layout is part of libmongocrypt's ABI:
         // typedef struct _mongocrypt_binary_t {
-        //     uint8_t *data;
+        //     void *data;
         //     uint32_t len;
         // } mongocrypt_binary_t;
         // To improve performance, fields are read directly using `getPointer` and `getInt`.

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
@@ -73,6 +73,22 @@ public class CAPI {
      * mongocrypt_binary_destroy.
      */
     public static class mongocrypt_binary_t extends PointerType {
+        // The `mongocrypt_binary_t` struct layout is part of libmongocrypt's ABI:
+        // typedef struct _mongocrypt_binary_t {
+        //     uint8_t *data;
+        //     uint32_t len;
+        // } mongocrypt_binary_t;
+        // To improve performance, fields are read directly using `getPointer` and `getInt`.
+        // This results in observed performance improvements over using of `mongocrypt_binary_data` and `mongocrypt_binary_len`. Refer: MONGOCRYPT-589.
+        public mongocrypt_binary_t() {
+            super();
+        }
+        public Pointer data() {
+            return this.getPointer().getPointer(0);
+        }
+        public int len() {
+            return this.getPointer().getInt(Native.POINTER_SIZE);
+        }
     }
 
     /**

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPIHelper.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPIHelper.java
@@ -84,7 +84,7 @@ final class CAPIHelper {
 
     static void writeByteArrayToBinary(final mongocrypt_binary_t binary, byte[] bytes) {
         if (binary.len() < bytes.length) {
-            throw new AssertionError(format("mongocrypt binary of length %d is not large enough to hold %d bytes",
+            throw new IllegalArgumentException(format("mongocrypt binary of length %d is not large enough to hold %d bytes",
                     binary.len(), bytes.length));
         }
         Pointer outPointer = binary.data();

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPIHelper.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPIHelper.java
@@ -84,7 +84,7 @@ final class CAPIHelper {
 
     static void writeByteArrayToBinary(final mongocrypt_binary_t binary, byte[] bytes) {
         if (binary.len() < bytes.length) {
-            throw new IllegalArgumentException(format("mongocrypt binary of length %d is not large enough to hold %d bytes",
+            throw new AssertionError(format("mongocrypt binary of length %d is not large enough to hold %d bytes",
                     binary.len(), bytes.length));
         }
         Pointer outPointer = binary.data();

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPIHelper.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPIHelper.java
@@ -70,8 +70,8 @@ final class CAPIHelper {
     }
 
     static ByteBuffer toByteBuffer(final mongocrypt_binary_t binary) {
-        Pointer pointer = mongocrypt_binary_data(binary);
-        int length = mongocrypt_binary_len(binary);
+        Pointer pointer = binary.data();
+        int length = binary.len();
         return pointer.getByteBuffer(0, length);
     }
 
@@ -83,11 +83,11 @@ final class CAPIHelper {
     }
 
     static void writeByteArrayToBinary(final mongocrypt_binary_t binary, byte[] bytes) {
-        if (mongocrypt_binary_len(binary) < bytes.length) {
+        if (binary.len() < bytes.length) {
             throw new IllegalArgumentException(format("mongocrypt binary of length %d is not large enough to hold %d bytes",
-                    mongocrypt_binary_len(binary), bytes.length));
+                    binary.len(), bytes.length));
         }
-        Pointer outPointer = mongocrypt_binary_data(binary);
+        Pointer outPointer = binary.data();
         outPointer.write(0, bytes, 0, bytes.length);
     }
 

--- a/src/mongocrypt-binary-private.h
+++ b/src/mongocrypt-binary-private.h
@@ -21,11 +21,6 @@
 
 #include "mongocrypt.h"
 
-struct _mongocrypt_binary_t {
-    uint8_t *data;
-    uint32_t len;
-};
-
 bool _mongocrypt_binary_to_bson(mongocrypt_binary_t *binary, bson_t *out) MONGOCRYPT_WARN_UNUSED_RESULT;
 
 #endif /* MONGOCRYPT_BINARY_PRIVATE_H */

--- a/src/mongocrypt-crypto.c
+++ b/src/mongocrypt-crypto.c
@@ -78,7 +78,10 @@ static bool _crypto_aes_256_ctr_encrypt_decrypt_via_ecb(void *ctx,
 
         /* XOR resulting stream with original data */
         for (uint32_t i = 0; i < bytes_written && ptr < args.in->len; i++, ptr++) {
-            out_bin.data[ptr] = in_bin.data[ptr] ^ tmp_bin.data[i];
+            uint8_t *in_bin_u8 = in_bin.data;
+            uint8_t *out_bin_u8 = out_bin.data;
+            uint8_t *tmp_bin_u8 = tmp_bin.data;
+            out_bin_u8[ptr] = in_bin_u8[ptr] ^ tmp_bin_u8[i];
         }
 
         /* Increment value in CTR buffer */
@@ -86,9 +89,10 @@ static bool _crypto_aes_256_ctr_encrypt_decrypt_via_ecb(void *ctx,
         /* assert rather than return since this should never happen */
         BSON_ASSERT(ctr_bin.len == 0u || ctr_bin.len - 1u <= INT_MAX);
         for (int i = (int)ctr_bin.len - 1; i >= 0 && carry != 0; --i) {
-            uint32_t bpp = carry + ctr_bin.data[i];
+            uint8_t *ctr_bin_u8 = ctr_bin.data;
+            uint32_t bpp = carry + ctr_bin_u8[i];
             carry = bpp >> 8;
-            ctr_bin.data[i] = bpp & 0xFF;
+            ctr_bin_u8[i] = bpp & 0xFF;
         }
     }
 
@@ -1134,7 +1138,9 @@ static bool _mongocrypt_do_decryption(_mongocrypt_crypto_t *crypto,
         _mc_##name##_do_encryption,                                                                                    \
         _mc_##name##_do_decryption,                                                                                    \
     };                                                                                                                 \
-    const _mongocrypt_value_encryption_algorithm_t *_mc##name##Algorithm() { return &_mc##name##Algorithm_definition; }
+    const _mongocrypt_value_encryption_algorithm_t *_mc##name##Algorithm() {                                           \
+        return &_mc##name##Algorithm_definition;                                                                       \
+    }
 
 // FLE1 algorithm: AES-256-CBC HMAC/SHA-512-256 (SHA-512 truncated to 256 bits)
 DECLARE_ALGORITHM(FLE1, CBC, SHA_512_256)

--- a/src/mongocrypt-crypto.c
+++ b/src/mongocrypt-crypto.c
@@ -1138,9 +1138,7 @@ static bool _mongocrypt_do_decryption(_mongocrypt_crypto_t *crypto,
         _mc_##name##_do_encryption,                                                                                    \
         _mc_##name##_do_decryption,                                                                                    \
     };                                                                                                                 \
-    const _mongocrypt_value_encryption_algorithm_t *_mc##name##Algorithm() {                                           \
-        return &_mc##name##Algorithm_definition;                                                                       \
-    }
+    const _mongocrypt_value_encryption_algorithm_t *_mc##name##Algorithm() { return &_mc##name##Algorithm_definition; }
 
 // FLE1 algorithm: AES-256-CBC HMAC/SHA-512-256 (SHA-512 truncated to 256 bits)
 DECLARE_ALGORITHM(FLE1, CBC, SHA_512_256)

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -69,8 +69,14 @@ const char *mongocrypt_version(uint32_t *len);
  * mongocrypt_ctx_mongo_op guarantees that the viewed data of
  * mongocrypt_binary_t is valid until the parent ctx is destroyed with @ref
  * mongocrypt_ctx_destroy.
+ *
+ * The `mongocrypt_binary_t` struct definition is public.
+ * Consumers may rely on the struct layout.
  */
-typedef struct _mongocrypt_binary_t mongocrypt_binary_t;
+typedef struct _mongocrypt_binary_t {
+    uint8_t *data;
+    uint32_t len;
+} mongocrypt_binary_t;
 
 /**
  * Create a new non-owning view of a buffer (data + length).

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -74,7 +74,7 @@ const char *mongocrypt_version(uint32_t *len);
  * Consumers may rely on the struct layout.
  */
 typedef struct _mongocrypt_binary_t {
-    uint8_t *data;
+    void *data;
     uint32_t len;
 } mongocrypt_binary_t;
 

--- a/test/test-mongocrypt-crypto-hooks.c
+++ b/test/test-mongocrypt-crypto-hooks.c
@@ -67,7 +67,8 @@ static bool _mock_aes_256_xxx_encrypt(void *ctx,
     }
     _append_bin("in", in);
     /* append it directly, don't encrypt. */
-    memcpy(out->data + *bytes_written, in->data, in->len);
+    uint8_t *out_u8 = out->data;
+    memcpy(out_u8 + *bytes_written, in->data, in->len);
     *bytes_written += in->len;
     bson_string_append_printf(call_history, "ret:%s\n", BSON_FUNC);
     if (0 == strcmp((char *)ctx, "error_on:aes_256_cbc_encrypt")
@@ -92,7 +93,8 @@ static bool _mock_aes_256_xxx_decrypt(void *ctx,
     _append_bin("iv", iv);
     _append_bin("in", in);
     /* append it directly, don't decrypt. */
-    memcpy(out->data + *bytes_written, in->data, in->len);
+    uint8_t *out_u8 = out->data;
+    memcpy(out_u8 + *bytes_written, in->data, in->len);
     *bytes_written += in->len;
     bson_string_append_printf(call_history, "ret:%s\n", BSON_FUNC);
     if (0 == strcmp((char *)ctx, "error_on:aes_256_cbc_decrypt")


### PR DESCRIPTION
# Scope

- Export definition of `mongocrypt_binary_t`.
- Read fields of `mongocrypt_binary_t` directly in Java bindings.

# Motivation

Languages interfacing with libmongocrypt may observe slower throughput with frequent calls to C functions.

[HELP-27047](https://jira.mongodb.org/browse/HELP-27047) identifies a problematic workload: decrypting documents with 1500 encrypted values.

Profiling showed significant samples spent in calls to `mongocrypt_binary_data` and `mongocrypt_binary_len`.

[A prototype benchmark](https://github.com/mongodb/DRIVERS-2581) showed improvement by using the struct definition directly, rather than calling `mongocrypt_binary_data` and `mongocrypt_binary_len`:


```
run_test 'Baseline' ... begin
Baseline   (ms): 9.868333
Decrypting (ms): 35.971542
Overhead   (ms): 26.103209
Overhead   (+%): 264.51487804475187
run_test 'Baseline' ... end
run_test 'With Java using mongocrypt_binary_t definition' ... begin
Baseline   (ms): 9.756125
Decrypting (ms): 31.031459
Overhead   (ms): 21.275334
Overhead   (+%): 218.071560173737
run_test 'With Java using mongocrypt_binary_t definition' ... end
```

With these changes, the `benchmark-java` task [reported 40 ops/sec](https://spruce.mongodb.com/task/libmongocrypt_benchmark_benchmark_java_patch_ce14f0cebfe9d33bf5d2f5467a0fb8a36908e80c_64f72794d6d80a9b1bd6c970_23_09_05_13_05_25/trend-charts?execution=0). The previous run [reported 29 ops/sec](https://spruce.mongodb.com/task/libmongocrypt_benchmark_benchmark_java_ce14f0cebfe9d33bf5d2f5467a0fb8a36908e80c_23_09_05_12_41_16/trend-charts?execution=0).

# Rejected Alternatives.

The proposed changes use `getPointer()` and `getInt()` to read the `mongocrypt_binary_t` fields directly. Defining Structure was attempted:

```java
@Structure.FieldOrder({ "data", "len" })
public static class mongocrypt_binary_t extends Structure {
    public Pointer data;
    public int len;
}
```

A local run showed a decrease in ops/sec from the baseline (44  => 36). [Comparing profile snapshots](https://www.jetbrains.com/help/idea/compare-profiler-snapshots.html) showed many samples in translating Structure:

<img width="1472" alt="reading a Structure" src="https://github.com/mongodb/libmongocrypt/assets/992997/2bc5ae6a-88d4-4641-b4f4-8eceb80ef78d">

Red sections are new samples, green are missing samples. Since throughput reduced, I interpret these results to mean: less work was completed, and more of the time spent was translating Structure.