### PR TITLE
MONGOCRYPT-601 fix build for Alpine on ARM64

### DIFF
--- a/cmake/IntelDFP.cmake
+++ b/cmake/IntelDFP.cmake
@@ -45,6 +45,7 @@ FetchContent_Declare (
             ${patch_input_opt} "${PROJECT_SOURCE_DIR}/etc/mongo-inteldfp-s390x.patch"
             ${patch_input_opt} "${PROJECT_SOURCE_DIR}/etc/mongo-inteldfp-MONGOCRYPT-571.patch"
             ${patch_input_opt} "${PROJECT_SOURCE_DIR}/etc/mongo-inteldfp-libmongocrypt-pr-625.patch"
+            ${patch_input_opt} "${PROJECT_SOURCE_DIR}/etc/mongo-inteldfp-alpine-arm-fix.patch"
             --verbose
     )
 

--- a/etc/mongo-inteldfp-alpine-arm-fix.patch
+++ b/etc/mongo-inteldfp-alpine-arm-fix.patch
@@ -1,0 +1,17 @@
+diff --git a/cmake-build/_deps/intel_dfp-src/LIBRARY/src/bid_functions.h b/cmake-build/_deps/intel_dfp-src/LIBRARY/src/bid_functions.h
+index 7042eed..e55f59e 100755
+--- a/cmake-build/_deps/intel_dfp-src/LIBRARY/src/bid_functions.h
++++ b/cmake-build/_deps/intel_dfp-src/LIBRARY/src/bid_functions.h
+@@ -41,12 +41,6 @@
+ #endif
+ #include <ctype.h>
+ 
+-// Fix system header issue on Sun solaris and define required type by ourselves
+-#if !defined(_WCHAR_T) && !defined(_WCHAR_T_DEFINED) && !defined(__QNX__) && !defined(__cplusplus)
+-typedef int   wchar_t;
+-#endif
+-
+-
+ #ifdef IN_LIBGCC2
+ // When we are built as the part of the gcc runtime library, libgcc,
+ // we will use gcc types defined in bid_gcc_intrinsics.h.


### PR DESCRIPTION
MONGOCRYPT-601

Without this fix, building on Alpine on ARM64 results in the compiler error below.
Since we do not support ancient versions of Solaris, the redefinition of `wchar_t` does not seem necessary, therefore it is safe to remove.
```
In file included from /build/cmake-build/_deps/intel_dfp-src/LIBRARY/src/bid_internal.h:41,
                 from /build/cmake-build/_deps/intel_dfp-src/LIBRARY/src/bid_trans.h:61,
                 from /build/cmake-build/_deps/intel_dfp-src/LIBRARY/src/bid128_asin.c:29:
/build/cmake-build/_deps/intel_dfp-src/LIBRARY/src/bid_functions.h:46:15: error: conflicting types for 'wchar_t'; have 'int'
   46 | typedef int   wchar_t;
      |               ^~~~~~~
In file included from /usr/include/stdlib.h:21,
                 from /usr/include/fortify/stdlib.h:23,
                 from /build/cmake-build/_deps/intel_dfp-src/LIBRARY/src/bid_internal.h:33:
/usr/include/bits/alltypes.h:15:18: note: previous declaration of 'wchar_t' with type 'wchar_t' {aka 'unsigned int'}
   15 | typedef unsigned wchar_t;
      |                  ^~~~~~~
```