### PR TITLE
fix(NODE-6109): allow building from source on latest Node.js 20.x

### DIFF
--- a/bindings/node/addon/mongocrypt.h
+++ b/bindings/node/addon/mongocrypt.h
@@ -7,6 +7,7 @@
 // as an experimental feature (that has not been changed since then).
 #define NAPI_VERSION 6
 #define NAPI_EXPERIMENTAL
+#define NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT
 
 #include <napi.h>
 


### PR DESCRIPTION
### Description

#### What is changing?

- Add `NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT` to fix issue https://github.com/nodejs/node/issues/52229

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

- To get builds working again on Node.js 20.x

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Add `NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT` to fix building on Node.js 20.x

Node.js v20.12.0 introduced a change that prevented compiling the existing source without defining the above macro.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:eslint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
