### PR TITLE
CSHARP-4944: Enable use of native crypto in libmongocrypt bindings

### DIFF
--- a/bindings/cs/MongoDB.Libmongocrypt/CryptClientFactory.cs
+++ b/bindings/cs/MongoDB.Libmongocrypt/CryptClientFactory.cs
@@ -35,7 +35,7 @@ namespace MongoDB.Libmongocrypt
         private static Library.Delegates.CryptoHmacCallback __signRsaesPkcs1HmacCallback = new Library.Delegates.CryptoHmacCallback(SigningRSAESPKCSCallback.RsaSign);
 
         // mongocrypt_is_crypto_available is only available in libmongocrypt version >= 1.9
-        private static readonly Version __s_libVersionWithMongocryptIsCryptoAvailable = Version.Parse("1.9");
+        private static readonly Version __mongocryptIsCryptoAvailableMinVersion = Version.Parse("1.9");
 
         /// <summary>Creates a CryptClient with the specified options.</summary>
         /// <param name="options">The options.</param>
@@ -45,7 +45,7 @@ namespace MongoDB.Libmongocrypt
             MongoCryptSafeHandle handle = null;
             Status status = null;
 
-            var cryptoAvailable = Version.Parse(Library.Version) >= __s_libVersionWithMongocryptIsCryptoAvailable && Library.mongocrypt_is_crypto_available();
+            var cryptoAvailable = Version.Parse(Library.Version) >= __mongocryptIsCryptoAvailableMinVersion && Library.mongocrypt_is_crypto_available();
 
             try
             {

--- a/bindings/cs/MongoDB.Libmongocrypt/CryptClientFactory.cs
+++ b/bindings/cs/MongoDB.Libmongocrypt/CryptClientFactory.cs
@@ -42,14 +42,23 @@ namespace MongoDB.Libmongocrypt
             MongoCryptSafeHandle handle = null;
             Status status = null;
 
+            bool cryptoAvailable;
+            try
+            {
+                cryptoAvailable = Library.mongocrypt_is_crypto_available();
+            }
+            catch (LibraryLoader.FunctionNotFoundException)
+            {
+                // mongocrypt_is_crypto_available is only available in libmongocrypt version >= 1.9
+                cryptoAvailable = false;
+            }
+
             try
             {
                 handle = Library.mongocrypt_new();
                 status = new Status();
-
-                // The below code can be avoided on Windows. So, we don't call it on this system 
-                // to avoid restrictions on target frameworks that present in some of below
-                if (OperatingSystemHelper.CurrentOperatingSystem != OperatingSystemPlatform.Windows)
+                
+                if (!cryptoAvailable)
                 {
                     handle.Check(
                         status,

--- a/bindings/cs/MongoDB.Libmongocrypt/CryptClientFactory.cs
+++ b/bindings/cs/MongoDB.Libmongocrypt/CryptClientFactory.cs
@@ -42,16 +42,8 @@ namespace MongoDB.Libmongocrypt
             MongoCryptSafeHandle handle = null;
             Status status = null;
 
-            bool cryptoAvailable;
-            try
-            {
-                cryptoAvailable = Library.mongocrypt_is_crypto_available();
-            }
-            catch (LibraryLoader.FunctionNotFoundException)
-            {
-                // mongocrypt_is_crypto_available is only available in libmongocrypt version >= 1.9
-                cryptoAvailable = false;
-            }
+            // mongocrypt_is_crypto_available is only available in libmongocrypt version >= 1.9
+            var cryptoAvailable = Version.Parse(Library.Version) >= Version.Parse("1.9") && Library.mongocrypt_is_crypto_available();
 
             try
             {

--- a/bindings/cs/MongoDB.Libmongocrypt/CryptClientFactory.cs
+++ b/bindings/cs/MongoDB.Libmongocrypt/CryptClientFactory.cs
@@ -34,6 +34,9 @@ namespace MongoDB.Libmongocrypt
         private static Library.Delegates.RandomCallback __randomCallback = new Library.Delegates.RandomCallback(SecureRandomCallback.GenerateRandom);
         private static Library.Delegates.CryptoHmacCallback __signRsaesPkcs1HmacCallback = new Library.Delegates.CryptoHmacCallback(SigningRSAESPKCSCallback.RsaSign);
 
+        // mongocrypt_is_crypto_available is only available in libmongocrypt version >= 1.9
+        private static readonly Version __s_libVersionWithMongocryptIsCryptoAvailable = Version.Parse("1.9");
+
         /// <summary>Creates a CryptClient with the specified options.</summary>
         /// <param name="options">The options.</param>
         /// <returns>A CryptClient</returns>
@@ -42,8 +45,7 @@ namespace MongoDB.Libmongocrypt
             MongoCryptSafeHandle handle = null;
             Status status = null;
 
-            // mongocrypt_is_crypto_available is only available in libmongocrypt version >= 1.9
-            var cryptoAvailable = Version.Parse(Library.Version) >= Version.Parse("1.9") && Library.mongocrypt_is_crypto_available();
+            var cryptoAvailable = Version.Parse(Library.Version) >= __s_libVersionWithMongocryptIsCryptoAvailable && Library.mongocrypt_is_crypto_available();
 
             try
             {

--- a/bindings/cs/MongoDB.Libmongocrypt/CryptClientFactory.cs
+++ b/bindings/cs/MongoDB.Libmongocrypt/CryptClientFactory.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Linq;
 
 namespace MongoDB.Libmongocrypt
 {
@@ -45,7 +46,7 @@ namespace MongoDB.Libmongocrypt
             MongoCryptSafeHandle handle = null;
             Status status = null;
 
-            var cryptoAvailable = Version.Parse(Library.Version) >= __mongocryptIsCryptoAvailableMinVersion && Library.mongocrypt_is_crypto_available();
+            var cryptoAvailable = Version.Parse(Library.Version.Split('-', '+').First()) >= __mongocryptIsCryptoAvailableMinVersion && Library.mongocrypt_is_crypto_available();
 
             try
             {

--- a/bindings/cs/MongoDB.Libmongocrypt/Library.cs
+++ b/bindings/cs/MongoDB.Libmongocrypt/Library.cs
@@ -48,6 +48,9 @@ namespace MongoDB.Libmongocrypt
             _mongocrypt_ctx_setopt_key_encryption_key = new Lazy<Delegates.mongocrypt_ctx_setopt_key_encryption_key>(
                 () => __loader.Value.GetFunction<Delegates.mongocrypt_ctx_setopt_key_encryption_key>(
                     ("mongocrypt_ctx_setopt_key_encryption_key")), true);
+            
+            _mongocrypt_is_crypto_available = new Lazy<Delegates.mongocrypt_is_crypto_available>(
+                () => __loader.Value.GetFunction<Delegates.mongocrypt_is_crypto_available>("mongocrypt_is_crypto_available"), true);
 
             _mongocrypt_setopt_aes_256_ecb = new Lazy<Delegates.mongocrypt_setopt_aes_256_ecb>(
                 () => __loader.Value.GetFunction<Delegates.mongocrypt_setopt_aes_256_ecb>(
@@ -229,6 +232,8 @@ namespace MongoDB.Libmongocrypt
         internal static Delegates.mongocrypt_setopt_log_handler mongocrypt_setopt_log_handler => _mongocrypt_setopt_log_handler.Value;
         internal static Delegates.mongocrypt_setopt_kms_providers mongocrypt_setopt_kms_providers => _mongocrypt_setopt_kms_providers.Value;
         internal static Delegates.mongocrypt_ctx_setopt_key_encryption_key mongocrypt_ctx_setopt_key_encryption_key => _mongocrypt_ctx_setopt_key_encryption_key.Value;
+        
+        internal static Delegates.mongocrypt_is_crypto_available mongocrypt_is_crypto_available => _mongocrypt_is_crypto_available.Value;
 
         internal static Delegates.mongocrypt_setopt_aes_256_ecb mongocrypt_setopt_aes_256_ecb => _mongocrypt_setopt_aes_256_ecb.Value;
         internal static Delegates.mongocrypt_setopt_bypass_query_analysis mongocrypt_setopt_bypass_query_analysis => _mongocrypt_setopt_bypass_query_analysis.Value;
@@ -306,6 +311,8 @@ namespace MongoDB.Libmongocrypt
 
         private static readonly Lazy<Delegates.mongocrypt_setopt_kms_providers> _mongocrypt_setopt_kms_providers;
         private static readonly Lazy<Delegates.mongocrypt_ctx_setopt_key_encryption_key> _mongocrypt_ctx_setopt_key_encryption_key;
+        
+        private static readonly Lazy<Delegates.mongocrypt_is_crypto_available> _mongocrypt_is_crypto_available;
 
         private static readonly Lazy<Delegates.mongocrypt_setopt_aes_256_ecb> _mongocrypt_setopt_aes_256_ecb;
         private static readonly Lazy<Delegates.mongocrypt_setopt_bypass_query_analysis> _mongocrypt_setopt_bypass_query_analysis;
@@ -398,6 +405,9 @@ namespace MongoDB.Libmongocrypt
             public delegate IntPtr mongocrypt_version(out uint length);
 
             public delegate MongoCryptSafeHandle mongocrypt_new();
+
+            [return: MarshalAs(UnmanagedType.I1)]
+            public delegate bool mongocrypt_is_crypto_available();
 
             public delegate void LogCallback([MarshalAs(UnmanagedType.I4)] LogLevel level, IntPtr messasge,
                 uint message_length, IntPtr context);

--- a/bindings/cs/MongoDB.Libmongocrypt/LibraryLoader.cs
+++ b/bindings/cs/MongoDB.Libmongocrypt/LibraryLoader.cs
@@ -28,7 +28,7 @@ namespace MongoDB.Libmongocrypt
     internal class LibraryLoader
     {
         private ISharedLibraryLoader _loader;
-        private static readonly string __s_libmongocryptLibPath = Environment.GetEnvironmentVariable("LIBMONGOCRYPT_PATH");
+        private static readonly string __libmongocryptLibPath = Environment.GetEnvironmentVariable("LIBMONGOCRYPT_PATH");
 
         public LibraryLoader()
         {
@@ -124,7 +124,7 @@ namespace MongoDB.Libmongocrypt
             public const int RTLD_GLOBAL = 0x8;
             public const int RTLD_NOW = 0x2;
 
-            private static readonly string[] __s_suffixPaths = 
+            private static readonly string[] __suffixPaths = 
             {
                 "../../runtimes/osx/native/",
                 "runtimes/osx/native/",
@@ -134,7 +134,7 @@ namespace MongoDB.Libmongocrypt
             private readonly IntPtr _handle;
             public DarwinLibraryLoader(List<string> candidatePaths)
             {
-                var path = __s_libmongocryptLibPath ?? FindLibrary(candidatePaths, __s_suffixPaths, "libmongocrypt.dylib");
+                var path = __libmongocryptLibPath ?? FindLibrary(candidatePaths, __suffixPaths, "libmongocrypt.dylib");
                 _handle = dlopen(path, RTLD_GLOBAL | RTLD_NOW);
                 if (_handle == IntPtr.Zero)
                 {
@@ -169,7 +169,7 @@ namespace MongoDB.Libmongocrypt
             public const int RTLD_GLOBAL = 0x100;
             public const int RTLD_NOW = 0x2;
             
-            private static readonly string[] __s_suffixPaths = 
+            private static readonly string[] __suffixPaths = 
             {
                 "../../runtimes/linux/native/",
                 "runtimes/linux/native/",
@@ -179,7 +179,7 @@ namespace MongoDB.Libmongocrypt
             private readonly IntPtr _handle;
             public LinuxLibrary(List<string> candidatePaths)
             {
-                var path = __s_libmongocryptLibPath ?? FindLibrary(candidatePaths, __s_suffixPaths, "libmongocrypt.so");
+                var path = __libmongocryptLibPath ?? FindLibrary(candidatePaths, __suffixPaths, "libmongocrypt.so");
                 _handle = dlopen(path, RTLD_GLOBAL | RTLD_NOW);
                 if (_handle == IntPtr.Zero)
                 {
@@ -206,7 +206,7 @@ namespace MongoDB.Libmongocrypt
         /// </summary>
         private class WindowsLibrary : ISharedLibraryLoader
         {
-            private static readonly string[] __s_suffixPaths = 
+            private static readonly string[] __suffixPaths = 
             {
                 @"..\..\runtimes\win\native\",
                 @".\runtimes\win\native\",
@@ -216,7 +216,7 @@ namespace MongoDB.Libmongocrypt
             private readonly IntPtr _handle;
             public WindowsLibrary(List<string> candidatePaths)
             {
-                var path = __s_libmongocryptLibPath ?? FindLibrary(candidatePaths, __s_suffixPaths, "mongocrypt.dll");
+                var path = __libmongocryptLibPath ?? FindLibrary(candidatePaths, __suffixPaths, "mongocrypt.dll");
                 _handle = LoadLibrary(path);
                 if (_handle == IntPtr.Zero)
                 {

--- a/bindings/cs/MongoDB.Libmongocrypt/LibraryLoader.cs
+++ b/bindings/cs/MongoDB.Libmongocrypt/LibraryLoader.cs
@@ -124,7 +124,7 @@ namespace MongoDB.Libmongocrypt
             public const int RTLD_GLOBAL = 0x8;
             public const int RTLD_NOW = 0x2;
 
-            private static readonly string[] _suffixPaths = 
+            private static readonly string[] _s_suffixPaths = 
             {
                 "../../runtimes/osx/native/",
                 "runtimes/osx/native/",
@@ -134,7 +134,7 @@ namespace MongoDB.Libmongocrypt
             private readonly IntPtr _handle;
             public DarwinLibraryLoader(List<string> candidatePaths)
             {
-                var path = _libmongocryptLibPath ?? FindLibrary(candidatePaths, _suffixPaths, "libmongocrypt.dylib");
+                var path = _libmongocryptLibPath ?? FindLibrary(candidatePaths, _s_suffixPaths, "libmongocrypt.dylib");
                 _handle = dlopen(path, RTLD_GLOBAL | RTLD_NOW);
                 if (_handle == IntPtr.Zero)
                 {
@@ -169,7 +169,7 @@ namespace MongoDB.Libmongocrypt
             public const int RTLD_GLOBAL = 0x100;
             public const int RTLD_NOW = 0x2;
             
-            private static readonly string[] _suffixPaths = 
+            private static readonly string[] _s_suffixPaths = 
             {
                 "../../runtimes/linux/native/",
                 "runtimes/linux/native/",
@@ -179,7 +179,7 @@ namespace MongoDB.Libmongocrypt
             private readonly IntPtr _handle;
             public LinuxLibrary(List<string> candidatePaths)
             {
-                var path = _libmongocryptLibPath ?? FindLibrary(candidatePaths, _suffixPaths, "libmongocrypt.so");
+                var path = _libmongocryptLibPath ?? FindLibrary(candidatePaths, _s_suffixPaths, "libmongocrypt.so");
                 _handle = dlopen(path, RTLD_GLOBAL | RTLD_NOW);
                 if (_handle == IntPtr.Zero)
                 {
@@ -206,7 +206,7 @@ namespace MongoDB.Libmongocrypt
         /// </summary>
         private class WindowsLibrary : ISharedLibraryLoader
         {
-            private static readonly string[] _suffixPaths = 
+            private static readonly string[] _s_suffixPaths = 
             {
                 @"..\..\runtimes\win\native\",
                 @".\runtimes\win\native\",
@@ -216,7 +216,7 @@ namespace MongoDB.Libmongocrypt
             private readonly IntPtr _handle;
             public WindowsLibrary(List<string> candidatePaths)
             {
-                var path = _libmongocryptLibPath ?? FindLibrary(candidatePaths, _suffixPaths, "mongocrypt.dll");
+                var path = _libmongocryptLibPath ?? FindLibrary(candidatePaths, _s_suffixPaths, "mongocrypt.dll");
                 _handle = LoadLibrary(path);
                 if (_handle == IntPtr.Zero)
                 {

--- a/bindings/cs/MongoDB.Libmongocrypt/LibraryLoader.cs
+++ b/bindings/cs/MongoDB.Libmongocrypt/LibraryLoader.cs
@@ -28,7 +28,7 @@ namespace MongoDB.Libmongocrypt
     internal class LibraryLoader
     {
         private ISharedLibraryLoader _loader;
-        private static readonly string _libmongocryptLibPath = Environment.GetEnvironmentVariable("LIBMONGOCRYPT_PATH");
+        private static readonly string __s_libmongocryptLibPath = Environment.GetEnvironmentVariable("LIBMONGOCRYPT_PATH");
 
         public LibraryLoader()
         {
@@ -124,7 +124,7 @@ namespace MongoDB.Libmongocrypt
             public const int RTLD_GLOBAL = 0x8;
             public const int RTLD_NOW = 0x2;
 
-            private static readonly string[] _s_suffixPaths = 
+            private static readonly string[] __s_suffixPaths = 
             {
                 "../../runtimes/osx/native/",
                 "runtimes/osx/native/",
@@ -134,7 +134,7 @@ namespace MongoDB.Libmongocrypt
             private readonly IntPtr _handle;
             public DarwinLibraryLoader(List<string> candidatePaths)
             {
-                var path = _libmongocryptLibPath ?? FindLibrary(candidatePaths, _s_suffixPaths, "libmongocrypt.dylib");
+                var path = __s_libmongocryptLibPath ?? FindLibrary(candidatePaths, __s_suffixPaths, "libmongocrypt.dylib");
                 _handle = dlopen(path, RTLD_GLOBAL | RTLD_NOW);
                 if (_handle == IntPtr.Zero)
                 {
@@ -169,7 +169,7 @@ namespace MongoDB.Libmongocrypt
             public const int RTLD_GLOBAL = 0x100;
             public const int RTLD_NOW = 0x2;
             
-            private static readonly string[] _s_suffixPaths = 
+            private static readonly string[] __s_suffixPaths = 
             {
                 "../../runtimes/linux/native/",
                 "runtimes/linux/native/",
@@ -179,7 +179,7 @@ namespace MongoDB.Libmongocrypt
             private readonly IntPtr _handle;
             public LinuxLibrary(List<string> candidatePaths)
             {
-                var path = _libmongocryptLibPath ?? FindLibrary(candidatePaths, _s_suffixPaths, "libmongocrypt.so");
+                var path = __s_libmongocryptLibPath ?? FindLibrary(candidatePaths, __s_suffixPaths, "libmongocrypt.so");
                 _handle = dlopen(path, RTLD_GLOBAL | RTLD_NOW);
                 if (_handle == IntPtr.Zero)
                 {
@@ -206,7 +206,7 @@ namespace MongoDB.Libmongocrypt
         /// </summary>
         private class WindowsLibrary : ISharedLibraryLoader
         {
-            private static readonly string[] _s_suffixPaths = 
+            private static readonly string[] __s_suffixPaths = 
             {
                 @"..\..\runtimes\win\native\",
                 @".\runtimes\win\native\",
@@ -216,7 +216,7 @@ namespace MongoDB.Libmongocrypt
             private readonly IntPtr _handle;
             public WindowsLibrary(List<string> candidatePaths)
             {
-                var path = _libmongocryptLibPath ?? FindLibrary(candidatePaths, _s_suffixPaths, "mongocrypt.dll");
+                var path = __s_libmongocryptLibPath ?? FindLibrary(candidatePaths, __s_suffixPaths, "mongocrypt.dll");
                 _handle = LoadLibrary(path);
                 if (_handle == IntPtr.Zero)
                 {

--- a/bindings/cs/README.md
+++ b/bindings/cs/README.md
@@ -55,7 +55,7 @@ If you see `Windows Error: 126` during tests, like the example below, it means t
 3. dotnet build cs.build
 ```
 *Note*: You can use the ```LIBMONGOCRYPT_PATH``` environment variable to load a locally installed
-libmongocrypt build. You should specify the absolute path to the libmongocrypt library itself, not just the containing folder.  For example on Linux:
+libmongocrypt build. You should specify the absolute path to the libmongocrypt library itself, not just the containing folder. For example on Linux:
 ```$ export LIBMONGOCRYPT_PATH='/path/to/libmongocrypt.so'```.
 
 # Testing

--- a/bindings/cs/README.md
+++ b/bindings/cs/README.md
@@ -55,8 +55,8 @@ If you see `Windows Error: 126` during tests, like the example below, it means t
 3. dotnet build cs.build
 ```
 *Note*: You can use the ```LIBMONGOCRYPT_PATH``` environment variable to load a locally installed
-libmongocrypt build. For example:
-```$ export LIBMONGOCRYPT_PATH='/path/to/libmongocrypt'```.
+libmongocrypt build. You should specify the absolute path to the libmongocrypt build itself not just the containing folder.  For example on Linux:
+```$ export LIBMONGOCRYPT_PATH='/path/to/libmongocrypt.so'```.
 
 # Testing
 Do not modify xunit.runner.json

--- a/bindings/cs/README.md
+++ b/bindings/cs/README.md
@@ -55,7 +55,7 @@ If you see `Windows Error: 126` during tests, like the example below, it means t
 3. dotnet build cs.build
 ```
 *Note*: You can use the ```LIBMONGOCRYPT_PATH``` environment variable to load a locally installed
-libmongocrypt build. You should specify the absolute path to the libmongocrypt build itself not just the containing folder.  For example on Linux:
+libmongocrypt build. You should specify the absolute path to the libmongocrypt library itself, not just the containing folder.  For example on Linux:
 ```$ export LIBMONGOCRYPT_PATH='/path/to/libmongocrypt.so'```.
 
 # Testing

--- a/bindings/cs/README.md
+++ b/bindings/cs/README.md
@@ -54,6 +54,9 @@ If you see `Windows Error: 126` during tests, like the example below, it means t
 2. cd <build>/bindings/cs
 3. dotnet build cs.build
 ```
+*Note*: You can use the ```LIBMONGOCRYPT_PATH``` environment variable to load a locally installed
+libmongocrypt build. For example:
+```$ export LIBMONGOCRYPT_PATH='/path/to/libmongocrypt'```.
 
 # Testing
 Do not modify xunit.runner.json

--- a/bindings/cs/Scripts/build.cake
+++ b/bindings/cs/Scripts/build.cake
@@ -72,7 +72,7 @@ Task("Prepare")
             libmongocryptAllDirectory.Combine("ubuntu1804-64").Combine("nocrypto").Combine("lib").CombineWithFilePath("libmongocrypt.so"),
             downloadedMongocryptDirectory.CombineWithFilePath("libmongocrypt.so"));
         CopyFile(
-            libmongocryptAllDirectory.Combine("macos").Combine("nocrypto").Combine("lib").CombineWithFilePath("libmongocrypt.dylib"),
+            libmongocryptAllDirectory.Combine("macos").Combine("lib").CombineWithFilePath("libmongocrypt.dylib"),
             downloadedMongocryptDirectory.CombineWithFilePath("libmongocrypt.dylib"));
         CopyDirectory(downloadedMongocryptDirectory, libmongocryptRelWithDebInfoDirectory);
     });


### PR DESCRIPTION
### Description
Use libmongocrypt native crypto when available.

### What's changing

- Bundle crypto-enabled libmongocrypt on Mac.
- On linux continue to bundle crypto-disabled libmongocrypt, but inform users to install the crypto-enabled libmongocrypt on their system and use the new environment variable `LIBMONGOCRYPT_PATH` to make it available to the driver. If `LIBMONGOCRYPT_PATH` is not set then we default to using the packaged crypto-disabled libmongocrypt.

### Performance Results

#### Using crypto-disabled libmongocrypt:
| Method                     | ThreadsCount | Mean        | Error     | StdDev    | Median      |
|--------------------------- |------------- |------------:|----------:|----------:|------------:|
| BulkDecryptionUsingBinding | 1            |    50.83 ms |  0.975 ms |  2.279 ms |    49.70 ms |
| BulkDecryptionUsingBinding | 2            |    71.34 ms |  1.422 ms |  3.090 ms |    71.32 ms |
| BulkDecryptionUsingBinding | 8            |   766.59 ms | 23.535 ms | 69.393 ms |   776.18 ms |
| BulkDecryptionUsingBinding | 64           | 5,575.51 ms | 91.840 ms | 85.907 ms | 5,581.51 ms |


#### Using crypto-enabled libmongocrypt:
| Method                     | ThreadsCount | Mean      | Error    | StdDev   |
|--------------------------- |------------- |----------:|---------:|---------:|
| BulkDecryptionUsingBinding | 1            |  22.03 ms | 0.103 ms | 0.096 ms |
| BulkDecryptionUsingBinding | 2            |  22.89 ms | 0.117 ms | 0.104 ms |
| BulkDecryptionUsingBinding | 8            |  30.69 ms | 0.564 ms | 0.554 ms |
| BulkDecryptionUsingBinding | 64           | 201.37 ms | 1.997 ms | 1.559 ms |
