### PR TITLE
fix(NODE-5632): specify mongodb dependency <6.0.0 

### DIFF
--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -44,7 +44,7 @@
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.186.0",
         "gcp-metadata": "^5.2.0",
-        "mongodb": ">=3.4.0"
+        "mongodb": ">=3.4.0 <6.0.0"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -65,7 +65,7 @@
   "peerDependencies": {
     "@aws-sdk/credential-providers": "^3.186.0",
     "gcp-metadata": "^5.2.0",
-    "mongodb": ">=3.4.0"
+    "mongodb": ">=3.4.0 <6.0.0"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/credential-providers": {


### PR DESCRIPTION
This is a repeat of https://github.com/mongodb/libmongocrypt/pull/701.  The node-2.x branch #701 merged into was branched from the wrong Nodejs release tag.  I've reset the branch to the node-v2.9.0 release tag and am re-opening this PR.