### PR TITLE
PYTHON-3838 Add decryption benchmark

### DIFF
--- a/.evergreen/benchmark-python.sh
+++ b/.evergreen/benchmark-python.sh
@@ -24,7 +24,8 @@ cd bindings/python/
 
 /opt/mongodbtoolchain/v4/bin/python3 -m venv venv
 . ./venv/bin/activate
-python -m pip install .
+python -m pip install --prefer-binary -r test-requirements.txt
+python -m pip install -e .
 
 export OUTPUT_FILE=results.json
 

--- a/.evergreen/benchmark-python.sh
+++ b/.evergreen/benchmark-python.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+. "$(dirname "${BASH_SOURCE[0]}")/init.sh"
+
+if test "$OS_NAME" != "linux"; then
+    log "Warning: Script is expected only to run on distro: rhel90-dbx-perf-large"
+    log "More changes may be needed to run on other distros.";
+fi
+
+MONGOCRYPT_INSTALL_PREFIX=$LIBMONGOCRYPT_DIR/.install
+
+# Install libmongocrypt.
+build_dir="$LIBMONGOCRYPT_DIR/cmake-build"
+run_cmake \
+    -DCMAKE_INSTALL_PREFIX="$MONGOCRYPT_INSTALL_PREFIX" \
+    -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
+    -B"$build_dir"
+run_cmake --build "$build_dir" --target install
+
+# Run Python benchmarks.
+# Include path to installed libmongocrypt.so
+export LD_LIBRARY_PATH="$MONGOCRYPT_INSTALL_PREFIX/lib64"
+cd bindings/python/
+
+/opt/mongodbtoolchain/v4/bin/python3 -m venv venv
+. ./venv/bin/activate
+python -m pip install .
+
+export OUTPUT_FILE=results.json
+
+python test/performance/perf_test.py -v

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1584,3 +1584,4 @@ buildvariants:
   run_on: rhel90-dbx-perf-large
   tasks:
   - benchmark-java
+  - benchmark-python

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -987,6 +987,19 @@ tasks:
       params:
         file: libmongocrypt/bindings/java/mongocrypt/benchmarks/results.json
 
+- name: benchmark-python
+  commands:
+    - func: "fetch source"
+    - command: "subprocess.exec"
+      params:
+        binary: bash
+        working_dir: "./libmongocrypt"
+        args:
+          - "./.evergreen/benchmark-python.sh"
+    - command: "perf.send"
+      params:
+        file: libmongocrypt/bindings/python/results.json
+
 pre:
   # Update the evergreen expansion to dynamically set the ${libmongocrypt_s3_suffix} and ${libmongocrypt_s3_suffix_copy} expansions.
   - command: "shell.exec"

--- a/bindings/python/test/performance/keyDocument.json
+++ b/bindings/python/test/performance/keyDocument.json
@@ -1,0 +1,24 @@
+{
+  "_id": {
+    "$binary": {
+      "base64": "YWFhYWFhYWFhYWFhYWFhYQ==",
+      "subType": "04"
+    }
+  },
+  "keyMaterial": {
+    "$binary": {
+      "base64": "ACR7Hm33dDOAAD7l2ubZhSpSUWK8BkALUY+qW3UgBAEcTV8sBwZnaAWnzDsmrX55dgmYHWfynDlJogC/e33u6pbhyXvFTs5ow9OLCuCWBJ39T/Ivm3kMaZJybkejY0V+uc4UEdHvVVz/SbitVnzs2WXdMGmo1/HmDRrxGYZjewFslquv8wtUHF5pyB+QDlQBd/al9M444/8bJZFbMSmtIg==",
+      "subType": "00"
+    }
+  },
+  "creationDate": {
+    "$date": "2023-08-21T14:28:20.875Z"
+  },
+  "updateDate": {
+    "$date": "2023-08-21T14:28:20.875Z"
+  },
+  "status": 0,
+  "masterKey": {
+    "provider": "local"
+  }
+}

