### PR TITLE
MONGOCRYPT-647 test CTR hook can be set without other hooks

### DIFF
--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -1322,8 +1322,7 @@ bool mongocrypt_setopt_crypto_hooks(mongocrypt_t *crypt,
  * operation.
  * @param[in] aes_256_ctr_decrypt The crypto callback function for decrypt
  * operation.
- * @param[in] ctx A context passed as an argument to the crypto callback
- * every invocation.
+ * @param[in] ctx Unused.
  * @pre @ref mongocrypt_init has not been called on @p crypt.
  * @returns A boolean indicating success. If false, an error status is set.
  * Retrieve it with @ref mongocrypt_status
@@ -1343,8 +1342,7 @@ bool mongocrypt_setopt_aes_256_ctr(mongocrypt_t *crypt,
  * @param[in] crypt The @ref mongocrypt_t object.
  * @param[in] aes_256_ecb_encrypt The crypto callback function for encrypt
  * operation.
- * @param[in] ctx A context passed as an argument to the crypto callback
- * every invocation.
+ * @param[in] ctx Unused.
  * @pre @ref mongocrypt_init has not been called on @p crypt.
  * @returns A boolean indicating success. If false, an error status is set.
  * Retrieve it with @ref mongocrypt_status

--- a/test/test-mongocrypt-crypto-std-hooks.c
+++ b/test/test-mongocrypt-crypto-std-hooks.c
@@ -54,6 +54,46 @@ bool _std_hook_native_crypto_aes_256_cbc_decrypt(void *ctx,
     return _native_crypto_aes_256_cbc_decrypt(args);
 }
 
+bool _std_hook_native_crypto_aes_256_ctr_encrypt(void *ctx,
+                                                 mongocrypt_binary_t *key,
+                                                 mongocrypt_binary_t *iv,
+                                                 mongocrypt_binary_t *in,
+                                                 mongocrypt_binary_t *out,
+                                                 uint32_t *bytes_written,
+                                                 mongocrypt_status_t *status) {
+    _mongocrypt_buffer_t key_buf;
+    _mongocrypt_buffer_from_binary(&key_buf, key);
+    _mongocrypt_buffer_t iv_buf;
+    _mongocrypt_buffer_from_binary(&iv_buf, iv);
+    _mongocrypt_buffer_t in_buf;
+    _mongocrypt_buffer_from_binary(&in_buf, in);
+    _mongocrypt_buffer_t out_buf;
+    _mongocrypt_buffer_from_binary(&out_buf, out);
+
+    aes_256_args_t args = {&key_buf, &iv_buf, &in_buf, &out_buf, bytes_written, status};
+    return _native_crypto_aes_256_ctr_encrypt(args);
+}
+
+bool _std_hook_native_crypto_aes_256_ctr_decrypt(void *ctx,
+                                                 mongocrypt_binary_t *key,
+                                                 mongocrypt_binary_t *iv,
+                                                 mongocrypt_binary_t *in,
+                                                 mongocrypt_binary_t *out,
+                                                 uint32_t *bytes_written,
+                                                 mongocrypt_status_t *status) {
+    _mongocrypt_buffer_t key_buf;
+    _mongocrypt_buffer_from_binary(&key_buf, key);
+    _mongocrypt_buffer_t iv_buf;
+    _mongocrypt_buffer_from_binary(&iv_buf, iv);
+    _mongocrypt_buffer_t in_buf;
+    _mongocrypt_buffer_from_binary(&in_buf, in);
+    _mongocrypt_buffer_t out_buf;
+    _mongocrypt_buffer_from_binary(&out_buf, out);
+
+    aes_256_args_t args = {&key_buf, &iv_buf, &in_buf, &out_buf, bytes_written, status};
+    return _native_crypto_aes_256_ctr_decrypt(args);
+}
+
 bool _std_hook_native_crypto_random(void *ctx, mongocrypt_binary_t *out, uint32_t count, mongocrypt_status_t *status) {
     _mongocrypt_buffer_t outbuf;
     _mongocrypt_buffer_from_binary(&outbuf, out);

--- a/test/test-mongocrypt-crypto-std-hooks.h
+++ b/test/test-mongocrypt-crypto-std-hooks.h
@@ -40,6 +40,22 @@ bool _std_hook_native_crypto_aes_256_cbc_decrypt(void *ctx,
                                                  uint32_t *bytes_written,
                                                  mongocrypt_status_t *status);
 
+bool _std_hook_native_crypto_aes_256_ctr_encrypt(void *ctx,
+                                                 mongocrypt_binary_t *key,
+                                                 mongocrypt_binary_t *iv,
+                                                 mongocrypt_binary_t *in,
+                                                 mongocrypt_binary_t *out,
+                                                 uint32_t *bytes_written,
+                                                 mongocrypt_status_t *status);
+
+bool _std_hook_native_crypto_aes_256_ctr_decrypt(void *ctx,
+                                                 mongocrypt_binary_t *key,
+                                                 mongocrypt_binary_t *iv,
+                                                 mongocrypt_binary_t *in,
+                                                 mongocrypt_binary_t *out,
+                                                 uint32_t *bytes_written,
+                                                 mongocrypt_status_t *status);
+
 bool _std_hook_native_crypto_random(void *ctx, mongocrypt_binary_t *out, uint32_t count, mongocrypt_status_t *status);
 
 bool _std_hook_native_hmac_sha512(void *ctx,


### PR DESCRIPTION
# Summary

Test that crypto hooks may be set with `mongocrypt_setopt_aes_256_ctr` without setting other crypto hooks.

Document the `ctx` argument in `mongocrypt_setopt_aes_256_ctr` as unused.

# Background & Motivation

libmongocrypt provides native crypto primitive (HMAC, AES, SHA) implementations by default. The native crypto may be disabled with the CMake option `DISABLE_NATIVE_CRYPTO`. When native crypto is disabled, drivers are expected to provide crypto hooks (callbacks).

libmongocrypt native crypto for AES-CTR mode is not supported on macOS <= 10.14. noted in MONGOCRYPT-440:

> AES-CTR mode is required for Queryable Encryption (aka FLE 2). It is not supported on macOS 10.14 or earlier.

DRIVERS-2718 encourages drivers to prefer libmongocrypt with native crypto for improved performance:

> Package the crypto-enabled libmongocrypt on platforms where it is safe to do so

To continue to support macOS <= 10.14 in the Python bindings, https://github.com/mongodb/libmongocrypt/pull/756#issuecomment-1967497615 conditionally adds the AES-CTR hook:

```python
        elif sys.platform == 'darwin' and Version(platform.mac_ver()[0]) < Version("10.15"):
            # MONGOCRYPT-440 libmongocrypt does not support AES-CTR on macOS < 10.15.
            if not lib.mongocrypt_setopt_aes_256_ctr(
                    self.__crypt, aes_256_ctr_encrypt, aes_256_ctr_decrypt, ffi.NULL):
                self.__raise_from_status()
```

To ensure libmongocrypt continues to support setting the AES-CTR hook (without setting other hooks) a test is added using AES-CTR crypto when only the AES-CTR hooks are set.