### PR TITLE
MONGOCRYPT-663 Add cmake option to enable Range V2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,11 @@ option (ENABLE_PIC
 )
 option (ENABLE_BUILD_FOR_PPA "Maintainer-only option for preparing PPA build" OFF)
 option (ENABLE_ONLINE_TESTS "Enable online tests and the csfle utility" ON)
+# TODO MONGOCRYPT-661 When range V2 is default, remove this option.
+option (ENABLE_USE_RANGE_V2 "Enable the use_range_v2 flag by default for queryable encryption" OFF)
+if (ENABLE_USE_RANGE_V2)
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DQE_USE_RANGE_V2")
+endif ()
 
 if (ENABLE_WINDOWS_STATIC_RUNTIME)
    if (POLICY CMP0091)

--- a/src/mongocrypt-opts.c
+++ b/src/mongocrypt-opts.c
@@ -35,6 +35,9 @@ void _mongocrypt_opts_kms_providers_init(_mongocrypt_opts_kms_providers_t *kms_p
 void _mongocrypt_opts_init(_mongocrypt_opts_t *opts) {
     BSON_ASSERT_PARAM(opts);
     memset(opts, 0, sizeof(*opts));
+#ifdef QE_USE_RANGE_V2
+    opts->use_range_v2 = true;
+#endif
     _mongocrypt_opts_kms_providers_init(&opts->kms_providers);
 }
 

--- a/test/test-gcp-auth.c
+++ b/test/test-gcp-auth.c
@@ -157,7 +157,7 @@ static void _test_createdatakey_with_accesstoken(_mongocrypt_tester_t *tester) {
     crypt = mongocrypt_new();
     ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, TEST_BSON("{'gcp': {}}")), crypt);
     mongocrypt_setopt_use_need_kms_credentials_state(crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     ctx = mongocrypt_ctx_new(crypt);
     ASSERT_OK(mongocrypt_ctx_setopt_key_encryption_key(ctx, TEST_BSON(kek)), ctx);
     ASSERT_OK(mongocrypt_ctx_datakey_init(ctx), ctx);
@@ -199,7 +199,7 @@ static void _test_encrypt_with_accesstoken(_mongocrypt_tester_t *tester) {
     crypt = mongocrypt_new();
     ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, TEST_BSON("{'gcp': {}}")), crypt);
     mongocrypt_setopt_use_need_kms_credentials_state(crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     ctx = mongocrypt_ctx_new(crypt);
     uuid = mongocrypt_binary_new_from_data((uint8_t *)uuid_data, UUID_LEN);
     ASSERT_OK(mongocrypt_ctx_setopt_key_id(ctx, uuid), ctx);

--- a/test/test-mongocrypt-cleanup.c
+++ b/test/test-mongocrypt-cleanup.c
@@ -201,7 +201,7 @@ static void _test_cleanup_need_kms_credentials(_mongocrypt_tester_t *tester) {
     mongocrypt_setopt_use_need_kms_credentials_state(crypt);
     ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, TEST_BSON("{'aws': {}}")), crypt);
     mongocrypt_setopt_use_need_kms_credentials_state(crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
     ctx = mongocrypt_ctx_new(crypt);
     ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TEST_FILE("./test/data/cleanup/success/cmd.json")), ctx);
@@ -326,7 +326,7 @@ static void _test_cleanup_from_encrypted_field_config_map(_mongocrypt_tester_t *
                       crypt,
                       TEST_FILE("./test/data/cleanup/success/encrypted-field-config-map.json")),
                   crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     }
     ctx = mongocrypt_ctx_new(crypt);
 

--- a/test/test-mongocrypt-compact.c
+++ b/test/test-mongocrypt-compact.c
@@ -212,7 +212,7 @@ static void _test_compact_need_kms_credentials(_mongocrypt_tester_t *tester) {
     mongocrypt_setopt_use_need_kms_credentials_state(crypt);
     ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, TEST_BSON("{'aws': {}}")), crypt);
     mongocrypt_setopt_use_need_kms_credentials_state(crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
     ctx = mongocrypt_ctx_new(crypt);
     ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TEST_FILE("./test/data/compact/success/cmd.json")), ctx);
@@ -337,7 +337,7 @@ static void _test_compact_from_encrypted_field_config_map(_mongocrypt_tester_t *
                       crypt,
                       TEST_FILE("./test/data/compact/success/encrypted-field-config-map.json")),
                   crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     }
     ctx = mongocrypt_ctx_new(crypt);
 

--- a/test/test-mongocrypt-crypto-hooks.c
+++ b/test/test-mongocrypt-crypto-hooks.c
@@ -248,7 +248,7 @@ _create_mongocrypt_and_hooks(_mongocrypt_tester_t *tester, const char *error_on,
         ret = mongocrypt_setopt_aes_256_ecb(crypt, _mock_aes_256_xxx_encrypt, (void *)error_on);
         ASSERT_OK(ret, crypt);
     }
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     return crypt;
 }
 
@@ -553,7 +553,7 @@ static void _test_crypto_hooks_unset(_mongocrypt_tester_t *tester) {
 
     crypt = mongocrypt_new();
     mongocrypt_setopt_kms_provider_aws(crypt, "example", -1, "example", -1);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     mongocrypt_destroy(crypt);
 }
 
@@ -819,7 +819,7 @@ static void test_setting_only_ctr_hook(_mongocrypt_tester_t *tester) {
         mongocrypt_setopt_aes_256_ctr(crypt, _aes_256_ctr_encrypt_and_count, _aes_256_ctr_decrypt_and_count, NULL),
         crypt);
     ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
     // Encrypt with an algorithm using the CTR hook.
     ctr_encrypt_count = 0;

