### PR TITLE
SERVER-85740 Extend libmongocrypt to support trimFactor passthrough

### DIFF
--- a/src/mc-dec128.h
+++ b/src/mc-dec128.h
@@ -607,7 +607,7 @@ static inline char *mc_dec128_to_new_decimal_string(mc_dec128 d) {
     }
 }
 
-static inline mc_dec128 mc_dec128_from_bson_iter(bson_iter_t *it) {
+static inline mc_dec128 mc_dec128_from_bson_iter(const bson_iter_t *it) {
     bson_decimal128_t b;
     if (!bson_iter_decimal128(it, &b)) {
         mc_dec128 nan = MC_DEC128_POSITIVE_NAN;

--- a/src/mc-rangeopts-private.h
+++ b/src/mc-rangeopts-private.h
@@ -23,7 +23,7 @@
 #include "mongocrypt-status-private.h"
 
 typedef struct {
-    bson_t *bson;
+    bson_t* bson;
 
     struct {
         bson_iter_t value;
@@ -48,7 +48,7 @@ typedef struct {
  *    "precision": Optional<Int32>
  * }
  */
-bool mc_RangeOpts_parse(mc_RangeOpts_t *ro, const bson_t *in, mongocrypt_status_t *status);
+bool mc_RangeOpts_parse(mc_RangeOpts_t* ro, const bson_t* in, mongocrypt_status_t* status);
 
 /*
  * mc_RangeOpts_to_FLE2RangeInsertSpec creates a placeholder value to be
@@ -66,29 +66,29 @@ bool mc_RangeOpts_parse(mc_RangeOpts_t *ro, const bson_t *in, mongocrypt_status_
  *
  * Preconditions: out must be initialized by caller.
  */
-bool mc_RangeOpts_to_FLE2RangeInsertSpec(const mc_RangeOpts_t *ro,
-                                         const bson_t *v,
-                                         bson_t *out,
-                                         mongocrypt_status_t *status);
+bool mc_RangeOpts_to_FLE2RangeInsertSpec(const mc_RangeOpts_t* ro,
+                                         const bson_t* v,
+                                         bson_t* out,
+                                         mongocrypt_status_t* status);
 
 /* mc_RangeOpts_appendMin appends the minimum value of the range for a given
  * type. If `ro->min` is unset, uses the lowest representable value of the value
  * type. Errors if `valueType` does not match the type of `ro->min`. */
-bool mc_RangeOpts_appendMin(const mc_RangeOpts_t *ro,
+bool mc_RangeOpts_appendMin(const mc_RangeOpts_t* ro,
                             bson_type_t valueType,
-                            const char *fieldName,
-                            bson_t *out,
-                            mongocrypt_status_t *status);
+                            const char* fieldName,
+                            bson_t* out,
+                            mongocrypt_status_t* status);
 
 /* mc_RangeOpts_appendMax appends the maximum value of the range for a given
  * type. If `ro->max` is unset, uses the highest representable value of the
  * value type. Errors if `valueType` does not match the type of `ro->max`. */
-bool mc_RangeOpts_appendMax(const mc_RangeOpts_t *ro,
+bool mc_RangeOpts_appendMax(const mc_RangeOpts_t* ro,
                             bson_type_t valueType,
-                            const char *fieldName,
-                            bson_t *out,
-                            mongocrypt_status_t *status);
+                            const char* fieldName,
+                            bson_t* out,
+                            mongocrypt_status_t* status);
 
-void mc_RangeOpts_cleanup(mc_RangeOpts_t *ro);
+void mc_RangeOpts_cleanup(mc_RangeOpts_t* ro);
 
-#endif // MC_RANGEOPTS_PRIVATE_H
+#endif  // MC_RANGEOPTS_PRIVATE_H

--- a/src/mc-rangeopts-private.h
+++ b/src/mc-rangeopts-private.h
@@ -23,7 +23,7 @@
 #include "mongocrypt-status-private.h"
 
 typedef struct {
-    bson_t* bson;
+    bson_t *bson;
 
     struct {
         bson_iter_t value;
@@ -50,7 +50,7 @@ typedef struct {
  *    "trimFactor": Optional<Uint32>,
  * }
  */
-bool mc_RangeOpts_parse(mc_RangeOpts_t* ro, const bson_t* in, mongocrypt_status_t* status);
+bool mc_RangeOpts_parse(mc_RangeOpts_t *ro, const bson_t *in, mongocrypt_status_t *status);
 
 /*
  * mc_RangeOpts_to_FLE2RangeInsertSpec creates a placeholder value to be
@@ -68,38 +68,38 @@ bool mc_RangeOpts_parse(mc_RangeOpts_t* ro, const bson_t* in, mongocrypt_status_
  *
  * Preconditions: out must be initialized by caller.
  */
-bool mc_RangeOpts_to_FLE2RangeInsertSpec(const mc_RangeOpts_t* ro,
-                                         const bson_t* v,
-                                         bson_t* out,
-                                         mongocrypt_status_t* status);
+bool mc_RangeOpts_to_FLE2RangeInsertSpec(const mc_RangeOpts_t *ro,
+                                         const bson_t *v,
+                                         bson_t *out,
+                                         mongocrypt_status_t *status);
 
 /* mc_RangeOpts_appendMin appends the minimum value of the range for a given
  * type. If `ro->min` is unset, uses the lowest representable value of the value
  * type. Errors if `valueType` does not match the type of `ro->min`. */
-bool mc_RangeOpts_appendMin(const mc_RangeOpts_t* ro,
+bool mc_RangeOpts_appendMin(const mc_RangeOpts_t *ro,
                             bson_type_t valueType,
-                            const char* fieldName,
-                            bson_t* out,
-                            mongocrypt_status_t* status);
+                            const char *fieldName,
+                            bson_t *out,
+                            mongocrypt_status_t *status);
 
 /* mc_RangeOpts_appendMax appends the maximum value of the range for a given
  * type. If `ro->max` is unset, uses the highest representable value of the
  * value type. Errors if `valueType` does not match the type of `ro->max`. */
-bool mc_RangeOpts_appendMax(const mc_RangeOpts_t* ro,
+bool mc_RangeOpts_appendMax(const mc_RangeOpts_t *ro,
                             bson_type_t valueType,
-                            const char* fieldName,
-                            bson_t* out,
-                            mongocrypt_status_t* status);
+                            const char *fieldName,
+                            bson_t *out,
+                            mongocrypt_status_t *status);
 
 /* mc_RangeOpts_appendTrimFactor appends the trim factor of the field. If `ro->trimFactor` is unset,
  * defaults to 0. Errors if `ro->trimFactor` is out of bounds based on the size of the domain
  * computed from `valueType`, `ro->min` and `ro->max`. */
-bool mc_RangeOpts_appendTrimFactor(const mc_RangeOpts_t* ro,
+bool mc_RangeOpts_appendTrimFactor(const mc_RangeOpts_t *ro,
                                    bson_type_t valueType,
-                                   const char* fieldName,
-                                   bson_t* out,
-                                   mongocrypt_status_t* status);
+                                   const char *fieldName,
+                                   bson_t *out,
+                                   mongocrypt_status_t *status);
 
-void mc_RangeOpts_cleanup(mc_RangeOpts_t* ro);
+void mc_RangeOpts_cleanup(mc_RangeOpts_t *ro);
 
-#endif  // MC_RANGEOPTS_PRIVATE_H
+#endif // MC_RANGEOPTS_PRIVATE_H

--- a/src/mc-rangeopts-private.h
+++ b/src/mc-rangeopts-private.h
@@ -37,6 +37,7 @@ typedef struct {
 
     int64_t sparsity;
     mc_optional_uint32_t precision;
+    mc_optional_uint32_t trimFactor;
 } mc_RangeOpts_t;
 
 /* mc_RangeOpts_parse parses a BSON document into mc_RangeOpts_t.
@@ -45,7 +46,8 @@ typedef struct {
  *    "min": BSON value,
  *    "max": BSON value,
  *    "sparsity": Int64,
- *    "precision": Optional<Int32>
+ *    "precision": Optional<Uint32>,
+ *    "trimFactor": Optional<Uint32>,
  * }
  */
 bool mc_RangeOpts_parse(mc_RangeOpts_t* ro, const bson_t* in, mongocrypt_status_t* status);
@@ -88,6 +90,15 @@ bool mc_RangeOpts_appendMax(const mc_RangeOpts_t* ro,
                             const char* fieldName,
                             bson_t* out,
                             mongocrypt_status_t* status);
+
+/* mc_RangeOpts_appendTrimFactor appends the trim factor of the field. If `ro->trimFactor` is unset,
+ * defaults to 0. Errors if `ro->trimFactor` is out of bounds based on the size of the domain
+ * computed from `valueType`, `ro->min` and `ro->max`. */
+bool mc_RangeOpts_appendTrimFactor(const mc_RangeOpts_t* ro,
+                                   bson_type_t valueType,
+                                   const char* fieldName,
+                                   bson_t* out,
+                                   mongocrypt_status_t* status);
 
 void mc_RangeOpts_cleanup(mc_RangeOpts_t* ro);
 

--- a/src/mc-rangeopts-private.h
+++ b/src/mc-rangeopts-private.h
@@ -50,7 +50,7 @@ typedef struct {
  *    "trimFactor": Optional<Uint32>,
  * }
  */
-bool mc_RangeOpts_parse(mc_RangeOpts_t *ro, const bson_t *in, mongocrypt_status_t *status);
+bool mc_RangeOpts_parse(mc_RangeOpts_t *ro, const bson_t *in, bool use_range_v2, mongocrypt_status_t *status);
 
 /*
  * mc_RangeOpts_to_FLE2RangeInsertSpec creates a placeholder value to be

--- a/src/mc-rangeopts.c
+++ b/src/mc-rangeopts.c
@@ -18,33 +18,33 @@
 
 #include "mc-check-conversions-private.h"
 #include "mongocrypt-private.h"
-#include "mongocrypt-util-private.h" // mc_bson_type_to_string
+#include "mongocrypt-util-private.h"  // mc_bson_type_to_string
 
-#include <float.h> // DBL_MAX
+#include <float.h>  // DBL_MAX
 
 // Common logic for testing field name, tracking duplication, and presence.
-#define IF_FIELD(Name, ErrorPrefix)                                                                                    \
-    if (0 == strcmp(field, #Name)) {                                                                                   \
-        if (has_##Name) {                                                                                              \
-            CLIENT_ERR("%sUnexpected duplicate field '" #Name "'", ErrorPrefix);                                       \
-            return false;                                                                                              \
-        }                                                                                                              \
+#define IF_FIELD(Name, ErrorPrefix)                                              \
+    if (0 == strcmp(field, #Name)) {                                             \
+        if (has_##Name) {                                                        \
+            CLIENT_ERR("%sUnexpected duplicate field '" #Name "'", ErrorPrefix); \
+            return false;                                                        \
+        }                                                                        \
         has_##Name = true;
 
-#define END_IF_FIELD                                                                                                   \
-    continue;                                                                                                          \
+#define END_IF_FIELD \
+    continue;        \
     }
 
-#define CHECK_HAS(Name, ErrorPrefix)                                                                                   \
-    if (!has_##Name) {                                                                                                 \
-        CLIENT_ERR("%sMissing field '" #Name "'", ErrorPrefix);                                                        \
-        return false;                                                                                                  \
+#define CHECK_HAS(Name, ErrorPrefix)                            \
+    if (!has_##Name) {                                          \
+        CLIENT_ERR("%sMissing field '" #Name "'", ErrorPrefix); \
+        return false;                                           \
     }
 
-bool mc_RangeOpts_parse(mc_RangeOpts_t *ro, const bson_t *in, mongocrypt_status_t *status) {
+bool mc_RangeOpts_parse(mc_RangeOpts_t* ro, const bson_t* in, mongocrypt_status_t* status) {
     bson_iter_t iter;
     bool has_min = false, has_max = false, has_sparsity = false, has_precision = false;
-    const char *const error_prefix = "Error parsing RangeOpts: ";
+    const char* const error_prefix = "Error parsing RangeOpts: ";
 
     BSON_ASSERT_PARAM(ro);
     BSON_ASSERT_PARAM(in);
@@ -59,7 +59,7 @@ bool mc_RangeOpts_parse(mc_RangeOpts_t *ro, const bson_t *in, mongocrypt_status_
     }
 
     while (bson_iter_next(&iter)) {
-        const char *field = bson_iter_key(&iter);
+        const char* field = bson_iter_key(&iter);
         BSON_ASSERT(field);
 
         IF_FIELD(min, error_prefix)
@@ -114,9 +114,10 @@ bool mc_RangeOpts_parse(mc_RangeOpts_t *ro, const bson_t *in, mongocrypt_status_
 
         bson_type_t minType = bson_iter_type(&ro->min.value);
         if (minType != BSON_TYPE_DOUBLE && minType != BSON_TYPE_DECIMAL128) {
-            CLIENT_ERR("expected 'precision' to be set with double or decimal128 "
-                       "index, but got: %s min",
-                       mc_bson_type_to_string(minType));
+            CLIENT_ERR(
+                "expected 'precision' to be set with double or decimal128 "
+                "index, but got: %s min",
+                mc_bson_type_to_string(minType));
             return false;
         }
 
@@ -127,21 +128,24 @@ bool mc_RangeOpts_parse(mc_RangeOpts_t *ro, const bson_t *in, mongocrypt_status_
 
         bson_type_t maxType = bson_iter_type(&ro->max.value);
         if (maxType != BSON_TYPE_DOUBLE && maxType != BSON_TYPE_DECIMAL128) {
-            CLIENT_ERR("expected 'precision' to be set with double or decimal128 "
-                       "index, but got: %s max",
-                       mc_bson_type_to_string(maxType));
+            CLIENT_ERR(
+                "expected 'precision' to be set with double or decimal128 "
+                "index, but got: %s max",
+                mc_bson_type_to_string(maxType));
             return false;
         }
     }
 
     // Expect min and max to match types.
     if (ro->min.set && ro->max.set) {
-        bson_type_t minType = bson_iter_type(&ro->min.value), maxType = bson_iter_type(&ro->max.value);
+        bson_type_t minType = bson_iter_type(&ro->min.value),
+                    maxType = bson_iter_type(&ro->max.value);
         if (minType != maxType) {
-            CLIENT_ERR("expected 'min' and 'max' to be same type, but got: %s "
-                       "min and %s max",
-                       mc_bson_type_to_string(minType),
-                       mc_bson_type_to_string(maxType));
+            CLIENT_ERR(
+                "expected 'min' and 'max' to be same type, but got: %s "
+                "min and %s max",
+                mc_bson_type_to_string(minType),
+                mc_bson_type_to_string(maxType));
             return false;
         }
     }
@@ -152,7 +156,8 @@ bool mc_RangeOpts_parse(mc_RangeOpts_t *ro, const bson_t *in, mongocrypt_status_
             bson_type_t minType = bson_iter_type(&ro->min.value);
             if (minType == BSON_TYPE_DOUBLE || minType == BSON_TYPE_DECIMAL128) {
                 if (!has_precision) {
-                    CLIENT_ERR("expected 'precision' to be set with 'min' for %s", mc_bson_type_to_string(minType));
+                    CLIENT_ERR("expected 'precision' to be set with 'min' for %s",
+                               mc_bson_type_to_string(minType));
                     return false;
                 }
             }
@@ -162,7 +167,8 @@ bool mc_RangeOpts_parse(mc_RangeOpts_t *ro, const bson_t *in, mongocrypt_status_
             bson_type_t maxType = bson_iter_type(&ro->max.value);
             if (maxType == BSON_TYPE_DOUBLE || maxType == BSON_TYPE_DECIMAL128) {
                 if (!has_precision) {
-                    CLIENT_ERR("expected 'precision' to be set with 'max' for %s", mc_bson_type_to_string(maxType));
+                    CLIENT_ERR("expected 'precision' to be set with 'max' for %s",
+                               mc_bson_type_to_string(maxType));
                     return false;
                 }
             }
@@ -172,16 +178,16 @@ bool mc_RangeOpts_parse(mc_RangeOpts_t *ro, const bson_t *in, mongocrypt_status_
     return true;
 }
 
-bool mc_RangeOpts_to_FLE2RangeInsertSpec(const mc_RangeOpts_t *ro,
-                                         const bson_t *v,
-                                         bson_t *out,
-                                         mongocrypt_status_t *status) {
+bool mc_RangeOpts_to_FLE2RangeInsertSpec(const mc_RangeOpts_t* ro,
+                                         const bson_t* v,
+                                         bson_t* out,
+                                         mongocrypt_status_t* status) {
     BSON_ASSERT_PARAM(ro);
     BSON_ASSERT_PARAM(v);
     BSON_ASSERT_PARAM(out);
     BSON_ASSERT(status || true);
 
-    const char *const error_prefix = "Error making FLE2RangeInsertSpec: ";
+    const char* const error_prefix = "Error making FLE2RangeInsertSpec: ";
     bson_iter_t v_iter;
     if (!bson_iter_init_find(&v_iter, v, "v")) {
         CLIENT_ERR("Unable to find 'v' in input");
@@ -220,11 +226,11 @@ bool mc_RangeOpts_to_FLE2RangeInsertSpec(const mc_RangeOpts_t *ro,
     return true;
 }
 
-bool mc_RangeOpts_appendMin(const mc_RangeOpts_t *ro,
+bool mc_RangeOpts_appendMin(const mc_RangeOpts_t* ro,
                             bson_type_t valueType,
-                            const char *fieldName,
-                            bson_t *out,
-                            mongocrypt_status_t *status) {
+                            const char* fieldName,
+                            bson_t* out,
+                            mongocrypt_status_t* status) {
     BSON_ASSERT_PARAM(ro);
     BSON_ASSERT_PARAM(fieldName);
     BSON_ASSERT_PARAM(out);
@@ -232,10 +238,11 @@ bool mc_RangeOpts_appendMin(const mc_RangeOpts_t *ro,
 
     if (ro->min.set) {
         if (bson_iter_type(&ro->min.value) != valueType) {
-            CLIENT_ERR("expected matching 'min' and value type. Got range option "
-                       "'min' of type %s and value of type %s",
-                       mc_bson_type_to_string(bson_iter_type(&ro->min.value)),
-                       mc_bson_type_to_string(valueType));
+            CLIENT_ERR(
+                "expected matching 'min' and value type. Got range option "
+                "'min' of type %s and value of type %s",
+                mc_bson_type_to_string(bson_iter_type(&ro->min.value)),
+                mc_bson_type_to_string(valueType));
             return false;
         }
         if (!bson_append_iter(out, fieldName, -1, &ro->min.value)) {
@@ -245,8 +252,10 @@ bool mc_RangeOpts_appendMin(const mc_RangeOpts_t *ro,
         return true;
     }
 
-    if (valueType == BSON_TYPE_INT32 || valueType == BSON_TYPE_INT64 || valueType == BSON_TYPE_DATE_TIME) {
-        CLIENT_ERR("Range option 'min' is required for type: %s", mc_bson_type_to_string(valueType));
+    if (valueType == BSON_TYPE_INT32 || valueType == BSON_TYPE_INT64 ||
+        valueType == BSON_TYPE_DATE_TIME) {
+        CLIENT_ERR("Range option 'min' is required for type: %s",
+                   mc_bson_type_to_string(valueType));
         return false;
     } else if (valueType == BSON_TYPE_DOUBLE) {
         if (!BSON_APPEND_DOUBLE(out, fieldName, -DBL_MAX)) {
@@ -260,11 +269,12 @@ bool mc_RangeOpts_appendMin(const mc_RangeOpts_t *ro,
             CLIENT_ERR("failed to append BSON");
             return false;
         }
-#else  // ↑↑↑↑↑↑↑↑ With Decimal128 / Without ↓↓↓↓↓↓↓↓↓↓
-        CLIENT_ERR("unsupported BSON type (Decimal128) for range: libmongocrypt "
-                   "was built without extended Decimal128 support");
+#else   // ↑↑↑↑↑↑↑↑ With Decimal128 / Without ↓↓↓↓↓↓↓↓↓↓
+        CLIENT_ERR(
+            "unsupported BSON type (Decimal128) for range: libmongocrypt "
+            "was built without extended Decimal128 support");
         return false;
-#endif // MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
+#endif  // MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
     } else {
         CLIENT_ERR("unsupported BSON type: %s for range", mc_bson_type_to_string(valueType));
         return false;
@@ -272,11 +282,11 @@ bool mc_RangeOpts_appendMin(const mc_RangeOpts_t *ro,
     return true;
 }
 
-bool mc_RangeOpts_appendMax(const mc_RangeOpts_t *ro,
+bool mc_RangeOpts_appendMax(const mc_RangeOpts_t* ro,
                             bson_type_t valueType,
-                            const char *fieldName,
-                            bson_t *out,
-                            mongocrypt_status_t *status) {
+                            const char* fieldName,
+                            bson_t* out,
+                            mongocrypt_status_t* status) {
     BSON_ASSERT_PARAM(ro);
     BSON_ASSERT_PARAM(fieldName);
     BSON_ASSERT_PARAM(out);
@@ -284,10 +294,11 @@ bool mc_RangeOpts_appendMax(const mc_RangeOpts_t *ro,
 
     if (ro->max.set) {
         if (bson_iter_type(&ro->max.value) != valueType) {
-            CLIENT_ERR("expected matching 'max' and value type. Got range option "
-                       "'max' of type %s and value of type %s",
-                       mc_bson_type_to_string(bson_iter_type(&ro->max.value)),
-                       mc_bson_type_to_string(valueType));
+            CLIENT_ERR(
+                "expected matching 'max' and value type. Got range option "
+                "'max' of type %s and value of type %s",
+                mc_bson_type_to_string(bson_iter_type(&ro->max.value)),
+                mc_bson_type_to_string(valueType));
             return false;
         }
         if (!bson_append_iter(out, fieldName, -1, &ro->max.value)) {
@@ -297,8 +308,10 @@ bool mc_RangeOpts_appendMax(const mc_RangeOpts_t *ro,
         return true;
     }
 
-    if (valueType == BSON_TYPE_INT32 || valueType == BSON_TYPE_INT64 || valueType == BSON_TYPE_DATE_TIME) {
-        CLIENT_ERR("Range option 'max' is required for type: %s", mc_bson_type_to_string(valueType));
+    if (valueType == BSON_TYPE_INT32 || valueType == BSON_TYPE_INT64 ||
+        valueType == BSON_TYPE_DATE_TIME) {
+        CLIENT_ERR("Range option 'max' is required for type: %s",
+                   mc_bson_type_to_string(valueType));
         return false;
     } else if (valueType == BSON_TYPE_DOUBLE) {
         if (!BSON_APPEND_DOUBLE(out, fieldName, DBL_MAX)) {
@@ -312,11 +325,12 @@ bool mc_RangeOpts_appendMax(const mc_RangeOpts_t *ro,
             CLIENT_ERR("failed to append BSON");
             return false;
         }
-#else  // ↑↑↑↑↑↑↑↑ With Decimal128 / Without ↓↓↓↓↓↓↓↓↓↓
-        CLIENT_ERR("unsupported BSON type (Decimal128) for range: libmongocrypt "
-                   "was built without extended Decimal128 support");
+#else   // ↑↑↑↑↑↑↑↑ With Decimal128 / Without ↓↓↓↓↓↓↓↓↓↓
+        CLIENT_ERR(
+            "unsupported BSON type (Decimal128) for range: libmongocrypt "
+            "was built without extended Decimal128 support");
         return false;
-#endif // MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
+#endif  // MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
     } else {
         CLIENT_ERR("unsupported BSON type: %s for range", mc_bson_type_to_string(valueType));
         return false;
@@ -324,7 +338,7 @@ bool mc_RangeOpts_appendMax(const mc_RangeOpts_t *ro,
     return true;
 }
 
-void mc_RangeOpts_cleanup(mc_RangeOpts_t *ro) {
+void mc_RangeOpts_cleanup(mc_RangeOpts_t* ro) {
     if (!ro) {
         return;
     }

--- a/src/mc-rangeopts.c
+++ b/src/mc-rangeopts.c
@@ -521,7 +521,7 @@ bool mc_RangeOpts_appendTrimFactor(const mc_RangeOpts_t* ro,
             nbits);
         return false;
     }
-    if (!BSON_APPEND_INT32(out, fieldName, ro->trimFactor.value)) {
+    if (!BSON_APPEND_INT32(out, fieldName, (int32_t)ro->trimFactor.value)) {
         CLIENT_ERR("failed to append BSON");
         return false;
     }

--- a/src/mc-rangeopts.c
+++ b/src/mc-rangeopts.c
@@ -43,7 +43,7 @@
         return false;                                                                                                  \
     }
 
-bool mc_RangeOpts_parse(mc_RangeOpts_t *ro, const bson_t *in, mongocrypt_status_t *status) {
+bool mc_RangeOpts_parse(mc_RangeOpts_t *ro, const bson_t *in, bool use_range_v2, mongocrypt_status_t *status) {
     bson_iter_t iter;
     bool has_min = false, has_max = false, has_sparsity = false, has_precision = false, has_trimFactor = false;
     const char *const error_prefix = "Error parsing RangeOpts: ";
@@ -188,8 +188,15 @@ bool mc_RangeOpts_parse(mc_RangeOpts_t *ro, const bson_t *in, mongocrypt_status_
         }
     }
 
-    // At this point, we do not know the type of the field if min and max are unspecified. Wait to
-    // validate trimFactor.
+    if (ro->trimFactor.set) {
+        if (!use_range_v2) {
+            // Once `use_range_v2` is default true, this block may be removed.
+            CLIENT_ERR("trimFactor is not supported for QE range v1");
+            return false;
+        }
+        // At this point, we do not know the type of the field if min and max are unspecified. Wait to
+        // validate the value of trimFactor.
+    }
 
     return true;
 }

--- a/src/mc-rangeopts.c
+++ b/src/mc-rangeopts.c
@@ -466,10 +466,9 @@ bool mc_getNumberOfBits(const mc_RangeOpts_t* ro,
             mc_optional_dec128_t rmin, rmax;
             mc_optional_uint32_t prec = ro->precision;
             if (ro->min.set) {
-                value = bson_iter_decimal128(&ro->min.value);
+                value = mc_dec128_from_bson_iter(&ro->min.value);
                 rmin = OPT_MC_DEC128(value);
-                rmax = OPT_MC_DEC128(bson_iter_decimal128(&ro->max.value));
-
+                rmax = OPT_MC_DEC128(mc_dec128_from_bson_iter(&ro->max.value));
             } else {
                 value = MC_DEC128_ZERO;
                 rmin.set = false;
@@ -512,6 +511,7 @@ bool mc_RangeOpts_appendTrimFactor(const mc_RangeOpts_t* ro,
     if (!mc_getNumberOfBits(ro, valueType, &nbits, status)) {
         return false;
     }
+    printf("nbits %d\n", nbits);
     // if nbits = 0, we want to allow trim factor = 0.
     uint32_t test = nbits ? nbits : 1;
     if (ro->trimFactor.value >= test) {

--- a/src/mc-rangeopts.c
+++ b/src/mc-rangeopts.c
@@ -374,6 +374,7 @@ bool mc_getNumberOfBits(const mc_RangeOpts_t *ro,
         int32_t value = 0;
         mc_optional_int32_t rmin = {false, 0}, rmax = {false, 0};
         if (ro->min.set) {
+            BSON_ASSERT(ro->max.set);
             value = bson_iter_int32(&ro->min.value);
             rmin = OPT_I32(value);
             rmax = OPT_I32(bson_iter_int32(&ro->max.value));
@@ -389,6 +390,7 @@ bool mc_getNumberOfBits(const mc_RangeOpts_t *ro,
         int64_t value = 0;
         mc_optional_int64_t rmin = {false, 0}, rmax = {false, 0};
         if (ro->min.set) {
+            BSON_ASSERT(ro->max.set);
             value = bson_iter_int64(&ro->min.value);
             rmin = OPT_I64(value);
             rmax = OPT_I64(bson_iter_int64(&ro->max.value));
@@ -404,6 +406,7 @@ bool mc_getNumberOfBits(const mc_RangeOpts_t *ro,
         int64_t value = 0;
         mc_optional_int64_t rmin = {false, 0}, rmax = {false, 0};
         if (ro->min.set) {
+            BSON_ASSERT(ro->max.set);
             value = bson_iter_date_time(&ro->min.value);
             rmin = OPT_I64(value);
             rmax = OPT_I64(bson_iter_date_time(&ro->max.value));
@@ -420,6 +423,7 @@ bool mc_getNumberOfBits(const mc_RangeOpts_t *ro,
         mc_optional_double_t rmin = {false, 0}, rmax = {false, 0};
         mc_optional_uint32_t prec = ro->precision;
         if (ro->min.set) {
+            BSON_ASSERT(ro->max.set);
             value = bson_iter_double(&ro->min.value);
             rmin = OPT_DOUBLE(value);
             rmax = OPT_DOUBLE(bson_iter_double(&ro->max.value));
@@ -438,6 +442,7 @@ bool mc_getNumberOfBits(const mc_RangeOpts_t *ro,
         mc_optional_dec128_t rmin = {false, MC_DEC128_ZERO}, rmax = {false, MC_DEC128_ZERO};
         mc_optional_uint32_t prec = ro->precision;
         if (ro->min.set) {
+            BSON_ASSERT(ro->max.set);
             value = mc_dec128_from_bson_iter(&ro->min.value);
             rmin = OPT_MC_DEC128(value);
             rmax = OPT_MC_DEC128(mc_dec128_from_bson_iter(&ro->max.value));

--- a/src/mc-rangeopts.c
+++ b/src/mc-rangeopts.c
@@ -364,16 +364,12 @@ bool mc_getNumberOfBits(const mc_RangeOpts_t *ro,
     // which tells us how many bits are needed to represent the whole domain.
     // note - can't use a switch statement because of -Werror=switch-enum
     if (valueType == BSON_TYPE_INT32) {
-        int32_t value;
-        mc_optional_int32_t rmin, rmax;
+        int32_t value = 0;
+        mc_optional_int32_t rmin = {false, 0}, rmax = {false, 0};
         if (ro->min.set) {
             value = bson_iter_int32(&ro->min.value);
             rmin = OPT_I32(value);
             rmax = OPT_I32(bson_iter_int32(&ro->max.value));
-        } else {
-            value = 0;
-            rmin.set = false;
-            rmax.set = false;
         }
         mc_getTypeInfo32_args_t args = {value, rmin, rmax};
         mc_OSTType_Int32 out;
@@ -383,16 +379,12 @@ bool mc_getNumberOfBits(const mc_RangeOpts_t *ro,
         *bitsOut = 32 - (uint32_t)mc_count_leading_zeros_u32(out.max);
         return true;
     } else if (valueType == BSON_TYPE_INT64) {
-        int64_t value;
-        mc_optional_int64_t rmin, rmax;
+        int64_t value = 0;
+        mc_optional_int64_t rmin = {false, 0}, rmax = {false, 0};
         if (ro->min.set) {
             value = bson_iter_int64(&ro->min.value);
             rmin = OPT_I64(value);
             rmax = OPT_I64(bson_iter_int64(&ro->max.value));
-        } else {
-            value = 0;
-            rmin.set = false;
-            rmax.set = false;
         }
         mc_getTypeInfo64_args_t args = {value, rmin, rmax};
         mc_OSTType_Int64 out;
@@ -402,16 +394,12 @@ bool mc_getNumberOfBits(const mc_RangeOpts_t *ro,
         *bitsOut = 64 - (uint32_t)mc_count_leading_zeros_u64(out.max);
         return true;
     } else if (valueType == BSON_TYPE_DATE_TIME) {
-        int64_t value;
-        mc_optional_int64_t rmin, rmax;
+        int64_t value = 0;
+        mc_optional_int64_t rmin = {false, 0}, rmax = {false, 0};
         if (ro->min.set) {
             value = bson_iter_date_time(&ro->min.value);
             rmin = OPT_I64(value);
             rmax = OPT_I64(bson_iter_date_time(&ro->max.value));
-        } else {
-            value = 0;
-            rmin.set = false;
-            rmax.set = false;
         }
         mc_getTypeInfo64_args_t args = {value, rmin, rmax};
         mc_OSTType_Int64 out;
@@ -421,18 +409,13 @@ bool mc_getNumberOfBits(const mc_RangeOpts_t *ro,
         *bitsOut = 64 - (uint32_t)mc_count_leading_zeros_u64(out.max);
         return true;
     } else if (valueType == BSON_TYPE_DOUBLE) {
-        double value;
-        mc_optional_double_t rmin, rmax;
+        double value = 0;
+        mc_optional_double_t rmin = {false, 0}, rmax = {false, 0};
         mc_optional_uint32_t prec = ro->precision;
         if (ro->min.set) {
             value = bson_iter_double(&ro->min.value);
             rmin = OPT_DOUBLE(value);
             rmax = OPT_DOUBLE(bson_iter_double(&ro->max.value));
-
-        } else {
-            value = 0;
-            rmin.set = false;
-            rmax.set = false;
         }
         mc_getTypeInfoDouble_args_t args = {value, rmin, rmax, prec};
         mc_OSTType_Double out;
@@ -444,17 +427,13 @@ bool mc_getNumberOfBits(const mc_RangeOpts_t *ro,
     }
 #if MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
     else if (valueType == BSON_TYPE_DECIMAL128) {
-        mc_dec128 value;
-        mc_optional_dec128_t rmin, rmax;
+        mc_dec128 value = MC_DEC128_ZERO;
+        mc_optional_dec128_t rmin = {false, MC_DEC128_ZERO}, rmax = {false, MC_DEC128_ZERO};
         mc_optional_uint32_t prec = ro->precision;
         if (ro->min.set) {
             value = mc_dec128_from_bson_iter(&ro->min.value);
             rmin = OPT_MC_DEC128(value);
             rmax = OPT_MC_DEC128(mc_dec128_from_bson_iter(&ro->max.value));
-        } else {
-            value = MC_DEC128_ZERO;
-            rmin.set = false;
-            rmax.set = false;
         }
         mc_getTypeInfoDecimal128_args_t args = {value, rmin, rmax, prec};
         mc_OSTType_Decimal128 out;

--- a/src/mc-rangeopts.c
+++ b/src/mc-rangeopts.c
@@ -511,7 +511,6 @@ bool mc_RangeOpts_appendTrimFactor(const mc_RangeOpts_t* ro,
     if (!mc_getNumberOfBits(ro, valueType, &nbits, status)) {
         return false;
     }
-    printf("nbits %d\n", nbits);
     // if nbits = 0, we want to allow trim factor = 0.
     uint32_t test = nbits ? nbits : 1;
     if (ro->trimFactor.value >= test) {

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -1071,7 +1071,7 @@ bool mongocrypt_ctx_setopt_algorithm_range(mongocrypt_ctx_t *ctx, mongocrypt_bin
         return _mongocrypt_ctx_fail_w_msg(ctx, "invalid BSON");
     }
 
-    if (!mc_RangeOpts_parse(&ctx->opts.rangeopts.value, &as_bson, ctx->status)) {
+    if (!mc_RangeOpts_parse(&ctx->opts.rangeopts.value, &as_bson, ctx->crypt->opts.use_range_v2, ctx->status)) {
         return _mongocrypt_ctx_fail(ctx);
     }
 

--- a/src/mongocrypt-opts-private.h
+++ b/src/mongocrypt-opts-private.h
@@ -120,6 +120,9 @@ typedef struct {
     // When creating new encrypted payloads,
     // use V2 variants of the FLE2 datatypes.
     bool use_fle2_v2;
+
+    // Use the Queryable Encryption Range V2 protocol.
+    bool use_range_v2;
 } _mongocrypt_opts_t;
 
 void _mongocrypt_opts_kms_providers_cleanup(_mongocrypt_opts_kms_providers_t *kms_providers);

--- a/src/mongocrypt-private.h
+++ b/src/mongocrypt-private.h
@@ -174,4 +174,14 @@ bool _mongocrypt_needs_credentials_for_provider(mongocrypt_t *crypt,
  */
 bool mongocrypt_setopt_fle2v2(mongocrypt_t *crypt, bool enable);
 
+/**
+ * Enable use of Queryable Encryption Range V2 protocol.
+ *
+ * @param[in] crypt The @ref mongocrypt_t object.
+ *
+ * @returns A boolean indicating success. If false, an error status is set.
+ * Retrieve it with @ref mongocrypt_status
+ */
+bool mongocrypt_enable_range_v2(mongocrypt_t *crypt);
+
 #endif /* MONGOCRYPT_PRIVATE_H */

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -153,6 +153,13 @@ bool mongocrypt_setopt_fle2v2(mongocrypt_t *crypt, bool enable) {
     return true;
 }
 
+bool mongocrypt_enable_range_v2(mongocrypt_t *crypt) {
+    ASSERT_MONGOCRYPT_PARAM_UNINIT(crypt);
+
+    crypt->opts.use_range_v2 = true;
+    return true;
+}
+
 bool mongocrypt_setopt_log_handler(mongocrypt_t *crypt, mongocrypt_log_fn_t log_fn, void *log_ctx) {
     ASSERT_MONGOCRYPT_PARAM_UNINIT(crypt);
     crypt->opts.log_fn = log_fn;

--- a/test/test-mc-fle2-rfds.c
+++ b/test/test-mc-fle2-rfds.c
@@ -325,7 +325,7 @@ static void test_mc_FLE2RangeFindDriverSpec_to_placeholders(_mongocrypt_tester_t
     bson_t *range_opts_bson =
         TMP_BSON("{'min': %d, 'max': %d, 'sparsity': {'$numberLong': '%d'}}", indexMin, indexMax, sparsity);
 
-    ASSERT_OK_STATUS(mc_RangeOpts_parse(&range_opts, range_opts_bson, status), status);
+    ASSERT_OK_STATUS(mc_RangeOpts_parse(&range_opts, range_opts_bson, true /* use_range_v2 */, status), status);
 
     for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
         testcase_t *test = tests + i;

--- a/test/test-mc-rangeopts.c
+++ b/test/test-mc-rangeopts.c
@@ -64,7 +64,7 @@ static void test_mc_RangeOpts_parse(_mongocrypt_tester_t *tester) {
          .in = RAW_STRING({"min" : 0.0, "sparsity" : {"$numberLong" : "1"}}),
          .expectError = "expected 'precision'"},
         {.desc = "Errors on negative trim factor",
-         .in = RAW_STRING({"trimFactor": -1, "sparsity" : {"$numberLong" : "1"}}),
+         .in = RAW_STRING({"trimFactor" : -1, "sparsity" : {"$numberLong" : "1"}}),
          .expectError = "'trimFactor' must be non-negative"},
     };
 
@@ -118,115 +118,173 @@ static void test_mc_RangeOpts_to_FLE2RangeInsertSpec(_mongocrypt_tester_t *teste
          .v = RAW_STRING({"foo" : "bar"}),
          .expectError = "Unable to find 'v'"},
         // Tests of trim factor
-         {.desc = "tf = 0 works",
-         .in = RAW_STRING({"trimFactor": 0, "min" : 0, "max" : 1, "sparsity": {"$numberLong": "1"}}),
+        {.desc = "tf = 0 works",
+         .in = RAW_STRING({"trimFactor" : 0, "min" : 0, "max" : 1, "sparsity" : {"$numberLong" : "1"}}),
          .v = RAW_STRING({"v" : 0}),
-         .expect = RAW_STRING({"v": {"v": 0, "min" : 0, "max" : 1, "trimFactor": 0}})},
-         {.desc = "tf = 1 fails when domain size is 2 = 2^1",
-         .in = RAW_STRING({"trimFactor": 1, "min" : 0, "max" : 1, "sparsity": {"$numberLong": "1"}}),
+         .expect = RAW_STRING({"v" : {"v" : 0, "min" : 0, "max" : 1, "trimFactor" : 0}})},
+        {.desc = "tf = 1 fails when domain size is 2 = 2^1",
+         .in = RAW_STRING({"trimFactor" : 1, "min" : 0, "max" : 1, "sparsity" : {"$numberLong" : "1"}}),
          .v = RAW_STRING({"v" : 0}),
-         .expectError = "Trim factor (1) must be less than the total number of bits (1) used to represent any element in the domain."},
-         {.desc = "tf = 1 works when domain size is 3 > 2^1",
-         .in = RAW_STRING({"trimFactor": 1, "min" : 0, "max" : 2, "sparsity": {"$numberLong": "1"}}),
+         .expectError = "Trim factor (1) must be less than the total number of bits (1) used to represent any element "
+                        "in the domain."},
+        {.desc = "tf = 1 works when domain size is 3 > 2^1",
+         .in = RAW_STRING({"trimFactor" : 1, "min" : 0, "max" : 2, "sparsity" : {"$numberLong" : "1"}}),
          .v = RAW_STRING({"v" : 0}),
-         .expect = RAW_STRING({"v": {"v": 0, "min" : 0, "max" : 2, "trimFactor": 1}})},
-         {.desc = "tf = 2 fails when domain size is 3 <= 2^2",
-         .in = RAW_STRING({"trimFactor": 2, "min" : 0, "max" : 2, "sparsity": {"$numberLong": "1"}}),
+         .expect = RAW_STRING({"v" : {"v" : 0, "min" : 0, "max" : 2, "trimFactor" : 1}})},
+        {.desc = "tf = 2 fails when domain size is 3 <= 2^2",
+         .in = RAW_STRING({"trimFactor" : 2, "min" : 0, "max" : 2, "sparsity" : {"$numberLong" : "1"}}),
          .v = RAW_STRING({"v" : 0}),
-         .expectError = "Trim factor (2) must be less than the total number of bits (2) used to represent any element in the domain."},
-         
-         // min = INT32_MIN, max = INT32_MAX
-         {.desc = "tf = 31 works for unbounded int32 (domain size = 2^32)",
-         .in = RAW_STRING({"trimFactor": 31, "min" : -2147483648, "max" : 2147483647, "sparsity" : {"$numberLong" : "1"}}),
-         .v = RAW_STRING({"v" : 0}),
-         .expect = RAW_STRING({"v": {"v": 0, "min" : -2147483648, "max" : 2147483647, "trimFactor": 31}})},
-         {.desc = "tf = 32 fails for unbounded int32 (domain size = 2^32)",
-         .in = RAW_STRING({"trimFactor": 32, "min" : -2147483648, "max" : 2147483647, "sparsity" : {"$numberLong" : "1"}}),
-         .v = RAW_STRING({"v" : 0}),
-         .expectError = "Trim factor (32) must be less than the total number of bits (32) used to represent any element in the domain."},
+         .expectError = "Trim factor (2) must be less than the total number of bits (2) used to represent any element "
+                        "in the domain."},
 
-         // min = INT64_MIN, max = INT64_MAX
-         {.desc = "tf = 63 works for int64 with no min/max (domain size = 2^64)",
-         .in = RAW_STRING({"trimFactor": 63, "min" : -9223372036854775808, "max" : 9223372036854775807, "sparsity" : {"$numberLong" : "1"}}),
+        // min = INT32_MIN, max = INT32_MAX
+        {.desc = "tf = 31 works for unbounded int32 (domain size = 2^32)",
+         .in = RAW_STRING(
+             {"trimFactor" : 31, "min" : -2147483648, "max" : 2147483647, "sparsity" : {"$numberLong" : "1"}}),
+         .v = RAW_STRING({"v" : 0}),
+         .expect = RAW_STRING({"v" : {"v" : 0, "min" : -2147483648, "max" : 2147483647, "trimFactor" : 31}})},
+        {.desc = "tf = 32 fails for unbounded int32 (domain size = 2^32)",
+         .in = RAW_STRING(
+             {"trimFactor" : 32, "min" : -2147483648, "max" : 2147483647, "sparsity" : {"$numberLong" : "1"}}),
+         .v = RAW_STRING({"v" : 0}),
+         .expectError = "Trim factor (32) must be less than the total number of bits (32) used to represent any "
+                        "element in the domain."},
+
+        // min = INT64_MIN, max = INT64_MAX
+        {.desc = "tf = 63 works for int64 with no min/max (domain size = 2^64)",
+         .in = RAW_STRING({
+             "trimFactor" : 63,
+             "min" : -9223372036854775808,
+             "max" : 9223372036854775807,
+             "sparsity" : {"$numberLong" : "1"}
+         }),
          .v = RAW_STRING({"v" : {"$numberLong" : "0"}}),
-         .expect = RAW_STRING({"v": {"v": {"$numberLong" : "0"}, "min" : {"$numberLong" : "-9223372036854775808"}, "max" : {"$numberLong" : "9223372036854775807"}, "trimFactor": 63}})},
+         .expect = RAW_STRING({
+             "v" : {
+                 "v" : {"$numberLong" : "0"},
+                 "min" : {"$numberLong" : "-9223372036854775808"},
+                 "max" : {"$numberLong" : "9223372036854775807"},
+                 "trimFactor" : 63
+             }
+         })},
         {.desc = "tf = 64 fails for int64 with no min/max (domain size = 2^64)",
-         .in = RAW_STRING({"trimFactor": 64,  "min" : -9223372036854775808, "max" : 9223372036854775807, "sparsity" : {"$numberLong" : "1"}}),
+         .in = RAW_STRING({
+             "trimFactor" : 64,
+             "min" : -9223372036854775808,
+             "max" : 9223372036854775807,
+             "sparsity" : {"$numberLong" : "1"}
+         }),
          .v = RAW_STRING({"v" : {"$numberLong" : "0"}}),
-         .expectError = "Trim factor (64) must be less than the total number of bits (64) used to represent any element in the domain."},
+         .expectError = "Trim factor (64) must be less than the total number of bits (64) used to represent any "
+                        "element in the domain."},
 
         {.desc = "tf = 63 works for date with no min/max (domain size = 2^64)",
          .in = RAW_STRING({
-            "trimFactor": 63,  
-            "min" : {
-                "$date": {
-                    "$numberLong": "-9223372036854775808"
-                }
-            }, 
-            "max" : {
-                "$date": {
-                    "$numberLong": "9223372036854775807"
-                }
-            }, 
-            "sparsity" : {"$numberLong" : "1"}
-        }),
-         .v = RAW_STRING({"v" : {"$date": {"$numberLong" : "0"}}}),
-         .expect = RAW_STRING({"v": {"v": {"$date": {"$numberLong" : "0"}}, "min" : {"$date": {"$numberLong" : "-9223372036854775808"}}, "max" : {"$date": {"$numberLong" : "9223372036854775807"}}, "trimFactor": 63}})},
+             "trimFactor" : 63,
+             "min" : {"$date" : {"$numberLong" : "-9223372036854775808"}},
+             "max" : {"$date" : {"$numberLong" : "9223372036854775807"}},
+             "sparsity" : {"$numberLong" : "1"}
+         }),
+         .v = RAW_STRING({"v" : {"$date" : {"$numberLong" : "0"}}}),
+         .expect = RAW_STRING({
+             "v" : {
+                 "v" : {"$date" : {"$numberLong" : "0"}},
+                 "min" : {"$date" : {"$numberLong" : "-9223372036854775808"}},
+                 "max" : {"$date" : {"$numberLong" : "9223372036854775807"}},
+                 "trimFactor" : 63
+             }
+         })},
         {.desc = "tf = 64 fails for date with no min/max (domain size = 2^64)",
          .in = RAW_STRING({
-            "trimFactor": 64,  
-            "min" : {
-                "$date": {
-                    "$numberLong": "-9223372036854775808"
-                }
-            }, 
-            "max" : {
-                "$date": {
-                    "$numberLong": "9223372036854775807"
-                }
-            }, 
-            "sparsity" : {"$numberLong" : "1"}
-        }),
-         .v = RAW_STRING({"v" : {"$date": {"$numberLong" : "0"}}}),
-         .expectError = "Trim factor (64) must be less than the total number of bits (64) used to represent any element in the domain."},
-         
-        {.desc = "tf bound check passes correctly for double with min, max, precision set (tf = 9, 2^9 < domain size < 2^10)",
-         .in = RAW_STRING({"trimFactor": 9, "min" : 0.0, "max" : 100.0, "precision": 1, "sparsity" : {"$numberLong" : "1"}}),
+             "trimFactor" : 64,
+             "min" : {"$date" : {"$numberLong" : "-9223372036854775808"}},
+             "max" : {"$date" : {"$numberLong" : "9223372036854775807"}},
+             "sparsity" : {"$numberLong" : "1"}
+         }),
+         .v = RAW_STRING({"v" : {"$date" : {"$numberLong" : "0"}}}),
+         .expectError = "Trim factor (64) must be less than the total number of bits (64) used to represent any "
+                        "element in the domain."},
+
+        {.desc = "tf bound check passes correctly for double with min, max, precision set (tf = 9, 2^9 < domain size < "
+                 "2^10)",
+         .in = RAW_STRING(
+             {"trimFactor" : 9, "min" : 0.0, "max" : 100.0, "precision" : 1, "sparsity" : {"$numberLong" : "1"}}),
          .v = RAW_STRING({"v" : 0.0}),
-         .expect = RAW_STRING({"v": {"v": 0.0, "min" : 0.0, "max" : 100.0, "precision": 1, "trimFactor": 9}})},
+         .expect = RAW_STRING({"v" : {"v" : 0.0, "min" : 0.0, "max" : 100.0, "precision" : 1, "trimFactor" : 9}})},
         {.desc = "tf bound check fails correctly for double with min, max, precision set (tf = 10, domain size < 2^10)",
-         .in = RAW_STRING({"trimFactor": 10, "min" : 0.0, "max" : 100.0, "precision": 1, "sparsity" : {"$numberLong" : "1"}}),
+         .in = RAW_STRING(
+             {"trimFactor" : 10, "min" : 0.0, "max" : 100.0, "precision" : 1, "sparsity" : {"$numberLong" : "1"}}),
          .v = RAW_STRING({"v" : 0.0}),
-         .expectError = "Trim factor (10) must be less than the total number of bits (10) used to represent any element in the domain."},
-        
+         .expectError = "Trim factor (10) must be less than the total number of bits (10) used to represent any "
+                        "element in the domain."},
+
         {.desc = "tf = 63 works for unbounded double (domain size = 2^64)",
-         .in = RAW_STRING({"trimFactor": 63, "sparsity" : {"$numberLong" : "1"}}),
+         .in = RAW_STRING({"trimFactor" : 63, "sparsity" : {"$numberLong" : "1"}}),
          .v = RAW_STRING({"v" : 0.0}),
          // note - when min and max are unset, they are added into the insert spec.
-         .expect = RAW_STRING({"v": {"v": 0.0, "min" : { "$numberDouble" : "-1.7976931348623157081e+308" }, "max" : { "$numberDouble" : "1.7976931348623157081e+308" },"trimFactor": 63}})},
+         .expect = RAW_STRING({
+             "v" : {
+                 "v" : 0.0,
+                 "min" : {"$numberDouble" : "-1.7976931348623157081e+308"},
+                 "max" : {"$numberDouble" : "1.7976931348623157081e+308"},
+                 "trimFactor" : 63
+             }
+         })},
         {.desc = "tf = 64 fails for unbounded double (domain size = 2^64))",
-         .in = RAW_STRING({"trimFactor": 64, "sparsity" : {"$numberLong" : "1"}}),
+         .in = RAW_STRING({"trimFactor" : 64, "sparsity" : {"$numberLong" : "1"}}),
          .v = RAW_STRING({"v" : 0.0}),
-         .expectError = "Trim factor (64) must be less than the total number of bits (64) used to represent any element in the domain."},
+         .expectError = "Trim factor (64) must be less than the total number of bits (64) used to represent any "
+                        "element in the domain."},
 
