### PR TITLE
MONGOCRYPT-680 attach Augmented SBOM to release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,3 @@ VERSION_CURRENT
 .csfle
 *.pyc
 .DS_Store
-

--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,3 @@ VERSION_CURRENT
 *.pyc
 .DS_Store
 
-# Ignore the Augmented SBOM that is downloaded to attach to releases.
-cyclonedx.augmented.sbom.json

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ VERSION_CURRENT
 .csfle
 *.pyc
 .DS_Store
+
+# Ignore the Augmented SBOM that is downloaded to attach to releases.
+cyclonedx.augmented.sbom.json

--- a/Earthfile
+++ b/Earthfile
@@ -477,3 +477,24 @@ sbom-generate:
         --sbom-out cyclonedx.sbom.json
     # Save the result back to the host:
     SAVE ARTIFACT /s/cyclonedx.sbom.json AS LOCAL etc/cyclonedx.sbom.json
+
+# sbom-download:
+#   Download the Augmented SBOM file from Silk.
+#
+# See https://wiki.corp.mongodb.com/display/DRIVERS/Using+AWS+Secrets+Manager+to+Store+Testing+Secrets for instructions to get secrets from AWS Secrets Manager. Secrets are available under `drivers/libmongocrypt`.
+# See https://docs.devprod.prod.corp.mongodb.com/mms/python/src/sbom/silkbomb/ for documentation of silkbomb.
+sbom-download:
+    FROM artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0
+    # Alias the silkbom executable to a simpler name:
+    RUN ln -s /python/src/sbom/silkbomb/bin /usr/local/bin/silkbomb
+    WORKDIR /s
+    # Download the Augmented SBOM file:
+    RUN --secret silk_client_id --secret silk_client_secret \
+        SILK_CLIENT_ID=${silk_client_id} \
+        SILK_CLIENT_SECRET=${silk_client_secret} \
+        silkbomb download \
+        --sbom-out cyclonedx.augmented.sbom.json \
+        --silk-asset-group libmongocrypt
+    # Save the result back to the host:
+    SAVE ARTIFACT /s/cyclonedx.augmented.sbom.json AS LOCAL etc/cyclonedx.augmented.sbom.json
+    RUN echo "Augmented SBOM saved to etc/cyclonedx.augmented.sbom.json"

--- a/Earthfile
+++ b/Earthfile
@@ -493,7 +493,7 @@ sbom-download:
     FROM +silkbomb
     WORKDIR /s
     # Download the Augmented SBOM file:
-    RUN --secret silk_client_id --secret silk_client_secret \
+    RUN --no-cache --secret silk_client_id --secret silk_client_secret \
         SILK_CLIENT_ID=${silk_client_id} \
         SILK_CLIENT_SECRET=${silk_client_secret} \
         silkbomb download \

--- a/Earthfile
+++ b/Earthfile
@@ -490,6 +490,7 @@ sbom-generate:
 # See https://wiki.corp.mongodb.com/display/DRIVERS/Using+AWS+Secrets+Manager+to+Store+Testing+Secrets for instructions to get secrets from AWS Secrets Manager. Secrets are available under `drivers/libmongocrypt`.
 #
 sbom-download:
+    ARG --required out
     FROM +silkbomb
     WORKDIR /s
     # Download the Augmented SBOM file:
@@ -500,5 +501,5 @@ sbom-download:
         --sbom-out cyclonedx.augmented.sbom.json \
         --silk-asset-group libmongocrypt
     # Save the result back to the host:
-    SAVE ARTIFACT /s/cyclonedx.augmented.sbom.json AS LOCAL etc/cyclonedx.augmented.sbom.json
-    RUN echo "Augmented SBOM saved to etc/cyclonedx.augmented.sbom.json"
+    SAVE ARTIFACT /s/cyclonedx.augmented.sbom.json AS LOCAL ${out}
+    RUN echo "Augmented SBOM saved to ${out}"

--- a/Earthfile
+++ b/Earthfile
@@ -456,17 +456,23 @@ sign:
     RUN gpgv --keyring "/keyring" "/s/file.asc" "/s/file"
     SAVE ARTIFACT /s/file.asc AS LOCAL ${output_file}
 
-# sbom-generate :
+# silkbomb:
+#   An environment with the `silkbomb` command.
+#
+# See https://docs.devprod.prod.corp.mongodb.com/mms/python/src/sbom/silkbomb/ for documentation of silkbomb.
+silkbomb:
+    FROM artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0
+    # Alias the silkbom executable to a simpler name:
+    RUN ln -s /python/src/sbom/silkbomb/bin /usr/local/bin/silkbomb
+
+# sbom-generate:
 #   Generate/update the etc/cyclonedx.sbom.json file from the etc/purls.txt file.
 #
 # This target will update the existing etc/cyclonedx.sbom.json file in-place based
 # on the content of etc/purls.txt.
 #