--- a/test/test-mongocrypt-ctx-decrypt.c
+++ b/test/test-mongocrypt-ctx-decrypt.c
@@ -129,7 +129,7 @@ void _test_decrypt_empty_aws(_mongocrypt_tester_t *tester) {
 
     crypt = mongocrypt_new();
     ASSERT_OK(mongocrypt_setopt_kms_provider_aws(crypt, "", -1, "", -1), crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
     ctx = mongocrypt_ctx_new(crypt);
     ASSERT_OK(mongocrypt_ctx_decrypt_init(ctx, TEST_FILE("./test/data/encrypted-cmd.json")), ctx);
@@ -184,7 +184,7 @@ static void _test_decrypt_per_ctx_credentials(_mongocrypt_tester_t *tester) {
     crypt = mongocrypt_new();
     mongocrypt_setopt_use_need_kms_credentials_state(crypt);
     mongocrypt_setopt_kms_providers(crypt, TEST_BSON("{'aws': {}}"));
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     ctx = mongocrypt_ctx_new(crypt);
 
     /* Encrypt an empty binary value. */
@@ -233,7 +233,7 @@ static void _test_decrypt_per_ctx_credentials_local(_mongocrypt_tester_t *tester
     crypt = mongocrypt_new();
     mongocrypt_setopt_use_need_kms_credentials_state(crypt);
     mongocrypt_setopt_kms_providers(crypt, TEST_BSON("{'local': {}}"));
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     ctx = mongocrypt_ctx_new(crypt);
 
     /* Encrypt an empty binary value. */

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -660,7 +660,7 @@ static void _test_local_schema(_mongocrypt_tester_t *tester) {
     schema_map = TEST_FILE("./test/data/schema-map.json");
     ASSERT_OK(mongocrypt_setopt_kms_provider_aws(crypt, "example", -1, "example", -1), crypt);
     ASSERT_OK(mongocrypt_setopt_schema_map(crypt, schema_map), crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
     /* Schema map has test.test, we should jump right to NEED_MONGO_MARKINGS */
     ctx = mongocrypt_ctx_new(crypt);
@@ -837,7 +837,7 @@ static void _test_encrypt_is_remote_schema(_mongocrypt_tester_t *tester) {
     crypt = mongocrypt_new();
     ASSERT_OK(mongocrypt_setopt_kms_provider_aws(crypt, "example", -1, "example", -1), crypt);
     ASSERT_OK(mongocrypt_setopt_schema_map(crypt, TEST_FILE("./test/data/schema-map.json")), crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     ctx = mongocrypt_ctx_new(crypt);
     ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "test", -1, TEST_FILE("./test/example/cmd.json")), ctx);
     _mongocrypt_tester_run_ctx_to(tester, ctx, MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
@@ -1087,7 +1087,7 @@ void _test_encrypt_empty_aws(_mongocrypt_tester_t *tester) {
 
     crypt = mongocrypt_new();
     ASSERT_OK(mongocrypt_setopt_kms_provider_aws(crypt, "", -1, "", -1), crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
     ctx = mongocrypt_ctx_new(crypt);
     ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TEST_FILE("./test/example/cmd.json")), ctx);
@@ -1139,7 +1139,7 @@ static void _test_encrypt_per_ctx_credentials(_mongocrypt_tester_t *tester) {
     crypt = mongocrypt_new();
     mongocrypt_setopt_use_need_kms_credentials_state(crypt);
     mongocrypt_setopt_kms_providers(crypt, TEST_BSON("{'aws': {}}"));
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     ctx = mongocrypt_ctx_new(crypt);
     ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "test", -1, TEST_FILE("./test/example/cmd.json")), ctx);
     _mongocrypt_tester_run_ctx_to(tester, ctx, MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
@@ -1172,7 +1172,7 @@ static void _test_encrypt_per_ctx_credentials_given_empty(_mongocrypt_tester_t *
     crypt = mongocrypt_new();
     mongocrypt_setopt_use_need_kms_credentials_state(crypt);
     mongocrypt_setopt_kms_providers(crypt, TEST_BSON("{'aws': {}}"));
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     ctx = mongocrypt_ctx_new(crypt);
     ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "test", -1, TEST_FILE("./test/example/cmd.json")), ctx);
     _mongocrypt_tester_run_ctx_to(tester, ctx, MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
@@ -1194,7 +1194,7 @@ static void _test_encrypt_per_ctx_credentials_local(_mongocrypt_tester_t *tester
     crypt = mongocrypt_new();
     mongocrypt_setopt_use_need_kms_credentials_state(crypt);
     mongocrypt_setopt_kms_providers(crypt, TEST_BSON("{'local': {}}"));
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     ctx = mongocrypt_ctx_new(crypt);
     ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "test", -1, TEST_FILE("./test/example/cmd.json")), ctx);
     _mongocrypt_tester_run_ctx_to(tester, ctx, MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);
@@ -1225,7 +1225,7 @@ static void _test_encrypt_with_aws_session_token(_mongocrypt_tester_t *tester) {
                                                         "'accessKeyId': 'myAccessKeyId', "
                                                         "'secretAccessKey': 'mySecretAccessKey'}}")),
               crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
     ctx = mongocrypt_ctx_new(crypt);
     ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "test", -1, TEST_FILE("./test/example/cmd.json")), ctx);
@@ -1305,7 +1305,7 @@ static void _test_encrypt_with_encrypted_field_config_map(_mongocrypt_tester_t *
     // TODO(MONGOCRYPT-572): This test uses the QEv1 protocol. Update this test for QEv2 or remove. Note: decrypting
     // QEv1 is still supported.
     ASSERT_OK(mongocrypt_setopt_fle2v2(crypt, false), crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
     /* Test encrypting a command on a collection present in the encrypted field
      * config map. */
@@ -1351,7 +1351,7 @@ static void _test_encrypt_with_encrypted_field_config_map_bypassed(_mongocrypt_t
         mongocrypt_setopt_kms_providers(crypt, TEST_BSON("{'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'bar'}}")),
         crypt);
     ASSERT_OK(mongocrypt_setopt_encrypted_field_config_map(crypt, TEST_BSON("{'db.coll': {'fields': []}}")), crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
     ctx = mongocrypt_ctx_new(crypt);
     /* 'drop' is bypassed. Expect that no 'encryptionInformation' is appended. */
@@ -1415,7 +1415,7 @@ static void _test_encrypt_remote_encryptedfields(_mongocrypt_tester_t *tester) {
     // TODO(MONGOCRYPT-572): This test uses the QEv1 protocol. Update this test for QEv2 or remove. Note: decrypting
     // QEv1 is still supported.
     ASSERT_OK(mongocrypt_setopt_fle2v2(crypt, false), crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     /* Test success. */
     {
         ctx = mongocrypt_ctx_new(crypt);
@@ -1480,7 +1480,7 @@ static void _test_encrypt_remote_encryptedfields(_mongocrypt_tester_t *tester) {
         // TODO(MONGOCRYPT-572): This test uses the QEv1 protocol. Update this test for QEv2 or remove. Note: decrypting
         // QEv1 is still supported.
         ASSERT_OK(mongocrypt_setopt_fle2v2(crypt, false), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
         ctx = mongocrypt_ctx_new(crypt);
         ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TEST_FILE("./test/data/fle2-find-explicit/cmd.json")),
                   ctx);
@@ -1530,7 +1530,7 @@ static void _test_encrypt_with_bypassqueryanalysis(_mongocrypt_tester_t *tester)
         // TODO(MONGOCRYPT-572): This test uses the QEv1 protocol. Update this test for QEv2 or remove. Note: decrypting
         // QEv1 is still supported.
         ASSERT_OK(mongocrypt_setopt_fle2v2(crypt, false), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         ctx = mongocrypt_ctx_new(crypt);
         ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TEST_FILE("./test/data/fle2-find-explicit/cmd.json")),
@@ -1562,7 +1562,7 @@ static void _test_encrypt_with_bypassqueryanalysis(_mongocrypt_tester_t *tester)
         // TODO(MONGOCRYPT-572): This test uses the QEv1 protocol. Update this test for QEv2 or remove. Note: decrypting
         // QEv1 is still supported.
         ASSERT_OK(mongocrypt_setopt_fle2v2(crypt, false), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         ctx = mongocrypt_ctx_new(crypt);
         ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TEST_FILE("./test/data/fle2-find-explicit/cmd.json")),
@@ -1970,7 +1970,7 @@ static void _test_encrypt_fle2_encryption_placeholder(_mongocrypt_tester_t *test
         MAKE_PATH("encrypted-field-map.json");
         ASSERT_OK(mongocrypt_setopt_encrypted_field_config_map(crypt, TEST_FILE(pathbuf)), crypt);
         mongocrypt_binary_destroy(localkey);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     }
 
     /* Create encryption context. */
@@ -2194,7 +2194,7 @@ static mongocrypt_t *_crypt_with_rng(_test_rng_data_source *rng_source, bool use
     // TODO(MONGOCRYPT-572): This test uses the QEv1 protocol. Update this test for QEv2 or remove. Note: decrypting
     // QEv1 is still supported.
     ASSERT_OK(mongocrypt_setopt_fle2v2(crypt, use_v2), crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     return crypt;
 }
 
@@ -3162,7 +3162,7 @@ static void _test_encrypt_applies_default_state_collections(_mongocrypt_tester_t
         // TODO(MONGOCRYPT-572): This test uses the QEv1 protocol. Update this test for QEv2 or remove. Note: decrypting
         // QEv1 is still supported.
         ASSERT_OK(mongocrypt_setopt_fle2v2(crypt, false), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
         ctx = mongocrypt_ctx_new(crypt);
         ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TEST_BSON("{'find': 'coll'}")), ctx);
         ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
@@ -3197,7 +3197,7 @@ static void _test_encrypt_applies_default_state_collections(_mongocrypt_tester_t
                       TEST_BSON("{'db.coll': { 'fields': [], 'escCollection': 'esc', "
                                 "'eccCollection': 'ecc', 'ecocCollection': 'ecoc'}}")),
                   crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
         ctx = mongocrypt_ctx_new(crypt);
         ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TEST_BSON("{'find': 'coll'}")), ctx);
         ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
@@ -3231,7 +3231,7 @@ static void _test_encrypt_applies_default_state_collections(_mongocrypt_tester_t
                                                          TEST_BSON("{'fields': [], 'db.coll': {'escCollection': "
                                                                    "'esc', 'eccCollection': 'ecc', 'fields': []}}")),
             crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
         ctx = mongocrypt_ctx_new(crypt);
         ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TEST_BSON("{'find': 'coll'}")), ctx);
         ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
@@ -3373,7 +3373,7 @@ static void _test_encrypt_fle2_delete_v1(_mongocrypt_tester_t *tester) {
             // decrypting
             // QEv1 is still supported.
             ASSERT_OK(mongocrypt_setopt_fle2v2(crypt, false), crypt);
-            ASSERT_OK(mongocrypt_init(crypt), crypt);
+            ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
         }
 
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
@@ -3430,7 +3430,7 @@ static void _test_encrypt_fle2_delete_v1(_mongocrypt_tester_t *tester) {
             // decrypting
             // QEv1 is still supported.
             ASSERT_OK(mongocrypt_setopt_fle2v2(crypt, false), crypt);
-            ASSERT_OK(mongocrypt_init(crypt), crypt);
+            ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
         }
 
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
@@ -3496,7 +3496,7 @@ static void _test_encrypt_fle2_delete_v1(_mongocrypt_tester_t *tester) {
             // decrypting
             // QEv1 is still supported.
             ASSERT_OK(mongocrypt_setopt_fle2v2(crypt, false), crypt);
-            ASSERT_OK(mongocrypt_init(crypt), crypt);
+            ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
         }
 
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
@@ -3627,7 +3627,7 @@ static void _test_encrypt_fle2_delete_v2(_mongocrypt_tester_t *tester) {
             mongocrypt_binary_destroy(localkey);
             mongocrypt_setopt_bypass_query_analysis(crypt);
             mongocrypt_setopt_fle2v2(crypt, true);
-            ASSERT_OK(mongocrypt_init(crypt), crypt);
+            ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
         }
 
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
@@ -3670,7 +3670,7 @@ static void _test_encrypt_fle2_delete_v2(_mongocrypt_tester_t *tester) {
                                                                              "encrypted-field-config-map.json")),
                       crypt);
             mongocrypt_setopt_fle2v2(crypt, true);
-            ASSERT_OK(mongocrypt_init(crypt), crypt);
+            ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
         }
 
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
@@ -3729,7 +3729,7 @@ static void _test_encrypt_fle2_delete_v2(_mongocrypt_tester_t *tester) {
                       crypt);
             mongocrypt_setopt_bypass_query_analysis(crypt);
             mongocrypt_setopt_fle2v2(crypt, true);
-            ASSERT_OK(mongocrypt_init(crypt), crypt);
+            ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
         }
 
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
@@ -4329,7 +4329,7 @@ static void _test_fle1_create_with_schema(_mongocrypt_tester_t *tester) {
     ASSERT_OK(mongocrypt_setopt_kms_provider_aws(crypt, "example", -1, "example", -1), crypt);
     ASSERT_OK(mongocrypt_setopt_schema_map(crypt, TEST_FILE("./test/data/fle1-create/with-schema/schema-map.json")),
               crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
     mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
 
@@ -4507,7 +4507,7 @@ static void _test_fle2_create(_mongocrypt_tester_t *tester) {
                   crypt,
                   TEST_FILE("./test/data/fle2-create/encrypted-field-config-map.json")),
               crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
     mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
 
@@ -4563,7 +4563,7 @@ static void _test_fle2_create_bypass_query_analysis(_mongocrypt_tester_t *tester
                   TEST_FILE("./test/data/fle2-create/encrypted-field-config-map.json")),
               crypt);
     mongocrypt_setopt_bypass_query_analysis(crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
     mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
 
@@ -4688,7 +4688,7 @@ static void _test_bulkWrite(_mongocrypt_tester_t *tester) {
                       crypt,
                       TEST_FILE("./test/data/bulkWrite/simple/encrypted-field-map.json")),
                   crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Successful case.
         {
@@ -4754,7 +4754,7 @@ static void _test_bulkWrite(_mongocrypt_tester_t *tester) {
                       crypt,
                       TEST_FILE("./test/data/bulkWrite/simple/encrypted-field-map.json")),
                   crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
 
@@ -4809,7 +4809,7 @@ static void _test_bulkWrite(_mongocrypt_tester_t *tester) {
             crypt,
             TEST_BSON(BSON_STR({"local" : {"key" : {"$binary" : {"base64" : "%s", "subType" : "00"}}}}), local_kek));
 
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
 
@@ -4883,7 +4883,7 @@ static void _test_bulkWrite(_mongocrypt_tester_t *tester) {
             crypt,
             TEST_BSON(BSON_STR({"local" : {"key" : {"$binary" : {"base64" : "%s", "subType" : "00"}}}}), local_kek));
 
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
 
@@ -4907,7 +4907,7 @@ static void _test_bulkWrite(_mongocrypt_tester_t *tester) {
             crypt,
             TEST_BSON(BSON_STR({"local" : {"key" : {"$binary" : {"base64" : "%s", "subType" : "00"}}}}), local_kek));
 
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
 
@@ -5003,7 +5003,7 @@ static void _test_bulkWrite(_mongocrypt_tester_t *tester) {
                       crypt,
                       TEST_FILE("./test/data/bulkWrite/simple/encrypted-field-map.json")),
                   crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
 
@@ -5037,7 +5037,7 @@ static void _test_bulkWrite(_mongocrypt_tester_t *tester) {
 
         // Associate a JSON schema to the collection to enable CSFLE.
         ASSERT_OK(mongocrypt_setopt_schema_map(crypt, TEST_BSON(BSON_STR({"db.test" : {}}))), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
 

--- a/test/test-mongocrypt-ctx-rewrap-many-datakey.c
+++ b/test/test-mongocrypt-ctx-rewrap-many-datakey.c
@@ -753,7 +753,7 @@ static void _test_rewrap_many_datakey_kms_credentials(_mongocrypt_tester_t *test
         crypt = mongocrypt_new();
         mongocrypt_setopt_use_need_kms_credentials_state(crypt);
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, TEST_BSON("{'aws': {}}")), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
         ctx = mongocrypt_ctx_new(crypt);
 
         ASSERT_OK(ctx, crypt);
@@ -828,7 +828,7 @@ static void _test_rewrap_many_datakey_kms_credentials(_mongocrypt_tester_t *test
                                                         "   'accessKeyId': 'example',"
                                                         "   'secretAccessKey': 'example'}}")),
               crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     ctx = mongocrypt_ctx_new(crypt);
     ASSERT_OK(ctx, crypt);
     ASSERT_OK(mongocrypt_ctx_rewrap_many_datakey_init(ctx, TEST_BSON("{}")), ctx);

--- a/test/test-mongocrypt-ctx-setopt.c
+++ b/test/test-mongocrypt-ctx-setopt.c
@@ -1149,7 +1149,7 @@ static void _test_createdatakey_with_wrong_kms_provider_helper(_mongocrypt_teste
     crypt = mongocrypt_new();
     ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_provider), crypt);
     mongocrypt_setopt_use_need_kms_credentials_state(crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     ctx = mongocrypt_ctx_new(crypt);
     ASSERT_OK(mongocrypt_ctx_setopt_key_encryption_key(ctx, TEST_BSON(kek)), ctx);
     ASSERT_FAILS(mongocrypt_ctx_datakey_init(ctx), ctx, "kms provider required by datakey is not configured");

--- a/test/test-mongocrypt-datakey.c
+++ b/test/test-mongocrypt-datakey.c
@@ -211,7 +211,7 @@ static void _test_datakey_kms_per_ctx_credentials(_mongocrypt_tester_t *tester) 
     crypt = mongocrypt_new();
     mongocrypt_setopt_use_need_kms_credentials_state(crypt);
     ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, TEST_BSON("{'aws': {}}")), crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     ctx = mongocrypt_ctx_new(crypt);
     ASSERT_OK(mongocrypt_ctx_setopt_masterkey_aws(ctx, "region", -1, "cmk", -1), ctx);
     ASSERT_OK(mongocrypt_ctx_setopt_masterkey_aws_endpoint(ctx, "example.com", -1), ctx);
@@ -259,7 +259,7 @@ static void _test_datakey_kms_per_ctx_credentials_not_requested(_mongocrypt_test
                                               TEST_BSON("{'aws': {}, 'azure': {'tenantId': '', 'clientId': "
                                                         "'', 'clientSecret': '' }}")),
               crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     ctx = mongocrypt_ctx_new(crypt);
     ASSERT_OK(mongocrypt_ctx_setopt_key_encryption_key(ctx,
                                                        TEST_BSON("{'provider': 'azure', 'keyVaultEndpoint': "
@@ -287,7 +287,7 @@ static void _test_datakey_kms_per_ctx_credentials_local(_mongocrypt_tester_t *te
     crypt = mongocrypt_new();
     mongocrypt_setopt_use_need_kms_credentials_state(crypt);
     ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, TEST_BSON("{'local': {}}")), crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     ctx = mongocrypt_ctx_new(crypt);
     ASSERT_OK(mongocrypt_ctx_setopt_key_encryption_key(ctx, TEST_BSON("{'provider': 'local' }")), ctx);
     ASSERT_OK(mongocrypt_ctx_datakey_init(ctx), ctx);

--- a/test/test-mongocrypt-log.c
+++ b/test/test-mongocrypt-log.c
@@ -104,7 +104,7 @@ static void _test_no_log(_mongocrypt_tester_t *tester) {
     status = mongocrypt_status_new();
     crypt = mongocrypt_new();
     mongocrypt_setopt_kms_provider_aws(crypt, "example", -1, "example", -1);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     _mongocrypt_log(&crypt->log, MONGOCRYPT_LOG_LEVEL_FATAL, "Please don't log");
     mongocrypt_status_destroy(status);
     mongocrypt_destroy(crypt);

--- a/test/test-mongocrypt-opts.c
+++ b/test/test-mongocrypt-opts.c
@@ -25,7 +25,7 @@ static void test_mongocrypt_opts_kms_providers_lookup(_mongocrypt_tester_t *test
 
     mongocrypt_t *crypt = mongocrypt_new();
     ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, bson), crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
     mc_kms_creds_t got;
     ASSERT(_mongocrypt_opts_kms_providers_lookup(&crypt->opts.kms_providers, "azure", &got));

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -513,7 +513,9 @@ mongocrypt_t *_mongocrypt_tester_mongocrypt(tester_mongocrypt_flags flags) {
 
 bool _mongocrypt_init_for_test(mongocrypt_t *crypt) {
     BSON_ASSERT_PARAM(crypt);
-    // Even if the ENABLE_USE_RANGE_V2 compile flag is on, we should have range V2 off by default for testing, as many existing tests are based around range V2 being disabled. To use range V2, use the TESTER_MONGOCRYPT_WITH_RANGE_V2 flag with the above function.
+    // Even if the ENABLE_USE_RANGE_V2 compile flag is on, we should have range V2 off by default for testing, as many
+    // existing tests are based around range V2 being disabled. To use range V2, use the TESTER_MONGOCRYPT_WITH_RANGE_V2
+    // flag with the above function.
     crypt->opts.use_range_v2 = false;
     return mongocrypt_init(crypt);
 }

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -497,6 +497,8 @@ mongocrypt_t *_mongocrypt_tester_mongocrypt(tester_mongocrypt_flags flags) {
     }
     if (flags & TESTER_MONGOCRYPT_WITH_RANGE_V2) {
         ASSERT(mongocrypt_setopt_use_range_v2(crypt));
+    } else {
+        crypt->opts.use_range_v2 = false;
     }
     ASSERT_OK(mongocrypt_init(crypt), crypt);
     if (flags & TESTER_MONGOCRYPT_WITH_CRYPT_SHARED_LIB) {
@@ -509,6 +511,13 @@ mongocrypt_t *_mongocrypt_tester_mongocrypt(tester_mongocrypt_flags flags) {
     return crypt;
 }
 
+bool _mongocrypt_init_for_test(mongocrypt_t *crypt) {
+    BSON_ASSERT_PARAM(crypt);
+    // Even if the ENABLE_USE_RANGE_V2 compile flag is on, we should have range V2 off by default for testing, as many existing tests are based around range V2 being disabled. To use range V2, use the TESTER_MONGOCRYPT_WITH_RANGE_V2 flag with the above function.
+    crypt->opts.use_range_v2 = false;
+    return mongocrypt_init(crypt);
+}
+
 static void _test_mongocrypt_bad_init(_mongocrypt_tester_t *tester) {
     mongocrypt_t *crypt;
     mongocrypt_binary_t *local_key;
@@ -516,7 +525,7 @@ static void _test_mongocrypt_bad_init(_mongocrypt_tester_t *tester) {
 
     /* Omitting a KMS provider must fail. */
     crypt = mongocrypt_new();
-    ASSERT_FAILS(mongocrypt_init(crypt), crypt, "no kms provider set");
+    ASSERT_FAILS(_mongocrypt_init_for_test(crypt), crypt, "no kms provider set");
     mongocrypt_destroy(crypt);
 
     /* Bad KMS provider options must fail. */
@@ -554,13 +563,13 @@ static void _test_mongocrypt_bad_init(_mongocrypt_tester_t *tester) {
     /* Reinitialization must fail. */
     crypt = mongocrypt_new();
     ASSERT_OK(mongocrypt_setopt_kms_provider_aws(crypt, "example", -1, "example", -1), crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
-    ASSERT_FAILS(mongocrypt_init(crypt), crypt, "already initialized");
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
+    ASSERT_FAILS(_mongocrypt_init_for_test(crypt), crypt, "already initialized");
     mongocrypt_destroy(crypt);
     /* Setting options after initialization must fail. */
     crypt = mongocrypt_new();
     ASSERT_OK(mongocrypt_setopt_kms_provider_aws(crypt, "example", -1, "example", -1), crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     ASSERT_FAILS(mongocrypt_setopt_kms_provider_aws(crypt, "example", -1, "example", -1),
                  crypt,
                  "options cannot be set after initialization");
@@ -604,7 +613,7 @@ static void _test_setopt_encrypted_field_config_map(_mongocrypt_tester_t *tester
     ASSERT_OK(
         mongocrypt_setopt_encrypted_field_config_map(crypt, TEST_FILE("./test/data/encrypted-field-config-map.json")),
         crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     mongocrypt_destroy(crypt);
 
     /* Test double setting. */
@@ -645,7 +654,7 @@ static void _test_setopt_encrypted_field_config_map(_mongocrypt_tester_t *tester
     ASSERT_OK(
         mongocrypt_setopt_kms_providers(crypt, TEST_BSON("{'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'bar'}}")),
         crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     mongocrypt_destroy(crypt);
 
     /* Test that it is an error to set both the encrypted field config map and
@@ -657,7 +666,7 @@ static void _test_setopt_encrypted_field_config_map(_mongocrypt_tester_t *tester
     ASSERT_OK(
         mongocrypt_setopt_kms_providers(crypt, TEST_BSON("{'aws': {'accessKeyId': 'foo', 'secretAccessKey': 'bar'}}")),
         crypt);
-    ASSERT_FAILS(mongocrypt_init(crypt),
+    ASSERT_FAILS(_mongocrypt_init_for_test(crypt),
                  crypt,
                  "db.coll1 is present in both schema_map and encrypted_field_config_map");
     mongocrypt_destroy(crypt);
@@ -670,7 +679,7 @@ static void _test_setopt_invalid_kms_providers(_mongocrypt_tester_t *tester) {
 
     crypt = mongocrypt_new();
     ASSERT_OK(mongocrypt_setopt_kms_provider_aws(crypt, "", 0, "", 0), crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
     ctx = mongocrypt_ctx_new(crypt);
     ASSERT_OK(mongocrypt_ctx_setopt_masterkey_aws(ctx, "region", -1, "cmk", 3), ctx);
@@ -688,7 +697,7 @@ static void _test_setopt_invalid_kms_providers(_mongocrypt_tester_t *tester) {
     crypt = mongocrypt_new();
     mongocrypt_setopt_use_need_kms_credentials_state(crypt);
     ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, TEST_BSON("{}")), crypt);
-    ASSERT_FAILS(mongocrypt_init(crypt), crypt, "no kms provider set");
+    ASSERT_FAILS(_mongocrypt_init_for_test(crypt), crypt, "no kms provider set");
     mongocrypt_destroy(crypt);
 }
 
@@ -781,9 +790,9 @@ static void _test_setopt_kms_providers(_mongocrypt_tester_t *tester) {
         if (!test->errmsg) {
             ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, TEST_BSON(test->value)), crypt);
             if (!test->errmsg_init) {
-                ASSERT_OK(mongocrypt_init(crypt), crypt);
+                ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
             } else {
-                ASSERT_FAILS(mongocrypt_init(crypt), crypt, test->errmsg_init);
+                ASSERT_FAILS(_mongocrypt_init_for_test(crypt), crypt, test->errmsg_init);
             }
         } else {
             ASSERT_FAILS(mongocrypt_setopt_kms_providers(crypt, TEST_BSON(test->value)), crypt, test->errmsg);

--- a/test/test-mongocrypt.h
+++ b/test/test-mongocrypt.h
@@ -98,6 +98,9 @@ void _mongocrypt_tester_fill_buffer(_mongocrypt_buffer_t *buf, int n);
 /* Return a new initialized mongocrypt_t for testing. */
 mongocrypt_t *_mongocrypt_tester_mongocrypt(tester_mongocrypt_flags options);
 
+/* Initialize a new mongocrypt_t for use in testing. */
+bool _mongocrypt_init_for_test(mongocrypt_t *);
+
 typedef enum { CRYPTO_REQUIRED, CRYPTO_OPTIONAL, CRYPTO_PROHIBITED } _mongocrypt_tester_crypto_spec_t;
 
 void _mongocrypt_tester_install(_mongocrypt_tester_t *tester,

--- a/test/test-named-kms-providers.c
+++ b/test/test-named-kms-providers.c
@@ -250,7 +250,7 @@ static void test_configuring_named_kms_providers(_mongocrypt_tester_t *tester) {
                       LOCAL_KEK2_BASE64);
         bool ok = mongocrypt_setopt_kms_providers(crypt, kms_providers);
         ASSERT_OK(ok, crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
         mongocrypt_destroy(crypt);
     }
 
@@ -315,7 +315,7 @@ static void test_configuring_named_kms_providers(_mongocrypt_tester_t *tester) {
                       LOCAL_KEK1_BASE64);
         bool ok = mongocrypt_setopt_kms_providers(crypt, kms_providers);
         ASSERT_OK(ok, crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
         mongocrypt_destroy(crypt);
     }
 
@@ -325,7 +325,7 @@ static void test_configuring_named_kms_providers(_mongocrypt_tester_t *tester) {
         mongocrypt_binary_t *kms_providers = TEST_BSON(BSON_STR({"local:name1" : {"key" : "%s"}}), LOCAL_KEK1_BASE64);
         bool ok = mongocrypt_setopt_kms_providers(crypt, kms_providers);
         ASSERT_OK(ok, crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
         mongocrypt_destroy(crypt);
     }
 
@@ -344,7 +344,7 @@ static void test_create_datakey_with_named_kms_provider(_mongocrypt_tester_t *te
         mongocrypt_t *crypt = mongocrypt_new();
         mongocrypt_binary_t *kms_providers = TEST_BSON(BSON_STR({"local:name1" : {"key" : "%s"}}), LOCAL_KEK1_BASE64);
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Create with named KMS provider.
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
@@ -367,7 +367,7 @@ static void test_create_datakey_with_named_kms_provider(_mongocrypt_tester_t *te
                       LOCAL_KEK1_BASE64,
                       LOCAL_KEK2_BASE64);
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Create with named KMS provider.
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
@@ -390,7 +390,7 @@ static void test_create_datakey_with_named_kms_provider(_mongocrypt_tester_t *te
             TEST_BSON(BSON_STR({"local" : {}, "local:name1" : {"key" : "%s"}}), LOCAL_KEK1_BASE64, LOCAL_KEK2_BASE64);
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
         mongocrypt_setopt_use_need_kms_credentials_state(crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Create with named KMS provider.
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
@@ -410,7 +410,7 @@ static void test_create_datakey_with_named_kms_provider(_mongocrypt_tester_t *te
         mongocrypt_t *crypt = mongocrypt_new();
         mongocrypt_binary_t *kms_providers = TEST_BSON(BSON_STR({"local:name1" : {"key" : "%s"}}), LOCAL_KEK1_BASE64);
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Create with named KMS provider.
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
@@ -444,7 +444,7 @@ static void test_create_datakey_with_named_kms_provider(_mongocrypt_tester_t *te
             }
         }));
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Create with named KMS provider.
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
@@ -503,7 +503,7 @@ static void test_create_datakey_with_named_kms_provider(_mongocrypt_tester_t *te
         mongocrypt_t *crypt = mongocrypt_new();
         mongocrypt_binary_t *kms_providers = TEST_BSON(BSON_STR({"azure:name1" : {"accessToken" : "foo"}}));
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Create with named KMS provider.
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
@@ -562,7 +562,7 @@ static void test_create_datakey_with_named_kms_provider(_mongocrypt_tester_t *te
             }
         }));
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Create with `azure:name1`.
         {
@@ -678,7 +678,7 @@ static void test_create_datakey_with_named_kms_provider(_mongocrypt_tester_t *te
         mongocrypt_binary_t *kms_providers =
             TEST_BSON(BSON_STR({"kmip:name1" : {"endpoint" : "placeholder1-endpoint.com"}}));
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Create with named KMS provider.
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
@@ -730,7 +730,7 @@ static void test_create_datakey_with_named_kms_provider(_mongocrypt_tester_t *te
         mongocrypt_binary_t *kms_providers =
             TEST_BSON(BSON_STR({"kmip:name1" : {"endpoint" : "placeholder1-endpoint.com"}}));
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Create with named KMS provider.
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
@@ -835,7 +835,7 @@ static void create_dek(_mongocrypt_tester_t *tester, create_dek_args args, _mong
 
     mongocrypt_t *crypt = mongocrypt_new();
     ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, args.kms_providers), crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
     mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
     ASSERT_OK(mongocrypt_ctx_setopt_key_encryption_key(ctx, args.kek), ctx);
@@ -927,7 +927,7 @@ static void test_explicit_with_named_kms_provider_for_azure(_mongocrypt_tester_t
     {
         mongocrypt_t *crypt = mongocrypt_new();
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Test encrypting without cached DEK. Store result for later decryption.
         {
@@ -997,7 +997,7 @@ static void test_explicit_with_named_kms_provider_for_azure(_mongocrypt_tester_t
     {
         mongocrypt_t *crypt = mongocrypt_new();
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Test decrypting without cached DEK.
         {
@@ -1063,7 +1063,7 @@ static void test_explicit_with_named_kms_provider_for_azure(_mongocrypt_tester_t
     {
         mongocrypt_t *crypt = mongocrypt_new();
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Decrypt.
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
@@ -1125,7 +1125,7 @@ static void test_explicit_with_named_kms_provider_for_azure(_mongocrypt_tester_t
     {
         mongocrypt_t *crypt = mongocrypt_new();
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Encrypt with azure:name1
         {
@@ -1229,7 +1229,7 @@ static void test_explicit_with_named_kms_provider_for_azure(_mongocrypt_tester_t
             TEST_BSON(BSON_STR({"azure:name3_withAccessToken" : {"accessToken" : "placeholder3-accesstoken"}}));
 
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers_withAccessToken), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Create `dek3` from `azure:name3_withAccessToken`
         _mongocrypt_buffer_t dek3;
@@ -1337,7 +1337,7 @@ static void test_explicit_with_named_kms_provider_for_gcp(_mongocrypt_tester_t *
     {
         mongocrypt_t *crypt = mongocrypt_new();
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Test encrypting without cached DEK. Store result for later decryption.
         {
@@ -1407,7 +1407,7 @@ static void test_explicit_with_named_kms_provider_for_gcp(_mongocrypt_tester_t *
     {
         mongocrypt_t *crypt = mongocrypt_new();
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Test decrypting without cached DEK.
         {
@@ -1473,7 +1473,7 @@ static void test_explicit_with_named_kms_provider_for_gcp(_mongocrypt_tester_t *
     {
         mongocrypt_t *crypt = mongocrypt_new();
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Decrypt.
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
@@ -1535,7 +1535,7 @@ static void test_explicit_with_named_kms_provider_for_gcp(_mongocrypt_tester_t *
     {
         mongocrypt_t *crypt = mongocrypt_new();
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Encrypt with gcp:name1
         {
@@ -1635,7 +1635,7 @@ static void test_explicit_with_named_kms_provider_for_gcp(_mongocrypt_tester_t *
     {
         mongocrypt_t *crypt = mongocrypt_new();
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
         ASSERT_OK(mongocrypt_ctx_setopt_key_alt_name(ctx, TEST_BSON(BSON_STR({"keyAltName" : "gcp1"}))), ctx);
@@ -1664,7 +1664,7 @@ static void test_explicit_with_named_kms_provider_for_gcp(_mongocrypt_tester_t *
     {
         mongocrypt_t *crypt = mongocrypt_new();
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
         ASSERT_OK(mongocrypt_ctx_setopt_key_alt_name(ctx, TEST_BSON(BSON_STR({"keyAltName" : "gcp1"}))), ctx);
@@ -1711,7 +1711,7 @@ static void test_explicit_with_named_kms_provider_for_gcp(_mongocrypt_tester_t *
             TEST_BSON(BSON_STR({"gcp:name3_withAccessToken" : {"accessToken" : "placeholder3-accesstoken"}}));
 
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers_withAccessToken), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Create `dek3` from `gcp:name3_withAccessToken`
         _mongocrypt_buffer_t dek3;
@@ -1814,7 +1814,7 @@ static void test_explicit_with_named_kms_provider_for_aws(_mongocrypt_tester_t *
     {
         mongocrypt_t *crypt = mongocrypt_new();
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Test encrypting without cached DEK. Store result for later decryption.
         {
@@ -1870,7 +1870,7 @@ static void test_explicit_with_named_kms_provider_for_aws(_mongocrypt_tester_t *
     {
         mongocrypt_t *crypt = mongocrypt_new();
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Test decrypting without cached DEK.
         {
@@ -1956,7 +1956,7 @@ static void test_explicit_with_named_kms_provider_for_kmip(_mongocrypt_tester_t 
     {
         mongocrypt_t *crypt = mongocrypt_new();
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Test encrypting without cached DEK. Store result for later decryption.
         {
@@ -2020,7 +2020,7 @@ static void test_explicit_with_named_kms_provider_for_kmip(_mongocrypt_tester_t 
     {
         mongocrypt_t *crypt = mongocrypt_new();
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         // Test decrypting without cached DEK.
         {
@@ -2100,7 +2100,7 @@ static void test_rewrap_with_named_kms_provider_local2local(_mongocrypt_tester_t
     {
         mongocrypt_t *crypt = mongocrypt_new();
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
         ASSERT_OK(mongocrypt_ctx_setopt_key_encryption_key(ctx, TEST_BSON(BSON_STR({"provider" : "local:name2"}))),
@@ -2163,7 +2163,7 @@ static void test_rewrap_with_named_kms_provider_azure2azure(_mongocrypt_tester_t
     {
         mongocrypt_t *crypt = mongocrypt_new();
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
         ASSERT_OK(mongocrypt_ctx_setopt_key_encryption_key(ctx, TEST_BSON(BSON_STR({
@@ -2283,7 +2283,7 @@ static void test_rewrap_with_named_kms_provider_azure2local(_mongocrypt_tester_t
     {
         mongocrypt_t *crypt = mongocrypt_new();
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
         mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
         ASSERT_OK(mongocrypt_ctx_setopt_key_encryption_key(ctx, TEST_BSON(BSON_STR({"provider" : "local:name1"}))),
@@ -2346,7 +2346,7 @@ static void test_mongocrypt_kms_ctx_get_kms_provider(_mongocrypt_tester_t *teste
 
     mongocrypt_t *crypt = mongocrypt_new();
     ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
 
     mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
     ASSERT_OK(


### PR DESCRIPTION
When the option is enabled, newly created mongocrypt_t objects will have use_range_v2 set to true. In testing, we add a new _mongocrypt_init_for_testing which disables this option before calling mongocrypt_init, which is needed because there are a multitude of tests which implicitly rely on the range V1 behavior (ex. by testing the actual encrypted payload blob against a specific encrypted payload blob). As part of MONGOCRYPT-661 (enabling this flag by default), we will audit these tests and decide which ones to update for the new behavior, which to leave as-is (while explicitly disabling range V2) and which to remove.