### PR TITLE
PYTHON-3838 Use mongocrypt_binary_t definition to improve performance

### DIFF
--- a/bindings/python/pymongocrypt/binary.py
+++ b/bindings/python/pymongocrypt/binary.py
@@ -20,20 +20,20 @@ from pymongocrypt.errors import MongoCryptError
 
 def _to_bytes(mongocrypt_binary):
     """Returns this mongocrypt_binary_t as bytes."""
-    data = lib.mongocrypt_binary_data(mongocrypt_binary)
+    data = mongocrypt_binary.data
     if data == ffi.NULL:
-        raise MongoCryptError('mongocrypt_binary_data returned NULL')
-    data_len = lib.mongocrypt_binary_len(mongocrypt_binary)
-    return ffi.unpack(ffi.cast("char*", data), data_len)
+        raise MongoCryptError('mongocrypt_binary_t.data returned NULL')
+    return ffi.unpack(ffi.cast("char*", data), mongocrypt_binary.len)
 
 
 def _write_bytes(mongocrypt_binary, data):
     """Writes the given data to a mongocrypt_binary_t."""
-    buf = lib.mongocrypt_binary_data(mongocrypt_binary)
+    buf = mongocrypt_binary.data
     if buf == ffi.NULL:
-        raise MongoCryptError('mongocrypt_binary_data returned NULL')
+        raise MongoCryptError('mongocrypt_binary_t.data returned NULL')
 
     ffi.memmove(buf, data, len(data))
+    mongocrypt_binary.len = len(data)
 
 
 class _MongoCryptBinary(object):
@@ -60,11 +60,10 @@ class _MongoCryptBinary(object):
 
     def to_bytes(self):
         """Returns this mongocrypt_binary_t as bytes."""
-        data = lib.mongocrypt_binary_data(self.bin)
+        data = self.bin.data
         if data == ffi.NULL:
             return b''
-        data_len = lib.mongocrypt_binary_len(self.bin)
-        return ffi.unpack(ffi.cast("char*", data), data_len)
+        return ffi.unpack(ffi.cast("char*", data), self.bin.len)
 
 
 class MongoCryptBinaryOut(_MongoCryptBinary):

--- a/bindings/python/pymongocrypt/binding.py
+++ b/bindings/python/pymongocrypt/binding.py
@@ -84,8 +84,14 @@ const char *mongocrypt_version(uint32_t *len);
  * mongocrypt_ctx_mongo_op guarantees that the viewed data of
  * mongocrypt_binary_t is valid until the parent ctx is destroyed with @ref
  * mongocrypt_ctx_destroy.
+ *
+ * The `mongocrypt_binary_t` struct definition is public.
+ * Consumers may rely on the struct layout.
  */
-typedef struct _mongocrypt_binary_t mongocrypt_binary_t;
+typedef struct _mongocrypt_binary_t {
+    void *data;
+    uint32_t len;
+} mongocrypt_binary_t;
 
 /**
  * Create a new non-owning view of a buffer (data + length).

--- a/bindings/python/test/performance/perf_test.py
+++ b/bindings/python/test/performance/perf_test.py
@@ -35,9 +35,10 @@ sys.path[0:0] = [""]
 
 from test.test_mongocrypt import MockCallback
 
-from pymongocrypt.binding import lib
-from pymongocrypt.explicit_encrypter import ExplicitEncrypter, ExplicitEncryptOpts
+from pymongocrypt.binding import lib, libmongocrypt_version
+from pymongocrypt.explicit_encrypter import ExplicitEncrypter
 from pymongocrypt.mongocrypt import MongoCrypt, MongoCryptOptions
+from pymongocrypt.version import __version__
 
 NUM_ITERATIONS = 10
 MAX_TIME = 1
@@ -136,7 +137,7 @@ class TestBulkDecryption(unittest.TestCase):
                     self.results.append(sum(thread_results) / interval)
             median = self.percentile(50)
             print(
-                f"Finished {self.__class__.__name__}, threads={n_threads}. MEDIAN ops_per_second={median:.2f}"
+                f"Finished {self.__class__.__name__}, threads={n_threads}, median ops_per_second={median:.2f}"
             )
             # Remove "Test" so that TestBulkDecryption is reported as "BulkDecryption".
             name = self.__class__.__name__[4:]
@@ -156,4 +157,5 @@ class TestBulkDecryption(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    print(f"Running benchmark with pymongocrypt: {__version__} libmongocrypt: {libmongocrypt_version()}")
     unittest.main()


### PR DESCRIPTION
The second half of https://jira.mongodb.org/browse/PYTHON-3838.

Note we don't have to update our `_MIN_LIBMONGOCRYPT_VERSION` because the mongocrypt_binary_t definition hasn't changed.

Benchmark before this change:
```
[2023/12/05 14:23:50.775] Finished TestBulkDecryption, threads=1. MEDIAN ops_per_second=11.68
[2023/12/05 14:23:50.775] Finished TestBulkDecryption, threads=2. MEDIAN ops_per_second=4.22
[2023/12/05 14:23:50.775] Finished TestBulkDecryption, threads=8. MEDIAN ops_per_second=2.55
[2023/12/05 14:23:50.775] Finished TestBulkDecryption, threads=64. MEDIAN ops_per_second=2.42
```
Benchmark after:
```
[2023/12/05 14:21:44.102] Finished TestBulkDecryption, threads=1, median ops_per_second=12.45
[2023/12/05 14:21:44.102] Finished TestBulkDecryption, threads=2, median ops_per_second=5.58
[2023/12/05 14:21:44.102] Finished TestBulkDecryption, threads=8, median ops_per_second=4.28
[2023/12/05 14:21:44.102] Finished TestBulkDecryption, threads=64, median ops_per_second=3.95
```

% improvement in each case:
```
threads=1: +6%
threads=2: +32%
threads=8: +68%
threads=64: +63%
```