### PR TITLE
PYTHON-3838 Run benchmark with native libmongocrypt crypto

### DIFF
--- a/bindings/python/pymongocrypt/mongocrypt.py
+++ b/bindings/python/pymongocrypt/mongocrypt.py
@@ -218,18 +218,18 @@ class MongoCrypt(object):
         if self.__opts.bypass_query_analysis:
             lib.mongocrypt_setopt_bypass_query_analysis(self.__crypt)
 
-        if not lib.mongocrypt_setopt_crypto_hooks(
-                self.__crypt, aes_256_cbc_encrypt, aes_256_cbc_decrypt,
-                secure_random, hmac_sha_512, hmac_sha_256, sha_256, ffi.NULL):
-            self.__raise_from_status()
-
-        if not lib.mongocrypt_setopt_crypto_hook_sign_rsaes_pkcs1_v1_5(
-                self.__crypt, sign_rsaes_pkcs1_v1_5, ffi.NULL):
-            self.__raise_from_status()
-
-        if not lib.mongocrypt_setopt_aes_256_ctr(
-                self.__crypt, aes_256_ctr_encrypt, aes_256_ctr_decrypt, ffi.NULL):
-            self.__raise_from_status()
+        # if not lib.mongocrypt_setopt_crypto_hooks(
+        #         self.__crypt, aes_256_cbc_encrypt, aes_256_cbc_decrypt,
+        #         secure_random, hmac_sha_512, hmac_sha_256, sha_256, ffi.NULL):
+        #     self.__raise_from_status()
+        #
+        # if not lib.mongocrypt_setopt_crypto_hook_sign_rsaes_pkcs1_v1_5(
+        #         self.__crypt, sign_rsaes_pkcs1_v1_5, ffi.NULL):
+        #     self.__raise_from_status()
+        #
+        # if not lib.mongocrypt_setopt_aes_256_ctr(
+        #         self.__crypt, aes_256_ctr_encrypt, aes_256_ctr_decrypt, ffi.NULL):
+        #     self.__raise_from_status()
 
         if self.__opts.crypt_shared_lib_path is not None:
             lib.mongocrypt_setopt_set_crypt_shared_lib_path_override(


### PR DESCRIPTION
Testing out the benchmark with native libmongocrypt crypto. Unsurprisingly it results in significant perf improvements:
![Screenshot 2023-12-05 at 4 39 06 PM](https://github.com/mongodb/libmongocrypt/assets/5015933/90a26008-783f-41a5-991f-c764c79e8168)
https://spruce.mongodb.com/task/libmongocrypt_benchmark_benchmark_python_patch_cb6487c29c7ce15003963b691db4475c9b4e973d_656fbeb1e3c331461f98cab9_23_12_06_00_22_10/trend-charts?execution=0

The change in #713 provides a modest 6% improvement on the single threaded benchmark, whereas using native crypto provides a 952% improvement.