### PR TITLE
MONGOCRYPT-625 address Coverity issues

### DIFF
--- a/kms-message/src/kms_gcp_request.c
+++ b/kms-message/src/kms_gcp_request.c
@@ -87,7 +87,7 @@ kms_gcp_request_oauth_new (const char *host,
       req->crypto.sign_ctx = opt->crypto.sign_ctx;
    }
 
-   jwt_signature = malloc (SIGNATURE_LEN);
+   jwt_signature = calloc (1, SIGNATURE_LEN);
    if (!req->crypto.sign_rsaes_pkcs1_v1_5 (
           req->crypto.sign_ctx,
           private_key_data,

--- a/kms-message/src/kms_request_str.c
+++ b/kms-message/src/kms_request_str.c
@@ -366,7 +366,7 @@ kms_request_str_append_hashed (_kms_crypto_t *crypto,
                                kms_request_str_t *str,
                                kms_request_str_t *appended)
 {
-   uint8_t hash[32];
+   uint8_t hash[32] = {0};
    char *hex_chars;
 
    if (!crypto->sha256 (crypto->ctx, appended->str, appended->len, hash)) {

--- a/src/crypto/libcrypto.c
+++ b/src/crypto/libcrypto.c
@@ -117,7 +117,7 @@ done:
 static bool _decrypt_with_cipher(const EVP_CIPHER *cipher, aes_256_args_t args) {
     EVP_CIPHER_CTX *ctx;
     bool ret = false;
-    int intermediate_bytes_written;
+    int intermediate_bytes_written = 0;
     mongocrypt_status_t *status = args.status;
 
     ctx = EVP_CIPHER_CTX_new();
@@ -147,6 +147,7 @@ static bool _decrypt_with_cipher(const EVP_CIPHER *cipher, aes_256_args_t args) 
         goto done;
     }
 
+    BSON_ASSERT(intermediate_bytes_written >= 0 && intermediate_bytes_written <= UINT32_MAX);
     /* intermediate_bytes_written cannot be negative, so int -> uint32_t is OK */
     *args.bytes_written = (uint32_t)intermediate_bytes_written;
 

--- a/src/crypto/libcrypto.c
+++ b/src/crypto/libcrypto.c
@@ -61,7 +61,7 @@ void _native_crypto_init(void) {
 static bool _encrypt_with_cipher(const EVP_CIPHER *cipher, aes_256_args_t args) {
     EVP_CIPHER_CTX *ctx;
     bool ret = false;
-    int intermediate_bytes_written;
+    int intermediate_bytes_written = 0;
     mongocrypt_status_t *status = args.status;
 
     ctx = EVP_CIPHER_CTX_new();
@@ -89,6 +89,7 @@ static bool _encrypt_with_cipher(const EVP_CIPHER *cipher, aes_256_args_t args) 
         goto done;
     }
 
+    BSON_ASSERT(intermediate_bytes_written >= 0 && intermediate_bytes_written <= UINT32_MAX);
     /* intermediate_bytes_written cannot be negative, so int -> uint32_t is OK */
     *args.bytes_written = (uint32_t)intermediate_bytes_written;
 

--- a/src/crypto/libcrypto.c
+++ b/src/crypto/libcrypto.c
@@ -89,7 +89,7 @@ static bool _encrypt_with_cipher(const EVP_CIPHER *cipher, aes_256_args_t args) 
         goto done;
     }
 
-    BSON_ASSERT(intermediate_bytes_written >= 0 && intermediate_bytes_written <= UINT32_MAX);
+    BSON_ASSERT(intermediate_bytes_written >= 0 && (uint64_t)intermediate_bytes_written <= UINT32_MAX);
     /* intermediate_bytes_written cannot be negative, so int -> uint32_t is OK */
     *args.bytes_written = (uint32_t)intermediate_bytes_written;
 
@@ -147,7 +147,7 @@ static bool _decrypt_with_cipher(const EVP_CIPHER *cipher, aes_256_args_t args) 
         goto done;
     }
 
-    BSON_ASSERT(intermediate_bytes_written >= 0 && intermediate_bytes_written <= UINT32_MAX);
+    BSON_ASSERT(intermediate_bytes_written >= 0 && (uint64_t)intermediate_bytes_written <= UINT32_MAX);
     /* intermediate_bytes_written cannot be negative, so int -> uint32_t is OK */
     *args.bytes_written = (uint32_t)intermediate_bytes_written;
 

--- a/src/crypto/libcrypto.c
+++ b/src/crypto/libcrypto.c
@@ -206,7 +206,7 @@ static bool _hmac_with_hash(const EVP_MD *hash,
 
     if (out->len != (uint32_t)EVP_MD_size(hash)) {
         CLIENT_ERR("out does not contain %d bytes", EVP_MD_size(hash));
-        return false;
+        goto done;
     }
 
     if (!HMAC_Init_ex(ctx, key->data, (int)key->len, hash, NULL /* engine */)) {

--- a/src/mc-fle2-encryption-placeholder.c
+++ b/src/mc-fle2-encryption-placeholder.c
@@ -53,7 +53,7 @@ void mc_FLE2EncryptionPlaceholder_init(mc_FLE2EncryptionPlaceholder_t *placehold
 bool mc_FLE2EncryptionPlaceholder_parse(mc_FLE2EncryptionPlaceholder_t *out,
                                         const bson_t *in,
                                         mongocrypt_status_t *status) {
-    bson_iter_t iter;
+    bson_iter_t iter = {0};
     bool has_t = false, has_a = false, has_v = false, has_cm = false;
     bool has_ki = false, has_ku = false;
     bool has_s = false;

--- a/src/mc-fle2-payload-iev-v2.c
+++ b/src/mc-fle2-payload-iev-v2.c
@@ -196,7 +196,7 @@ bool mc_FLE2IndexedEncryptedValueV2_add_S_Key(_mongocrypt_crypto_t *crypto,
     BSON_ASSERT(bytes_written == DecryptedServerEncryptedValueLen);
     if (!_mongocrypt_buffer_from_subrange(&iev->K_KeyId, &iev->DecryptedServerEncryptedValue, 0, UUID_LEN)) {
         CLIENT_ERR("Error creating K_KeyId subrange from DecryptedServerEncryptedValue");
-        return false;
+        goto fail;
     }
     iev->K_KeyId.subtype = BSON_SUBTYPE_UUID;
 
@@ -207,7 +207,7 @@ bool mc_FLE2IndexedEncryptedValueV2_add_S_Key(_mongocrypt_crypto_t *crypto,
                                           iev->DecryptedServerEncryptedValue.len - UUID_LEN)) {
         CLIENT_ERR("Error creating ClientEncryptedValue subrange from "
                    "DecryptedServerEncryptedValue");
-        return false;
+        goto fail;
     }
 
     iev->ClientEncryptedValueDecoded = true;

--- a/src/mc-fle2-rfds.c
+++ b/src/mc-fle2-rfds.c
@@ -105,7 +105,7 @@ parse_aggregate_expression(const bson_t *orig, bson_iter_t *in, operator_value_t
     BSON_ASSERT_PARAM(out);
     BSON_ASSERT(status || true);
 
-    bson_iter_t array, value;
+    bson_iter_t array = {0}, value;
     const char *op_type_str = bson_iter_key(in);
     bool ok = false;
     const char *field;

--- a/src/mc-fle2-rfds.c
+++ b/src/mc-fle2-rfds.c
@@ -70,7 +70,7 @@ static bool parse_and(const bson_t *in, bson_iter_t *out, mongocrypt_status_t *s
     BSON_ASSERT_PARAM(out);
     BSON_ASSERT(status || true);
 
-    bson_iter_t and;
+    bson_iter_t and = {0};
     if (!bson_iter_init(&and, in) || !bson_iter_next(&and) || 0 != strcmp(bson_iter_key(&and), "$and")) {
         ERR_WITH_BSON(in, "%s", "error unable to find '$and'");
         return false;

--- a/src/mc-fle2-rfds.c
+++ b/src/mc-fle2-rfds.c
@@ -162,7 +162,7 @@ parse_match_expression(const bson_t *orig, bson_iter_t *in, operator_value_t *ou
     BSON_ASSERT_PARAM(out);
     BSON_ASSERT(status || true);
 
-    bson_iter_t document, value;
+    bson_iter_t document = {0}, value;
     const char *op_type_str;
     bool ok = false;
     const char *field = bson_iter_key(in);

--- a/src/mc-rangeopts.c
+++ b/src/mc-rangeopts.c
@@ -49,7 +49,7 @@
 #define ERROR_PREFIX "Error parsing RangeOpts"
 
 bool mc_RangeOpts_parse(mc_RangeOpts_t *ro, const bson_t *in, bool use_range_v2, mongocrypt_status_t *status) {
-    bson_iter_t iter;
+    bson_iter_t iter = {0};
     bool has_min = false, has_max = false, has_sparsity = false, has_precision = false, has_trimFactor = false;
     BSON_ASSERT_PARAM(ro);
     BSON_ASSERT_PARAM(in);

--- a/src/mongocrypt-cache-key.c
+++ b/src/mongocrypt-cache-key.c
@@ -85,6 +85,7 @@ static void _dump_attr(void *attr_in) {
     for (altname = attr->alt_names; NULL != altname; altname = altname->next) {
         printf("%s\n", _mongocrypt_key_alt_name_get_string(altname));
     }
+    bson_free(hex);
 }
 
 _mongocrypt_cache_key_value_t *_mongocrypt_cache_key_value_new(_mongocrypt_key_doc_t *key_doc,

--- a/src/mongocrypt-ctx-decrypt.c
+++ b/src/mongocrypt-ctx-decrypt.c
@@ -504,6 +504,7 @@ static bool _collect_K_KeyID_from_FLE2IndexedEncryptedValueV2(void *ctx,
                 || (in->data[0] == MC_SUBTYPE_FLE2IndexedRangeEncryptedValueV2));
 
     mc_FLE2IndexedEncryptedValueV2_t *iev = mc_FLE2IndexedEncryptedValueV2_new();
+    _mongocrypt_buffer_t S_Key = {0};
     CHECK_AND_RETURN(iev);
     CHECK_AND_RETURN(mc_FLE2IndexedEncryptedValueV2_parse(iev, in, status));
 
@@ -511,7 +512,6 @@ static bool _collect_K_KeyID_from_FLE2IndexedEncryptedValueV2(void *ctx,
     CHECK_AND_RETURN(S_KeyId);
 
     _mongocrypt_key_broker_t *kb = ctx;
-    _mongocrypt_buffer_t S_Key = {0};
     CHECK_AND_RETURN_KB_STATUS(_mongocrypt_key_broker_decrypted_key_by_id(kb, S_KeyId, &S_Key));
 
     /* Decrypt InnerEncrypted to get K_KeyId. */

--- a/src/mongocrypt-ctx-decrypt.c
+++ b/src/mongocrypt-ctx-decrypt.c
@@ -604,7 +604,7 @@ static bool _check_for_K_KeyId(mongocrypt_ctx_t *ctx) {
     }
 
     bson_t as_bson;
-    bson_iter_t iter;
+    bson_iter_t iter = {0};
     _mongocrypt_ctx_decrypt_t *dctx = (_mongocrypt_ctx_decrypt_t *)ctx;
     if (!_mongocrypt_buffer_to_bson(&dctx->original_doc, &as_bson)) {
         return _mongocrypt_ctx_fail_w_msg(ctx, "error converting original_doc to bson");

--- a/src/mongocrypt-ctx-decrypt.c
+++ b/src/mongocrypt-ctx-decrypt.c
@@ -843,7 +843,7 @@ static bool _kms_done(mongocrypt_ctx_t *ctx) {
 bool mongocrypt_ctx_decrypt_init(mongocrypt_ctx_t *ctx, mongocrypt_binary_t *doc) {
     _mongocrypt_ctx_decrypt_t *dctx;
     bson_t as_bson;
-    bson_iter_t iter;
+    bson_iter_t iter = {0};
     _mongocrypt_ctx_opts_spec_t opts_spec;
 
     memset(&opts_spec, 0, sizeof(opts_spec));

--- a/src/mongocrypt-ctx-decrypt.c
+++ b/src/mongocrypt-ctx-decrypt.c
@@ -537,6 +537,7 @@ static bool _collect_K_KeyID_from_FLE2IndexedEncryptedValue(void *ctx,
     BSON_ASSERT_PARAM(in);
     BSON_ASSERT(in->data);
     bool ret = false;
+    _mongocrypt_buffer_t S_Key = {0};
 
     BSON_ASSERT((in->data[0] == MC_SUBTYPE_FLE2IndexedEqualityEncryptedValue)
                 || (in->data[0] == MC_SUBTYPE_FLE2IndexedRangeEncryptedValue));
@@ -549,7 +550,6 @@ static bool _collect_K_KeyID_from_FLE2IndexedEncryptedValue(void *ctx,
     CHECK_AND_RETURN(S_KeyId);
 
     _mongocrypt_key_broker_t *kb = ctx;
-    _mongocrypt_buffer_t S_Key = {0};
     CHECK_AND_RETURN_KB_STATUS(_mongocrypt_key_broker_decrypted_key_by_id(kb, S_KeyId, &S_Key));
 
     /* Decrypt InnerEncrypted to get K_KeyId. */

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -1780,6 +1780,9 @@ static bool FLE2RangeFindDriverSpec_to_ciphertexts(mongocrypt_ctx_t *ctx, mongoc
     BSON_ASSERT_PARAM(ctx);
     BSON_ASSERT_PARAM(out);
 
+    bson_t with_placholders = BSON_INITIALIZER;
+    bson_t with_ciphertexts = BSON_INITIALIZER;
+
     if (!ctx->opts.rangeopts.set) {
         _mongocrypt_ctx_fail_w_msg(ctx, "Expected RangeOpts to be set for Range Find");
         goto fail;
@@ -1789,8 +1792,6 @@ static bool FLE2RangeFindDriverSpec_to_ciphertexts(mongocrypt_ctx_t *ctx, mongoc
         goto fail;
     }
 
-    bson_t with_placholders = BSON_INITIALIZER;
-    bson_t with_ciphertexts = BSON_INITIALIZER;
     bson_t in_bson;
     if (!_mongocrypt_buffer_to_bson(&ectx->original_cmd, &in_bson)) {
         _mongocrypt_ctx_fail_w_msg(ctx, "unable to convert input to BSON");

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -2620,7 +2620,7 @@ static bool _check_cmd_for_auto_encrypt_bulkWrite(mongocrypt_binary_t *cmd,
     BSON_ASSERT_PARAM(target_coll);
 
     bson_t as_bson;
-    bson_iter_t cmd_iter;
+    bson_iter_t cmd_iter = {0};
 
     if (!_mongocrypt_binary_to_bson(cmd, &as_bson) || !bson_iter_init(&cmd_iter, &as_bson)) {
         CLIENT_ERR("invalid command BSON");

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -1405,7 +1405,7 @@ static moe_result must_omit_encryptionInformation(const char *command_name,
     }
 
     bool has_payload_requiring_encryptionInformation = false;
-    bson_iter_t iter;
+    bson_iter_t iter = {0};
     if (!bson_iter_init(&iter, command)) {
         CLIENT_ERR("unable to iterate command");
         return (moe_result){.ok = false};

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -2016,7 +2016,7 @@ fail:
 
 static bool _finalize(mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out) {
     bson_t as_bson, converted;
-    bson_iter_t iter;
+    bson_iter_t iter = {0};
     _mongocrypt_ctx_encrypt_t *ectx;
     bool res;
 

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -2667,7 +2667,7 @@ static bool _check_cmd_for_auto_encrypt_bulkWrite(mongocrypt_binary_t *cmd,
 static bool
 _check_cmd_for_auto_encrypt(mongocrypt_binary_t *cmd, bool *bypass, char **target_coll, mongocrypt_status_t *status) {
     bson_t as_bson;
-    bson_iter_t iter, target_coll_iter;
+    bson_iter_t iter = {0}, target_coll_iter;
     const char *cmd_name;
     bool eligible = false;
 

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -1690,7 +1690,7 @@ static bool _fle2_finalize(mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out) {
         bson_copy_to(&original_cmd_bson, &converted);
     } else {
         bson_t as_bson;
-        bson_iter_t iter;
+        bson_iter_t iter = {0};
 
         if (!_mongocrypt_buffer_to_bson(&ectx->marked_cmd, &as_bson)) {
             return _mongocrypt_ctx_fail_w_msg(ctx, "malformed bson");

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -874,7 +874,7 @@ static bool _collect_key_from_marking(void *ctx, _mongocrypt_buffer_t *in, mongo
 static bool _mongo_feed_markings(mongocrypt_ctx_t *ctx, mongocrypt_binary_t *in) {
     /* Find keys. */
     bson_t as_bson;
-    bson_iter_t iter;
+    bson_iter_t iter = {0};
     _mongocrypt_ctx_encrypt_t *ectx;
 
     BSON_ASSERT_PARAM(ctx);

--- a/src/mongocrypt-key.c
+++ b/src/mongocrypt-key.c
@@ -127,7 +127,7 @@ bool _mongocrypt_key_alt_name_from_iter(const bson_iter_t *iter_in,
 
 /* Takes ownership of all fields. */
 bool _mongocrypt_key_parse_owned(const bson_t *bson, _mongocrypt_key_doc_t *out, mongocrypt_status_t *status) {
-    bson_iter_t iter;
+    bson_iter_t iter = {0};
     bool has_id = false, has_key_material = false, has_status = false, has_creation_date = false,
          has_update_date = false, has_master_key = false;
 

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -42,7 +42,7 @@
 
 static bool
 _mongocrypt_marking_parse_fle1_placeholder(const bson_t *in, _mongocrypt_marking_t *out, mongocrypt_status_t *status) {
-    bson_iter_t iter;
+    bson_iter_t iter = {0};
     bool has_ki = false, has_ka = false, has_a = false, has_v = false;
 
     BSON_ASSERT_PARAM(in);

--- a/src/mongocrypt-util.c
+++ b/src/mongocrypt-util.c
@@ -81,7 +81,7 @@ current_module_result current_module_path(void) {
 #elif defined(_GNU_SOURCE) || defined(_DARWIN_C_SOURCE) || defined(__FreeBSD__)
     // Darwin/BSD/glibc define extensions for finding dynamic library info from
     // the address of a symbol.
-    Dl_info info;
+    Dl_info info = {0};
     int rc = dladdr((const void *)current_module_path, &info);
     if (rc == 0) {
         // Failed to resolve the symbol

--- a/src/os_posix/os_dll.c
+++ b/src/os_posix/os_dll.c
@@ -104,9 +104,10 @@ bool mcr_dll_path_supported(void) {
 #include <link.h>
 
 mcr_dll_path_result mcr_dll_path(mcr_dll dll) {
-    struct link_map *map;
+    struct link_map *map = NULL;
     int rc = dlinfo(dll._native_handle, RTLD_DI_LINKMAP, &map);
     if (rc == 0) {
+        assert(NULL != map);
         return (mcr_dll_path_result){.path = mstr_copy_cstr(map->l_name)};
     } else {
         return (mcr_dll_path_result){.error_string = mstr_copy_cstr(dlerror())};


### PR DESCRIPTION
This PR addresses some issues identified by Coverity. See individual commits for the CID.

# Background & Motivation
There are many Coverity issues referencing uninitialized access of the `bson_iter_t::value` field:

```c
bson_iter_t iter1;
BSON_ASSERT (bson_iter_init (&iter1, &bson)); // Does not initialize `iter1.value`
bson_iter_t iter2 = iter1; // Assigns uninitialized `value`.
```

I expect this is OK in practice. I do not expect `bson_iter_t::value` is meant to be directly accessed. The `bson_iter_t::value` is initialized and returned in `bson_iter_value`. Regardless, this PR errs towards safety and zero-initializes the `bson_iter_t` where issues were reported.

Once https://github.com/mongodb/mongo-c-driver/pull/1587 is released in libbson, libmongocrypt can upgrade the libbson dependency to avoid this issue in the future.