--- a/bindings/python/test/performance/perf_test.py
+++ b/bindings/python/test/performance/perf_test.py
@@ -1,0 +1,144 @@
+# Copyright 2023-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark pymongocrypt performance."""
+from __future__ import annotations
+
+import functools
+import os
+import sys
+import time
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, List
+
+try:
+    import simplejson as json
+except ImportError:
+    import json  # type: ignore[no-redef]
+
+import bson
+from bson import json_util
+
+sys.path[0:0] = [""]
+
+
+from pymongocrypt.binding import lib
+from pymongocrypt.explicit_encrypter import ExplicitEncrypter, ExplicitEncryptOpts
+from pymongocrypt.mongocrypt import MongoCrypt, MongoCryptOptions
+from test.test_mongocrypt import MockCallback
+
+
+NUM_ITERATIONS = 1
+MAX_TIME = 1
+NUM_FIELDS = 1500
+LOCAL_MASTER_KEY = (
+    b'\x9d\x94K\r\x93\xd0\xc5D\xa5r\xfd2\x1b\x940\x90#5s|\xf0\xf6\xc2\xf4\xda#V\xe7\x8f\x04'
+    b'\xcc\xfa\xdeu\xb4Q\x87\xf3\x8b\x97\xd7KD;\xac9\xa2\xc6M\x91\x00>\xd1\xfaJ0\xc1\xd2'
+    b'\xc6^\xfb\xacA\xf2H\x13<\x9bP\xfc\xa7$z.\x02c\xa3\xc6\x16%QPx>\x0f\xd8n\x84\xa6\xec'
+    b'\x8d-$G\xe5\xaf')
+
+OUTPUT_FILE = os.environ.get("OUTPUT_FILE")
+
+result_data: List = []
+
+
+def read(filename, **kwargs):
+    with open(os.path.join(os.path.dirname(__file__), filename), **kwargs) as fp:
+        return fp.read()
+
+
+def json_data(filename):
+    return json_util.loads(read(filename))
+
+
+def bson_data(filename):
+    return bson.encode(json_data(filename))
+
+
+def tearDownModule():
+    output = json.dumps(result_data, indent=4)
+    if OUTPUT_FILE:
+        with open(OUTPUT_FILE, "w") as opf:
+            opf.write(output)
+    else:
+        print(output)
+
+
+class TestBulkDecryption(unittest.TestCase):
+    def setUp(self):
+        opts = MongoCryptOptions({'local': {'key': LOCAL_MASTER_KEY}})
+        callback = MockCallback(key_docs=[bson_data('keyDocument.json')])
+        self.mongocrypt = MongoCrypt(opts, callback)
+        self.encrypter = ExplicitEncrypter(callback, opts)
+        self.addCleanup(self.mongocrypt.close)
+        self.addCleanup(self.encrypter.close)
+
+    def tearDown(self):
+        self.mongocrypt.close()
+
+    def do_task(self, encrypted, duration=MAX_TIME):
+        start = time.monotonic()
+        ops = 0
+        while time.monotonic() - start < duration:
+            with self.mongocrypt.decryption_context(encrypted) as ctx:
+                self.assertEqual(ctx.state, lib.MONGOCRYPT_CTX_READY)
+                _ = ctx.finish()
+            ops += 1
+        return ops
+
+    def percentile(self, percentile):
+        sorted_results = sorted(self.results)
+        percentile_index = int(len(sorted_results) * percentile / 100) - 1
+        return sorted_results[percentile_index]
+
+    def runTest(self):
+        doc = {}
+        key_id = json_data('keyDocument.json')['_id']
+        for i in range(NUM_FIELDS):
+            val = bson.encode({"v": f"value {i:04}"})
+            doc[f"key{i:04}"] = self.encrypter.encrypt(val, "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic", key_id=key_id)
+        encrypted = bson.encode(doc)
+        # Warm up benchmark and discard the result.
+        self.do_task(encrypted, duration=2)
+
+        for n_threads in [1, 2, 8, 64]:
+            start = time.monotonic()
+            with ThreadPoolExecutor(max_workers=n_threads) as executor:
+                self.results = []
+                for _ in range(NUM_ITERATIONS):
+                    thread_results = list(executor.map(self.do_task, [encrypted] * n_threads))
+                    self.results.append(sum(thread_results))
+            interval = time.monotonic() - start
+            median = self.percentile(50) / interval
+            print(f"Finished {self.__class__.__name__}, threads={n_threads}. MEDIAN ops_per_second={median}")
+            # Remove "Test" so that TestBulkDecryption is reported as "BulkDecryption".
+            name = self.__class__.__name__[4:]
+            result_data.append(
+                {
+                    "info": {
+                        "test_name": name,
+                        "args": {
+                            "threads": n_threads,
+                        },
+                    },
+                    "metrics": [
+                        {"name": "ops_per_second", "type": "MEDIAN", "value": median},
+                    ],
+                }
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bindings/python/test/performance/perf_test.py
+++ b/bindings/python/test/performance/perf_test.py
@@ -139,7 +139,7 @@ class TestBulkDecryption(unittest.TestCase):
             interval = time.monotonic() - start
             median = self.percentile(50) / interval
             print(
-                f"Finished {self.__class__.__name__}, threads={n_threads}. MEDIAN ops_per_second={median}"
+                f"Finished {self.__class__.__name__}, threads={n_threads}. MEDIAN ops_per_second={median:.2f}"
             )
             # Remove "Test" so that TestBulkDecryption is reported as "BulkDecryption".
             name = self.__class__.__name__[4:]


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-3838

Implements the decryption benchmark described in https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/benchmarks.rst#benchmarking-bulk-decryption

Modeled after the Java benchmark here: https://github.com/mongodb/libmongocrypt/blob/4e64586/bindings/java/mongocrypt/benchmarks/src/main/java/com/mongodb/crypt/benchmark/BenchmarkRunner.java