### PR TITLE
MONGOCRYPT-623 use `include_expansions_in_env` to pass expansions

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -183,17 +183,19 @@ functions:
           ./libmongocrypt/.evergreen/print-env-info.sh
     - command: shell.exec
       params:
+        include_expansions_in_env:
+          - nexus_username
+          - nexus_password
+          - signing_password
+          - signing_keyId
+          - ring_file_gpg_base64
+
         script: |-
           if [ "${is_patch}" = "true" ]; then
             echo "Patch build detected, skipping"
             exit 0
           fi
           export PROJECT_DIRECTORY=${project_directory}
-          export NEXUS_USERNAME=${nexus_username}
-          export NEXUS_PASSWORD=${nexus_password}
-          export SIGNING_PASSWORD=${signing_password}
-          export SIGNING_KEY_ID=${signing_keyId}
-          export RING_FILE_GPG_BASE64=${ring_file_gpg_base64}
           cd ./libmongocrypt/bindings/java/mongocrypt && ${test_env|} ./.evergreen/publish.sh
 
   "download tarball":

--- a/bindings/java/mongocrypt/.evergreen/publish.sh
+++ b/bindings/java/mongocrypt/.evergreen/publish.sh
@@ -8,14 +8,14 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #            Main Program                  #
 ############################################
 
-echo ${RING_FILE_GPG_BASE64} | base64 -d > ${PROJECT_DIRECTORY}/secring.gpg
+echo ${ring_file_gpg_base64} | base64 -d > ${PROJECT_DIRECTORY}/secring.gpg
 
 trap "rm ${PROJECT_DIRECTORY}/secring.gpg; exit" EXIT HUP
 
-export ORG_GRADLE_PROJECT_nexusUsername=${NEXUS_USERNAME}
-export ORG_GRADLE_PROJECT_nexusPassword=${NEXUS_PASSWORD}
-export ORG_GRADLE_PROJECT_signing_keyId=${SIGNING_KEY_ID}
-export ORG_GRADLE_PROJECT_signing_password=${SIGNING_PASSWORD}
+export ORG_GRADLE_PROJECT_nexusUsername=${nexus_username}
+export ORG_GRADLE_PROJECT_nexusPassword=${nexus_password}
+export ORG_GRADLE_PROJECT_signing_keyId=${signing_keyId}
+export ORG_GRADLE_PROJECT_signing_password=${signing_password}
 export ORG_GRADLE_PROJECT_signing_secretKeyRingFile=${PROJECT_DIRECTORY}/secring.gpg
 
 echo "Publishing snapshot with jdk11"


### PR DESCRIPTION
# Summary

- use `include_expansions_in_env` to pass expansions

# Background & Motivation

Prior to this PR, internal [Agent Logs](https://spruce.mongodb.com/task/libmongocrypt_java_release_publish_java_4261b443ef174ae741d7d45ead83f37c70d64de2_24_02_07_02_01_25/logs?execution=0&logtype=agent) included the evaluated expansions. Changes in this PR were verified by inspecting the [Agent Logs](https://spruce.mongodb.com/task/libmongocrypt_java_release_publish_java_patch_1be6cd3908bc23ac0404c2be73afed929597fdfd_65cbc8df1e2d1751c8d7263d_24_02_13_19_54_08/logs?execution=0&logtype=agent) on a patch build.

This PR uses `include_expansions_in_env` to pass expansions as environment variables to the publish.sh script. Using `include_expansions_in_env` is a suggested solution in [Unsafe Secret Usage in Evergreen Projects
](https://docs.google.com/document/d/1qflQNi1LMYa-ccCIfeUc0hKQ3zJm0b3fzFKaYcW3sLk/edit#heading=h.twryuj7s45ks)