### PR TITLE
MONGOCRYPT-595 pool `Cipher` instances

### DIFF
--- a/bindings/java/mongocrypt/.gitignore
+++ b/bindings/java/mongocrypt/.gitignore
@@ -35,5 +35,5 @@ local.properties
 .java-version
 
 # bin
-./bin
+/bin
 

--- a/bindings/java/mongocrypt/.gitignore
+++ b/bindings/java/mongocrypt/.gitignore
@@ -36,4 +36,4 @@ local.properties
 
 # bin
 /bin
-
+/benchmarks/bin

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CipherCallback.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CipherCallback.java
@@ -24,8 +24,14 @@ import com.mongodb.crypt.capi.CAPI.mongocrypt_status_t;
 import com.sun.jna.Pointer;
 
 import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
+
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 import static com.mongodb.crypt.capi.CAPI.MONGOCRYPT_STATUS_ERROR_CLIENT;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_status_set;
@@ -37,7 +43,17 @@ class CipherCallback implements mongocrypt_crypto_fn {
     private final String transformation;
     private final int mode;
 
+    // `cipherPoolMap` is a map from a String transformation (e.g. "AES/CBC/NoPadding") to a pool of Cipher instances.
+    // `cipherPoolMap` is shared by all instances of CipherCallback and is not synchronized.
+    // `cipherPoolMap` is written in a static initializer and later only read.
+    private static final Map<String, CipherPool> cipherPoolMap = new HashMap<>();
+    static {
+        cipherPoolMap.put("AES/CBC/NoPadding", new CipherPool("AES/CBC/NoPadding"));
+        cipherPoolMap.put("AES/CTR/NoPadding", new CipherPool("AES/CTR/NoPadding"));
+    }
+
     CipherCallback(final String algorithm, final String transformation, final int mode) {
+        assert cipherPoolMap.containsKey(transformation) : "pool missing for '" + transformation + "'. Missing entry?";
         this.algorithm = algorithm;
         this.transformation = transformation;
         this.mode = mode;
@@ -47,10 +63,13 @@ class CipherCallback implements mongocrypt_crypto_fn {
     public boolean crypt(final Pointer ctx, final mongocrypt_binary_t key, final mongocrypt_binary_t iv,
                          final mongocrypt_binary_t in, final mongocrypt_binary_t out,
                          final Pointer bytesWritten, final mongocrypt_status_t status) {
+        CipherPool cipherPool = cipherPoolMap.get(transformation);
+        assert cipherPool != null;
+        Cipher cipher = null;
         try {
             IvParameterSpec ivParameterSpec = new IvParameterSpec(toByteArray(iv));
             SecretKeySpec secretKeySpec = new SecretKeySpec(toByteArray(key), algorithm);
-            Cipher cipher = Cipher.getInstance(transformation);
+            cipher = cipherPool.get();
             cipher.init(mode, secretKeySpec, ivParameterSpec);
 
             byte[] result = cipher.doFinal(toByteArray(in));
@@ -61,6 +80,32 @@ class CipherCallback implements mongocrypt_crypto_fn {
         } catch (Exception e) {
             mongocrypt_status_set(status, MONGOCRYPT_STATUS_ERROR_CLIENT, 0, new cstring(e.toString()), -1);
             return false;
+        } finally {
+            if (cipher != null) {
+                cipherPool.release(cipher);
+            }
         }
     }
+}
+
+class CipherPool {
+    private final ConcurrentLinkedDeque<Cipher> available = new ConcurrentLinkedDeque<>();
+
+    CipherPool(String transformation) {
+        this.transformation = transformation;
+    }
+
+    Cipher get() throws NoSuchAlgorithmException, NoSuchPaddingException {
+        Cipher cipher = available.pollLast();
+        if (cipher != null) {
+            return cipher;
+        }
+        return Cipher.getInstance(transformation);
+    }
+
+    void release(final Cipher cipher) {
+        available.addLast(cipher);
+    }
+
+    String transformation;
 }


### PR DESCRIPTION
# Summary
- Add multi-threaded bulk decryption benchmark.
- Pool `Cipher` instances to improve throughput.

# Background & Motivation

Profiling showed significant samples spent in calls to `Cipher.getInstance`.

[A prototype benchmark](https://github.com/mongodb/DRIVERS-2581) showed improvement by using a ThreadLocal for `Cipher` instances. Use of a ThreadLocal is not proposed given ["Thread-local variables" of JEP 444](https://openjdk.org/jeps/444#:~:text=This%20JEP%20proposes%20to%20finalize,cannot%20have%20thread%2Dlocal%20variables.):

> because virtual threads can be very numerous, use thread locals only after careful consideration.

This PR proposes adding a pool of `Cipher` objects. `CipherPool` is loosely based on [`PowerOfTwoBufferPool`](https://github.com/mongodb/mongo-java-driver/blob/ed1fadbeb30731b80a02d5a3aaead816af2b823d/driver-core/src/main/com/mongodb/internal/connection/PowerOfTwoBufferPool.java#L37).

Adding a pruning task to `CipherPool` was considered. A local benchmark run with 64 threads showing a final pool size of 8. Given the small pool size, this PR proposes not pruning the pool for simplicity.

# Results

Here are results of the median of five runs of `benchmark-java` task before and after this changeset:

Medians of 'Baseline' (patches: [1](https://spruce.mongodb.com/version/650857173627e02671763864/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) [2](https://spruce.mongodb.com/version/6508570e1e2d173d1b0e47a6/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) [3](https://spruce.mongodb.com/version/650856f232f4172609c4e69d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) [4](https://spruce.mongodb.com/version/650856a561837d11e53d92fc/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) [5](https://spruce.mongodb.com/version/65084f299ccd4ed99725a2fe/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)):

| 1 threads   | 2 threads   | 8 threads   | 64 threads   |
|-------------|-------------|-------------|--------------|
| 44 ops/sec  | 69 ops/sec  | 241 ops/sec | 267 ops/sec  |


Medians of 'With CipherPool' (patches: [1](https://spruce.mongodb.com/task/libmongocrypt_benchmark_benchmark_java_patch_dd9e972177825eb73679d35ee6301a06397db1c3_650857740305b9a4bc6e07d9_23_09_18_13_58_14/trend-charts?execution=0) [2](https://spruce.mongodb.com/version/6508578ea4cf47fd38b5e231) [3](https://spruce.mongodb.com/version/65085745850e61371fe73ba7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) [4](https://spruce.mongodb.com/version/65085760e3c331c94f5862a1/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) [5](https://perf-summarizer-service.server-tig.prod.corp.mongodb.com/results/evergreen/tasks/libmongocrypt_benchmark_benchmark_java_patch_dd9e972177825eb73679d35ee6301a06397db1c3_650853233627e02671762b04_23_09_18_13_39_48)):

| 1 threads   | 2 threads   | 8 threads   | 64 threads   |
|-------------|-------------|-------------|--------------|
| 68 ops/sec  | 110 ops/sec | 293 ops/sec | 256 ops/sec  |

This PR assumes the smaller loss in throughput at high thread counts is acceptable given the higher observed throughput at low thread counts.
