### PR TITLE
MONGOCRYPT-672 Add SBOM Lite

### DIFF
--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -1,6 +1,7 @@
 include (FetchContent)
 
 # Set the tag that we will fetch.
+# When updating the version of libbson, also update the version in etc/purls.txt
 set (MONGOC_FETCH_TAG_FOR_LIBBSON "1.17.7" CACHE STRING "The Git tag of mongo-c-driver that will be fetched to obtain libbson")
 
 # Fetch the source archive for the requested tag from GitHub

--- a/cmake/IntelDFP.cmake
+++ b/cmake/IntelDFP.cmake
@@ -3,6 +3,7 @@ include (FetchContent)
 find_program (GIT_EXECUTABLE git)
 find_program (PATCH_EXECUTABLE patch)
 
+# When updating the version of IntelDFP, also update the version in etc/purls.txt
 set (_default_url "${PROJECT_SOURCE_DIR}/third-party/IntelRDFPMathLib20U2.tar.xz")
 
 set (INTEL_DFP_LIBRARY_URL "${_default_url}"

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -7,6 +7,7 @@ Version numbers of libmongocrypt must follow the format 1.[0-9].[0-9] for releas
 
 ## Steps to release ##
 Do the following when releasing:
+- Ensure `etc/purls.txt` is up-to-date. 
 - If this is a feature release (e.g. `x.y.0` or `x.0.0`), follow these steps: [Creating SSDLC static analysis reports](https://docs.google.com/document/d/1rkFL8ymbkc0k8Apky9w5pTPbvKRm68wj17mPJt2_0yo/edit).
 - Update CHANGELOG.md with the version being released.
 - Check out the release branch. For a release `x.y.z`, the release branch is `rx.y`. If this is a new minor release (`x.y.0`), create the release branch.

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -2,6 +2,7 @@
   "components": [
     {
       "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.17.0#src/libbson",
+      "copyright": "Copyright 2024-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
@@ -13,6 +14,13 @@
         }
       ],
       "group": "mongodb",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
       "name": "mongo-c-driver",
       "purl": "pkg:github/mongodb/mongo-c-driver@v1.17.0#src/libbson",
       "type": "library",
@@ -20,10 +28,18 @@
     },
     {
       "bom-ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz",
+      "copyright": "Copyright (c) 2018, Intel Corp.",
       "externalReferences": [
         {
           "type": "distribution",
           "url": "https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
         }
       ],
       "name": "IntelRDFPMathLib",
@@ -41,7 +57,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2024-05-08T18:29:20.968894+00:00",
+    "timestamp": "2024-05-09T14:53:50.877648+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -2,7 +2,7 @@
   "components": [
     {
       "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.17.0#src/libbson",
-      "copyright": "Copyright 2020-present MongoDB, Inc.",
+      "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -1,0 +1,92 @@
+{
+  "components": [
+    {
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.17.0#src/libbson",
+      "externalReferences": [
+        {
+          "type": "distribution",
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/v1.17.0.tar.gz"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/v1.17.0"
+        }
+      ],
+      "group": "mongodb",
+      "name": "mongo-c-driver",
+      "purl": "pkg:github/mongodb/mongo-c-driver@v1.17.0#src/libbson",
+      "type": "library",
+      "version": "v1.17.0"
+    },
+    {
+      "bom-ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz",
+      "externalReferences": [
+        {
+          "type": "distribution",
+          "url": "https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz"
+        }
+      ],
+      "name": "IntelRDFPMathLib",
+      "purl": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz",
+      "type": "library",
+      "version": "20U2"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz"
+    },
+    {
+      "ref": "pkg:github/mongodb/mongo-c-driver@v1.17.0#src/libbson"
+    }
+  ],
+  "metadata": {
+    "timestamp": "2024-05-08T18:29:20.968894+00:00",
+    "tools": [
+      {
+        "externalReferences": [
+          {
+            "type": "build-system",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/actions"
+          },
+          {
+            "type": "distribution",
+            "url": "https://pypi.org/project/cyclonedx-python-lib/"
+          },
+          {
+            "type": "documentation",
+            "url": "https://cyclonedx-python-library.readthedocs.io/"
+          },
+          {
+            "type": "issue-tracker",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/issues"
+          },
+          {
+            "type": "license",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/LICENSE"
+          },
+          {
+            "type": "release-notes",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CHANGELOG.md"
+          },
+          {
+            "type": "vcs",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib"
+          },
+          {
+            "type": "website",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/#readme"
+          }
+        ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "6.4.4"
+      }
+    ]
+  },
+  "serialNumber": "urn:uuid:879e1b41-08d8-4505-8c89-2285bc3e442c",
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -2,7 +2,7 @@
   "components": [
     {
       "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.17.0#src/libbson",
-      "copyright": "Copyright 2024-present MongoDB, Inc.",
+      "copyright": "Copyright 2020-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",

--- a/etc/purls.txt
+++ b/etc/purls.txt
@@ -5,8 +5,8 @@
 # instead of modifying the SBOM JSON directly. After modifying this file, be sure to
 # re-generate the SBOM JSON file with: `./.evergreen/earthly.sh +sbom-generate`
 
-# libbson is downloaded `cmake/FetchMongoC.cmake`.
+# libbson is obtained via `cmake/FetchMongoC.cmake`.
 pkg:github/mongodb/mongo-c-driver@v1.17.0?#src/libbson
 
-# IntelDFP is included in `etc/IntelRDFPMathLib20U2.tar.gz.`
+# IntelDFP is obtained via `cmake/IntelDFP.cmake`
 pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz

--- a/etc/purls.txt
+++ b/etc/purls.txt
@@ -3,7 +3,9 @@
 
 # This file is fed to silkbomb to generate the cyclonedx.sbom.json file. Edit this file
 # instead of modifying the SBOM JSON directly. After modifying this file, be sure to
-# re-generate the SBOM JSON file with: `./.evergreen/earthly.sh +sbom-generate`
+# re-generate the SBOM JSON file with: `./.evergreen/earthly.sh +sbom-generate`. If
+# adding a new dependency, ensure the resulting SBOM JSON includes the `licenses` and
+# `copyright` property. This information can be manually added.
 
 # libbson is obtained via `cmake/FetchMongoC.cmake`.
 pkg:github/mongodb/mongo-c-driver@v1.17.0?#src/libbson

--- a/etc/purls.txt
+++ b/etc/purls.txt
@@ -1,0 +1,12 @@
+# These package URLs (purls) point to the versions (tags) of external dependencies
+# that are committed to the project. Refer: https://github.com/package-url/purl-spec
+
+# This file is fed to silkbomb to generate the cyclonedx.sbom.json file. Edit this file
+# instead of modifying the SBOM JSON directly. After modifying this file, be sure to
+# re-generate the SBOM JSON file with: `./.evergreen/earthly.sh +sbom-generate`
+
+# libbson is downloaded `cmake/FetchMongoC.cmake`.
+pkg:github/mongodb/mongo-c-driver@v1.17.0?#src/libbson
+
+# IntelDFP is included in `etc/IntelRDFPMathLib20U2.tar.gz.`
+pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz


### PR DESCRIPTION
# Summary

Add an SBOM Lite to describe bundled dependencies. Partially resolves MONGOCRYPT-672.

# Background & Motivation

The `sbom-generate` Earthly target was copied from https://github.com/mongodb/mongo-c-driver/pull/1594

Though `libbson` is not third-party, I expect including `libbson` is required. I [suggested clarifying](https://docs.google.com/document/d/1mXxDdY38nGVKWJhIbH83X6mcHsxllAiunH2hg-NdDsY/edit?disco=AAABM36ReZg) in the scope goals with rationale.

Dependencies for libmongocrypt language bindings are not included. I expect language bindings will define their own SBOM Lite files referring to the libmongocrypt C library, as is [done for Node](https://github.com/mongodb/libmongocrypt/blob/6bd195e8e6cd027a71925a7c83413d53d9521365/bindings/node/sbom.json).
