### PR TITLE
PYTHON-4181 Use libmongocrypt native crypto when available for 10-50x better performance

### DIFF
--- a/bindings/python/.evergreen/test.sh
+++ b/bindings/python/.evergreen/test.sh
@@ -47,7 +47,7 @@ elif [ "Darwin" = "$(uname -s)" ]; then
       --version latest --out ../crypt_shared/
 else
     export PYMONGOCRYPT_LIB=${MONGOCRYPT_DIR}/nocrypto/lib64/libmongocrypt.so
-    PYMONGOCRYPT_LIB_CRYPTO=${MONGOCRYPT_DIR}/lib/libmongocrypt.dylib
+    PYMONGOCRYPT_LIB_CRYPTO=${MONGOCRYPT_DIR}/lib/libmongocrypt.so
     
     export CRYPT_SHARED_PATH="../crypt_shared/lib/mongo_crypt_v1.so"
     MACHINE=$(uname -m)

--- a/bindings/python/.evergreen/test.sh
+++ b/bindings/python/.evergreen/test.sh
@@ -46,8 +46,13 @@ elif [ "Darwin" = "$(uname -s)" ]; then
     python3 drivers-evergreen-tools/.evergreen/mongodl.py --component crypt_shared \
       --version latest --out ../crypt_shared/
 else
-    export PYMONGOCRYPT_LIB=${MONGOCRYPT_DIR}/nocrypto/lib64/libmongocrypt.so
-    PYMONGOCRYPT_LIB_CRYPTO=${MONGOCRYPT_DIR}/lib/libmongocrypt.so
+    if [ -f "${MONGOCRYPT_DIR}/lib64/" ]; then
+        export PYMONGOCRYPT_LIB=${MONGOCRYPT_DIR}/nocrypto/lib64/libmongocrypt.so
+        PYMONGOCRYPT_LIB_CRYPTO=${MONGOCRYPT_DIR}/lib64/libmongocrypt.so
+    else
+        export PYMONGOCRYPT_LIB=${MONGOCRYPT_DIR}/nocrypto/lib/libmongocrypt.so
+        PYMONGOCRYPT_LIB_CRYPTO=${MONGOCRYPT_DIR}/lib/libmongocrypt.so
+    fi
     
     export CRYPT_SHARED_PATH="../crypt_shared/lib/mongo_crypt_v1.so"
     MACHINE=$(uname -m)

--- a/bindings/python/.evergreen/test.sh
+++ b/bindings/python/.evergreen/test.sh
@@ -46,7 +46,7 @@ elif [ "Darwin" = "$(uname -s)" ]; then
     python3 drivers-evergreen-tools/.evergreen/mongodl.py --component crypt_shared \
       --version latest --out ../crypt_shared/
 else
-    if [ -f "${MONGOCRYPT_DIR}/lib64/" ]; then
+    if [ -e "${MONGOCRYPT_DIR}/lib64/" ]; then
         export PYMONGOCRYPT_LIB=${MONGOCRYPT_DIR}/nocrypto/lib64/libmongocrypt.so
         PYMONGOCRYPT_LIB_CRYPTO=${MONGOCRYPT_DIR}/lib64/libmongocrypt.so
     else

--- a/bindings/python/CHANGELOG.rst
+++ b/bindings/python/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changes in Version 1.9.0
 
 - Add support for named KMS providers like "local:name1".
   This feature requires libmongocrypt >= 1.9.0.
-- Use libmongocrypt native crypto when available for better performance.
+- Use libmongocrypt native crypto when available which results in 10-50x better performance.
   On Linux, it is recommended to download the platform specific build and
   set PYMONGOCRYPT_LIB to the crypto-enabled libmongocrypt.so.
 - Bundle the crypto-enabled libmongocrypt builds in macOS and Windows wheels for better performance.

--- a/bindings/python/CHANGELOG.rst
+++ b/bindings/python/CHANGELOG.rst
@@ -6,6 +6,10 @@ Changes in Version 1.9.0
 
 - Add support for named KMS providers like "local:name1".
   This feature requires libmongocrypt >= 1.9.0.
+- Use libmongocrypt native crypto when available for better performance.
+  On Linux, it is recommended to download the platform specific build and
+  set PYMONGOCRYPT_LIB to the crypto-enabled libmongocrypt.so.
+- Bundle the crypto-enabled libmongocrypt builds in macOS and Windows wheels for better performance.
 - Bundle libmongocrypt 1.9.0 in release wheels.
 
 Changes in Version 1.8.0

