### PR TITLE
MONGOCRYPT-625 Fix additional coverity warnings

### DIFF
--- a/src/mongocrypt-ctx-decrypt.c
+++ b/src/mongocrypt-ctx-decrypt.c
@@ -406,7 +406,7 @@ static bool _replace_ciphertext_with_plaintext(void *ctx,
 
 static bool _finalize(mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out) {
     bson_t as_bson, final_bson;
-    bson_iter_t iter;
+    bson_iter_t iter = {0};
     _mongocrypt_ctx_decrypt_t *dctx;
     bool res;
 

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -2231,6 +2231,7 @@ static bool _try_schema_from_cache(mongocrypt_ctx_t *ctx) {
 
     if (collinfo) {
         if (!_set_schema_from_collinfo(ctx, collinfo)) {
+            bson_destroy(collinfo);
             return _mongocrypt_ctx_fail(ctx);
         }
         ctx->state = MONGOCRYPT_CTX_NEED_MONGO_MARKINGS;


### PR DESCRIPTION
This is a follow-up to https://github.com/mongodb/libmongocrypt/pull/782 to address additional issues reported in Coverity.