### PR TITLE
MONGOCRYPT-603 Don't return a compile error if dll_path unsupported

### DIFF
--- a/src/mongocrypt-util.c
+++ b/src/mongocrypt-util.c
@@ -90,8 +90,8 @@ current_module_result current_module_path(void) {
         ret_str = mstr_copy_cstr(info.dli_fname);
     }
 #else
-   // Not supported on this system.
-   ret_error = ENOSYS;
+    // Not supported on this system.
+    ret_error = ENOSYS;
 #endif
     return (current_module_result){.path = ret_str, .error = ret_error};
 }

--- a/src/mongocrypt-util.c
+++ b/src/mongocrypt-util.c
@@ -90,7 +90,7 @@ current_module_result current_module_path(void) {
         ret_str = mstr_copy_cstr(info.dli_fname);
     }
 #else
-#error "Don't know how to get the module path on this platform"
+    return (current_module_result){.path = NULL, .error = ENOSYS};
 #endif
     return (current_module_result){.path = ret_str, .error = ret_error};
 }

--- a/src/mongocrypt-util.c
+++ b/src/mongocrypt-util.c
@@ -90,7 +90,8 @@ current_module_result current_module_path(void) {
         ret_str = mstr_copy_cstr(info.dli_fname);
     }
 #else
-    return (current_module_result){.path = NULL, .error = ENOSYS};
+   // Not supported on this system.
+   ret_error = ENOSYS;
 #endif
     return (current_module_result){.path = ret_str, .error = ret_error};
 }


### PR DESCRIPTION
This returns an error to the caller instead of a hard compile error. The 34a6e9d585e4b8fd1c4f18ffa57a08a6f3338546 commit partially addressed this, but this file wasn't touched by it.

This lets mongocrypt work on a platform without dll_path support, like AIX, but CSFLE is untested.