### PR TITLE
MONGOCRYPT-416 build on Alpine Linux 3.18 (via Earthly)

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -411,6 +411,17 @@ tasks:
   - func: "create packages and repos"
   - func: "upload packages and repos"
 
+- name: build-with-earthly
+  commands:
+  - func: "fetch source"
+  - func: "earthly"
+    vars:
+      args: +build --env=${earthly_env}
+  - func: "earthly"
+    vars:
+      args: --artifact +build/libmongocrypt-install ${workdir}/install
+  - func: "tar and upload libmongocrypt libraries"
+
 - name: build-deb-packages-with-earthly
   commands:
   - func: "fetch source"
@@ -1602,6 +1613,22 @@ buildvariants:
   tasks:
   - benchmark-java
   - benchmark-python
+
+- name: alpine-amd64-earthly
+  display_name: "Alpine Linux 3.18 amd64 (via Earthly)"
+  expansions:
+    earthly_env: alpine
+  tasks:
+  - name: build-with-earthly
+    run_on: ubuntu2204-small
+
+- name: alpine-arm64-earthly
+  display_name: "Alpine Linux 3.18 arm64 (via Earthly)"
+  expansions:
+    earthly_env: alpine
+  tasks:
+  - name: build-with-earthly
+    run_on: ubuntu2204-arm64-small
 
 - name: debian11-arm64-earthly
   display_name: "Debian 11 arm64 (via Earthly)"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -711,6 +711,10 @@ tasks:
       name: build-and-test-and-upload
     - variant: macos
       name: build-and-test-and-upload
+    - variant: alpine-amd64-earthly
+      name: build-with-earthly
+    - variant: alpine-arm64-earthly
+      name: build-with-earthly
   commands:
     - func: "fetch source"
     - command: shell.exec
@@ -780,6 +784,10 @@ tasks:
       vars: { variant_name: "ubuntu2204-arm64" }
     - func: "download tarball"
       vars: { variant_name: "macos" }
+    - func: "download tarball"
+      vars: { variant_name: "alpine-amd64-earthly" }
+    - func: "download tarball"
+      vars: { variant_name: "alpine-arm64-earthly" }
     - command: archive.targz_pack
       params:
         target: libmongocrypt-all.tar.gz

--- a/Earthfile
+++ b/Earthfile
@@ -212,7 +212,7 @@ env.sles15:
     DO +SLES_SETUP
 
 env.alpine:
-    FROM +init --base=docker.io/library/alpine:3.17
+    FROM +init --base=docker.io/library/alpine:3.18
     DO +ALPINE_SETUP
 
 # Utility: Warm-up obtaining CMake and Ninja for the build. This is usually
@@ -382,6 +382,7 @@ build:
         CACHE /s/libmongocrypt/cmake-build
     END
     RUN env USE_NINJA=1 bash libmongocrypt/.evergreen/build_all.sh
+    SAVE ARTIFACT /s/install /libmongocrypt-install
 
 # `create-deb-packages-and-repos` creates the .deb packages and repo directories intended for the PPA on debian-like distros. Options:
 #   • --env=[...]


### PR DESCRIPTION
This PR adds amd64 and arm64 builds of libmongocrypt for Alpine Linux 3.18 (a musl-based distro).

The approach uses the same `"tar and upload libmongocrypt libraries"` function in the Evergreen configuration that is used by other tasks. This way, consumers who want the Alpine artifacts can retrieve them based on the build variant name, as with artifacts built for other platforms and distros.

Evergreen patch build: https://spruce.mongodb.com/version/663d35d51c3e9b0007936faf/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

I confirmed that the artifacts produced by these tasks are for the correct architectures:

```
roberto@build01:~/Downloads$  find libmongocrypt-a* -name '*.so'
libmongocrypt-amd64/sharedbson/lib/libmongocrypt.so
libmongocrypt-amd64/sharedbson/lib/libkms_message.so
libmongocrypt-amd64/nocrypto/lib/libmongocrypt.so
libmongocrypt-amd64/nocrypto/lib/libkms_message.so
libmongocrypt-amd64/lib/libmongocrypt.so
libmongocrypt-amd64/lib/libkms_message.so
libmongocrypt-arm64/sharedbson/lib/libmongocrypt.so
libmongocrypt-arm64/sharedbson/lib/libkms_message.so
libmongocrypt-arm64/nocrypto/lib/libmongocrypt.so
libmongocrypt-arm64/nocrypto/lib/libkms_message.so
libmongocrypt-arm64/lib/libmongocrypt.so
libmongocrypt-arm64/lib/libkms_message.so
roberto@build01:~/Downloads$  file libmongocrypt-amd64/lib/libmongocrypt.so
libmongocrypt-amd64/lib/libmongocrypt.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=f087b766de9529b170f29d130da7a2988f79edf2, with debug_info, not stripped
roberto@build01:~/Downloads$  file libmongocrypt-arm64/lib/libmongocrypt.so
libmongocrypt-arm64/lib/libmongocrypt.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=f087b766de9529b170f29d130da7a2988f79edf2, with debug_info, not stripped
```