### PR TITLE
ci(NODE-4193): Add Enterprise RHEL 8 zSeries

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1078,6 +1078,8 @@ buildvariants:
   run_on: rhel83-zseries-small
   tasks:
   - build-and-test-and-upload
+  - build-and-test-node
+  - build-and-publish-node
 - name: windows-vs2015-compile
   display_name: "Windows VS 2015 compile"
   run_on: windows-64-vs2015-test


### PR DESCRIPTION
Add `build-and-test-node` and `build-and-publish-node` tasks to `rhel83-zseries`.
