### PR TITLE
MONGOCRYPT-580 treat "arm64" as "aarch64" on RPM-based distros

### DIFF
--- a/etc/packager.py
+++ b/etc/packager.py
@@ -230,9 +230,8 @@ class Distro(object):
                 return "s390x"
             elif arch.endswith("86"):
                 return "i686"
-            elif arch == "arm64":
-                return "arm64"
-            elif arch == "aarch64":
+            # MC: transform arm64 -> aarch64 to match the structure of the PPA
+            elif arch == "arm64" or arch == "aarch64":
                 return "aarch64"
             return "x86_64"
         else:


### PR DESCRIPTION
for the purposes of creating packages published in the PPA

Follow-up for ef5b0b54adaadf3b8a1a151aa31b91702bf17187

After merging this into `master`, I will also cherry-pick to `r1.8`.