### PR TITLE
PYTHON-4373 Add minimum dep for dnspython

### DIFF
--- a/bindings/python/test-requirements.txt
+++ b/bindings/python/test-requirements.txt
@@ -1,4 +1,5 @@
 pymongo[aws]>=4
+dnspython>=2.6.1
 cffi>=1.12.0,<2
 cryptography>=2
 requests_mock>=1.10


### PR DESCRIPTION
We need to wait until we drop support for Python 3.7.