### PR TITLE
fix(NODE-5632): specify mongodb dependency <6.0.0

### DIFF
--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -44,7 +44,7 @@
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.186.0",
         "gcp-metadata": "^5.2.0",
-        "mongodb": ">=3.4.0"
+        "mongodb": ">=3.4.0 <6.0.0"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -65,7 +65,7 @@
   "peerDependencies": {
     "@aws-sdk/credential-providers": "^3.186.0",
     "gcp-metadata": "^5.2.0",
-    "mongodb": ">=3.4.0"
+    "mongodb": ">=3.4.0 <6.0.0"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/credential-providers": {


### PR DESCRIPTION
version 6x of the Node driver is incompatible with mongodb-client-encryption <6.0.0.  This PR specifies that the 2.x version of mongodb-client-encryption must be used with a <6.0.0 driver in the package.json.

this change is only for Node driver CI on the 4.x branch.

successful patch: https://spruce.mongodb.com/version/652045a92a60ed19da065615/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC