### PR TITLE
MONGOCRYPT-622 publish Debian 12 packages

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1241,6 +1241,7 @@ buildvariants:
     has_packages: true
     packager_distro: debian12
     packager_arch: x86_64
+    python: python3
   tasks:
   - build-and-test-and-upload
   - name: publish-packages

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1235,7 +1235,7 @@ buildvariants:
     distros:
     - ubuntu2004-small
 - name: debian12
-  display_name: "Debian 12.0"
+  display_name: "Debian 12"
   run_on: debian12-large
   expansions:
     has_packages: true

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1219,7 +1219,7 @@ buildvariants:
     distros:
     - rhel70-small
 - name: debian11
-  display_name: "Debian 11.0"
+  display_name: "Debian 11"
   run_on: debian11-large
   expansions:
     has_packages: true
@@ -1248,7 +1248,7 @@ buildvariants:
     distros:
     - ubuntu2004-small
 - name: debian10
-  display_name: "Debian 10.0"
+  display_name: "Debian 10"
   run_on: debian10-test
   expansions:
     has_packages: true

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -664,6 +664,8 @@ tasks:
       name: build-and-test-and-upload
     - variant: amazon2023-arm64
       name: build-and-test-and-upload
+    - variant: debian12
+      name: build-and-test-and-upload
     - variant: debian11
       name: build-and-test-and-upload
     - variant: debian10
@@ -731,6 +733,8 @@ tasks:
       vars: { variant_name: "amazon2023" }
     - func: "download tarball"
       vars: { variant_name: "amazon2023-arm64" }
+    - func: "download tarball"
+      vars: { variant_name: "debian12" }
     - func: "download tarball"
       vars: { variant_name: "debian11" }
     - func: "download tarball"
@@ -1230,6 +1234,18 @@ buildvariants:
   - name: publish-packages
     distros:
     - ubuntu2004-small
+- name: debian12
+  display_name: "Debian 12.0"
+  run_on: debian12-large
+  expansions:
+    has_packages: true
+    packager_distro: debian12
+    packager_arch: x86_64
+  tasks:
+  - build-and-test-and-upload
+  - name: publish-packages
+    distros:
+    - ubuntu2004-small
 - name: debian10
   display_name: "Debian 10.0"
   run_on: debian10-test
@@ -1604,6 +1620,21 @@ buildvariants:
     packager_distro: debian11
     packager_arch: arm64
     earthly_env: deb11
+  tasks:
+  - name: build-deb-packages-with-earthly
+    # Use an arm64 distro to match the intended target architecture of .deb packages.
+    run_on: ubuntu2204-arm64-small
+  - name: publish-deb-packages-with-earthly
+    # Use a distro suitable for running curator to publish .deb packages.
+    run_on: ubuntu2004-small
+
+- name: debian12-arm64-earthly
+  display_name: "Debian 12 arm64 (via Earthly)"
+  expansions:
+    has_packages: true
+    packager_distro: debian12
+    packager_arch: arm64
+    earthly_env: deb12
   tasks:
   - name: build-deb-packages-with-earthly
     # Use an arm64 distro to match the intended target architecture of .deb packages.

--- a/Earthfile
+++ b/Earthfile
@@ -46,6 +46,7 @@
     #   • deb9 - Debian 9.2
     #   • deb10 - Debian 10.0
     #   • deb11 - Debian 11.0
+    #   • deb12 - Debian 12.0
     #   • sles15 - OpenSUSE Leap 15.0
     #   • alpine - Alpine Linux 3.18
     #
@@ -200,6 +201,10 @@ env.deb-unstable:
 env.deb11:
     # A Debian 11.0 environment
     DO +ENV_DEBIAN --version 11.0
+
+env.deb12:
+    # A Debian 12.0 environment
+    DO +ENV_DEBIAN --version 12.0
 
 env.sles15:
     # An OpenSUSE Leap 15.0 environment.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Second, create a list entry for the repository.  For Ubuntu systems (be sure to 
 echo "deb https://libmongocrypt.s3.amazonaws.com/apt/ubuntu <release>/libmongocrypt/1.9 universe" | sudo tee /etc/apt/sources.list.d/libmongocrypt.list
 ```
 
-For Debian systems (be sure to change `<release>` to `stretch`, `buster`, or `bullseye`, as appropriate to your system):
+For Debian systems (be sure to change `<release>` to `stretch`, `buster`, `bullseye`, or `bookworm` as appropriate to your system):
 
 ```
 echo "deb https://libmongocrypt.s3.amazonaws.com/apt/debian <release>/libmongocrypt/1.9 main" | sudo tee /etc/apt/sources.list.d/libmongocrypt.list

--- a/etc/packager.py
+++ b/etc/packager.py
@@ -338,6 +338,8 @@ class Distro(object):
                 return 'buster'
             elif build_os == 'debian11':
                 return 'bullseye'
+            elif build_os == 'debian12':
+                return 'bookworm'
             else:
                 raise Exception("unsupported build_os: %s" % build_os)
         else:
@@ -390,7 +392,7 @@ class Distro(object):
                 "ubuntu2204",
             ]
         elif self.dname == 'debian':
-            return ["debian81", "debian92", "debian10", "debian11"]
+            return ["debian81", "debian92", "debian10", "debian11", "debian12"]
         else:
             raise Exception("BUG: unsupported platform?")
 

--- a/etc/repo_config.yaml
+++ b/etc/repo_config.yaml
@@ -231,6 +231,18 @@ repos:
     repos:
       - apt/debian/dists/bullseye/libmongocrypt
 
+  - name: debian12
+    type: deb
+    code_name: "bookworm"
+    bucket: libmongocrypt
+    region: us-east-1
+    edition: org
+    component: main
+    architectures:
+      - amd64
+    repos:
+      - apt/debian/dists/bookworm/libmongocrypt
+
   - name: ubuntu1404
     type: deb
     code_name: "trusty"


### PR DESCRIPTION
This PR adds PPA publishing to Debian 12 (both arm64 and x86_64).
Development packages were uploaded in [this patch build](https://spruce.mongodb.com/version/65d8f2291e2d17c1f5afdae5/), and can be tested with Earthly:
```
./.evergreen/earthly.sh +test-deb-packages-from-ppa --env=deb12 --distro="debian bookworm"
```

Release packages are expected with the 1.9.1 release.