### PR TITLE
Use Fedora 38 for RPM build

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -249,7 +249,7 @@ BUILD_EXAMPLE_STATE_MACHINE:
     RUN cd /s && /s/example-state-machine
 
 rpm-build:
-    FROM +init --base fedora:rawhide
+    FROM +init --base fedora:38
     GIT CLONE https://src.fedoraproject.org/rpms/libmongocrypt.git /R
     # Install the packages listed by "BuildRequires" and rpm-build:
     RUN __install $(awk '/^BuildRequires:/ { print $2 }' /R/libmongocrypt.spec) \
@@ -265,7 +265,7 @@ rpm-build:
 
 rpm-install-runtime:
     # Install the runtime RPM
-    FROM +init --base fedora:rawhide
+    FROM +init --base fedora:38
     COPY +rpm-build/RPMS /tmp/libmongocrypt-rpm/
     RUN dnf makecache
     RUN __install $(find /tmp/libmongocrypt-rpm/ -name 'libmongocrypt-1.*.rpm')


### PR DESCRIPTION
This fixes the `rpm-package-build` task.

Evergreen patch build: https://evergreen.mongodb.com/version/64f9d75132f4173437b314b2?redirect_spruce_users=true

I would also cherry-pick this change onto the `r1.8` branch to make the `rpm-package-build` task green on that branch as well.