--- a/bindings/python/README.rst
+++ b/bindings/python/README.rst
@@ -123,15 +123,15 @@ For example::
 macOS::
 
   $ # Set PYMONGOCRYPT_LIB for macOS:
-  $ export PYMONGOCRYPT_LIB=$(pwd)/libmongocrypt-all/macos/nocrypto/lib/libmongocrypt.dylib
+  $ export PYMONGOCRYPT_LIB=$(pwd)/libmongocrypt-all/macos/lib/libmongocrypt.dylib
   $ python -c "import pymongocrypt; print(pymongocrypt.libmongocrypt_version())"
   1.2.1
 
 Windows::
 
   $ # Set PYMONGOCRYPT_LIB for Windows:
-  $ chmod +x $(pwd)/libmongocrypt-all/windows-test/nocrypto/bin/mongocrypt.dll
-  $ export PYMONGOCRYPT_LIB=$(pwd)/libmongocrypt-all/windows-test/nocrypto/bin/mongocrypt.dll
+  $ chmod +x $(pwd)/libmongocrypt-all/windows-test/bin/mongocrypt.dll
+  $ export PYMONGOCRYPT_LIB=$(pwd)/libmongocrypt-all/windows-test/bin/mongocrypt.dll
   $ python -c "import pymongocrypt; print(pymongocrypt.libmongocrypt_version())"
   1.2.1
 

--- a/bindings/python/README.rst
+++ b/bindings/python/README.rst
@@ -114,18 +114,19 @@ For example::
   $ curl -O https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz
   $ mkdir libmongocrypt-all && tar xzf libmongocrypt-all.tar.gz -C libmongocrypt-all
   $ ls libmongocrypt-all
-  amazon2             rhel-62-64-bit      rhel72-zseries-test ubuntu1604-arm64
-  debian10            rhel-67-s390x       suse12-64           ubuntu1804-64
-  debian92            rhel-70-64-bit      suse12-s390x        ubuntu1804-arm64
-  linux-64-amazon-ami rhel-71-ppc64el     suse15-64           windows-test
-  macos               rhel-80-64-bit      ubuntu1604
+  amazon2             debian92            rhel-80-64-bit      rhel72-zseries-test ubuntu1804-arm64
+  amazon2-arm64       linux-64-amazon-ami rhel-81-ppc64el     suse12-64           ubuntu2004-64
+  amazon2023          macos               rhel-82-arm64       suse15-64           ubuntu2004-arm64
+  amazon2023-arm64    rhel-62-64-bit      rhel-83-zseries     ubuntu1604          ubuntu2204-64
+  debian10            rhel-70-64-bit      rhel-91-64-bit      ubuntu1604-arm64    ubuntu2204-arm64
+  debian11            rhel-71-ppc64el     rhel-91-arm64       ubuntu1804-64       windows-test
 
 macOS::
 
   $ # Set PYMONGOCRYPT_LIB for macOS:
   $ export PYMONGOCRYPT_LIB=$(pwd)/libmongocrypt-all/macos/lib/libmongocrypt.dylib
   $ python -c "import pymongocrypt; print(pymongocrypt.libmongocrypt_version())"
-  1.2.1
+  1.9.0
 
 Windows::
 
@@ -133,14 +134,23 @@ Windows::
   $ chmod +x $(pwd)/libmongocrypt-all/windows-test/bin/mongocrypt.dll
   $ export PYMONGOCRYPT_LIB=$(pwd)/libmongocrypt-all/windows-test/bin/mongocrypt.dll
   $ python -c "import pymongocrypt; print(pymongocrypt.libmongocrypt_version())"
-  1.2.1
+  1.9.0
 
-Linux::
+Linux: set the libmongocrypt build for your platform, for example for Ubuntu 22.04 x86_64::
+
+  $ # Set PYMONGOCRYPT_LIB for Ubuntu 22.04 x86_64:
+  $ export PYMONGOCRYPT_LIB=$(pwd)/libmongocrypt-all/ubuntu2204-64/lib/libmongocrypt.so
+  $ python -c "import pymongocrypt; print(pymongocrypt.libmongocrypt_version())"
+  1.9.0
+
+Note if your Linux platform is not available, the generic RHEL 6.2 x86_64 "nocrypto" build
+should still be compatible however the "nocrypto" build will result in lower performance
+for encryption and decryption::
 
   $ # Set PYMONGOCRYPT_LIB for RHEL 6.2 x86_64:
   $ export PYMONGOCRYPT_LIB=$(pwd)/libmongocrypt-all/rhel-62-64-bit/nocrypto/lib64/libmongocrypt.so
   $ python -c "import pymongocrypt; print(pymongocrypt.libmongocrypt_version())"