-# See https://docs.devprod.prod.corp.mongodb.com/mms/python/src/sbom/silkbomb/ for documentation of silkbomb.
 sbom-generate:
-    FROM artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0
-    # Alias the silkbom executable to a simpler name:
-    RUN ln -s /python/src/sbom/silkbomb/bin /usr/local/bin/silkbomb
+    FROM +silkbomb
     # Copy in the relevant files:
     WORKDIR /s
     COPY etc/purls.txt etc/cyclonedx.sbom.json /s/
@@ -482,11 +488,9 @@ sbom-generate:
 #   Download the Augmented SBOM file from Silk.
 #
 # See https://wiki.corp.mongodb.com/display/DRIVERS/Using+AWS+Secrets+Manager+to+Store+Testing+Secrets for instructions to get secrets from AWS Secrets Manager. Secrets are available under `drivers/libmongocrypt`.
-# See https://docs.devprod.prod.corp.mongodb.com/mms/python/src/sbom/silkbomb/ for documentation of silkbomb.
+#
 sbom-download:
-    FROM artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0
-    # Alias the silkbom executable to a simpler name:
-    RUN ln -s /python/src/sbom/silkbomb/bin /usr/local/bin/silkbomb
+    FROM +silkbomb
     WORKDIR /s
     # Download the Augmented SBOM file:
     RUN --secret silk_client_id --secret silk_client_secret \

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -26,6 +26,15 @@ Do the following when releasing:
       - If the `publish-packages` tasks fail with an error like `[curator] 2024/01/02 13:56:17 [p=emergency]: problem submitting repobuilder job: 404 (Not Found)`, this suggests the published path does not yet exist. Barque (the Linux package publishing service) has protection to avoid unintentional publishes. File a DEVPROD ticket ([example](https://jira.mongodb.org/browse/DEVPROD-4053)) and assign to the team called Release Infrastructure to request the path be created. Then re-run the failing `publish-packages` task. Ask in the slack channel `#devprod-release-tools` for further help with `Barque` or `curator`.
 - Create the release from the GitHub releases page from the new tag.
    - Attach the tarball and signature file from the Files tab of the `windows-upload-release` task. [Example](https://github.com/mongodb/libmongocrypt/releases/tag/1.10.0).
+   - Attach the Augmented SBOM file. Download the Augmented SBOM using:
+     ```bash
+     ./.evergreen/earthly.sh \
+        --secret silk_client_id=${silk_client_id} \
+        --secret silk_client_secret=${silk_client_secret} \
+        +sbom-download
+     ```
+     Secrets can be obtained from [AWS Secrets Manager](https://wiki.corp.mongodb.com/display/DRIVERS/Using+AWS+Secrets+Manager+to+Store+Testing+Secrets) under `drivers/libmongocrypt`.
+
 - If this is a new minor release (e.g. `x.y.0`), file a DOCSP ticket to update the installation instructions on [Install libmongocrypt](https://www.mongodb.com/docs/manual/core/csfle/reference/libmongocrypt/). ([Example](https://jira.mongodb.org/browse/DOCSP-36863))
 - Make a PR to apply the "Update CHANGELOG.md for x.y.z" commit to the `master` branch.
 - Update the release on the [Jira releases page](https://jira.mongodb.org/projects/MONGOCRYPT/versions).

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -31,7 +31,8 @@ Do the following when releasing:
      ./.evergreen/earthly.sh \
         --secret silk_client_id=${silk_client_id} \
         --secret silk_client_secret=${silk_client_secret} \
-        +sbom-download
+        +sbom-download \
+        --out cyclonedx.augmented.sbom.json
      ```
      Secrets can be obtained from [AWS Secrets Manager](https://wiki.corp.mongodb.com/display/DRIVERS/Using+AWS+Secrets+Manager+to+Store+Testing+Secrets) under `drivers/libmongocrypt`.
 


### PR DESCRIPTION
# Summary

Add an `sbom-download` target to download an Augmented SBOM. Add step to release to attach Augmented SBOM.

Partially resolves MONGOCRYPT-680.

# Background & Motivation

Addresses the requirement:

> Drivers MUST publish Augmented SBOM documents (produced by Silk processing SBOM Lite documents) alongside releases.

Related: I expect it is not needed to run `silkbomb upload`. Onboarding to [SilkBomb > Generate SBOM from purls](https://docs.devprod.prod.corp.mongodb.com/mms/python/src/sbom/silkbomb/docs/ONBOARDING/#generate-sbom-from-purls) notes:
> (Preferred) Commit the generated CycloneDx SBOM to source control. Silk will automatically get the latest version of your SBOM every night.

The SBOM Lite is committed to `etc/cyclonedx.sbom.json`.
