### PR TITLE
MONGOCRYPT-590 fix `publish-java` timeout

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -184,10 +184,10 @@ functions:
     - command: shell.exec
       params:
         script: |-
-          # if [ "${is_patch}" = "true" ]; then
-          #   echo "Patch build detected, skipping"
-          #   exit 0
-          # fi
+          if [ "${is_patch}" = "true" ]; then
+            echo "Patch build detected, skipping"
+            exit 0
+          fi
           export PROJECT_DIRECTORY=${project_directory}
           export NEXUS_USERNAME=${nexus_username}
           export NEXUS_PASSWORD=${nexus_password}

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -184,10 +184,10 @@ functions:
     - command: shell.exec
       params:
         script: |-
-          if [ "${is_patch}" = "true" ]; then
-            echo "Patch build detected, skipping"
-            exit 0
-          fi
+          # if [ "${is_patch}" = "true" ]; then
+          #   echo "Patch build detected, skipping"
+          #   exit 0
+          # fi
           export PROJECT_DIRECTORY=${project_directory}
           export NEXUS_USERNAME=${nexus_username}
           export NEXUS_PASSWORD=${nexus_password}

--- a/bindings/java/mongocrypt/.evergreen/publish.sh
+++ b/bindings/java/mongocrypt/.evergreen/publish.sh
@@ -42,4 +42,4 @@ SYSTEM_PROPERTIES="-Dorg.gradle.internal.publish.checksums.insecure=true -Dorg.g
 }
 
 ./gradlew -version
-./gradlew ${SYSTEM_PROPERTIES} --stacktrace --info  publishToSonatype
+./gradlew ${SYSTEM_PROPERTIES} --stacktrace --info  downloadJava

--- a/bindings/java/mongocrypt/.evergreen/publish.sh
+++ b/bindings/java/mongocrypt/.evergreen/publish.sh
@@ -42,4 +42,4 @@ SYSTEM_PROPERTIES="-Dorg.gradle.internal.publish.checksums.insecure=true -Dorg.g
 }
 
 ./gradlew -version
-./gradlew ${SYSTEM_PROPERTIES} --stacktrace --info  downloadJava
+./gradlew ${SYSTEM_PROPERTIES} --stacktrace --info  publishToSonatype

--- a/bindings/java/mongocrypt/.evergreen/publish.sh
+++ b/bindings/java/mongocrypt/.evergreen/publish.sh
@@ -23,5 +23,23 @@ export JAVA_HOME="/opt/java/jdk8"
 
 SYSTEM_PROPERTIES="-Dorg.gradle.internal.publish.checksums.insecure=true -Dorg.gradle.internal.http.connectionTimeout=120000 -Dorg.gradle.internal.http.socketTimeout=120000"
 
+{
+    # Add output of git commands as system properties.
+    # These values can be computed in Gradle. This is to work around observed hangs computing these values in Gradle on JDK 8. Refer: MONGOCRYPT-590.
+    # Once JDK 8 is no longer the minimum this block may be removed.
+    gitDescribe="$(git describe --tags --always --dirty)"
+    gitRevision="$(git rev-parse HEAD)"
+    if git describe --tags --exact-match HEAD >/dev/null 2>&1; then
+        # Commit is tagged. Check if it is a "java-" tag.
+        if [[ "$gitDescribe" == "java-"* ]]; then
+            # Get commit for the libmongocrypt tag by removing the "java-" prefix.
+            libmongocryptTag="${gitDescribe:5}"
+            # Use `git rev-list` to get tagged commit hash. (`git rev-parse` returns the tag hash)
+            gitRevision=$(git rev-list -n 1 $libmongocryptTag)
+        fi
+    fi
+    SYSTEM_PROPERTIES="$SYSTEM_PROPERTIES -DgitDescribe=${gitDescribe} -DgitRevision=${gitRevision}"
+}
+
 ./gradlew -version
 ./gradlew ${SYSTEM_PROPERTIES} --stacktrace --info  publishToSonatype

--- a/bindings/java/mongocrypt/.evergreen/test.sh
+++ b/bindings/java/mongocrypt/.evergreen/test.sh
@@ -11,5 +11,7 @@ else
    export JAVA_HOME=/opt/java/jdk8
 fi
 
+gitDescribe="$(git describe --tags --always --dirty)"
+
 ./gradlew -version
-./gradlew clean downloadJnaLibs check --info -DgitRevision=${GIT_REVISION}
+./gradlew clean downloadJnaLibs check --info -DgitRevision=${GIT_REVISION} -DgitDescribe=${gitDescribe}

--- a/bindings/java/mongocrypt/build.gradle.kts
+++ b/bindings/java/mongocrypt/build.gradle.kts
@@ -75,14 +75,14 @@ dependencies {
  */
 
 // Returns a String representing the output of `git describe`
-val gitDescribe by lazy {
+val gitDescribe : String = System.getProperties().computeIfAbsent("gitDescribe") {
     val describeStdOut = ByteArrayOutputStream()
     exec {
         commandLine = listOf("git", "describe", "--tags", "--always", "--dirty")
         standardOutput = describeStdOut
     }
     describeStdOut.toString().trim()
-}
+}.toString()
 
 val isJavaTag by lazy { gitDescribe.startsWith("java") }
 val gitVersion by lazy { gitDescribe.subSequence(gitDescribe.toCharArray().indexOfFirst { it.isDigit() }, gitDescribe.length).toString() }


### PR DESCRIPTION
# Summary

Use bash to compute git information, instead of Gradle's `exec`, to work around observed timeout in `publish-java` tasks.

# Background & Motivation

The `publish-java` task is timing out on the waterfall. [Example](https://spruce.mongodb.com/task/libmongocrypt_java_release_publish_java_4261b443ef174ae741d7d45ead83f37c70d64de2_24_02_07_02_01_25/logs?execution=0) logs:

```
[2024/02/06 21:28:17.119] Starting process 'command 'git''. Working directory: /data/mci/2eacaca1c550360db302b8eebefffc65/libmongocrypt/bindings/java/mongocrypt Command: git describe --tags --always --dirty
[2024/02/06 23:28:17.219] Hit idle timeout (no message on stdout/stderr for more than 2h0m0s)
```

I expect this is related to observed timeouts reported in MONGOCRYPT-590. Using JDK 9 or higher appears to resolve this issue. However, I assume JDK 8 is required until the minimum JDK is raised for the Java driver (JAVA-4709 proposes raising minimum to 11).

The hang appears on running `exec` to run git commands. This PR proposes running the commands in bash and passing the output with system properties to Gradle.

# Testing

To test in Evergreen, temporary changes were made to remove the patch build skip, and replace calling `publishToSonatype` with `downloadJava` to avoid publishing in a patch build. With the changes in this PR, the `publish-java` task passed:
https://spruce.mongodb.com/version/65cc103ad6d80a78928b50a2

The script to compute `gitDescribe` and `gitRevision` was tested locally with [this script](https://gist.github.com/kevinAlbs/a8c0332cebd7554def52d379597a55dd) running against various git checkouts.
