### PR TITLE
MONGOCRYPT-593 Skip or remove `test-java` tasks failing to find JDK.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1369,7 +1369,6 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
-  - test-java
   - name: publish-packages
     distros:
     - rhel70-small

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1199,7 +1199,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
-  - test-java
+  # - test-java - Fails with `JAVA_HOME is set to an invalid directory`. Unskip once MONGOCRYPT-593 is resolved.
   - name: publish-packages
     distros:
     - ubuntu2004-small
@@ -1484,7 +1484,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
-  - test-java
+  # - test-java - Fails with `JAVA_HOME is set to an invalid directory`. Unskip once MONGOCRYPT-593 is resolved.
   - name: publish-packages
     distros:
     - ubuntu2004-small
@@ -1521,7 +1521,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
-  - test-java
+  # - test-java - Fails with `JAVA_HOME is set to an invalid directory`. Unskip once MONGOCRYPT-593 is resolved.
   - name: publish-packages
     distros:
     - ubuntu2004-small


### PR DESCRIPTION
# Summary
- Skip or remove `test-java` tasks failing to find JDK.

# Background & Motivation
Some `test-java` tasks fail to locate the JDK ([example](https://spruce.mongodb.com/task/libmongocrypt_debian11_test_java_ce14f0cebfe9d33bf5d2f5467a0fb8a36908e80c_23_09_05_12_41_16/logs?execution=0)):
```
[2023/09/05 13:04:41.741] + JAVA_HOME=/opt/java/jdk8
[2023/09/05 13:04:41.741] + ./gradlew -version
[2023/09/05 13:04:41.745] ERROR: JAVA_HOME is set to an invalid directory: /opt/java/jdk8
[2023/09/05 13:04:41.745] Please set the JAVA_HOME variable in your environment to match the
[2023/09/05 13:04:41.745] location of your Java installation.
```

Java does not appear installed on `debian11-large` (`java` results in `command not found` and `locate java` does not locate a JDK). A JDK install may need to be requested with a BUILD ticket.

Some failing `test-java` tasks are skipped rather than removed. This PR assumes the `test-java` tasks will eventually want to run on newer distros.

- `test-java` on "Debian 11.0" (distro: `debian11-large`) is skipped.
- `test-java` on "SLES 12 64-bit" (distro: `suse12-sp5-small`) is removed. `test-java` is passing on the newer "SLES 15 64-bit" (distro `suse15-test`).
- `test-java` on "Ubuntu 20.04 arm64" (distro: `ubuntu2004-arm64-small`) is skipped.
- `test-java` on "Ubuntu 22.04 arm64" (distro: `ubuntu2204-arm64-small`) is skipped.