### PR TITLE
run `processResources` after `unzipJava`

### DIFF
--- a/bindings/java/mongocrypt/build.gradle.kts
+++ b/bindings/java/mongocrypt/build.gradle.kts
@@ -129,6 +129,12 @@ tasks.register<Download>("downloadJava") {
     overwrite(true)
 }
 
+// The `processResources` task (defined by the `java-library` plug-in) consumes files in the main source set.
+// Add a dependency on `unzipJava`. `unzipJava` adds libmongocrypt libraries to the main source set.
+tasks.processResources {
+    mustRunAfter(tasks.named("unzipJava"))
+}
+
 tasks.register<Copy>("unzipJava") {
     outputs.upToDateWhen { false }
     from(tarTree(resources.gzip("${jnaDownloadsDir}/libmongocrypt-java.tar.gz")))


### PR DESCRIPTION


# Summary

Add a `mustRunAfter("unzipJava")` for `processResources`.

This is a follow-up PR to https://github.com/mongodb/libmongocrypt/pull/789 intended to address the `test-java` task failures.

Here is a patch build with both the `test-java` and `benchmark-java` tasks passing: https://spruce.mongodb.com/version/66475f9231a6190007b5316f 

# Background

https://github.com/mongodb/libmongocrypt/pull/789 tried using `dependsOn`, but resulted in a failure in the `benchmark-java` task. I expect there is opportunity to further improve the Gradle config for the benchmark project. Example: there is an (unrelated?) [exception thrown](https://parsley.mongodb.com/evergreen/libmongocrypt_benchmark_benchmark_java_f8eb858170f1c3e08dfe36508731adb734b7d64d_24_05_15_16_53_31/0/task?bookmarks=0,1242&shareLine=900) in the benchmark-java task. This PR does not try to address. This PR is only intended to address the task failure.
