### PR TITLE
MONGOCRYPT-617 Use trim factor in the edges + mincover algorithms

### DIFF
--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
@@ -593,6 +593,7 @@ public class CAPI {
      *    "max": Optional&#60;BSON value&#62;,
      *    "sparsity": Int64,
      *    "precision": Optional&#60;Int32&#62;
+     *    "trimFactor": Optional&#60;Int32&#62;
      * }
      *
      * @param ctx The @ref mongocrypt_ctx_t object.

--- a/bindings/python/pymongocrypt/binding.py
+++ b/bindings/python/pymongocrypt/binding.py
@@ -1373,7 +1373,8 @@ bool mongocrypt_ctx_setopt_query_type(mongocrypt_ctx_t *ctx, const char *query_t
  *    "min": Optional<BSON value>,
  *    "max": Optional<BSON value>,
  *    "sparsity": Int64,
- *    "precision": Optional<Int32>
+ *    "precision": Optional<Int32>,
+ *    "trimFactor": Optional<Int32>
  * }
  *
  * @param[in] ctx The @ref mongocrypt_ctx_t object.

--- a/src/mc-fle2-encryption-placeholder-private.h
+++ b/src/mc-fle2-encryption-placeholder-private.h
@@ -50,6 +50,8 @@ typedef struct {
     // precision determines the number of digits after the decimal point for
     // floating point values.
     mc_optional_uint32_t precision;
+    // trimFactor determines how many root levels of the hypertree to trim.
+    mc_optional_uint32_t trimFactor;
 } mc_FLE2RangeFindSpecEdgesInfo_t;
 
 /** FLE2RangeFindSpec represents the range find specification that is encoded
@@ -74,7 +76,7 @@ typedef struct {
     mc_FLE2RangeOperator_t secondOperator;
 } mc_FLE2RangeFindSpec_t;
 
-bool mc_FLE2RangeFindSpec_parse(mc_FLE2RangeFindSpec_t *out, const bson_iter_t *in, mongocrypt_status_t *status);
+bool mc_FLE2RangeFindSpec_parse(mc_FLE2RangeFindSpec_t *out, const bson_iter_t *in, bool use_range_v2, mongocrypt_status_t *status);
 
 /** mc_FLE2RangeInsertSpec_t represents the range insert specification that is
  * encoded inside of a FLE2EncryptionPlaceholder. See
@@ -90,9 +92,11 @@ typedef struct {
     // precision determines the number of digits after the decimal point for
     // floating point values.
     mc_optional_uint32_t precision;
+    // trimFactor determines how many root levels of the hypertree to trim.
+    mc_optional_uint32_t trimFactor;
 } mc_FLE2RangeInsertSpec_t;
 
-bool mc_FLE2RangeInsertSpec_parse(mc_FLE2RangeInsertSpec_t *out, const bson_iter_t *in, mongocrypt_status_t *status);
+bool mc_FLE2RangeInsertSpec_parse(mc_FLE2RangeInsertSpec_t *out, const bson_iter_t *in, bool use_range_v2, mongocrypt_status_t *status);
 
 /** FLE2EncryptionPlaceholder implements Encryption BinData (subtype 6)
  * sub-subtype 0, the intent-to-encrypt mapping. Contains a value to encrypt and

--- a/src/mc-fle2-encryption-placeholder-private.h
+++ b/src/mc-fle2-encryption-placeholder-private.h
@@ -76,7 +76,10 @@ typedef struct {
     mc_FLE2RangeOperator_t secondOperator;
 } mc_FLE2RangeFindSpec_t;
 
-bool mc_FLE2RangeFindSpec_parse(mc_FLE2RangeFindSpec_t *out, const bson_iter_t *in, bool use_range_v2, mongocrypt_status_t *status);
+bool mc_FLE2RangeFindSpec_parse(mc_FLE2RangeFindSpec_t *out,
+                                const bson_iter_t *in,
+                                bool use_range_v2,
+                                mongocrypt_status_t *status);
 
 /** mc_FLE2RangeInsertSpec_t represents the range insert specification that is
  * encoded inside of a FLE2EncryptionPlaceholder. See
@@ -96,7 +99,10 @@ typedef struct {
     mc_optional_uint32_t trimFactor;
 } mc_FLE2RangeInsertSpec_t;
 
-bool mc_FLE2RangeInsertSpec_parse(mc_FLE2RangeInsertSpec_t *out, const bson_iter_t *in, bool use_range_v2, mongocrypt_status_t *status);
+bool mc_FLE2RangeInsertSpec_parse(mc_FLE2RangeInsertSpec_t *out,
+                                  const bson_iter_t *in,
+                                  bool use_range_v2,
+                                  mongocrypt_status_t *status);
 
 /** FLE2EncryptionPlaceholder implements Encryption BinData (subtype 6)
  * sub-subtype 0, the intent-to-encrypt mapping. Contains a value to encrypt and

--- a/src/mc-fle2-encryption-placeholder.c
+++ b/src/mc-fle2-encryption-placeholder.c
@@ -314,7 +314,10 @@ fail:
     return false;
 }
 
-bool mc_FLE2RangeFindSpec_parse(mc_FLE2RangeFindSpec_t *out, const bson_iter_t *in, bool use_range_v2, mongocrypt_status_t *status) {
+bool mc_FLE2RangeFindSpec_parse(mc_FLE2RangeFindSpec_t *out,
+                                const bson_iter_t *in,
+                                bool use_range_v2,
+                                mongocrypt_status_t *status) {
     BSON_ASSERT_PARAM(out);
     BSON_ASSERT_PARAM(in);
 
@@ -395,7 +398,10 @@ fail:
     return false;
 }
 
-bool mc_FLE2RangeInsertSpec_parse(mc_FLE2RangeInsertSpec_t *out, const bson_iter_t *in, bool use_range_v2, mongocrypt_status_t *status) {
+bool mc_FLE2RangeInsertSpec_parse(mc_FLE2RangeInsertSpec_t *out,
+                                  const bson_iter_t *in,
+                                  bool use_range_v2,
+                                  mongocrypt_status_t *status) {
     BSON_ASSERT_PARAM(out);
     BSON_ASSERT_PARAM(in);
 

--- a/src/mc-fle2-rfds-private.h
+++ b/src/mc-fle2-rfds-private.h
@@ -76,6 +76,7 @@ typedef struct {
     int64_t maxContentionFactor;
     int64_t sparsity;
     mc_optional_uint32_t precision;
+    mc_optional_uint32_t trimFactor;
 } mc_makeRangeFindPlaceholder_args_t;
 
 // mc_makeRangeFindPlaceholder creates a placeholder to be consumed by

--- a/src/mc-fle2-rfds.c
+++ b/src/mc-fle2-rfds.c
@@ -367,6 +367,10 @@ bool mc_makeRangeFindPlaceholder(mc_makeRangeFindPlaceholder_args_t *args,
             BSON_ASSERT(args->precision.value <= INT32_MAX);
             TRY(BSON_APPEND_INT32(edgesInfo, "precision", (int32_t)args->precision.value));
         }
+        if(args->trimFactor.set) {
+            BSON_ASSERT(args->trimFactor.value <= INT32_MAX);
+            TRY(BSON_APPEND_INT32(edgesInfo, "trimFactor", (int32_t)args->trimFactor.value));
+        }
         TRY(BSON_APPEND_DOCUMENT(v, "edgesInfo", edgesInfo));
     }
 
@@ -470,7 +474,8 @@ bool mc_FLE2RangeFindDriverSpec_to_placeholders(mc_FLE2RangeFindDriverSpec_t *sp
                                                .indexMax = indexMax,
                                                .precision = range_opts->precision,
                                                .maxContentionFactor = maxContentionFactor,
-                                               .sparsity = range_opts->sparsity};
+                                               .sparsity = range_opts->sparsity,
+                                               .trimFactor = range_opts->trimFactor};
 
     // First operator is the non-stub.
     if (!mc_makeRangeFindPlaceholder(&args, &p1, status)) {

--- a/src/mc-fle2-rfds.c
+++ b/src/mc-fle2-rfds.c
@@ -367,7 +367,7 @@ bool mc_makeRangeFindPlaceholder(mc_makeRangeFindPlaceholder_args_t *args,
             BSON_ASSERT(args->precision.value <= INT32_MAX);
             TRY(BSON_APPEND_INT32(edgesInfo, "precision", (int32_t)args->precision.value));
         }
-        if(args->trimFactor.set) {
+        if (args->trimFactor.set) {
             BSON_ASSERT(args->trimFactor.value <= INT32_MAX);
             TRY(BSON_APPEND_INT32(edgesInfo, "trimFactor", (int32_t)args->trimFactor.value));
         }

--- a/src/mc-range-edge-generation-private.h
+++ b/src/mc-range-edge-generation-private.h
@@ -42,6 +42,7 @@ typedef struct {
     mc_optional_int32_t min;
     mc_optional_int32_t max;
     size_t sparsity;
+    uint32_t trimFactor;
 } mc_getEdgesInt32_args_t;
 
 // mc_getEdgesInt32 implements the Edge Generation algorithm described in
@@ -53,6 +54,7 @@ typedef struct {
     mc_optional_int64_t min;
     mc_optional_int64_t max;
     size_t sparsity;
+    uint32_t trimFactor;
 } mc_getEdgesInt64_args_t;
 
 // mc_getEdgesInt64 implements the Edge Generation algorithm described in
@@ -65,6 +67,7 @@ typedef struct {
     mc_optional_double_t min;
     mc_optional_double_t max;
     mc_optional_uint32_t precision;
+    uint32_t trimFactor;
 } mc_getEdgesDouble_args_t;
 
 // mc_getEdgesDouble implements the Edge Generation algorithm described in
@@ -77,6 +80,7 @@ typedef struct {
     size_t sparsity;
     mc_optional_dec128_t min, max;
     mc_optional_uint32_t precision;
+    uint32_t trimFactor;
 } mc_getEdgesDecimal128_args_t;
 
 mc_edges_t *mc_getEdgesDecimal128(mc_getEdgesDecimal128_args_t args, mongocrypt_status_t *status);

--- a/src/mc-range-edge-generation.c
+++ b/src/mc-range-edge-generation.c
@@ -57,7 +57,8 @@ static mc_edges_t *mc_edges_new(const char *leaf, size_t sparsity, uint32_t trim
     _mc_array_append_val(&edges->edges, leaf_copy);
 
     // Start loop at max(trimFactor, 1). The full leaf is unconditionally appended after loop.
-    for (size_t i = trimFactor > 0 ? trimFactor : 1; i < leaf_len; i++) {
+    size_t startLevel = trimFactor > 0 ? trimFactor : 1;
+    for (size_t i = startLevel; i < leaf_len; i++) {
         if (i % sparsity == 0) {
             char *edge = bson_malloc(i + 1);
             bson_strncpy(edge, leaf, i + 1);

--- a/src/mc-range-edge-generation.c
+++ b/src/mc-range-edge-generation.c
@@ -37,8 +37,10 @@ static mc_edges_t *mc_edges_new(const char *leaf, size_t sparsity, uint32_t trim
 
     const size_t leaf_len = strlen(leaf);
     if (trimFactor != 0 && trimFactor >= leaf_len) {
-        // We append a total of leaf_len + 1 (for the root) - trimFactor edges. When this number is equal to 1, we degenerate into equality, which is not desired, so trimFactor must be less than leaf_len.
-        CLIENT_ERR("trimFactor must be less than the number of bits (%ld) used to represent an element of the domain", leaf_len);
+        // We append a total of leaf_len + 1 (for the root) - trimFactor edges. When this number is equal to 1, we
+        // degenerate into equality, which is not desired, so trimFactor must be less than leaf_len.
+        CLIENT_ERR("trimFactor must be less than the number of bits (%ld) used to represent an element of the domain",
+                   leaf_len);
         return NULL;
     }
 
@@ -46,7 +48,7 @@ static mc_edges_t *mc_edges_new(const char *leaf, size_t sparsity, uint32_t trim
     edges->sparsity = sparsity;
     _mc_array_init(&edges->edges, sizeof(char *));
 
-    if(trimFactor == 0) {
+    if (trimFactor == 0) {
         char *root = bson_strdup("root");
         _mc_array_append_val(&edges->edges, root);
     }

--- a/src/mc-range-mincover-generator.template.h
+++ b/src/mc-range-mincover-generator.template.h
@@ -101,6 +101,7 @@ typedef struct {
     UINT_T _rangeMin;
     UINT_T _rangeMax;
     size_t _sparsity;
+    uint32_t _trimFactor;
     // _maxlen is the maximum bit length of edges in the mincover.
     size_t _maxlen;
 } DECORATE_NAME(MinCoverGenerator);
@@ -110,6 +111,7 @@ static inline DECORATE_NAME(MinCoverGenerator)
                                            UINT_T rangeMax,
                                            UINT_T max,
                                            size_t sparsity,
+                                           uint32_t trimFactor,
                                            mongocrypt_status_t *status) {
     BSON_ASSERT_PARAM(status);
 
@@ -131,11 +133,17 @@ static inline DECORATE_NAME(MinCoverGenerator)
         CLIENT_ERR("Sparsity must be > 0");
         return NULL;
     }
+    size_t maxlen = (size_t)BITS - DECORATE_NAME(mc_count_leading_zeros)(max);
+    if (trimFactor != 0 && trimFactor >= maxlen) {
+        CLIENT_ERR("Trim factor must be less than the number of bits (%ld) used to represent an element of the domain", maxlen);
+        return NULL;
+    }
     DECORATE_NAME(MinCoverGenerator) *mcg = bson_malloc0(sizeof(DECORATE_NAME(MinCoverGenerator)));
     mcg->_rangeMin = rangeMin;
     mcg->_rangeMax = rangeMax;
     mcg->_maxlen = (size_t)BITS - DECORATE_NAME(mc_count_leading_zeros)(max);
     mcg->_sparsity = sparsity;
+    mcg->_trimFactor = trimFactor;
     return mcg;
 }
 
@@ -164,7 +172,7 @@ static inline bool DECORATE_NAME(MinCoverGenerator_isLevelStored)(DECORATE_NAME(
                                                                   size_t maskedBits) {
     BSON_ASSERT_PARAM(mcg);
     size_t level = mcg->_maxlen - maskedBits;
-    return 0 == maskedBits || 0 == (level % mcg->_sparsity);
+    return 0 == maskedBits || (level >= mcg->_trimFactor && 0 == (level % mcg->_sparsity));
 }
 
 char *

--- a/src/mc-range-mincover-generator.template.h
+++ b/src/mc-range-mincover-generator.template.h
@@ -135,7 +135,8 @@ static inline DECORATE_NAME(MinCoverGenerator)
     }
     size_t maxlen = (size_t)BITS - DECORATE_NAME(mc_count_leading_zeros)(max);
     if (trimFactor != 0 && trimFactor >= maxlen) {
-        CLIENT_ERR("Trim factor must be less than the number of bits (%ld) used to represent an element of the domain", maxlen);
+        CLIENT_ERR("Trim factor must be less than the number of bits (%ld) used to represent an element of the domain",
+                   maxlen);
         return NULL;
     }
     DECORATE_NAME(MinCoverGenerator) *mcg = bson_malloc0(sizeof(DECORATE_NAME(MinCoverGenerator)));

--- a/src/mc-range-mincover-private.h
+++ b/src/mc-range-mincover-private.h
@@ -44,6 +44,7 @@ typedef struct {
     mc_optional_int32_t min;
     mc_optional_int32_t max;
     size_t sparsity;
+    uint32_t trimFactor;
 } mc_getMincoverInt32_args_t;
 
 // mc_getMincoverInt32 implements the Mincover Generation algorithm described in
@@ -59,6 +60,7 @@ typedef struct {
     mc_optional_int64_t min;
     mc_optional_int64_t max;
     size_t sparsity;
+    uint32_t trimFactor;
 } mc_getMincoverInt64_args_t;
 
 // mc_getMincoverInt64 implements the Mincover Generation algorithm described in
@@ -75,6 +77,7 @@ typedef struct {
     mc_optional_double_t min;
     mc_optional_double_t max;
     mc_optional_uint32_t precision;
+    uint32_t trimFactor;
 } mc_getMincoverDouble_args_t;
 
 // mc_getMincoverDouble implements the Mincover Generation algorithm described
@@ -91,6 +94,7 @@ typedef struct {
     size_t sparsity;
     mc_optional_dec128_t min, max;
     mc_optional_uint32_t precision;
+    uint32_t trimFactor;
 } mc_getMincoverDecimal128_args_t;
 
 // mc_getMincoverDecimal128 implements the Mincover Generation algorithm

--- a/src/mc-range-mincover.c
+++ b/src/mc-range-mincover.c
@@ -149,7 +149,8 @@ mc_mincover_t *mc_getMincoverInt32(mc_getMincoverInt32_args_t args, mongocrypt_s
         return NULL;
     }
 
-    MinCoverGenerator_u32 *mcg = MinCoverGenerator_new_u32(a.value, b.value, a.max, args.sparsity, args.trimFactor, status);
+    MinCoverGenerator_u32 *mcg =
+        MinCoverGenerator_new_u32(a.value, b.value, a.max, args.sparsity, args.trimFactor, status);
     if (!mcg) {
         return NULL;
     }
@@ -180,7 +181,8 @@ mc_mincover_t *mc_getMincoverInt64(mc_getMincoverInt64_args_t args, mongocrypt_s
         return NULL;
     }
 
-    MinCoverGenerator_u64 *mcg = MinCoverGenerator_new_u64(a.value, b.value, a.max, args.sparsity, args.trimFactor, status);
+    MinCoverGenerator_u64 *mcg =
+        MinCoverGenerator_new_u64(a.value, b.value, a.max, args.sparsity, args.trimFactor, status);
     if (!mcg) {
         return NULL;
     }
@@ -220,7 +222,8 @@ mc_mincover_t *mc_getMincoverDouble(mc_getMincoverDouble_args_t args, mongocrypt
         return NULL;
     }
 
-    MinCoverGenerator_u64 *mcg = MinCoverGenerator_new_u64(a.value, b.value, a.max, args.sparsity, args.trimFactor, status);
+    MinCoverGenerator_u64 *mcg =
+        MinCoverGenerator_new_u64(a.value, b.value, a.max, args.sparsity, args.trimFactor, status);
     if (!mcg) {
         return NULL;
     }
@@ -260,7 +263,8 @@ mc_mincover_t *mc_getMincoverDecimal128(mc_getMincoverDecimal128_args_t args, mo
         return NULL;
     }
 
-    MinCoverGenerator_u128 *mcg = MinCoverGenerator_new_u128(a.value, b.value, a.max, args.sparsity, args.trimFactor, status);
+    MinCoverGenerator_u128 *mcg =
+        MinCoverGenerator_new_u128(a.value, b.value, a.max, args.sparsity, args.trimFactor, status);
     if (!mcg) {
         return NULL;
     }

--- a/src/mc-range-mincover.c
+++ b/src/mc-range-mincover.c
@@ -149,7 +149,7 @@ mc_mincover_t *mc_getMincoverInt32(mc_getMincoverInt32_args_t args, mongocrypt_s
         return NULL;
     }
 
-    MinCoverGenerator_u32 *mcg = MinCoverGenerator_new_u32(a.value, b.value, a.max, args.sparsity, status);
+    MinCoverGenerator_u32 *mcg = MinCoverGenerator_new_u32(a.value, b.value, a.max, args.sparsity, args.trimFactor, status);
     if (!mcg) {
         return NULL;
     }
@@ -180,7 +180,7 @@ mc_mincover_t *mc_getMincoverInt64(mc_getMincoverInt64_args_t args, mongocrypt_s
         return NULL;
     }
 
-    MinCoverGenerator_u64 *mcg = MinCoverGenerator_new_u64(a.value, b.value, a.max, args.sparsity, status);
+    MinCoverGenerator_u64 *mcg = MinCoverGenerator_new_u64(a.value, b.value, a.max, args.sparsity, args.trimFactor, status);
     if (!mcg) {
         return NULL;
     }
@@ -220,7 +220,7 @@ mc_mincover_t *mc_getMincoverDouble(mc_getMincoverDouble_args_t args, mongocrypt
         return NULL;
     }
 
-    MinCoverGenerator_u64 *mcg = MinCoverGenerator_new_u64(a.value, b.value, a.max, args.sparsity, status);
+    MinCoverGenerator_u64 *mcg = MinCoverGenerator_new_u64(a.value, b.value, a.max, args.sparsity, args.trimFactor, status);
     if (!mcg) {
         return NULL;
     }
@@ -260,7 +260,7 @@ mc_mincover_t *mc_getMincoverDecimal128(mc_getMincoverDecimal128_args_t args, mo
         return NULL;
     }
 
-    MinCoverGenerator_u128 *mcg = MinCoverGenerator_new_u128(a.value, b.value, a.max, args.sparsity, status);
+    MinCoverGenerator_u128 *mcg = MinCoverGenerator_new_u128(a.value, b.value, a.max, args.sparsity, args.trimFactor, status);
     if (!mcg) {
         return NULL;
     }

--- a/src/mc-rangeopts.c
+++ b/src/mc-rangeopts.c
@@ -191,7 +191,7 @@ bool mc_RangeOpts_parse(mc_RangeOpts_t *ro, const bson_t *in, bool use_range_v2,
     if (ro->trimFactor.set) {
         if (!use_range_v2) {
             // Once `use_range_v2` is default true, this block may be removed.
-            CLIENT_ERR("trimFactor is not supported for QE range v1");
+            CLIENT_ERR("%strimFactor is not supported for QE range v1", error_prefix);
             return false;
         }
         // At this point, we do not know the type of the field if min and max are unspecified. Wait to
@@ -471,12 +471,9 @@ bool mc_RangeOpts_appendTrimFactor(const mc_RangeOpts_t *ro,
     BSON_ASSERT(status || true);
 
     if (!ro->trimFactor.set) {
-        if (!BSON_APPEND_INT32(out, fieldName, 0)) {
-            CLIENT_ERR("failed to append BSON");
-            return false;
-        }
         return true;
     }
+    BSON_ASSERT(ro->trimFactor.value <= INT32_MAX);
 
     uint32_t nbits;
     if (!mc_getNumberOfBits(ro, valueType, &nbits, status)) {

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -901,8 +901,9 @@ static mc_edges_t *get_edges(mc_FLE2RangeInsertSpec_t *insertSpec, size_t sparsi
     }
 
     else if (value_type == BSON_TYPE_DOUBLE) {
-        mc_getEdgesDouble_args_t args = {.value = bson_iter_double(&insertSpec->v), .sparsity = sparsity,
-                                                          .trimFactor = trimFactor};
+        mc_getEdgesDouble_args_t args = {.value = bson_iter_double(&insertSpec->v),
+                                         .sparsity = sparsity,
+                                         .trimFactor = trimFactor};
         if (insertSpec->precision.set) {
             // If precision is set, pass min/max/precision to mc_getEdgesDouble.
             // Do not pass min/max if precision is not set. All three must be set
@@ -1405,7 +1406,7 @@ mc_get_mincover_from_FLE2RangeFindSpec(mc_FLE2RangeFindSpec_t *findSpec, size_t 
         BSON_ASSERT(bson_iter_type(&upperBound) == BSON_TYPE_INT32);
         BSON_ASSERT(bson_iter_type(&findSpec->edgesInfo.value.indexMin) == BSON_TYPE_INT32);
         BSON_ASSERT(bson_iter_type(&findSpec->edgesInfo.value.indexMax) == BSON_TYPE_INT32);
-        
+
         return mc_getMincoverInt32(
             (mc_getMincoverInt32_args_t){.lowerBound = bson_iter_int32(&lowerBound),
                                          .includeLowerBound = includeLowerBound,

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -1441,7 +1441,8 @@ bool mongocrypt_ctx_setopt_query_type(mongocrypt_ctx_t *ctx, const char *query_t
  *    "min": Optional<BSON value>,
  *    "max": Optional<BSON value>,
  *    "sparsity": Int64,
- *    "precision": Optional<Int32>
+ *    "precision": Optional<Int32>,
+ *    "trimFactor": Optional<Int32>
  * }
  *
  * @param[in] ctx The @ref mongocrypt_ctx_t object.

--- a/test/test-mc-fle2-rfds.c
+++ b/test/test-mc-fle2-rfds.c
@@ -323,8 +323,11 @@ static void test_mc_FLE2RangeFindDriverSpec_to_placeholders(_mongocrypt_tester_t
 
     };
 
-    bson_t *range_opts_bson =
-        TMP_BSON("{'min': %d, 'max': %d, 'sparsity': {'$numberLong': '%d'}, 'trimFactor': %d}", indexMin, indexMax, sparsity, trimFactor);
+    bson_t *range_opts_bson = TMP_BSON("{'min': %d, 'max': %d, 'sparsity': {'$numberLong': '%d'}, 'trimFactor': %d}",
+                                       indexMin,
+                                       indexMax,
+                                       sparsity,
+                                       trimFactor);
 
     ASSERT_OK_STATUS(mc_RangeOpts_parse(&range_opts, range_opts_bson, true /* use_range_v2 */, status), status);
 

--- a/test/test-mc-fle2-rfds.c
+++ b/test/test-mc-fle2-rfds.c
@@ -202,6 +202,7 @@ static void test_mc_FLE2RangeFindDriverSpec_to_placeholders(_mongocrypt_tester_t
     int32_t indexMin = 5;
     int32_t indexMax = 200;
     int32_t payloadId = 123;
+    int32_t trimFactor = 1;
 
     typedef struct {
         const char *desc;
@@ -323,7 +324,7 @@ static void test_mc_FLE2RangeFindDriverSpec_to_placeholders(_mongocrypt_tester_t
     };
 
     bson_t *range_opts_bson =
-        TMP_BSON("{'min': %d, 'max': %d, 'sparsity': {'$numberLong': '%d'}}", indexMin, indexMax, sparsity);
+        TMP_BSON("{'min': %d, 'max': %d, 'sparsity': {'$numberLong': '%d'}, 'trimFactor': %d}", indexMin, indexMax, sparsity, trimFactor);
 
     ASSERT_OK_STATUS(mc_RangeOpts_parse(&range_opts, range_opts_bson, true /* use_range_v2 */, status), status);
 
@@ -355,7 +356,8 @@ static void test_mc_FLE2RangeFindDriverSpec_to_placeholders(_mongocrypt_tester_t
                                                                    .indexMin = TMP_ITER(indexMin),
                                                                    .indexMax = TMP_ITER(indexMax),
                                                                    .maxContentionFactor = maxContentionFactor,
-                                                                   .sparsity = sparsity};
+                                                                   .sparsity = sparsity,
+                                                                   .trimFactor = OPT_U32(trimFactor)};
 
                 ASSERT_OK_STATUS(mc_makeRangeFindPlaceholder(&p1_args_full, &p1, status), status);
             }
@@ -374,7 +376,8 @@ static void test_mc_FLE2RangeFindDriverSpec_to_placeholders(_mongocrypt_tester_t
                                                                    .indexMin = TMP_ITER(indexMin),
                                                                    .indexMax = TMP_ITER(indexMax),
                                                                    .maxContentionFactor = maxContentionFactor,
-                                                                   .sparsity = sparsity};
+                                                                   .sparsity = sparsity,
+                                                                   .trimFactor = OPT_U32(trimFactor)};
 
                 ASSERT_OK_STATUS(mc_makeRangeFindPlaceholder(&p2_args_full, &p2, status), status);
             }

--- a/test/test-mc-range-edge-generation.c
+++ b/test/test-mc-range-edge-generation.c
@@ -80,7 +80,8 @@ static void _test_getEdgesInt32(_mongocrypt_tester_t *tester) {
          .max = OPT_I32_C(7),
          .sparsity = 1,
          .trimFactor = 3,
-         .expectError = "trimFactor must be less than the number of bits (3) used to represent an element of the domain"},
+         .expectError =
+             "trimFactor must be less than the number of bits (3) used to represent an element of the domain"},
         {.value = 2,
          .min = OPT_I32_C(0),
          .max = OPT_I32_C(7),

--- a/test/test-mc-range-edge-generation.c
+++ b/test/test-mc-range-edge-generation.c
@@ -172,7 +172,7 @@ static void _test_getEdgesInt64(_mongocrypt_tester_t *tester) {
          .max = OPT_I64_C(7),
          .sparsity = 2,
          .expectEdges = {"root", "010", "01"}},
-         {.value = INT64_C(2),
+        {.value = INT64_C(2),
          .min = OPT_I64_C(0),
          .max = OPT_I64_C(7),
          .sparsity = 1,

--- a/test/test-mc-range-edge-generation.c
+++ b/test/test-mc-range-edge-generation.c
@@ -32,6 +32,7 @@ typedef struct {
     // expectEdges includes a trailing NULL pointer.
     const char *expectEdges[MAX_INT32_EDGES + 1];
     const char *expectError;
+    uint32_t trimFactor;
 } Int32Test;
 
 #undef MAX_INT32_EDGES
@@ -62,6 +63,42 @@ static void _test_getEdgesInt32(_mongocrypt_tester_t *tester) {
          .expectEdges = {"root", "010", "0", "01"}},
         {.value = 2, .min = OPT_I32_C(0), .max = OPT_I32_C(7), .sparsity = 2, .expectEdges = {"root", "010", "01"}},
         {.value = 1, .sparsity = 0, .expectError = "sparsity must be 1 or larger"},
+        {.value = 2,
+         .min = OPT_I32_C(0),
+         .max = OPT_I32_C(7),
+         .sparsity = 1,
+         .trimFactor = 1,
+         .expectEdges = {"010", "0", "01"}},
+        {.value = 2,
+         .min = OPT_I32_C(0),
+         .max = OPT_I32_C(7),
+         .sparsity = 1,
+         .trimFactor = 2,
+         .expectEdges = {"010", "01"}},
+        {.value = 2,
+         .min = OPT_I32_C(0),
+         .max = OPT_I32_C(7),
+         .sparsity = 1,
+         .trimFactor = 3,
+         .expectError = "trimFactor must be less than the number of bits (3) used to represent an element of the domain"},
+        {.value = 2,
+         .min = OPT_I32_C(0),
+         .max = OPT_I32_C(7),
+         .sparsity = 2,
+         .trimFactor = 0,
+         .expectEdges = {"root", "010", "01"}},
+        {.value = 2,
+         .min = OPT_I32_C(0),
+         .max = OPT_I32_C(7),
+         .sparsity = 2,
+         .trimFactor = 1,
+         .expectEdges = {"010", "01"}},
+        {.value = 2,
+         .min = OPT_I32_C(0),
+         .max = OPT_I32_C(7),
+         .sparsity = 2,
+         .trimFactor = 2,
+         .expectEdges = {"010", "01"}},
 #include "data/range-edge-generation/edges_int32.cstruct"
     };
 
@@ -71,7 +108,8 @@ static void _test_getEdgesInt32(_mongocrypt_tester_t *tester) {
         mc_getEdgesInt32_args_t args = {.value = test->value,
                                         .min = test->min,
                                         .max = test->max,
-                                        .sparsity = test->sparsity};
+                                        .sparsity = test->sparsity,
+                                        .trimFactor = test->trimFactor};
         mc_edges_t *got = mc_getEdgesInt32(args, status);
         if (test->expectError != NULL) {
             ASSERT_OR_PRINT_MSG(NULL == got, "expected error, got success");

--- a/test/test-mc-range-edge-generation.c
+++ b/test/test-mc-range-edge-generation.c
@@ -201,7 +201,8 @@ static void _test_getEdgesInt64(_mongocrypt_tester_t *tester) {
         mc_getEdgesInt64_args_t args = {.value = test->value,
                                         .min = test->min,
                                         .max = test->max,
-                                        .sparsity = test->sparsity};
+                                        .sparsity = test->sparsity,
+                                        .trimFactor = test->trimFactor};
         mc_edges_t *got = mc_getEdgesInt64(args, status);
         if (test->expectError != NULL) {
             ASSERT_OR_PRINT_MSG(NULL == got, "expected error, got success");

--- a/test/test-mc-range-edge-generation.c
+++ b/test/test-mc-range-edge-generation.c
@@ -155,6 +155,7 @@ typedef struct {
     // expectEdges includes a trailing NULL pointer.
     const char *expectEdges[MAX_INT64_EDGES + 1];
     const char *expectError;
+    uint32_t trimFactor;
 } Int64Test;
 
 #undef MAX_INT64_EDGES
@@ -171,6 +172,25 @@ static void _test_getEdgesInt64(_mongocrypt_tester_t *tester) {
          .max = OPT_I64_C(7),
          .sparsity = 2,
          .expectEdges = {"root", "010", "01"}},
+         {.value = INT64_C(2),
+         .min = OPT_I64_C(0),
+         .max = OPT_I64_C(7),
+         .sparsity = 1,
+         .trimFactor = 1,
+         .expectEdges = {"010", "0", "01"}},
+        {.value = INT64_C(2),
+         .min = OPT_I64_C(0),
+         .max = OPT_I64_C(7),
+         .sparsity = 1,
+         .trimFactor = 2,
+         .expectEdges = {"010", "01"}},
+        {.value = INT64_C(2),
+         .min = OPT_I64_C(0),
+         .max = OPT_I64_C(7),
+         .sparsity = 1,
+         .trimFactor = 3,
+         .expectError =
+             "trimFactor must be less than the number of bits (3) used to represent an element of the domain"},
         {.value = 1, .sparsity = 0, .expectError = "sparsity must be 1 or larger"},
 #include "data/range-edge-generation/edges_int64.cstruct"
     };
@@ -224,6 +244,7 @@ typedef struct {
     // expectEdges includes a trailing NULL pointer.
     const char *expectEdges[MAX_DOUBLE_EDGES + 1];
     const char *expectError;
+    uint32_t trimFactor;
 } DoubleTest;
 
 #undef MAX_DOUBLE_EDGES

--- a/test/test-mc-range-mincover.c
+++ b/test/test-mc-range-mincover.c
@@ -37,6 +37,7 @@ typedef struct {
     mc_optional_int32_t min;
     mc_optional_int32_t max;
     size_t sparsity;
+    uint32_t trimFactor;
     const char *expectMincoverStrings[MAX_MINCOVER_STRINGS];
     const char *expectError;
 } Int32Test;
@@ -99,7 +100,8 @@ static mc_mincover_t *_test_getMincover32(void *tests, size_t idx, mongocrypt_st
                                                             .includeUpperBound = test->includeUpperBound,
                                                             .min = test->min,
                                                             .max = test->max,
-                                                            .sparsity = test->sparsity},
+                                                            .sparsity = test->sparsity,
+                                                            .trimFactor = test->trimFactor},
                                status);
 }
 
@@ -429,6 +431,41 @@ static void _test_getMincoverInt32(_mongocrypt_tester_t *tester) {
          .max = OPT_I32_C(7),
          .sparsity = 1,
          .expectError = "less than or equal to the maximum value"},
+        {.lowerBound = 0,
+         .includeLowerBound = true,
+         .upperBound = 7,
+         .includeUpperBound = true,
+         .min = OPT_I32_C(0),
+         .max = OPT_I32_C(7),
+         .sparsity = 1,
+         .expectMincoverStrings = {"root"}},
+        {.lowerBound = 0,
+         .includeLowerBound = true,
+         .upperBound = 7,
+         .includeUpperBound = true,
+         .min = OPT_I32_C(0),
+         .max = OPT_I32_C(7),
+         .sparsity = 1,
+         .trimFactor = 1,
+         .expectMincoverStrings = {"0", "1"}},
+        {.lowerBound = 0,
+         .includeLowerBound = true,
+         .upperBound = 7,
+         .includeUpperBound = true,
+         .min = OPT_I32_C(0),
+         .max = OPT_I32_C(7),
+         .sparsity = 1,
+         .trimFactor = 2,
+         .expectMincoverStrings = {"00", "01", "10", "11"}},
+        {.lowerBound = 0,
+         .includeLowerBound = true,
+         .upperBound = 7,
+         .includeUpperBound = true,
+         .min = OPT_I32_C(0),
+         .max = OPT_I32_C(7),
+         .sparsity = 1,
+         .trimFactor = 3,
+         .expectError = "Trim factor must be less than the number of bits (3) used to represent an element of the domain"},
 
 #include "./data/range-min-cover/mincover_int32.cstruct"
 

--- a/test/test-mc-range-mincover.c
+++ b/test/test-mc-range-mincover.c
@@ -465,7 +465,8 @@ static void _test_getMincoverInt32(_mongocrypt_tester_t *tester) {
          .max = OPT_I32_C(7),
          .sparsity = 1,
          .trimFactor = 3,
-         .expectError = "Trim factor must be less than the number of bits (3) used to represent an element of the domain"},
+         .expectError =
+             "Trim factor must be less than the number of bits (3) used to represent an element of the domain"},
 
 #include "./data/range-min-cover/mincover_int32.cstruct"
 

--- a/test/test-mc-rangeopts.c
+++ b/test/test-mc-rangeopts.c
@@ -76,7 +76,7 @@ static void test_mc_RangeOpts_parse(_mongocrypt_tester_t *tester) {
         {.desc = "Errors on negative trim factor",
          .in = RAW_STRING({"trimFactor" : -1, "sparsity" : {"$numberLong" : "1"}}),
          .useRangeV2 = true,
-        .expectError = "'trimFactor' must be non-negative"},
+         .expectError = "'trimFactor' must be non-negative"},
     };
 
     for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {

--- a/test/test-mc-rangeopts.c
+++ b/test/test-mc-rangeopts.c
@@ -29,6 +29,7 @@ static void test_mc_RangeOpts_parse(_mongocrypt_tester_t *tester) {
         int64_t expectSparsity;
         mc_optional_uint32_t expectPrecision;
         mc_optional_uint32_t expectTrimFactor;
+        bool useRangeV2;
     } testcase;
 
     testcase tests[] = {
@@ -63,9 +64,19 @@ static void test_mc_RangeOpts_parse(_mongocrypt_tester_t *tester) {
         {.desc = "Requires precision for double when only min is set",
          .in = RAW_STRING({"min" : 0.0, "sparsity" : {"$numberLong" : "1"}}),
          .expectError = "expected 'precision'"},
+        // Once `use_range_v2` is default true, this test may be removed.
+        {.desc = "Fails when trim factor is set but Range V2 is disabled",
+         .in = RAW_STRING({"trimFactor" : 1, "sparsity" : {"$numberLong" : "1"}}),
+         .expectError = "trimFactor is not supported for QE range v1"},
+        {.desc = "Works when trim factor is set and Range V2 is enabled",
+         .in = RAW_STRING({"trimFactor" : 1, "sparsity" : {"$numberLong" : "1"}}),
+         .useRangeV2 = true,
+         .expectSparsity = 1,
+         .expectTrimFactor = OPT_U32(1)},
         {.desc = "Errors on negative trim factor",
          .in = RAW_STRING({"trimFactor" : -1, "sparsity" : {"$numberLong" : "1"}}),
-         .expectError = "'trimFactor' must be non-negative"},
+         .useRangeV2 = true,
+        .expectError = "'trimFactor' must be non-negative"},
     };
 
     for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
@@ -73,7 +84,7 @@ static void test_mc_RangeOpts_parse(_mongocrypt_tester_t *tester) {
         mongocrypt_status_t *status = mongocrypt_status_new();
         mc_RangeOpts_t ro;
         printf("running test_mc_RangeOpts_parse subtest: %s\n", test->desc);
-        bool ret = mc_RangeOpts_parse(&ro, TMP_BSON(test->in), true /* use_range_v2 */, status);
+        bool ret = mc_RangeOpts_parse(&ro, TMP_BSON(test->in), test->useRangeV2, status);
         if (!test->expectError) {
             ASSERT_OK_STATUS(ret, status);
             ASSERT_CMPINT(test->expectMin.set, ==, ro.min.set);
@@ -87,23 +98,11 @@ static void test_mc_RangeOpts_parse(_mongocrypt_tester_t *tester) {
             ASSERT_CMPINT64(test->expectSparsity, ==, ro.sparsity);
             ASSERT_CMPINT(test->expectPrecision.set, ==, ro.precision.set);
             ASSERT_CMPINT(test->expectPrecision.value, ==, ro.precision.value);
+            ASSERT_CMPINT(test->expectTrimFactor.set, ==, ro.trimFactor.set);
+            ASSERT_CMPINT(test->expectTrimFactor.value, ==, ro.trimFactor.value);
         } else {
             ASSERT_FAILS_STATUS(ret, status, test->expectError);
         }
-        mc_RangeOpts_cleanup(&ro);
-        mongocrypt_status_destroy(status);
-    }
-
-    // Test parsing range V2 options when range V2 is not enabled.
-    // Once `use_range_v2` is default true, this block may be removed.
-    {
-        mongocrypt_status_t *status = mongocrypt_status_new();
-        mc_RangeOpts_t ro;
-        bool ok = mc_RangeOpts_parse(&ro,
-                                     TMP_BSON(RAW_STRING({"trimFactor" : 1, "sparsity" : {"$numberLong" : "1"}})),
-                                     false /* use_range_v2 */,
-                                     status);
-        ASSERT_FAILS_STATUS(ok, status, "trimFactor is not supported for QE range v1");
         mc_RangeOpts_cleanup(&ro);
         mongocrypt_status_destroy(status);
     }
@@ -122,11 +121,11 @@ static void test_mc_RangeOpts_to_FLE2RangeInsertSpec(_mongocrypt_tester_t *teste
         {.desc = "Works",
          .in = RAW_STRING({"min" : 123, "max" : 456, "sparsity" : {"$numberLong" : "1"}}),
          .v = RAW_STRING({"v" : 789}),
-         .expect = RAW_STRING({"v" : {"v" : 789, "min" : 123, "max" : 456, "trimFactor" : 0}})},
+         .expect = RAW_STRING({"v" : {"v" : 789, "min" : 123, "max" : 456}})},
         {.desc = "Works with precision",
          .in = RAW_STRING({"min" : 123.0, "max" : 456.0, "precision" : 2, "sparsity" : {"$numberLong" : "1"}}),
          .v = RAW_STRING({"v" : 789.0}),
-         .expect = RAW_STRING({"v" : {"v" : 789.0, "min" : 123.0, "max" : 456.0, "precision" : 2, "trimFactor" : 0}})},
+         .expect = RAW_STRING({"v" : {"v" : 789.0, "min" : 123.0, "max" : 456.0, "precision" : 2}})},
         {.desc = "Errors with missing 'v'",
          .in = RAW_STRING({"min" : 123, "max" : 456, "sparsity" : {"$numberLong" : "1"}}),
          .v = RAW_STRING({"foo" : "bar"}),

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1663,7 +1663,7 @@ static void _test_FLE2EncryptionPlaceholder_range_parse(_mongocrypt_tester_t *te
         {
             mc_FLE2RangeInsertSpec_t spec;
 
-            ASSERT_OK_STATUS(mc_FLE2RangeInsertSpec_parse(&spec, &placeholder.v_iter, status), status);
+            ASSERT_OK_STATUS(mc_FLE2RangeInsertSpec_parse(&spec, &placeholder.v_iter, true /* use_range_v2 */, status), status);
 
             ASSERT(BSON_ITER_HOLDS_INT32(&spec.v));
             ASSERT_CMPINT32(bson_iter_int32(&spec.v), ==, 123456);
@@ -1719,7 +1719,7 @@ static void _test_FLE2EncryptionPlaceholder_range_parse(_mongocrypt_tester_t *te
         {
             mc_FLE2RangeFindSpec_t spec;
 
-            ASSERT_OK_STATUS(mc_FLE2RangeFindSpec_parse(&spec, &placeholder.v_iter, status), status);
+            ASSERT_OK_STATUS(mc_FLE2RangeFindSpec_parse(&spec, &placeholder.v_iter, true /* use_range_v2 */, status), status);
 
             ASSERT(spec.edgesInfo.set);
 
@@ -1790,7 +1790,7 @@ static void _test_FLE2EncryptionPlaceholder_range_parse(_mongocrypt_tester_t *te
         {
             mc_FLE2RangeFindSpec_t spec;
 
-            ASSERT_OK_STATUS(mc_FLE2RangeFindSpec_parse(&spec, &placeholder.v_iter, status), status);
+            ASSERT_OK_STATUS(mc_FLE2RangeFindSpec_parse(&spec, &placeholder.v_iter, true /* use_range_v2 */, status), status);
 
             ASSERT(spec.edgesInfo.set);
 
@@ -1859,7 +1859,7 @@ static void _test_FLE2EncryptionPlaceholder_range_parse(_mongocrypt_tester_t *te
         {
             mc_FLE2RangeInsertSpec_t spec;
 
-            ASSERT_OK_STATUS(mc_FLE2RangeInsertSpec_parse(&spec, &placeholder.v_iter, status), status);
+            ASSERT_OK_STATUS(mc_FLE2RangeInsertSpec_parse(&spec, &placeholder.v_iter, true /* use_range_v2 */, status), status);
 
             ASSERT(BSON_ITER_HOLDS_DOUBLE(&spec.v));
             ASSERT_CMPDOUBLE(bson_iter_double(&spec.v), ==, 123.456);

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1663,7 +1663,8 @@ static void _test_FLE2EncryptionPlaceholder_range_parse(_mongocrypt_tester_t *te
         {
             mc_FLE2RangeInsertSpec_t spec;
 
-            ASSERT_OK_STATUS(mc_FLE2RangeInsertSpec_parse(&spec, &placeholder.v_iter, true /* use_range_v2 */, status), status);
+            ASSERT_OK_STATUS(mc_FLE2RangeInsertSpec_parse(&spec, &placeholder.v_iter, true /* use_range_v2 */, status),
+                             status);
 
             ASSERT(BSON_ITER_HOLDS_INT32(&spec.v));
             ASSERT_CMPINT32(bson_iter_int32(&spec.v), ==, 123456);
@@ -1719,7 +1720,8 @@ static void _test_FLE2EncryptionPlaceholder_range_parse(_mongocrypt_tester_t *te
         {
             mc_FLE2RangeFindSpec_t spec;
 
-            ASSERT_OK_STATUS(mc_FLE2RangeFindSpec_parse(&spec, &placeholder.v_iter, true /* use_range_v2 */, status), status);
+            ASSERT_OK_STATUS(mc_FLE2RangeFindSpec_parse(&spec, &placeholder.v_iter, true /* use_range_v2 */, status),
+                             status);
 
             ASSERT(spec.edgesInfo.set);
 
@@ -1790,7 +1792,8 @@ static void _test_FLE2EncryptionPlaceholder_range_parse(_mongocrypt_tester_t *te
         {
             mc_FLE2RangeFindSpec_t spec;
 
-            ASSERT_OK_STATUS(mc_FLE2RangeFindSpec_parse(&spec, &placeholder.v_iter, true /* use_range_v2 */, status), status);
+            ASSERT_OK_STATUS(mc_FLE2RangeFindSpec_parse(&spec, &placeholder.v_iter, true /* use_range_v2 */, status),
+                             status);
 
             ASSERT(spec.edgesInfo.set);
 
@@ -1859,7 +1862,8 @@ static void _test_FLE2EncryptionPlaceholder_range_parse(_mongocrypt_tester_t *te
         {
             mc_FLE2RangeInsertSpec_t spec;
 
-            ASSERT_OK_STATUS(mc_FLE2RangeInsertSpec_parse(&spec, &placeholder.v_iter, true /* use_range_v2 */, status), status);
+            ASSERT_OK_STATUS(mc_FLE2RangeInsertSpec_parse(&spec, &placeholder.v_iter, true /* use_range_v2 */, status),
+                             status);
 
             ASSERT(BSON_ITER_HOLDS_DOUBLE(&spec.v));
             ASSERT_CMPDOUBLE(bson_iter_double(&spec.v), ==, 123.456);

--- a/test/test-mongocrypt-marking.c
+++ b/test/test-mongocrypt-marking.c
@@ -292,7 +292,7 @@ static void test_mc_get_mincover_from_FLE2RangeFindSpec(_mongocrypt_tester_t *te
              "ubIncluded" : true,
              "indexMin" : {"$numberInt" : "0"},
              "indexMax" : {"$numberInt" : "31"},
-             "trimFactor": 1
+             "trimFactor" : 1
          }),
          .expectedMinCover = "0\n"
                              "1\n"},
@@ -304,7 +304,7 @@ static void test_mc_get_mincover_from_FLE2RangeFindSpec(_mongocrypt_tester_t *te
              "ubIncluded" : true,
              "indexMin" : {"$numberInt" : "0"},
              "indexMax" : {"$numberInt" : "31"},
-             "trimFactor": 3
+             "trimFactor" : 3
          }),
          .expectedMinCover = "000\n"
                              "001\n"
@@ -335,7 +335,7 @@ static void test_mc_get_mincover_from_FLE2RangeFindSpec(_mongocrypt_tester_t *te
              "ubIncluded" : true,
              "indexMin" : {"$numberInt" : "0"},
              "indexMax" : {"$numberInt" : "32"},
-             "trimFactor": 1
+             "trimFactor" : 1
          }),
          .expectedMinCover = "0\n"
                              "100000\n"},
@@ -347,12 +347,12 @@ static void test_mc_get_mincover_from_FLE2RangeFindSpec(_mongocrypt_tester_t *te
              "ubIncluded" : true,
              "indexMin" : {"$numberInt" : "0"},
              "indexMax" : {"$numberInt" : "32"},
-             "trimFactor": 2
+             "trimFactor" : 2
          }),
          .expectedMinCover = "00\n"
                              "01\n"
                              "100000\n"},
-        
+
         {.description = "Int32 infinite both bounds TF=3",
          .findSpecJSON = RAW_STRING({
              "lowerBound" : {"$numberDouble" : "-Infinity"},
@@ -361,7 +361,7 @@ static void test_mc_get_mincover_from_FLE2RangeFindSpec(_mongocrypt_tester_t *te
              "ubIncluded" : true,
              "indexMin" : {"$numberInt" : "0"},
              "indexMax" : {"$numberInt" : "32"},
-             "trimFactor": 3
+             "trimFactor" : 3
          }),
          .expectedMinCover = "000\n"
                              "001\n"
@@ -376,7 +376,7 @@ static void test_mc_get_mincover_from_FLE2RangeFindSpec(_mongocrypt_tester_t *te
              "ubIncluded" : true,
              "indexMin" : {"$numberInt" : "0"},
              "indexMax" : {"$numberInt" : "32"},
-             "trimFactor": 3
+             "trimFactor" : 3
          }),
          .sparsity = OPT_I64(2),
          .expectedMinCover = "0000\n"
@@ -396,9 +396,10 @@ static void test_mc_get_mincover_from_FLE2RangeFindSpec(_mongocrypt_tester_t *te
              "ubIncluded" : true,
              "indexMin" : {"$numberInt" : "0"},
              "indexMax" : {"$numberInt" : "32"},
-             "trimFactor": 6
+             "trimFactor" : 6
          }),
-         .expectedError = "Trim factor must be less than the number of bits (6) used to represent an element of the domain"},
+         .expectedError =
+             "Trim factor must be less than the number of bits (6) used to represent an element of the domain"},
         {.description = "Int64 Bounds included",
          .findSpecJSON = RAW_STRING({
              "lowerBound" : {"$numberLong" : "0"},


### PR DESCRIPTION
Please recommend any tests that you think should be added; there were a few existing tests (such as `test-mongocrypt-ctx-encrypt`) which I wasn't able to figure out how to expand to fit trim factor tests in.