### PR TITLE
MONGOCRYPT-593 Unskip `test-java` task on `Debian 11.0`

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1485,7 +1485,6 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
-  # - test-java - Fails with `JAVA_HOME is set to an invalid directory`. Unskip once MONGOCRYPT-593 is resolved.
   - name: publish-packages
     distros:
     - ubuntu2004-small
@@ -1522,7 +1521,6 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
-  # - test-java - Fails with `JAVA_HOME is set to an invalid directory`. Unskip once MONGOCRYPT-593 is resolved.
   - name: publish-packages
     distros:
     - ubuntu2004-small

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1201,7 +1201,7 @@ buildvariants:
   - build-and-test-shared-bson
   - build-and-test-asan
   - build-and-test-node
-  # - test-java - Fails with `JAVA_HOME is set to an invalid directory`. Unskip once MONGOCRYPT-593 is resolved.
+  - test-java
   - name: publish-packages
     distros:
     - ubuntu2004-small


### PR DESCRIPTION
# Summary

Unskip `test-java` task on `Debian 11.0`. Remove `test-java` tasks on `Ubuntu 20.04 arm64` and `Ubuntu 22.04 arm64`.

`test-java` was run on `Debian 11.0` in this patch build: https://spruce.mongodb.com/version/656e42417742ae3e6c6607b6

# Background & Motivation

BUILD-17899 includes the JDK on `Debian 11.0`. Comments suggest `Ubuntu 20.04 arm64` and `Ubuntu 22.04 arm64` are not expected to include JDK.
