### PR TITLE
MONGOCRYPT-610 fix leak after repeated configuring of "aws" and "local" creds

### DIFF
--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -1248,6 +1248,10 @@ bool _mongocrypt_parse_kms_providers(mongocrypt_binary_t *kms_providers_definiti
         } else if (0 == strcmp(field_name, "local") && bson_empty(&field_bson)) {
             kms_providers->need_credentials |= MONGOCRYPT_KMS_PROVIDER_LOCAL;
         } else if (0 == strcmp(field_name, "local")) {
+            if (0 != (kms_providers->configured_providers & MONGOCRYPT_KMS_PROVIDER_LOCAL)) {
+                CLIENT_ERR("local KMS provider already set");
+                return false;
+            }
             if (!_mongocrypt_parse_required_binary(&as_bson, "local.key", &kms_providers->local.key, status)) {
                 return false;
             }
@@ -1264,6 +1268,11 @@ bool _mongocrypt_parse_kms_providers(mongocrypt_binary_t *kms_providers_definiti
         } else if (0 == strcmp(field_name, "aws") && bson_empty(&field_bson)) {
             kms_providers->need_credentials |= MONGOCRYPT_KMS_PROVIDER_AWS;
         } else if (0 == strcmp(field_name, "aws")) {
+            if (0 != (kms_providers->configured_providers & MONGOCRYPT_KMS_PROVIDER_AWS)) {
+                CLIENT_ERR("aws KMS provider already set");
+                return false;
+            }
+
             if (!_mongocrypt_parse_required_utf8(&as_bson,
                                                  "aws.accessKeyId",
                                                  &kms_providers->aws.access_key_id,


### PR DESCRIPTION
# Summary

Fix leak (and return error) if configuring "aws" and "local" with `mongocrypt_setopt_kms_providers` after credentials were previously configured.

# Background & Motivation

Calling `mongocrypt_setopt_kms_providers` with "aws" twice or after configuring with `mongocrypt_setopt_kms_provider_aws` results in a memory leak. Here is a report from LSan:
```
Direct leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x1051ff978 in malloc+0x8c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x53978)
    #1 0x102ed8980 in bson_malloc bson-memory.c:70
    #2 0x102ede58c in bson_strndup bson-string.c:448
    #3 0x102e5cbac in _mongocrypt_validate_and_copy_string mongocrypt.c:971
    #4 0x102e5c7cc in mongocrypt_setopt_kms_provider_aws mongocrypt.c:186
    #5 0x102d84280 in _test_setopt_kms_providers test-mongocrypt.c:817
    #6 0x102d76c04 in main test-mongocrypt.c:935
    #7 0x104c01088 in start+0x204 (dyld:arm64+0x5088)
    #8 0x7c3d7ffffffffffc  (<unknown module>)
```

Calling `mongocrypt_setopt_kms_providers` with "local" twice or after configuring with `mongocrypt_setopt_kms_provider_local` results in a memory leak. Here is a report from LSan:
```
Direct leak of 96 byte(s) in 1 object(s) allocated from:
    #0 0x1051ff978 in malloc+0x8c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x53978)
    #1 0x102ed8980 in bson_malloc bson-memory.c:70
    #2 0x102dc94d4 in _make_owned mongocrypt-buffer.c:37
    #3 0x102dcaa7c in _mongocrypt_buffer_copy_from_binary mongocrypt-buffer.c:195
    #4 0x102e5e594 in mongocrypt_setopt_kms_provider_local mongocrypt.c:348
    #5 0x102d83e7c in _test_setopt_kms_providers test-mongocrypt.c:805
    #6 0x102d76c04 in main test-mongocrypt.c:935
    #7 0x104c01088 in start+0x204 (dyld:arm64+0x5088)
    #8 0x7c3d7ffffffffffc  (<unknown module>)
```

Meanwhile, calling `mongocrypt_setopt_kms_providers` with "azure", "kmip", or "gcp" twice results in an error (e.g. `azure KMS provider already set`)

I expect there is no use case to repeatedly configure "aws" or "local" credentials. I expect this to have no impact to current driver implementations. Surveying driver implementations suggests none are using `mongocrypt_setopt_kms_provider_aws` or `mongocrypt_setopt_kms_provider_local` or calling `mongocrypt_setopt_kms_providers` repeatedly.

This PR is intended to improve consistency of parsing KMS providers. It may be relevant to upcoming changes for parsing named KMS providers in MONGOCRYPT-605.
