### PR TITLE
Fix KMIP operations reference in comment

### DIFF
--- a/kms-message/src/kms_kmip_request.c
+++ b/kms-message/src/kms_kmip_request.c
@@ -182,7 +182,7 @@ kms_kmip_request_activate_new (void *reserved, const char *unique_identifer)
    kmip_writer_close_struct (writer); /* KMIP_TAG_RequestHeader */
 
    kmip_writer_begin_struct (writer, KMIP_TAG_BatchItem);
-   /* 0x0A == Get */
+   /* 0x12 == Activate */
    kmip_writer_write_enumeration (writer, KMIP_TAG_Operation, 0x12);
    kmip_writer_begin_struct (writer, KMIP_TAG_RequestPayload);
    kmip_writer_write_string (writer,


### PR DESCRIPTION
Just a tiny comment fix, but this was apparently lying around in my local checkout of libmongocrypt for a couple months 🙂  

Refs: http://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Ref242030690