### PR TITLE
MONGOCRYPT-676 add release step to generate SSDLC static analysis report

### DIFF
--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -7,6 +7,7 @@ Version numbers of libmongocrypt must follow the format 1.[0-9].[0-9] for releas
 
 ## Steps to release ##
 Do the following when releasing:
+- If this is a feature release (e.g. `x.y.0` or `x.0.0`), follow these steps: [Creating SSDLC static analysis reports](https://docs.google.com/document/d/1rkFL8ymbkc0k8Apky9w5pTPbvKRm68wj17mPJt2_0yo/edit).
 - Update CHANGELOG.md with the version being released.
 - Check out the release branch. For a release `x.y.z`, the release branch is `rx.y`. If this is a new minor release (`x.y.0`), create the release branch.
 - If this is a new minor release (e.g. `x.y.0`):


### PR DESCRIPTION
This is intended to satisfy the static analysis reporting requirement of SSDLC. Rather than finding a tool that exports SARIF, this chooses the alternative:

> If SARIF output is not supported, teams MUST manually report JIRA tickets and create static analysis reports

An `SSDLC Report` view has been added to Coverity to reduce needed manual effort. The resulting spreadsheet appears consistent with how the server reports Coverity issues.

I expect this process can also be used by C and C++ too if desired.