### PR TITLE
MONGOCRYPT-616 add `mongocrypt_is_crypto_available`

### DIFF
--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -891,6 +891,14 @@ bool mongocrypt_init(mongocrypt_t *crypt) {
     return _try_enable_csfle(crypt);
 }
 
+bool mongocrypt_is_crypto_available(void) {
+#ifdef MONGOCRYPT_ENABLE_CRYPTO
+    return true;
+#else
+    return false;
+#endif
+}
+
 bool mongocrypt_status(mongocrypt_t *crypt, mongocrypt_status_t *out) {
     BSON_ASSERT_PARAM(crypt);
 

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -54,8 +54,6 @@ const char *mongocrypt_version(uint32_t *len);
  * If libmongocrypt was not built with native crypto support, setting crypto
  * hooks is required.
  *
- * @param[in] crypt The @ref mongocrypt_t object.
- *
  * @returns True if libmongocrypt was built with native crypto support.
  */
 MONGOCRYPT_EXPORT

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -49,6 +49,19 @@ MONGOCRYPT_EXPORT
 const char *mongocrypt_version(uint32_t *len);
 
 /**
+ * Returns true if libmongocrypt was built with native crypto support.
+ *
+ * If libmongocrypt was not built with native crypto support, setting crypto
+ * hooks is required.
+ *
+ * @param[in] crypt The @ref mongocrypt_t object.
+ *
+ * @returns True if libmongocrypt was built with native crypto support.
+ */
+MONGOCRYPT_EXPORT
+bool mongocrypt_is_crypto_available(void);
+
+/**
  * A non-owning view of a byte buffer.
  *
  * When constructing a mongocrypt_binary_t it is the responsibility of the

--- a/test/test-mongocrypt-crypto-hooks.c
+++ b/test/test-mongocrypt-crypto-hooks.c
@@ -759,6 +759,16 @@ void _test_fle2_crypto_via_ecb_hook(_mongocrypt_tester_t *tester) {
 }
 #endif
 
+static void test_is_crypto_available_with_crypto_required(_mongocrypt_tester_t *tester) {
+    // libmongocrypt is built with native crypto.
+    ASSERT(mongocrypt_is_crypto_available());
+}
+
+static void test_is_crypto_available_with_crypto_prohibited(_mongocrypt_tester_t *tester) {
+    // libmongocrypt is not built with native crypto.
+    ASSERT(!mongocrypt_is_crypto_available());
+}
+
 void _mongocrypt_tester_install_crypto_hooks(_mongocrypt_tester_t *tester) {
     INSTALL_TEST_CRYPTO(_test_crypto_hooks_encryption, CRYPTO_OPTIONAL);
     INSTALL_TEST_CRYPTO(_test_crypto_hooks_decryption, CRYPTO_OPTIONAL);
@@ -769,6 +779,8 @@ void _mongocrypt_tester_install_crypto_hooks(_mongocrypt_tester_t *tester) {
     INSTALL_TEST_CRYPTO(_test_crypto_hooks_explicit_err, CRYPTO_OPTIONAL);
     INSTALL_TEST_CRYPTO(_test_crypto_hooks_explicit_sha256_err, CRYPTO_OPTIONAL);
     INSTALL_TEST_CRYPTO(_test_crypto_hook_sign_rsaes_pkcs1_v1_5, CRYPTO_OPTIONAL);
+    INSTALL_TEST_CRYPTO(test_is_crypto_available_with_crypto_required, CRYPTO_REQUIRED);
+    INSTALL_TEST_CRYPTO(test_is_crypto_available_with_crypto_prohibited, CRYPTO_PROHIBITED);
 #ifdef MONGOCRYPT_ENABLE_CRYPTO_LIBCRYPTO
     INSTALL_TEST(_test_fle2_crypto_via_ecb_hook);
 #endif


### PR DESCRIPTION
# Summary

Add `mongocrypt_is_crypto_available` to report whether libmongocrypt is built with native crypto support.

# Background & Motivation

libmongocrypt can be built without native crypto support with the CMake option `DISABLE_NATIVE_CRYPTO`. If native crypto is disabled, crypto primitives must be supplied with callbacks (e.g. `mongocrypt_setopt_crypto_hooks` and friends).

DRIVERS-2718 proposes having driver bindings prefer using libmongocrypt with native crypto when available for the observed performance imporvement. This may require driver check if libmongocrypt is built with native crypto at runtime:

> Add a method in CAPI like bool isCryptoAvailable(). Change the wrapper to call that method and only register crypto callbacks if it returns false.