### PR TITLE
add dependency of `unzipJava` from `processResources`

### DIFF
--- a/bindings/java/mongocrypt/build.gradle.kts
+++ b/bindings/java/mongocrypt/build.gradle.kts
@@ -181,6 +181,12 @@ tasks.withType<PublishToMavenRepository> {
     sourceSets["main"].resources.srcDirs("resources", jnaResourcesDir)
 }
 
+// The `processResources` task (defined by the `java-library` plug-in) consumes files in the main source set.
+// Add a dependency on `unzipJava`. `unzipJava` adds libmongocrypt libraries to the main source set.
+tasks.processResources {
+    dependsOn(tasks.named("unzipJava"))
+}
+
 /*
  * Publishing
  */


### PR DESCRIPTION
# Summary

This PR is intended to address observed Gradle errors. [Example](https://spruce.mongodb.com/task/libmongocrypt_ubuntu2004_64_test_java_cde5f9a09da4da144d86a14345fb2d49c70db5d0_24_04_19_11_11_53/logs?execution=0):

```
Reason: Task ':processResources' uses this output of task ':unzipJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
Possible solutions:
  1. Declare task ':unzipJava' as an input of ':processResources'.
  2. Declare an explicit dependency on ':unzipJava' from ':processResources' using Task#dependsOn.
  3. Declare an explicit dependency on ':unzipJava' from ':processResources' using Task#mustRunAfter.
For more information, please refer to https://docs.gradle.org/8.6/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
```

This PR applies the first "Possible solution" logged. Here is a patch build with `test-java` tasks passing: https://spruce.mongodb.com/version/6626799d517a270007658bd9

# Background

The `processResources` task appears to be added by the Gradle `java-library` plugin. The `processResources` task (defined by the `java-library` plug-in) consumes files in the main source set. `unzipJava` adds libmongocrypt libraries to the main source set.

I am not sure what triggered the test failure. I can reproduce the error locally on commit 9ce5db1ca353a4b82788724257d460a9ce67a3e9, though the `test-java` tasks [passed](https://spruce.mongodb.com/version/libmongocrypt_9ce5db1ca353a4b82788724257d460a9ce67a3e9/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&taskName=test-java) on the same commit in Evergreen.
