### PR TITLE
ci(no-story): do not upgrade npm on node-2.x branch

### DIFF
--- a/bindings/node/.evergreen/install-dependencies.sh
+++ b/bindings/node/.evergreen/install-dependencies.sh
@@ -93,11 +93,13 @@ else
   mv "${NODE_ARTIFACTS_PATH}/${node_directory}" "${NODE_ARTIFACTS_PATH}/nodejs"
 fi
 
-if [[ $operating_system != "win" ]]; then
-  # Update npm to latest when we can
-  npm install --global npm@latest
-  hash -r
-fi
+# Most of `mongodb-client-encryption`'s builds use Node16, so we can't upgrade `npm` to latest
+# because npm 10 is not compatible with Node16
+# if [[ $operating_system != "win" ]]; then
+#   # Update npm to latest when we can
+#   npm install --global npm@latest
+#   hash -r
+# fi
 
 echo "npm location: $(which npm)"
 echo "npm version: $(npm -v)"


### PR DESCRIPTION
Most of our CI uses node 16, so we cannot upgrade `npm` to latest.