### PR TITLE
MONGOCRYPT-621 Rename rangePreview to range

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -1679,10 +1679,10 @@ static bool _fle2_finalize_explicit(mongocrypt_ctx_t *ctx, mongocrypt_binary_t *
     if (ctx->opts.query_type.set) {
         switch (ctx->opts.query_type.value) {
         case MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_DEPRECATED:
-        if(ctx->crypt->opts.use_range_v2) {
-            _mongocrypt_ctx_fail_w_msg(ctx, "Cannot use rangePreview query type with Range V2");
-            goto fail;
-        }
+            if (ctx->crypt->opts.use_range_v2) {
+                _mongocrypt_ctx_fail_w_msg(ctx, "Cannot use rangePreview query type with Range V2");
+                goto fail;
+            }
         // fallthrough
         case MONGOCRYPT_QUERY_TYPE_RANGE:
         case MONGOCRYPT_QUERY_TYPE_EQUALITY: marking.fle2.type = MONGOCRYPT_FLE2_PLACEHOLDER_TYPE_FIND; break;
@@ -1696,7 +1696,7 @@ static bool _fle2_finalize_explicit(mongocrypt_ctx_t *ctx, mongocrypt_binary_t *
     case MONGOCRYPT_INDEX_TYPE_EQUALITY: marking.fle2.algorithm = MONGOCRYPT_FLE2_ALGORITHM_EQUALITY; break;
     case MONGOCRYPT_INDEX_TYPE_NONE: marking.fle2.algorithm = MONGOCRYPT_FLE2_ALGORITHM_UNINDEXED; break;
     case MONGOCRYPT_INDEX_TYPE_RANGEPREVIEW_DEPRECATED:
-        if(ctx->crypt->opts.use_range_v2) {
+        if (ctx->crypt->opts.use_range_v2) {
             _mongocrypt_ctx_fail_w_msg(ctx, "Cannot use rangePreview index type with Range V2");
             goto fail;
         }
@@ -2253,7 +2253,9 @@ static bool explicit_encrypt_init(mongocrypt_ctx_t *ctx, mongocrypt_binary_t *ms
         return _mongocrypt_ctx_fail_w_msg(ctx, "contention factor is required for indexed algorithm");
     }
 
-    if (ctx->opts.index_type.set && (ctx->opts.index_type.value == MONGOCRYPT_INDEX_TYPE_RANGE || ctx->opts.index_type.value == MONGOCRYPT_INDEX_TYPE_RANGEPREVIEW_DEPRECATED)) {
+    if (ctx->opts.index_type.set
+        && (ctx->opts.index_type.value == MONGOCRYPT_INDEX_TYPE_RANGE
+            || ctx->opts.index_type.value == MONGOCRYPT_INDEX_TYPE_RANGEPREVIEW_DEPRECATED)) {
         if (!ctx->opts.contention_factor.set) {
             return _mongocrypt_ctx_fail_w_msg(ctx, "contention factor is required for range indexed algorithm");
         }
@@ -2279,7 +2281,8 @@ static bool explicit_encrypt_init(mongocrypt_ctx_t *ctx, mongocrypt_binary_t *ms
             break;
         case MONGOCRYPT_QUERY_TYPE_RANGE:
             // New query type is compatible with both new and old index types.
-            matches = (ctx->opts.index_type.value == MONGOCRYPT_INDEX_TYPE_RANGEPREVIEW_DEPRECATED || ctx->opts.index_type.value == MONGOCRYPT_INDEX_TYPE_RANGE);
+            matches = (ctx->opts.index_type.value == MONGOCRYPT_INDEX_TYPE_RANGEPREVIEW_DEPRECATED
+                       || ctx->opts.index_type.value == MONGOCRYPT_INDEX_TYPE_RANGE);
             break;
         case MONGOCRYPT_QUERY_TYPE_EQUALITY:
             matches = (ctx->opts.index_type.value == MONGOCRYPT_INDEX_TYPE_EQUALITY);
@@ -2353,7 +2356,9 @@ bool mongocrypt_ctx_explicit_encrypt_init(mongocrypt_ctx_t *ctx, mongocrypt_bina
     if (!explicit_encrypt_init(ctx, msg)) {
         return false;
     }
-    if (ctx->opts.query_type.set && (ctx->opts.query_type.value == MONGOCRYPT_QUERY_TYPE_RANGE || ctx->opts.query_type.value == MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_DEPRECATED)) {
+    if (ctx->opts.query_type.set
+        && (ctx->opts.query_type.value == MONGOCRYPT_QUERY_TYPE_RANGE
+            || ctx->opts.query_type.value == MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_DEPRECATED)) {
         return _mongocrypt_ctx_fail_w_msg(ctx, "Encrypt may not be used for range queries. Use EncryptExpression.");
     }
     return true;
@@ -2363,7 +2368,9 @@ bool mongocrypt_ctx_explicit_encrypt_expression_init(mongocrypt_ctx_t *ctx, mong
     if (!explicit_encrypt_init(ctx, msg)) {
         return false;
     }
-    if (!ctx->opts.query_type.set || !(ctx->opts.query_type.value == MONGOCRYPT_QUERY_TYPE_RANGE || ctx->opts.query_type.value == MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_DEPRECATED)) {
+    if (!ctx->opts.query_type.set
+        || !(ctx->opts.query_type.value == MONGOCRYPT_QUERY_TYPE_RANGE
+             || ctx->opts.query_type.value == MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_DEPRECATED)) {
         return _mongocrypt_ctx_fail_w_msg(ctx, "EncryptExpression may only be used for range queries.");
     }
     return true;

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -45,7 +45,11 @@ typedef enum {
 
 const char *_mongocrypt_index_type_to_string(mongocrypt_index_type_t val);
 
-typedef enum { MONGOCRYPT_QUERY_TYPE_EQUALITY = 1, MONGOCRYPT_QUERY_TYPE_RANGE = 2, MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_DEPRECATED = 3 } mongocrypt_query_type_t;
+typedef enum {
+    MONGOCRYPT_QUERY_TYPE_EQUALITY = 1,
+    MONGOCRYPT_QUERY_TYPE_RANGE = 2,
+    MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_DEPRECATED = 3
+} mongocrypt_query_type_t;
 
 const char *_mongocrypt_query_type_to_string(mongocrypt_query_type_t val);
 

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -39,12 +39,13 @@ typedef enum {
 typedef enum {
     MONGOCRYPT_INDEX_TYPE_NONE = 1,
     MONGOCRYPT_INDEX_TYPE_EQUALITY = 2,
-    MONGOCRYPT_INDEX_TYPE_RANGEPREVIEW = 3
+    MONGOCRYPT_INDEX_TYPE_RANGE = 3,
+    MONGOCRYPT_INDEX_TYPE_RANGEPREVIEW_DEPRECATED = 4
 } mongocrypt_index_type_t;
 
 const char *_mongocrypt_index_type_to_string(mongocrypt_index_type_t val);
 
-typedef enum { MONGOCRYPT_QUERY_TYPE_EQUALITY = 1, MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW = 2 } mongocrypt_query_type_t;
+typedef enum { MONGOCRYPT_QUERY_TYPE_EQUALITY = 1, MONGOCRYPT_QUERY_TYPE_RANGE = 2, MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_DEPRECATED = 3 } mongocrypt_query_type_t;
 
 const char *_mongocrypt_query_type_to_string(mongocrypt_query_type_t val);
 

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -262,7 +262,7 @@ bool mongocrypt_ctx_setopt_algorithm(mongocrypt_ctx_t *ctx, const char *algorith
         ctx->opts.index_type.value = MONGOCRYPT_INDEX_TYPE_RANGE;
         ctx->opts.index_type.set = true;
     } else if (mstr_eq_ignore_case(algo_str, mstrv_lit(MONGOCRYPT_ALGORITHM_RANGEPREVIEW_DEPRECATED_STR))) {
-        if(ctx->crypt->opts.use_range_v2) {
+        if (ctx->crypt->opts.use_range_v2) {
             _mongocrypt_ctx_fail_w_msg(ctx, "Algorithm 'rangePreview' is deprecated, please use 'range'");
             return false;
         }
@@ -1027,7 +1027,7 @@ bool mongocrypt_ctx_setopt_query_type(mongocrypt_ctx_t *ctx, const char *query_t
         ctx->opts.query_type.value = MONGOCRYPT_QUERY_TYPE_RANGE;
         ctx->opts.query_type.set = true;
     } else if (mstr_eq_ignore_case(qt_str, mstrv_lit(MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_DEPRECATED_STR))) {
-        if(ctx->crypt->opts.use_range_v2) {
+        if (ctx->crypt->opts.use_range_v2) {
             _mongocrypt_ctx_fail_w_msg(ctx, "Query type 'rangePreview' is deprecated, please use 'range'");
             return false;
         }

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -258,8 +258,15 @@ bool mongocrypt_ctx_setopt_algorithm(mongocrypt_ctx_t *ctx, const char *algorith
     } else if (mstr_eq_ignore_case(algo_str, mstrv_lit(MONGOCRYPT_ALGORITHM_UNINDEXED_STR))) {
         ctx->opts.index_type.value = MONGOCRYPT_INDEX_TYPE_NONE;
         ctx->opts.index_type.set = true;
-    } else if (mstr_eq_ignore_case(algo_str, mstrv_lit(MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR))) {
-        ctx->opts.index_type.value = MONGOCRYPT_INDEX_TYPE_RANGEPREVIEW;
+    } else if (mstr_eq_ignore_case(algo_str, mstrv_lit(MONGOCRYPT_ALGORITHM_RANGE_STR))) {
+        ctx->opts.index_type.value = MONGOCRYPT_INDEX_TYPE_RANGE;
+        ctx->opts.index_type.set = true;
+    } else if (mstr_eq_ignore_case(algo_str, mstrv_lit(MONGOCRYPT_ALGORITHM_RANGEPREVIEW_DEPRECATED_STR))) {
+        if(ctx->crypt->opts.use_range_v2) {
+            _mongocrypt_ctx_fail_w_msg(ctx, "Algorithm 'rangePreview' is deprecated, please use 'range'");
+            return false;
+        }
+        ctx->opts.index_type.value = MONGOCRYPT_INDEX_TYPE_RANGEPREVIEW_DEPRECATED;
         ctx->opts.index_type.set = true;
     } else {
         char *error = bson_strdup_printf("unsupported algorithm string \"%.*s\"",
@@ -1016,8 +1023,15 @@ bool mongocrypt_ctx_setopt_query_type(mongocrypt_ctx_t *ctx, const char *query_t
     if (mstr_eq_ignore_case(qt_str, mstrv_lit(MONGOCRYPT_QUERY_TYPE_EQUALITY_STR))) {
         ctx->opts.query_type.value = MONGOCRYPT_QUERY_TYPE_EQUALITY;
         ctx->opts.query_type.set = true;
-    } else if (mstr_eq_ignore_case(qt_str, mstrv_lit(MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR))) {
-        ctx->opts.query_type.value = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW;
+    } else if (mstr_eq_ignore_case(qt_str, mstrv_lit(MONGOCRYPT_QUERY_TYPE_RANGE_STR))) {
+        ctx->opts.query_type.value = MONGOCRYPT_QUERY_TYPE_RANGE;
+        ctx->opts.query_type.set = true;
+    } else if (mstr_eq_ignore_case(qt_str, mstrv_lit(MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_DEPRECATED_STR))) {
+        if(ctx->crypt->opts.use_range_v2) {
+            _mongocrypt_ctx_fail_w_msg(ctx, "Query type 'rangePreview' is deprecated, please use 'range'");
+            return false;
+        }
+        ctx->opts.query_type.value = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_DEPRECATED;
         ctx->opts.query_type.set = true;
     } else {
         /* don't check if qt_str.len fits in int; we want the diagnostic output */
@@ -1035,7 +1049,8 @@ const char *_mongocrypt_index_type_to_string(mongocrypt_index_type_t val) {
     switch (val) {
     case MONGOCRYPT_INDEX_TYPE_NONE: return "None";
     case MONGOCRYPT_INDEX_TYPE_EQUALITY: return "Equality";
-    case MONGOCRYPT_INDEX_TYPE_RANGEPREVIEW: return "RangePreview";
+    case MONGOCRYPT_INDEX_TYPE_RANGE: return "Range";
+    case MONGOCRYPT_INDEX_TYPE_RANGEPREVIEW_DEPRECATED: return "RangePreview";
     default: return "Unknown";
     }
 }
@@ -1043,7 +1058,8 @@ const char *_mongocrypt_index_type_to_string(mongocrypt_index_type_t val) {
 const char *_mongocrypt_query_type_to_string(mongocrypt_query_type_t val) {
     switch (val) {
     case MONGOCRYPT_QUERY_TYPE_EQUALITY: return "Equality";
-    case MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW: return "RangePreview";
+    case MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_DEPRECATED: return "RangePreview";
+    case MONGOCRYPT_QUERY_TYPE_RANGE: return "Range";
     default: return "Unknown";
     }
 }

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -674,10 +674,9 @@ bool mongocrypt_ctx_setopt_algorithm(mongocrypt_ctx_t *ctx, const char *algorith
 #define MONGOCRYPT_ALGORITHM_INDEXED_STR "Indexed"
 /// String constant for setopt_algorithm "Unindexed" explicit encryption
 #define MONGOCRYPT_ALGORITHM_UNINDEXED_STR "Unindexed"
-/// String constant for setopt_algorithm "rangePreview" explicit encryption
-/// NOTE: The RangePreview algorithm is experimental only. It is not intended
-/// for public use.
-#define MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR "RangePreview"
+/// String constant for setopt_algorithm "rangePreview" explicit encryption (deprecated in favor of "range")
+#define MONGOCRYPT_ALGORITHM_RANGEPREVIEW_DEPRECATED_STR "RangePreview"
+#define MONGOCRYPT_ALGORITHM_RANGE_STR "Range"
 
 /**
  * Identify the AWS KMS master key to use for creating a data key.
@@ -866,9 +865,7 @@ bool mongocrypt_ctx_explicit_encrypt_init(mongocrypt_ctx_t *ctx, mongocrypt_bina
 /**
  * Explicit helper method to encrypt a Match Expression or Aggregate Expression.
  * Contexts created for explicit encryption will not go through mongocryptd.
- * Requires query_type to be "rangePreview".
- * NOTE: The RangePreview algorithm is experimental only. It is not intended for
- * public use.
+ * Requires query_type to be "range" or "rangePreview".
  *
  * This method expects the passed-in BSON to be of the form:
  * { "v" : FLE2RangeFindDriverSpec }
@@ -1430,9 +1427,7 @@ MONGOCRYPT_EXPORT
 bool mongocrypt_ctx_setopt_query_type(mongocrypt_ctx_t *ctx, const char *query_type, int len);
 
 /**
- * Set options for explicit encryption with the "rangePreview" algorithm.
- * NOTE: The RangePreview algorithm is experimental only. It is not intended for
- * public use.
+ * Set options for explicit encryption with the "range" algorithm.
  *
  * @p opts is a BSON document of the form:
  * {
@@ -1454,8 +1449,8 @@ bool mongocrypt_ctx_setopt_algorithm_range(mongocrypt_ctx_t *ctx, mongocrypt_bin
 
 /// String constants for setopt_query_type
 #define MONGOCRYPT_QUERY_TYPE_EQUALITY_STR "equality"
-// NOTE: The RangePreview algorithm is experimental only. It is not intended for
-// public use.
-#define MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR "rangePreview"
+// 'rangePreview' is deprecated in favor of range.
+#define MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_DEPRECATED_STR "rangePreview"
+#define MONGOCRYPT_QUERY_TYPE_RANGE_STR "range"
 
 #endif /* MONGOCRYPT_H */

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -2672,7 +2672,7 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
 #include "./data/fle2-insert-range-explicit/int32/RNG_DATA.h"
         tc.rng_data = (_test_rng_data_source){.buf = {.data = (uint8_t *)RNG_DATA, .len = sizeof(RNG_DATA) - 1}};
 #undef RNG_DATA
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.index_key_id = &key123_id;
         tc.contention_factor = OPT_I64(0);
@@ -2693,7 +2693,7 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
 #include "./data/fle2-insert-range-explicit/int32/RNG_DATA.h"
         tc.rng_data = (_test_rng_data_source){.buf = {.data = (uint8_t *)RNG_DATA, .len = sizeof(RNG_DATA) - 1}};
 #undef RNG_DATA
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.index_key_id = &key123_id;
         tc.contention_factor = OPT_I64(0);
@@ -2715,7 +2715,7 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
 #include "./data/fle2-insert-range-explicit/sparsity-2/RNG_DATA.h"
         tc.rng_data = (_test_rng_data_source){.buf = {.data = (uint8_t *)RNG_DATA, .len = sizeof(RNG_DATA) - 1}};
 #undef RNG_DATA
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.index_key_id = &key123_id;
         tc.contention_factor = OPT_I64(0);
@@ -2736,7 +2736,7 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
 #include "./data/fle2-insert-range-explicit/sparsity-2/RNG_DATA.h"
         tc.rng_data = (_test_rng_data_source){.buf = {.data = (uint8_t *)RNG_DATA, .len = sizeof(RNG_DATA) - 1}};
 #undef RNG_DATA
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.index_key_id = &key123_id;
         tc.contention_factor = OPT_I64(0);
@@ -2755,11 +2755,11 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
     {
         ee_testcase tc = {0};
         tc.desc = "algorithm='Range' with query_type='range' with int32";
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.index_key_id = &keyABC_id;
         tc.contention_factor = OPT_I64(4);
-        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR;
+        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGE_STR;
         tc.range_opts = TEST_FILE("./test/data/fle2-find-range-explicit/"
                                   "int32/rangeopts.json");
         tc.msg = TEST_FILE("./test/data/fle2-find-range-explicit/int32/"
@@ -2774,11 +2774,11 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
     {
         ee_testcase tc = {0};
         tc.desc = "algorithm='Range' with query_type='range' with int32 (v2)";
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.index_key_id = &keyABC_id;
         tc.contention_factor = OPT_I64(4);
-        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR;
+        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGE_STR;
         tc.range_opts = TEST_FILE("./test/data/fle2-find-range-explicit/"
                                   "int32/rangeopts.json");
         tc.msg = TEST_FILE("./test/data/fle2-find-range-explicit/int32/"
@@ -2794,7 +2794,7 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
     {
         ee_testcase tc = {0};
         tc.desc = "An unsupported range BSON type is an error";
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.contention_factor = OPT_I64(0);
         tc.range_opts = TEST_BSON("{'min': 0, 'max': 1, 'sparsity': {'$numberLong': '1'}}");
@@ -2807,7 +2807,7 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
     {
         ee_testcase tc = {0};
         tc.desc = "An unsupported range BSON type is an error (v2)";
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.contention_factor = OPT_I64(0);
         tc.range_opts = TEST_BSON("{'min': 0, 'max': 1, 'sparsity': {'$numberLong': '1'}}");
@@ -2822,11 +2822,11 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
         ee_testcase tc = {0};
         tc.desc = "algorithm='Range' with query_type='range' with double with "
                   "precision";
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.index_key_id = &key123_id;
         tc.contention_factor = OPT_I64(0);
-        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR;
+        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGE_STR;
         tc.range_opts = TEST_FILE("./test/data/fle2-find-range-explicit/double-precision/"
                                   "rangeopts.json");
         tc.msg = TEST_FILE("./test/data/fle2-find-range-explicit/"
@@ -2843,11 +2843,11 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
         ee_testcase tc = {0};
         tc.desc = "algorithm='Range' with query_type='range' with double with "
                   "precision (v2)";
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.index_key_id = &key123_id;
         tc.contention_factor = OPT_I64(0);
-        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR;
+        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGE_STR;
         tc.range_opts = TEST_FILE("./test/data/fle2-find-range-explicit/double-precision/"
                                   "rangeopts.json");
         tc.msg = TEST_FILE("./test/data/fle2-find-range-explicit/"
@@ -2867,7 +2867,7 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
 #include "./data/fle2-insert-range-explicit/double-precision/RNG_DATA.h"
         tc.rng_data = (_test_rng_data_source){.buf = {.data = (uint8_t *)RNG_DATA, .len = sizeof(RNG_DATA) - 1}};
 #undef RNG_DATA
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.index_key_id = &key123_id;
         tc.contention_factor = OPT_I64(0);
@@ -2888,7 +2888,7 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
 #include "./data/fle2-insert-range-explicit/double-precision/RNG_DATA.h"
         tc.rng_data = (_test_rng_data_source){.buf = {.data = (uint8_t *)RNG_DATA, .len = sizeof(RNG_DATA) - 1}};
 #undef RNG_DATA
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.index_key_id = &key123_id;
         tc.contention_factor = OPT_I64(0);
@@ -2908,11 +2908,11 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
         ee_testcase tc = {0};
         tc.desc = "algorithm='Range' with query_type='range' with double without "
                   "precision";
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.index_key_id = &key123_id;
         tc.contention_factor = OPT_I64(0);
-        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR;
+        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGE_STR;
         tc.range_opts = TEST_FILE("./test/data/fle2-find-range-explicit/double/"
                                   "rangeopts.json");
         tc.msg = TEST_FILE("./test/data/fle2-find-range-explicit/double/value-to-encrypt.json");
@@ -2927,11 +2927,11 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
         ee_testcase tc = {0};
         tc.desc = "algorithm='Range' with query_type='range' with double without "
                   "precision (v2)";
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.index_key_id = &key123_id;
         tc.contention_factor = OPT_I64(0);
-        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR;
+        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGE_STR;
         tc.range_opts = TEST_FILE("./test/data/fle2-find-range-explicit/double/"
                                   "rangeopts.json");
         tc.msg = TEST_FILE("./test/data/fle2-find-range-explicit/double/value-to-encrypt.json");
@@ -2949,7 +2949,7 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
 #include "./data/fle2-insert-range-explicit/double/RNG_DATA.h"
         tc.rng_data = (_test_rng_data_source){.buf = {.data = (uint8_t *)RNG_DATA, .len = sizeof(RNG_DATA) - 1}};
 #undef RNG_DATA
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.index_key_id = &key123_id;
         tc.contention_factor = OPT_I64(0);
@@ -2969,7 +2969,7 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
 #include "./data/fle2-insert-range-explicit/double/RNG_DATA.h"
         tc.rng_data = (_test_rng_data_source){.buf = {.data = (uint8_t *)RNG_DATA, .len = sizeof(RNG_DATA) - 1}};
 #undef RNG_DATA
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.index_key_id = &key123_id;
         tc.contention_factor = OPT_I64(0);
@@ -2987,7 +2987,7 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
     {
         ee_testcase tc = {0};
         tc.desc = "min > max for insert";
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.contention_factor = OPT_I64(0);
         tc.range_opts = TEST_BSON("{'min': 1, 'max': 0, 'sparsity': {'$numberLong': '1'}}");
@@ -3000,7 +3000,7 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
     {
         ee_testcase tc = {0};
         tc.desc = "min > max for insert (v2)";
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.contention_factor = OPT_I64(0);
         tc.range_opts = TEST_BSON("{'min': 1, 'max': 0, 'sparsity': {'$numberLong': '1'}}");
@@ -3014,8 +3014,8 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
     {
         ee_testcase tc = {0};
         tc.desc = "min > max for find";
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
-        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
+        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.contention_factor = OPT_I64(0);
         tc.range_opts = TEST_BSON("{'min': 25, 'max': 24, 'sparsity': {'$numberLong': '1'}}");
@@ -3029,8 +3029,8 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
     {
         ee_testcase tc = {0};
         tc.desc = "min > max for find (v2)";
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
-        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
+        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.contention_factor = OPT_I64(0);
         tc.range_opts = TEST_BSON("{'min': 25, 'max': 24, 'sparsity': {'$numberLong': '1'}}");
@@ -3044,8 +3044,8 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
     {
         ee_testcase tc = {0};
         tc.desc = "open interval";
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
-        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
+        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.contention_factor = OPT_I64(0);
         tc.range_opts = TEST_FILE("./test/data/fle2-find-range-explicit/"
@@ -3062,8 +3062,8 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
     {
         ee_testcase tc = {0};
         tc.desc = "open interval (v2)";
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
-        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
+        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.contention_factor = OPT_I64(0);
         tc.range_opts = TEST_FILE("./test/data/fle2-find-range-explicit/"
@@ -3083,7 +3083,7 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
     {
         ee_testcase tc = {0};
         tc.desc = "min is required to insert int for range";
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.contention_factor = OPT_I64(0);
         tc.range_opts = TEST_BSON(RAW_STRING({"max" : {"$numberInt" : "200"}, "sparsity" : {"$numberLong" : "1"}}));
@@ -3096,7 +3096,7 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
     {
         ee_testcase tc = {0};
         tc.desc = "max is required to insert int for range";
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.contention_factor = OPT_I64(0);
         tc.range_opts = TEST_BSON(RAW_STRING({"min" : {"$numberInt" : "0"}, "sparsity" : {"$numberLong" : "1"}}));
@@ -3109,8 +3109,8 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
     {
         ee_testcase tc = {0};
         tc.desc = "min is required to find int for range";
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
-        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
+        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.contention_factor = OPT_I64(0);
         tc.range_opts = TEST_BSON(RAW_STRING({"max" : {"$numberInt" : "200"}, "sparsity" : {"$numberLong" : "1"}}));
@@ -3127,8 +3127,8 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
     {
         ee_testcase tc = {0};
         tc.desc = "max is required to find int for range";
-        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR;
-        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR;
+        tc.algorithm = MONGOCRYPT_ALGORITHM_RANGE_STR;
+        tc.query_type = MONGOCRYPT_QUERY_TYPE_RANGE_STR;
         tc.user_key_id = &keyABC_id;
         tc.contention_factor = OPT_I64(0);
         tc.range_opts = TEST_BSON(RAW_STRING({"min" : {"$numberInt" : "0"}, "sparsity" : {"$numberLong" : "1"}}));

--- a/test/test-mongocrypt-ctx-setopt.c
+++ b/test/test-mongocrypt-ctx-setopt.c
@@ -808,25 +808,25 @@ static void _test_setopt_for_explicit_encrypt(_mongocrypt_tester_t *tester) {
         ASSERT_EX_ENCRYPT_INIT_FAILS(bson, "contention factor is required");
     }
 
-    /* Contention factor is required for "rangePreview" algorithm. */
+    /* Contention factor is required for "range" algorithm. */
     {
         REFRESH;
         /* Set key ID to get past the 'either key id or key alt name required'
          * error */
         ASSERT_KEY_ID_OK(uuid);
         ASSERT_OK(mongocrypt_ctx_setopt_algorithm_range(ctx, rangeopts), ctx);
-        ASSERT_OK(mongocrypt_ctx_setopt_algorithm(ctx, MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR, -1), ctx);
+        ASSERT_OK(mongocrypt_ctx_setopt_algorithm(ctx, MONGOCRYPT_ALGORITHM_RANGE_STR, -1), ctx);
         ASSERT_EX_ENCRYPT_INIT_FAILS(bson, "contention factor is required");
     }
 
-    /* Range opts is required for "rangePreview" algorithm. */
+    /* Range opts is required for "range" algorithm. */
     {
         REFRESH;
         /* Set key ID to get past the 'either key id or key alt name required'
          * error */
         ASSERT_KEY_ID_OK(uuid);
         ASSERT_OK(mongocrypt_ctx_setopt_contention_factor(ctx, 0), ctx);
-        ASSERT_OK(mongocrypt_ctx_setopt_algorithm(ctx, MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR, -1), ctx);
+        ASSERT_OK(mongocrypt_ctx_setopt_algorithm(ctx, MONGOCRYPT_ALGORITHM_RANGE_STR, -1), ctx);
         ASSERT_EX_ENCRYPT_INIT_FAILS(bson, "range opts are required");
     }
 
@@ -841,27 +841,27 @@ static void _test_setopt_for_explicit_encrypt(_mongocrypt_tester_t *tester) {
                       TEST_BSON("{'min': 0, 'max': 1, 'sparsity': { '$numberLong': '-1'}}")),
                   ctx);
         ASSERT_OK(mongocrypt_ctx_setopt_contention_factor(ctx, 0), ctx);
-        ASSERT_OK(mongocrypt_ctx_setopt_algorithm(ctx, MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR, -1), ctx);
+        ASSERT_OK(mongocrypt_ctx_setopt_algorithm(ctx, MONGOCRYPT_ALGORITHM_RANGE_STR, -1), ctx);
         ASSERT_EX_ENCRYPT_INIT_FAILS(bson, "sparsity must be non-negative");
     }
 
-    /* Error if query_type == "rangePreview" and algorithm != "rangePreview". */
+    /* Error if query_type == "range" and algorithm != "range". */
     {
         REFRESH;
         ASSERT_KEY_ID_OK(uuid);
         ASSERT_ALGORITHM_OK(MONGOCRYPT_ALGORITHM_INDEXED_STR, -1);
-        ASSERT_QUERY_TYPE_OK(MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR, -1);
+        ASSERT_QUERY_TYPE_OK(MONGOCRYPT_QUERY_TYPE_RANGE_STR, -1);
         ASSERT_OK(mongocrypt_ctx_setopt_contention_factor(ctx, 0), ctx);
         ASSERT_EX_ENCRYPT_INIT_FAILS(bson, "must match index_type");
     }
 
-    /* Error if query_type == "rangePreview" for
+    /* Error if query_type == "range" for
      * mongocrypt_ctx_explicit_encrypt_init. */
     {
         REFRESH;
         ASSERT_KEY_ID_OK(uuid);
-        ASSERT_ALGORITHM_OK(MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR, -1);
-        ASSERT_QUERY_TYPE_OK(MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_STR, -1);
+        ASSERT_ALGORITHM_OK(MONGOCRYPT_ALGORITHM_RANGE_STR, -1);
+        ASSERT_QUERY_TYPE_OK(MONGOCRYPT_QUERY_TYPE_RANGE_STR, -1);
         ASSERT_OK(
             mongocrypt_ctx_setopt_algorithm_range(ctx,
                                                   TEST_BSON("{'min': 0, 'max': 1, 'sparsity': {'$numberLong': '1'}}")),
@@ -875,7 +875,7 @@ static void _test_setopt_for_explicit_encrypt(_mongocrypt_tester_t *tester) {
     {
         REFRESH;
         ASSERT_KEY_ID_OK(uuid);
-        ASSERT_ALGORITHM_OK(MONGOCRYPT_ALGORITHM_RANGEPREVIEW_STR, -1);
+        ASSERT_ALGORITHM_OK(MONGOCRYPT_ALGORITHM_RANGE_STR, -1);
         ASSERT_OK(
             mongocrypt_ctx_setopt_algorithm_range(ctx,
                                                   TEST_BSON("{'min': 0, 'max': 1, 'sparsity': {'$numberLong': '1'}}")),

--- a/test/test-mongocrypt-ctx-setopt.c
+++ b/test/test-mongocrypt-ctx-setopt.c
@@ -18,8 +18,8 @@
 
 #include <stdarg.h>
 
-#include "mongocrypt.h"
 #include "mongocrypt-binary-private.h"
+#include "mongocrypt.h"
 #include "test-mongocrypt.h"
 
 /* An orphaned UTF-8 continuation byte (10xxxxxx) is malformed UTF-8. */
@@ -83,14 +83,14 @@ static char invalid_utf8[] = {(char)0x80, (char)0x00};
 #define ASSERT_EX_DECRYPT_INIT_OK(bin) ASSERT_OK(mongocrypt_ctx_explicit_decrypt_init(ctx, bin), ctx);
 #define ASSERT_EX_DECRYPT_INIT_FAILS(bin, msg) ASSERT_FAILS(mongocrypt_ctx_explicit_decrypt_init(ctx, bin), ctx, msg);
 
-#define REFRESH                                                                                                  \
-    do {          \
-        mongocrypt_destroy(crypt); \
-        crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);                                                                      \
-        REFRESH_CTX;                                                                            \
+#define REFRESH                                                                                                        \
+    do {                                                                                                               \
+        mongocrypt_destroy(crypt);                                                                                     \
+        crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);                                              \
+        REFRESH_CTX;                                                                                                   \
     } while (0)
 
-#define REFRESH_CTX                                                                                                        \
+#define REFRESH_CTX                                                                                                    \
     do {                                                                                                               \
         mongocrypt_ctx_destroy(ctx);                                                                                   \
         ctx = mongocrypt_ctx_new(crypt);                                                                               \
@@ -884,17 +884,23 @@ static void _test_setopt_for_explicit_encrypt(_mongocrypt_tester_t *tester) {
         crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_WITH_RANGE_V2);
         REFRESH_CTX;
         ASSERT_KEY_ID_OK(uuid);
-        ASSERT_FAILS(mongocrypt_ctx_setopt_algorithm(ctx, MONGOCRYPT_ALGORITHM_RANGEPREVIEW_DEPRECATED_STR, -1), ctx, "'rangePreview' is deprecated");
+        ASSERT_FAILS(mongocrypt_ctx_setopt_algorithm(ctx, MONGOCRYPT_ALGORITHM_RANGEPREVIEW_DEPRECATED_STR, -1),
+                     ctx,
+                     "'rangePreview' is deprecated");
 
         mongocrypt_destroy(crypt);
         crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_WITH_RANGE_V2);
         REFRESH_CTX;
         ASSERT_KEY_ID_OK(uuid);
-        ASSERT_FAILS(mongocrypt_ctx_setopt_query_type(ctx, MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_DEPRECATED_STR, -1), ctx, "'rangePreview' is deprecated");
+        ASSERT_FAILS(mongocrypt_ctx_setopt_query_type(ctx, MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_DEPRECATED_STR, -1),
+                     ctx,
+                     "'rangePreview' is deprecated");
     }
 
     /* Error if query type == "rangePreview" and algorithm == "range" for range V1. */
-    // Explanation: Algorithm "rangePreview" accepts both query type "rangePreview" (for compatibility) and "range" (new behavior), but algorithm "range" only accepts query type "range". This is because if we are using the new algorithm type, we don't need to support the deprecated name for compatibility.    
+    // Explanation: Algorithm "rangePreview" accepts both query type "rangePreview" (for compatibility) and "range" (new
+    // behavior), but algorithm "range" only accepts query type "range". This is because if we are using the new
+    // algorithm type, we don't need to support the deprecated name for compatibility.
     {
         REFRESH;
         ASSERT_KEY_ID_OK(uuid);
@@ -916,7 +922,7 @@ static void _test_setopt_for_explicit_encrypt(_mongocrypt_tester_t *tester) {
         ASSERT_EX_ENCRYPT_EXPRESSION_INIT_OK(bson);
     }
 
-        /* If query type == algorithm == "rangePreview", succeeds for range V1. */
+    /* If query type == algorithm == "rangePreview", succeeds for range V1. */
     {
         REFRESH;
         ASSERT_KEY_ID_OK(uuid);
@@ -947,7 +953,6 @@ static void _test_setopt_for_explicit_encrypt(_mongocrypt_tester_t *tester) {
         ASSERT_OK(mongocrypt_ctx_setopt_contention_factor(ctx, 0), ctx);
         ASSERT_EX_ENCRYPT_EXPRESSION_INIT_OK(bson);
     }
-
 
     /* Error if query_type is unset for
      * mongocrypt_ctx_explicit_encrypt_expression_init. */

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -494,6 +494,9 @@ mongocrypt_t *_mongocrypt_tester_mongocrypt(tester_mongocrypt_flags flags) {
     if (flags & TESTER_MONGOCRYPT_WITH_CRYPT_SHARED_LIB) {
         mongocrypt_setopt_append_crypt_shared_lib_search_path(crypt, "$ORIGIN");
     }
+    if (flags & TESTER_MONGOCRYPT_WITH_RANGE_V2) {
+        ASSERT(mongocrypt_enable_range_v2(crypt));
+    }
     ASSERT_OK(mongocrypt_init(crypt), crypt);
     if (flags & TESTER_MONGOCRYPT_WITH_CRYPT_SHARED_LIB) {
         if (mongocrypt_crypt_shared_lib_version(crypt) == 0) {

--- a/test/test-mongocrypt.h
+++ b/test/test-mongocrypt.h
@@ -42,6 +42,8 @@ typedef enum tester_mongocrypt_flags {
     TESTER_MONGOCRYPT_WITH_CRYPT_SHARED_LIB = 1 << 0,
     /// Enable wire protocol version v1
     TESTER_MONGOCRYPT_WITH_CRYPT_V1 = 1 << 1,
+    /// Enable range V2
+    TESTER_MONGOCRYPT_WITH_RANGE_V2 = 1 << 2,
 } tester_mongocrypt_flags;
 
 /* Arbitrary max of 2048 instances of temporary test data. Increase as needed.


### PR DESCRIPTION
Related main repo changes: https://github.com/10gen/mongo/pull/19645
Related enterprise changes: https://github.com/10gen/mongo-enterprise-modules/pull/1994

The new "range" query/index type works with both range V1 and V2. When we are using range V2, we can't use "rangePreview" as either an index type or query type. 

For range V1, the "range" query type is compatible with the "rangePreview" index type; this is for the case where we are using an old collection with "rangePreview" query type since we want to encourage using the new name. The alternative behavior would be that when using range V1, we force users to always use "rangePreview". I thought this was undesirable if we want to treat that name as deprecated. Conversely, the "rangePreview" query type is incompatible with the "range" index type; in this case, we should always be using "range" queries. 