### PR TITLE
PYTHON-4172 Support named KMS providers

### DIFF
--- a/bindings/python/CHANGELOG.rst
+++ b/bindings/python/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Changes in Version 1.9.0
+------------------------
+
+- Add support for named KMS providers like "local:name1".
+  This feature requires libmongocrypt >= 1.9.0.
+
 Changes in Version 1.8.0
 ------------------------
 

--- a/bindings/python/pymongocrypt/credentials.py
+++ b/bindings/python/pymongocrypt/credentials.py
@@ -107,19 +107,9 @@ def _ask_for_kms_credentials(kms_providers):
 
     This is a separate function so it can be overridden in unit tests."""
     global _azure_creds_cache
-    on_demand_aws = []
-    on_demand_gcp = []
-    on_demand_azure = []
-    for name, provider in kms_providers.items():
-        # Account for provider names like "local:myname".
-        provider_type = name.split(":")[0]
-        if not len(provider):
-            if provider_type == 'aws':
-                on_demand_aws.append(name)
-            elif provider_type == 'gcp':
-                on_demand_gcp.append(name)
-            elif provider_type == 'azure':
-                on_demand_azure.append(name)
+    on_demand_aws = 'aws' in kms_providers and not len(kms_providers['aws'])
+    on_demand_gcp = 'gcp' in kms_providers and not len(kms_providers['gcp'])
+    on_demand_azure = 'azure' in kms_providers and not len(kms_providers['azure'])
 
     if not any([on_demand_aws, on_demand_gcp, on_demand_azure]):
         return {}
@@ -134,18 +124,13 @@ def _ask_for_kms_credentials(kms_providers):
         creds_dict = {"accessKeyId": aws_creds.username, "secretAccessKey": aws_creds.password}
         if aws_creds.token:
             creds_dict["sessionToken"] = aws_creds.token
-        for name in on_demand_aws:
-            creds[name] = creds_dict
+        creds['aws'] = creds_dict
     if on_demand_gcp:
-        gcp_creds = _get_gcp_credentials()
-        for name in on_demand_gcp:
-            creds[name] = gcp_creds
+        creds['gcp'] = _get_gcp_credentials()
     if on_demand_azure:
         try:
-            azure_creds = _get_azure_credentials()
+            creds['azure'] = _get_azure_credentials()
         except Exception:
             _azure_creds_cache = None
             raise
-        for name in on_demand_azure:
-            creds[name] = azure_creds
     return creds

--- a/bindings/python/pymongocrypt/explicit_encrypter.py
+++ b/bindings/python/pymongocrypt/explicit_encrypter.py
@@ -147,7 +147,8 @@ class ExplicitEncrypter(object):
 
         :Parameters:
           - `kms_provider`: The KMS provider to use. Supported values are
-            "aws", "azure", "gcp", "kmip", and "local".
+            "aws", "azure", "gcp", "kmip", "local", or a named provider like
+            "kmip:name".
           - `master_key`: See class:`DataKeyOpts`.
           - `key_alt_names` (optional): An optional list of string alternate
             names used to reference a key. If a key is created with alternate

--- a/bindings/python/pymongocrypt/mongocrypt.py
+++ b/bindings/python/pymongocrypt/mongocrypt.py
@@ -93,59 +93,42 @@ class MongoCryptOptions(object):
         if not kms_providers:
             raise ValueError('at least one KMS provider must be configured')
 
-        if 'aws' in kms_providers:
-            aws = kms_providers["aws"]
-            if not isinstance(aws, dict):
-                raise ValueError("kms_providers['aws'] must be a dict")
-            if len(aws):
-                if "accessKeyId" not in aws or "secretAccessKey" not in aws:
-                    raise ValueError("kms_providers['aws'] must contain "
-                                     "'accessKeyId' and 'secretAccessKey'")
-
-        if 'azure' in kms_providers:
-            azure = kms_providers["azure"]
-            if not isinstance(azure, dict):
-                raise ValueError("kms_providers['azure'] must be a dict")
-            if len(azure):
-                if 'clientId' not in azure or 'clientSecret' not in azure:
-                    raise ValueError("kms_providers['azure'] must contain "
-                                     "'clientId' and 'clientSecret'")
-
-        if 'gcp' in kms_providers:
-            gcp = kms_providers['gcp']
-            if not isinstance(gcp, dict):
-                raise ValueError("kms_providers['gcp'] must be a dict")
-            if len(gcp):
-                if 'email' not in gcp or 'privateKey' not in gcp:
-                    raise ValueError("kms_providers['gcp'] must contain "
-                                     "'email' and 'privateKey'")
-                if not isinstance(kms_providers['gcp']['privateKey'],
-                                  (bytes, unicode_type)):
-                    raise TypeError("kms_providers['gcp']['privateKey'] must "
-                                    "be an instance of bytes or str")
-
-        if 'kmip' in kms_providers:
-            kmip = kms_providers['kmip']
-            if not isinstance(kmip, dict):
-                raise ValueError("kms_providers['kmip'] must be a dict")
-            if 'endpoint' not in kmip:
-                raise ValueError("kms_providers['kmip'] must contain "
-                                 "'endpoint'")
-            if not isinstance(kms_providers['kmip']['endpoint'],
-                              (str, unicode_type)):
-                raise TypeError("kms_providers['kmip']['endpoint'] must "
-                                "be an instance of str")
-
-        if 'local' in kms_providers:
-            local = kms_providers['local']
-            if not isinstance(local, dict):
-                raise ValueError("kms_providers['local'] must be a dict")
-            if 'key' not in local:
-                raise ValueError("kms_providers['local'] must contain 'key'")
-            if not isinstance(kms_providers['local']['key'],
-                              (bytes, unicode_type)):
-                raise TypeError("kms_providers['local']['key'] must be an "
-                                "instance of bytes or str")
+        for name, provider in kms_providers.items():
+            # Account for provider names like "local:myname".
+            provider_type = name.split(":")[0]
+            if provider_type in ('aws', 'gcp', 'azure', 'kmip', 'local'):
+                if not isinstance(provider, dict):
+                    raise ValueError(f"kms_providers[{name!r}] must be a dict")
+            if provider_type == 'aws':
+                if len(provider):
+                    if "accessKeyId" not in provider or "secretAccessKey" not in provider:
+                        raise ValueError(f"kms_providers[{name!r}] must contain "
+                                         "'accessKeyId' and 'secretAccessKey'")
+            elif provider_type == 'azure':
+                if len(provider):
+                    if 'clientId' not in provider or 'clientSecret' not in provider:
+                        raise ValueError(f"kms_providers[{name!r}] must contain "
+                                         "'clientId' and 'clientSecret'")
+            elif provider_type == 'gcp':
+                if len(provider):
+                    if 'email' not in provider or 'privateKey' not in provider:
+                        raise ValueError(f"kms_providers[{name!r}] must contain "
+                                         "'email' and 'privateKey'")
+                    if not isinstance(provider['privateKey'], (bytes, unicode_type)):
+                        raise TypeError(f"kms_providers[{name!r}]['privateKey'] must "
+                                        "be an instance of bytes or str")
+            elif provider_type == 'kmip':
+                if 'endpoint' not in provider:
+                    raise ValueError(f"kms_providers[{name!r}] must contain 'endpoint'")
+                if not isinstance(provider['endpoint'], (str, unicode_type)):
+                    raise TypeError(f"kms_providers[{name!r}]['endpoint'] must "
+                                    "be an instance of str")
+            elif provider_type == 'local':
+                if 'key' not in provider:
+                    raise ValueError(f"kms_providers[{name!r}] must contain 'key'")
+                if not isinstance(provider['key'], (bytes, unicode_type)):
+                    raise TypeError(f"kms_providers[{name!r}]['key'] must be an "
+                                    "instance of bytes or str")
 
         if schema_map is not None and not isinstance(schema_map, bytes):
             raise TypeError("schema_map must be bytes or None")

--- a/bindings/python/pymongocrypt/mongocrypt.py
+++ b/bindings/python/pymongocrypt/mongocrypt.py
@@ -598,7 +598,7 @@ class DataKeyContext(MongoCryptContext):
         """
         super(DataKeyContext, self).__init__(ctx, kms_providers)
         try:
-            if kms_provider not in ['aws', 'gcp', 'azure', 'kmip', 'local']:
+            if kms_provider not in kms_providers:
                 raise ValueError('unknown kms_provider: %s' % (kms_provider,))
 
             if opts is None or opts.master_key is None:

--- a/bindings/python/pymongocrypt/mongocrypt.py
+++ b/bindings/python/pymongocrypt/mongocrypt.py
@@ -51,6 +51,10 @@ class MongoCryptOptions(object):
               - `kmip`: Map with "endpoint" as a string.
               - `local`: Map with "key" as a 96-byte array or the equivalent
                 base64-encoded string.
+
+            KMS providers may be specified with an optional name suffix
+            separated by a colon, for example "kmip:name". Named KMS providers
+            do not support automatic credential lookup.
           - `schema_map`: Optional map of collection namespace ("db.coll") to
             JSON Schema.  By default, a collection's JSONSchema is periodically
             polled with the listCollections command. But a JSONSchema may be

--- a/bindings/python/pymongocrypt/mongocrypt.py
+++ b/bindings/python/pymongocrypt/mongocrypt.py
@@ -601,36 +601,37 @@ class DataKeyContext(MongoCryptContext):
             if kms_provider not in kms_providers:
                 raise ValueError('unknown kms_provider: %s' % (kms_provider,))
 