-  1.2.1
+  1.9.0
 
 Dependencies
 ============
@@ -178,7 +188,7 @@ variables, like ``LD_LIBRARY_PATH``. For example::
 
   $ export PYMONGOCRYPT_LIB='/path/to/libmongocrypt.so'
   $ python -c "import pymongocrypt; print(pymongocrypt.libmongocrypt_version())"
-  1.2.1
+  1.9.0
 
 Testing
 =======

--- a/bindings/python/pymongocrypt/binding.py
+++ b/bindings/python/pymongocrypt/binding.py
@@ -64,6 +64,16 @@ ffi.cdef("""/*
 const char *mongocrypt_version(uint32_t *len);
 
 /**
+ * Returns true if libmongocrypt was built with native crypto support.
+ *
+ * If libmongocrypt was not built with native crypto support, setting crypto
+ * hooks is required.
+ *
+ * @returns True if libmongocrypt was built with native crypto support.
+ */
+bool mongocrypt_is_crypto_available(void);
+
+/**
  * A non-owning view of a byte buffer.
  *
  * When constructing a mongocrypt_binary_t it is the responsibility of the

--- a/bindings/python/pymongocrypt/mongocrypt.py
+++ b/bindings/python/pymongocrypt/mongocrypt.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
+import sys
+import platform
 
+from packaging.version import Version
 
 from pymongocrypt.binary import (MongoCryptBinaryIn,
                                  MongoCryptBinaryOut)
@@ -222,6 +224,11 @@ class MongoCrypt(object):
                     self.__crypt, sign_rsaes_pkcs1_v1_5, ffi.NULL):
                 self.__raise_from_status()
 
+            if not lib.mongocrypt_setopt_aes_256_ctr(
+                    self.__crypt, aes_256_ctr_encrypt, aes_256_ctr_decrypt, ffi.NULL):
+                self.__raise_from_status()
+        elif sys.platform == 'darwin' and Version(platform.mac_ver()[0]) < Version("10.15"):
+            # MONGOCRYPT-440 libmongocrypt does not support AES-CTR on macOS < 10.15.
             if not lib.mongocrypt_setopt_aes_256_ctr(
                     self.__crypt, aes_256_ctr_encrypt, aes_256_ctr_decrypt, ffi.NULL):
                 self.__raise_from_status()

--- a/bindings/python/pymongocrypt/mongocrypt.py
+++ b/bindings/python/pymongocrypt/mongocrypt.py
@@ -205,18 +205,20 @@ class MongoCrypt(object):
         if self.__opts.bypass_query_analysis:
             lib.mongocrypt_setopt_bypass_query_analysis(self.__crypt)
 
-        if not lib.mongocrypt_setopt_crypto_hooks(
-                self.__crypt, aes_256_cbc_encrypt, aes_256_cbc_decrypt,
-                secure_random, hmac_sha_512, hmac_sha_256, sha_256, ffi.NULL):
-            self.__raise_from_status()
+        # Prefer using the native crypto binding it's available.
+        if not (hasattr(lib, "mongocrypt_is_crypto_available") and lib.mongocrypt_is_crypto_available()):
+            if not lib.mongocrypt_setopt_crypto_hooks(
+                    self.__crypt, aes_256_cbc_encrypt, aes_256_cbc_decrypt,
+                    secure_random, hmac_sha_512, hmac_sha_256, sha_256, ffi.NULL):
+                self.__raise_from_status()
 
-        if not lib.mongocrypt_setopt_crypto_hook_sign_rsaes_pkcs1_v1_5(
-                self.__crypt, sign_rsaes_pkcs1_v1_5, ffi.NULL):
-            self.__raise_from_status()
+            if not lib.mongocrypt_setopt_crypto_hook_sign_rsaes_pkcs1_v1_5(
+                    self.__crypt, sign_rsaes_pkcs1_v1_5, ffi.NULL):
+                self.__raise_from_status()
 
-        if not lib.mongocrypt_setopt_aes_256_ctr(
-                self.__crypt, aes_256_ctr_encrypt, aes_256_ctr_decrypt, ffi.NULL):
-            self.__raise_from_status()
+            if not lib.mongocrypt_setopt_aes_256_ctr(
+                    self.__crypt, aes_256_ctr_encrypt, aes_256_ctr_decrypt, ffi.NULL):
+                self.__raise_from_status()
 
         if self.__opts.crypt_shared_lib_path is not None:
             lib.mongocrypt_setopt_set_crypt_shared_lib_path_override(

--- a/bindings/python/pymongocrypt/mongocrypt.py
+++ b/bindings/python/pymongocrypt/mongocrypt.py
@@ -205,8 +205,14 @@ class MongoCrypt(object):
         if self.__opts.bypass_query_analysis:
             lib.mongocrypt_setopt_bypass_query_analysis(self.__crypt)
 
-        # Prefer using the native crypto binding it's available.
-        if not (hasattr(lib, "mongocrypt_is_crypto_available") and lib.mongocrypt_is_crypto_available()):
+        # Prefer using the native crypto binding when we know it's available.
+        try:
+            crypto_available = lib.mongocrypt_is_crypto_available()
+        except AttributeError:
+            # libmongocrypt < 1.9
+            crypto_available = False
+
+        if not crypto_available:
             if not lib.mongocrypt_setopt_crypto_hooks(
                     self.__crypt, aes_256_cbc_encrypt, aes_256_cbc_decrypt,
                     secure_random, hmac_sha_512, hmac_sha_256, sha_256, ffi.NULL):

--- a/bindings/python/release.sh
+++ b/bindings/python/release.sh
@@ -66,7 +66,8 @@ if [ "Windows_NT" = "$OS" ]; then # Magic variable in cygwin
     dos2unix .venv/Scripts/activate || true
     . ./.venv/Scripts/activate
 
-    get_libmongocrypt windows-test libmongocrypt/nocrypto/bin/mongocrypt.dll
+    # Use crypto-enabled libmongocrypt.
+    get_libmongocrypt windows-test libmongocrypt/bin/mongocrypt.dll
     build_wheel
     test_dist dist/*.whl
 fi 
@@ -76,8 +77,9 @@ if [ "Darwin" = "$(uname -s)" ]; then
     $PYTHON -m venv .venv
     . .venv/bin/activate
 
+    # Use crypto-enabled libmongocrypt.
     # Build intel wheel for Python 3.7.
-    get_libmongocrypt macos_x86_64 libmongocrypt/nocrypto/lib/libmongocrypt.dylib
+    get_libmongocrypt macos_x86_64 libmongocrypt/lib/libmongocrypt.dylib
     # See https://github.com/pypa/cibuildwheel/blob/a3e5b541dc3111166a3abdbbc90ecb195c8cb9e2/cibuildwheel/macos.py#L247
     # for information on these environment variables.
     export MACOSX_DEPLOYMENT_TARGET=10.14
@@ -88,7 +90,7 @@ if [ "Darwin" = "$(uname -s)" ]; then
     fi
     
     # Build universal2 wheel.
-    get_libmongocrypt macos libmongocrypt/nocrypto/lib/libmongocrypt.dylib
+    get_libmongocrypt macos libmongocrypt/lib/libmongocrypt.dylib
     export MACOSX_DEPLOYMENT_TARGET=11.0
     export _PYTHON_HOST_PLATFORM=macosx-11.0-universal2
     build_wheel


### PR DESCRIPTION
PYTHON-4181 Use libmongocrypt native crypto when available for better performance

TODO:

- [X] Bundle crypto-enabled libmongocrypt on Mac and Windows.
- [x] Add tests for both crypto and nocrypto builds.
- [x] Add documentation.


Before:
```
[2024/02/22 11:54:56.554] Running benchmark with pymongocrypt: 1.9.0.dev0 libmongocrypt: 1.10.0-20240222+gitae4c445a80
[2024/02/22 11:54:56.554] Finished TestBulkDecryption, threads=1, median ops_per_second=13.17
[2024/02/22 11:54:56.554] Finished TestBulkDecryption, threads=2, median ops_per_second=5.24
[2024/02/22 11:54:56.554] Finished TestBulkDecryption, threads=8, median ops_per_second=4.41
[2024/02/22 11:54:56.554] Finished TestBulkDecryption, threads=64, median ops_per_second=4.01
```
After (10-50x higher throughput):
```
[2024/02/26 13:50:13.106] Running benchmark with pymongocrypt: 1.9.0.dev0 libmongocrypt: 1.8.1-20240226+gita6d8858092
[2024/02/26 13:50:13.106] Finished TestBulkDecryption, threads=1, median ops_per_second=132.25
[2024/02/26 13:50:13.106] Finished TestBulkDecryption, threads=2, median ops_per_second=171.99
[2024/02/26 13:50:13.106] Finished TestBulkDecryption, threads=8, median ops_per_second=204.54
[2024/02/26 13:50:13.106] Finished TestBulkDecryption, threads=64, median ops_per_second=224.22
```