### PR TITLE
MONGOCRYPT-481 Warn if `mcr_dll_path` not implemented

### DIFF
--- a/src/mongocrypt-dll-private.h
+++ b/src/mongocrypt-dll-private.h
@@ -83,7 +83,14 @@ typedef struct mcr_dll_path_result {
  * library, or an error string.
  *
  * @note Caller must free both `retval.path` and `retval.error_string`.
+ * @note Returns an error if not supported on this platform. Use
+ * `mcr_dll_path_supported` to check before calling.
  */
 mcr_dll_path_result mcr_dll_path(mcr_dll dll);
+
+/**
+ * @brief Return true if `mcr_dll_path` is supported on this platform.
+ */
+bool mcr_dll_path_supported(void);
 
 #endif // MONGOCRYPT_DLL_PRIVATE_H

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -552,6 +552,14 @@ static bool _validate_csfle_singleton(mongocrypt_t *crypt, _loaded_csfle found) 
 
     BSON_ASSERT_PARAM(crypt);
 
+    if (!mcr_dll_path_supported()) {
+        _mongocrypt_log(&crypt->log,
+                        MONGOCRYPT_LOG_LEVEL_WARNING,
+                        "Cannot get path of loaded library on this platform. Skipping validation to ensure "
+                        "exactly one csfle library is loaded.");
+        return true;
+    }
+
     status = crypt->status;
 
     // Path to the existing loaded csfle:

--- a/src/os_posix/os_dll.c
+++ b/src/os_posix/os_dll.c
@@ -95,6 +95,10 @@ mcr_dll_path_result mcr_dll_path(mcr_dll dll) {
     return (mcr_dll_path_result){.error_string = mstr_copy_cstr("Handle not found in loaded modules")};
 }
 
+bool mcr_dll_path_supported(void) {
+    return true;
+}
+
 #elif defined(__linux__) || defined(__FreeBSD__)
 
 #include <link.h>
@@ -109,12 +113,23 @@ mcr_dll_path_result mcr_dll_path(mcr_dll dll) {
     }
 }
 
+bool mcr_dll_path_supported(void) {
+    return true;
+}
+
 #elif defined(_WIN32)
 
 // Handled in os_win/os_dll.c
 
 #else
 
-#error "Don't know how to do mcr_dll_path() on this platform"
+mcr_dll_path_result mcr_dll_path(mcr_dll dll) {
+    return (mcr_dll_path_result){.error_string =
+                                     mstr_copy_cstr("Don't know how to do mcr_dll_path() on this platform")};
+}
+
+bool mcr_dll_path_supported(void) {
+    return false;
+}
 
 #endif

--- a/src/os_win/os_dll.c
+++ b/src/os_win/os_dll.c
@@ -76,4 +76,8 @@ mcr_dll_path_result mcr_dll_path(mcr_dll dll) {
     };
 }
 
+bool mcr_dll_path_supported(void) {
+    return true;
+}
+
 #endif


### PR DESCRIPTION
# Summary

Warn if `mcr_dll_path` is not supported.

# Background & Motivation

MONGOCRYPT-481 reports a build error on AIX due to no implementation of `mcr_dll_path`.

`mcr_dll_path` is only used by `_validate_csfle_singleton` to ensure a unique copy of the library is loaded. Validating is not strictly necessary to proceed.

This PR proposes warning if `mcr_dll_path` is not supported to enable building on more platforms.

## Testing


Tested locally by adding expectedly undefined macro to check:
```diff
--- a/src/os_posix/os_dll.c
+++ b/src/os_posix/os_dll.c
@@ -53,7 +53,7 @@ void *mcr_dll_sym(mcr_dll dll, const char *sym) {
 
 #endif
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(NOTDEFINED)
 
 #include <mach-o/dyld.h>
 #include <mach-o/nlist.h>
```

Running `./cmake-build/test-mongocrypt _test_csfle_load_twice` results in:
```
  begin _test_csfle_load_twice
INFO Opened CSFLE dynamic library [/Users/kevin.albertson/code/tasks/libmongocrypt-M481/cmake-build/mongo_crypt_v1.dylib]
INFO Opened CSFLE dynamic library [/Users/kevin.albertson/code/tasks/libmongocrypt-M481/cmake-build/mongo_crypt_v1.dylib]
WARNING Cannot get path of loaded library on this platform. Skipping validation to ensure exactly one csfle library is loaded.
  end _test_csfle_load_twice
```