+            # Account for provider names like "local:myname".
+            provider_type = kms_provider.split(":")[0]
             if opts is None or opts.master_key is None:
-                if kms_provider in ['kmip', 'local']:
+                if provider_type in ['kmip', 'local']:
                     master_key = {}
                 else:
                     raise ValueError(
-                        'master_key is required for kms_provider: "%s"' % (
-                            kms_provider,))
+                        f'master_key is required for kms_provider: {kms_provider!r}')
             else:
                 master_key = opts.master_key.copy()
 
-            if kms_provider == 'aws':
+            if provider_type == 'aws':
                 if ('region' not in master_key or
                         'key' not in master_key):
                     raise ValueError(
                         'master_key must include "region" and "key" for '
-                        'kms_provider: "aws"')
-            elif kms_provider == 'azure':
+                        f'kms_provider: {kms_provider!r}')
+            elif provider_type == 'azure':
                 if ('keyName' not in master_key or
                         'keyVaultEndpoint' not in master_key):
                     raise ValueError(
                         'master key must include "keyName" and '
-                        '"keyVaultEndpoint" for kms_provider: "azure"')
-            elif kms_provider == 'gcp':
+                        f'"keyVaultEndpoint" for kms_provider: {kms_provider!r}')
+            elif provider_type == 'gcp':
                 if ('projectId' not in master_key or
                         'location' not in master_key or
                         'keyRing' not in master_key or
                         'keyName' not in master_key):
                     raise ValueError(
                         'master key must include "projectId", "location",'
-                        '"keyRing", and "keyName" for kms_provider: "gcp"')
+                        f'"keyRing", and "keyName" for kms_provider: {kms_provider!r}')
 
             master_key['provider'] = kms_provider
             with MongoCryptBinaryIn(

--- a/bindings/python/pymongocrypt/version.py
+++ b/bindings/python/pymongocrypt/version.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '1.8.1.dev0'
+__version__ = '1.9.0.dev0'
 
 _MIN_LIBMONGOCRYPT_VERSION = '1.8.0'


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-4172

This change extends the python-side kms provider validation rules to the new named providers. Note that we already pass kms_providers directly to libmongocrypt so this change isn't a blocker. All users need to do is ensure they have a libmongocrypt with [MONGOCRYPT-605](https://jira.mongodb.org/browse/MONGOCRYPT-605) installed (>= v1.9.0).

This change also fixes a bug in the python binding which blocks named kms providers from being used in create_data_key. The bug results in this `EncryptionError: unknown kms_provider: aws:name1` error:
```python
    return target.create_data_key(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shane/git/mongo-python-driver/pymongo/encryption.py", line 747, in create_data_key
    with _wrap_encryption_errors():
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/contextlib.py", line 155, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/Users/shane/git/mongo-python-driver/pymongo/encryption.py", line 104, in _wrap_encryption_errors
    raise EncryptionError(exc) from None
pymongo.errors.EncryptionError: unknown kms_provider: aws:name1
```