### PR TITLE
fix earthly and format script

### DIFF
--- a/.evergreen/earthly.sh
+++ b/.evergreen/earthly.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 . "$(dirname "${BASH_SOURCE[0]}")/setup-env.sh"
 

--- a/etc/format.sh
+++ b/etc/format.sh
@@ -10,7 +10,7 @@ if ! run_python -c ''; then
 fi
 
 # Check that we have a pipx of the proper version:
-run_python -c 'import pkg_resources; pkg_resources.require("pipx>=0.17.0<2.0")'
+run_python -c 'import pkg_resources; pkg_resources.require("pipx>=0.17.0,<2.0")'
 
 # Give default clang-format an empty string on stdin if there are no inputs files
 printf '' | run_python -m pipx run "clang-format==${CLANG_FORMAT_VERSION:?}" "$@"


### PR DESCRIPTION
This PR makes minor changes to `./.evergreen/earthly.sh` and `etc/format.sh` to address the following errors encountered locally:

```
zsh: ./.evergreen/earthly.sh: bad interpreter: /usr/bin/bash: no such file or directory
```

```
pkg_resources.extern.packaging._tokenizer.ParserSyntaxError: Expected end or semicolon (after version specifier)
    pipx>=0.17.0<2.0
        ~~~~~~~~^
```