-        {.desc = "tf bound check passes correctly for decimal with min, max, precision set (tf = 9, 2^9 < domain size < 2^10)",
-         .in = RAW_STRING({"trimFactor": 9, "min" : {"$numberDecimal": "0"}, "max" : {"$numberDecimal": "100"}, "precision": 1, "sparsity" : {"$numberLong" : "1"}}),
-         .v = RAW_STRING({"v" : {"$numberDecimal": "0"}}),
-         .expect = RAW_STRING({"v": {"v": {"$numberDecimal": "0"}, "min" : {"$numberDecimal": "0"}, "max" : {"$numberDecimal": "100"}, "precision": 1, "trimFactor": 9}})},
-        {.desc = "tf bound check fails correctly for decimal with min, max, precision set (tf = 10, domain size < 2^10)",
-         .in = RAW_STRING({"trimFactor": 10, "min" : {"$numberDecimal": "0"}, "max" : {"$numberDecimal": "100"}, "precision": 1, "sparsity" : {"$numberLong" : "1"}}),
-         .v = RAW_STRING({"v" : {"$numberDecimal": "0"}}),
-         .expectError = "Trim factor (10) must be less than the total number of bits (10) used to represent any element in the domain."},
+        {.desc = "tf bound check passes correctly for decimal with min, max, precision set (tf = 9, 2^9 < domain size "
+                 "< 2^10)",
+         .in = RAW_STRING({
+             "trimFactor" : 9,
+             "min" : {"$numberDecimal" : "0"},
+             "max" : {"$numberDecimal" : "100"},
+             "precision" : 1,
+             "sparsity" : {"$numberLong" : "1"}
+         }),
+         .v = RAW_STRING({"v" : {"$numberDecimal" : "0"}}),
+         .expect = RAW_STRING({
+             "v" : {
+                 "v" : {"$numberDecimal" : "0"},
+                 "min" : {"$numberDecimal" : "0"},
+                 "max" : {"$numberDecimal" : "100"},
+                 "precision" : 1,
+                 "trimFactor" : 9
+             }
+         })},
+        {.desc =
+             "tf bound check fails correctly for decimal with min, max, precision set (tf = 10, domain size < 2^10)",
+         .in = RAW_STRING({
+             "trimFactor" : 10,
+             "min" : {"$numberDecimal" : "0"},
+             "max" : {"$numberDecimal" : "100"},
+             "precision" : 1,
+             "sparsity" : {"$numberLong" : "1"}
+         }),
+         .v = RAW_STRING({"v" : {"$numberDecimal" : "0"}}),
+         .expectError = "Trim factor (10) must be less than the total number of bits (10) used to represent any "
+                        "element in the domain."},
 
 #if MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
         {.desc = "tf = 127 works for unbounded decimal (domain size = 2^128)",
-         .in = RAW_STRING({"trimFactor": 127, "sparsity" : {"$numberLong" : "1"}}),
-         .v = RAW_STRING({"v" : {"$numberDecimal": "0"}}),
-         .expect = RAW_STRING({"v": {"v": {"$numberDecimal": "0"}, "min" : { "$numberDecimal" : "-9.999999999999999999999999999999999E+6144" }, "max" : { "$numberDecimal" : "9.999999999999999999999999999999999E+6144" }, "trimFactor": 127}})},
+         .in = RAW_STRING({"trimFactor" : 127, "sparsity" : {"$numberLong" : "1"}}),
+         .v = RAW_STRING({"v" : {"$numberDecimal" : "0"}}),
+         .expect = RAW_STRING({
+             "v" : {
+                 "v" : {"$numberDecimal" : "0"},
+                 "min" : {"$numberDecimal" : "-9.999999999999999999999999999999999E+6144"},
+                 "max" : {"$numberDecimal" : "9.999999999999999999999999999999999E+6144"},
+                 "trimFactor" : 127
+             }
+         })},
         {.desc = "tf = 128 fails for unbounded decimal (domain size = 2^128)",
-         .in = RAW_STRING({"trimFactor": 128, "sparsity" : {"$numberLong" : "1"}}),
-         .v = RAW_STRING({"v" : {"$numberDecimal": "0"}}),
-         .expectError = "Trim factor (128) must be less than the total number of bits (128) used to represent any element in the domain."},
+         .in = RAW_STRING({"trimFactor" : 128, "sparsity" : {"$numberLong" : "1"}}),
+         .v = RAW_STRING({"v" : {"$numberDecimal" : "0"}}),
+         .expectError = "Trim factor (128) must be less than the total number of bits (128) used to represent any "
+                        "element in the domain."},
 #endif
     };
 

