### PR TITLE
update CHANGELOG for 1.8.1 and 1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # ChangeLog
+## 1.8.2
+### Fixed
+- Fix possible leaks in Queryable Encryption in errors on malformed data.
+## 1.8.1
+- Bypass search index management commands in automatic encryption
 ## 1.8.0
 This release adds stable support of the Queryable Encryption (QE) feature for the "Indexed" and "Unindexed" algorithms.
 ## 1.8.0-alpha1


### PR DESCRIPTION
This PR copies missing CHANGELOG from the `r1.8` branch.