### PR TITLE
MONGOCRYPT-682 add step to record release

### DIFF
--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -27,6 +27,7 @@ Do the following when releasing:
 - If this is a new minor release (e.g. `x.y.0`), file a DOCSP ticket to update the installation instructions on [Install libmongocrypt](https://www.mongodb.com/docs/manual/core/csfle/reference/libmongocrypt/). ([Example](https://jira.mongodb.org/browse/DOCSP-36863))
 - Make a PR to apply the "Update CHANGELOG.md for x.y.z" commit to the `master` branch.
 - Update the release on the [Jira releases page](https://jira.mongodb.org/projects/MONGOCRYPT/versions).
+- Record the release on [C/C++ Release Info](https://docs.google.com/spreadsheets/d/1yHfGmDnbA5-Qt8FX4tKWC5xk9AhzYZx1SKF4AD36ecY/edit?usp=sharing). This is done to meet SSDLC reporting requirements.
 
 ## Homebrew steps ##
 Submit a PR to update the Homebrew package https://github.com/mongodb/homebrew-brew/blob/master/Formula/libmongocrypt.rb. ([Example](https://github.com/mongodb/homebrew-brew/pull/208)). If not on macOS, request a team member to do this step.


### PR DESCRIPTION
This PR intends to meet the requirement:

> Projects that are also published on distribution channels MUST comply with the corresponding SSDLC policy.

libmongocrypt is published to the MongoDB PPA. I expect that is considered a distribution channel. [Authorized publication on distribution channels (Change Log 1.1)](https://docs.google.com/document/d/1u0m4Kj2Ny30zU74KoEFCN4L6D_FbEYCaJ3CQdCYXTMc/edit#bookmark=id.5ed6jwn4f29f) describes the requirement for recording the release author and version.

This PR proposes adding a step to record this information to a spreadsheet. Updating the same spreadsheet is already part of the C driver release. I expect this can be done for the C++ driver too if desired.