--- a/test/test-mc-rangeopts.c
+++ b/test/test-mc-rangeopts.c
@@ -250,6 +250,7 @@ static void test_mc_RangeOpts_to_FLE2RangeInsertSpec(_mongocrypt_tester_t *teste
          .expectError = "Trim factor (64) must be less than the total number of bits (64) used to represent any "
                         "element in the domain."},
 
+#if MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
         {.desc = "tf bound check passes correctly for decimal with min, max, precision set (tf = 9, 2^9 < domain size "
                  "< 2^10)",
          .in = RAW_STRING({
@@ -282,7 +283,6 @@ static void test_mc_RangeOpts_to_FLE2RangeInsertSpec(_mongocrypt_tester_t *teste
          .expectError = "Trim factor (10) must be less than the total number of bits (10) used to represent any "
                         "element in the domain."},
 
-#if MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
         {.desc = "tf = 127 works for unbounded decimal (domain size = 2^128)",
          .in = RAW_STRING({"trimFactor" : 127, "sparsity" : {"$numberLong" : "1"}}),
          .v = RAW_STRING({"v" : {"$numberDecimal" : "0"}}),

--- a/test/test-mc-rangeopts.c
+++ b/test/test-mc-rangeopts.c
@@ -28,6 +28,7 @@ static void test_mc_RangeOpts_parse(_mongocrypt_tester_t *tester) {
         mc_optional_int32_t expectMax;
         int64_t expectSparsity;
         mc_optional_uint32_t expectPrecision;
+        mc_optional_uint32_t expectTrimFactor;
     } testcase;
 
     testcase tests[] = {
@@ -62,6 +63,9 @@ static void test_mc_RangeOpts_parse(_mongocrypt_tester_t *tester) {
         {.desc = "Requires precision for double when only min is set",
          .in = RAW_STRING({"min" : 0.0, "sparsity" : {"$numberLong" : "1"}}),
          .expectError = "expected 'precision'"},
+        {.desc = "Errors on negative trim factor",
+         .in = RAW_STRING({"trimFactor": -1, "sparsity" : {"$numberLong" : "1"}}),
+         .expectError = "'trimFactor' must be non-negative"},
     };
 
     for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
@@ -104,15 +108,126 @@ static void test_mc_RangeOpts_to_FLE2RangeInsertSpec(_mongocrypt_tester_t *teste
         {.desc = "Works",
          .in = RAW_STRING({"min" : 123, "max" : 456, "sparsity" : {"$numberLong" : "1"}}),
          .v = RAW_STRING({"v" : 789}),
-         .expect = RAW_STRING({"v" : {"v" : 789, "min" : 123, "max" : 456}})},
+         .expect = RAW_STRING({"v" : {"v" : 789, "min" : 123, "max" : 456, "trimFactor" : 0}})},
         {.desc = "Works with precision",
          .in = RAW_STRING({"min" : 123.0, "max" : 456.0, "precision" : 2, "sparsity" : {"$numberLong" : "1"}}),
          .v = RAW_STRING({"v" : 789.0}),
-         .expect = RAW_STRING({"v" : {"v" : 789.0, "min" : 123.0, "max" : 456.0, "precision" : 2}})},
+         .expect = RAW_STRING({"v" : {"v" : 789.0, "min" : 123.0, "max" : 456.0, "precision" : 2, "trimFactor" : 0}})},
         {.desc = "Errors with missing 'v'",
          .in = RAW_STRING({"min" : 123, "max" : 456, "sparsity" : {"$numberLong" : "1"}}),
          .v = RAW_STRING({"foo" : "bar"}),
-         .expectError = "Unable to find 'v'"}};
+         .expectError = "Unable to find 'v'"},
+        // Tests of trim factor
+         {.desc = "tf = 0 works",
+         .in = RAW_STRING({"trimFactor": 0, "min" : 0, "max" : 1, "sparsity": {"$numberLong": "1"}}),
+         .v = RAW_STRING({"v" : 0}),
+         .expect = RAW_STRING({"v": {"v": 0, "min" : 0, "max" : 1, "trimFactor": 0}})},
+         {.desc = "tf = 1 fails when domain size is 2 = 2^1",
+         .in = RAW_STRING({"trimFactor": 1, "min" : 0, "max" : 1, "sparsity": {"$numberLong": "1"}}),
+         .v = RAW_STRING({"v" : 0}),
+         .expectError = "Trim factor (1) must be less than the total number of bits (1) used to represent any element in the domain."},
+         {.desc = "tf = 1 works when domain size is 3 > 2^1",
+         .in = RAW_STRING({"trimFactor": 1, "min" : 0, "max" : 2, "sparsity": {"$numberLong": "1"}}),
+         .v = RAW_STRING({"v" : 0}),
+         .expect = RAW_STRING({"v": {"v": 0, "min" : 0, "max" : 2, "trimFactor": 1}})},
+         {.desc = "tf = 2 fails when domain size is 3 <= 2^2",
+         .in = RAW_STRING({"trimFactor": 2, "min" : 0, "max" : 2, "sparsity": {"$numberLong": "1"}}),
+         .v = RAW_STRING({"v" : 0}),
+         .expectError = "Trim factor (2) must be less than the total number of bits (2) used to represent any element in the domain."},
+         
+         // min = INT32_MIN, max = INT32_MAX
+         {.desc = "tf = 31 works for unbounded int32 (domain size = 2^32)",
+         .in = RAW_STRING({"trimFactor": 31, "min" : -2147483648, "max" : 2147483647, "sparsity" : {"$numberLong" : "1"}}),
+         .v = RAW_STRING({"v" : 0}),
+         .expect = RAW_STRING({"v": {"v": 0, "min" : -2147483648, "max" : 2147483647, "trimFactor": 31}})},
+         {.desc = "tf = 32 fails for unbounded int32 (domain size = 2^32)",
+         .in = RAW_STRING({"trimFactor": 32, "min" : -2147483648, "max" : 2147483647, "sparsity" : {"$numberLong" : "1"}}),
+         .v = RAW_STRING({"v" : 0}),
+         .expectError = "Trim factor (32) must be less than the total number of bits (32) used to represent any element in the domain."},
+
+         // min = INT64_MIN, max = INT64_MAX
+         {.desc = "tf = 63 works for int64 with no min/max (domain size = 2^64)",
+         .in = RAW_STRING({"trimFactor": 63, "min" : -9223372036854775808, "max" : 9223372036854775807, "sparsity" : {"$numberLong" : "1"}}),
+         .v = RAW_STRING({"v" : {"$numberLong" : "0"}}),
+         .expect = RAW_STRING({"v": {"v": {"$numberLong" : "0"}, "min" : {"$numberLong" : "-9223372036854775808"}, "max" : {"$numberLong" : "9223372036854775807"}, "trimFactor": 63}})},
+        {.desc = "tf = 64 fails for int64 with no min/max (domain size = 2^64)",
+         .in = RAW_STRING({"trimFactor": 64,  "min" : -9223372036854775808, "max" : 9223372036854775807, "sparsity" : {"$numberLong" : "1"}}),
+         .v = RAW_STRING({"v" : {"$numberLong" : "0"}}),
+         .expectError = "Trim factor (64) must be less than the total number of bits (64) used to represent any element in the domain."},
+
+        {.desc = "tf = 63 works for date with no min/max (domain size = 2^64)",
+         .in = RAW_STRING({
+            "trimFactor": 63,  
+            "min" : {
+                "$date": {
+                    "$numberLong": "-9223372036854775808"
+                }
+            }, 
+            "max" : {
+                "$date": {
+                    "$numberLong": "9223372036854775807"
+                }
+            }, 
+            "sparsity" : {"$numberLong" : "1"}
+        }),
+         .v = RAW_STRING({"v" : {"$date": {"$numberLong" : "0"}}}),
+         .expect = RAW_STRING({"v": {"v": {"$date": {"$numberLong" : "0"}}, "min" : {"$date": {"$numberLong" : "-9223372036854775808"}}, "max" : {"$date": {"$numberLong" : "9223372036854775807"}}, "trimFactor": 63}})},
+        {.desc = "tf = 64 fails for date with no min/max (domain size = 2^64)",
+         .in = RAW_STRING({
+            "trimFactor": 64,  
+            "min" : {
+                "$date": {
+                    "$numberLong": "-9223372036854775808"
+                }
+            }, 
+            "max" : {
+                "$date": {
+                    "$numberLong": "9223372036854775807"
+                }
+            }, 
+            "sparsity" : {"$numberLong" : "1"}
+        }),
+         .v = RAW_STRING({"v" : {"$date": {"$numberLong" : "0"}}}),
+         .expectError = "Trim factor (64) must be less than the total number of bits (64) used to represent any element in the domain."},
+         
+        {.desc = "tf bound check passes correctly for double with min, max, precision set (tf = 9, 2^9 < domain size < 2^10)",
+         .in = RAW_STRING({"trimFactor": 9, "min" : 0.0, "max" : 100.0, "precision": 1, "sparsity" : {"$numberLong" : "1"}}),
+         .v = RAW_STRING({"v" : 0.0}),
+         .expect = RAW_STRING({"v": {"v": 0.0, "min" : 0.0, "max" : 100.0, "precision": 1, "trimFactor": 9}})},
+        {.desc = "tf bound check fails correctly for double with min, max, precision set (tf = 10, domain size < 2^10)",
+         .in = RAW_STRING({"trimFactor": 10, "min" : 0.0, "max" : 100.0, "precision": 1, "sparsity" : {"$numberLong" : "1"}}),
+         .v = RAW_STRING({"v" : 0.0}),
+         .expectError = "Trim factor (10) must be less than the total number of bits (10) used to represent any element in the domain."},
+        
+        {.desc = "tf = 63 works for unbounded double (domain size = 2^64)",
+         .in = RAW_STRING({"trimFactor": 63, "sparsity" : {"$numberLong" : "1"}}),
+         .v = RAW_STRING({"v" : 0.0}),
+         // note - when min and max are unset, they are added into the insert spec.
+         .expect = RAW_STRING({"v": {"v": 0.0, "min" : { "$numberDouble" : "-1.7976931348623157081e+308" }, "max" : { "$numberDouble" : "1.7976931348623157081e+308" },"trimFactor": 63}})},
+        {.desc = "tf = 64 fails for unbounded double (domain size = 2^64))",
+         .in = RAW_STRING({"trimFactor": 64, "sparsity" : {"$numberLong" : "1"}}),
+         .v = RAW_STRING({"v" : 0.0}),
+         .expectError = "Trim factor (64) must be less than the total number of bits (64) used to represent any element in the domain."},
+
+        {.desc = "tf bound check passes correctly for decimal with min, max, precision set (tf = 9, 2^9 < domain size < 2^10)",
+         .in = RAW_STRING({"trimFactor": 9, "min" : {"$numberDecimal": "0"}, "max" : {"$numberDecimal": "100"}, "precision": 1, "sparsity" : {"$numberLong" : "1"}}),
+         .v = RAW_STRING({"v" : {"$numberDecimal": "0"}}),
+         .expect = RAW_STRING({"v": {"v": {"$numberDecimal": "0"}, "min" : {"$numberDecimal": "0"}, "max" : {"$numberDecimal": "100"}, "precision": 1, "trimFactor": 9}})},
+        {.desc = "tf bound check fails correctly for decimal with min, max, precision set (tf = 10, domain size < 2^10)",
+         .in = RAW_STRING({"trimFactor": 10, "min" : {"$numberDecimal": "0"}, "max" : {"$numberDecimal": "100"}, "precision": 1, "sparsity" : {"$numberLong" : "1"}}),
+         .v = RAW_STRING({"v" : {"$numberDecimal": "0"}}),
+         .expectError = "Trim factor (10) must be less than the total number of bits (10) used to represent any element in the domain."},
+        
+        {.desc = "tf = 127 works for unbounded decimal (domain size = 2^128)",
+         .in = RAW_STRING({"trimFactor": 127, "sparsity" : {"$numberLong" : "1"}}),
+         .v = RAW_STRING({"v" : {"$numberDecimal": "0"}}),
+         .expect = RAW_STRING({"v": {"v": {"$numberDecimal": "0"}, "min" : { "$numberDecimal" : "-9.999999999999999999999999999999999E+6144" }, "max" : { "$numberDecimal" : "9.999999999999999999999999999999999E+6144" }, "trimFactor": 127}})},
+        {.desc = "tf = 128 fails for unbounded decimal (domain size = 2^128)",
+         .in = RAW_STRING({"trimFactor": 128, "sparsity" : {"$numberLong" : "1"}}),
+         .v = RAW_STRING({"v" : {"$numberDecimal": "0"}}),
+         .expectError = "Trim factor (128) must be less than the total number of bits (128) used to represent any element in the domain."},
+
+    };
 
     for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
         testcase *test = tests + i;
@@ -120,8 +235,12 @@ static void test_mc_RangeOpts_to_FLE2RangeInsertSpec(_mongocrypt_tester_t *teste
         mc_RangeOpts_t ro;
         printf("running test_mc_RangeOpts_to_FLE2RangeInsertSpec subtest: %s\n", test->desc);
         ASSERT_OK_STATUS(mc_RangeOpts_parse(&ro, TMP_BSON(test->in), status), status);
+        printf("parsed good\n");
+        TMP_BSON(test->v);
+        printf("ok V\n");
         bson_t out = BSON_INITIALIZER;
         bool ret = mc_RangeOpts_to_FLE2RangeInsertSpec(&ro, TMP_BSON(test->v), &out, status);
+        printf("done range ins\n");
         if (!test->expectError) {
             ASSERT_OK_STATUS(ret, status);
             ASSERT_EQUAL_BSON(TMP_BSON(test->expect), &out);


### PR DESCRIPTION
Extends the FLE2RangeInsertSpec and RangeOpts structures to support the passthrough and bounds checking of trim factor. Does not actually use the trim factor in the query or insert algos yet.