### PR TITLE
MONGOCRYPT-680 Create Silk asset group in release

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -491,6 +491,7 @@ sbom-generate:
 #
 sbom-download:
     ARG --required out
+    ARG --required branch
     FROM +silkbomb
     WORKDIR /s
     # Download the Augmented SBOM file:
@@ -499,7 +500,7 @@ sbom-download:
         SILK_CLIENT_SECRET=${silk_client_secret} \
         silkbomb download \
         --sbom-out cyclonedx.augmented.sbom.json \
-        --silk-asset-group libmongocrypt
+        --silk-asset-group libmongocrypt-${branch}
     # Save the result back to the host:
     SAVE ARTIFACT /s/cyclonedx.augmented.sbom.json AS LOCAL ${out}
     RUN echo "Augmented SBOM saved to ${out}"

--- a/Earthfile
+++ b/Earthfile
@@ -504,3 +504,19 @@ sbom-download:
     # Save the result back to the host:
     SAVE ARTIFACT /s/cyclonedx.augmented.sbom.json AS LOCAL ${out}
     RUN echo "Augmented SBOM saved to ${out}"
+
+# silk-create-asset-group:
+#   Create an asset group for Silk.
+#
+# See https://wiki.corp.mongodb.com/display/DRIVERS/Using+AWS+Secrets+Manager+to+Store+Testing+Secrets for instructions to get secrets from AWS Secrets Manager. Secrets are available under `drivers/libmongocrypt`.
+#
+silk-create-asset-group:
+    ARG --required branch
+    FROM +env.alpine
+    RUN __install curl jq
+    COPY etc/silk-create-asset-group.sh /s/silk-create-asset-group.sh
+    RUN --no-cache --secret silk_client_id --secret silk_client_secret \
+        silk_client_id=${silk_client_id} \
+        silk_client_secret=${silk_client_secret} \
+        branch=${branch} \
+            /s/silk-create-asset-group.sh

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -40,6 +40,14 @@ Do the following when releasing:
 
 - If this is a new minor release (e.g. `x.y.0`):
    - File a DOCSP ticket to update the installation instructions on [Install libmongocrypt](https://www.mongodb.com/docs/manual/core/csfle/reference/libmongocrypt/). ([Example](https://jira.mongodb.org/browse/DOCSP-36863))
+   - Create a new Silk asset group. Use the newly created release branch (e.g. `rx.y`) as the `--branch` argument:
+     ```bash
+     ./.evergreen/earthly.sh \
+        --secret silk_client_id=${silk_client_id} \
+        --secret silk_client_secret=${silk_client_secret} \
+        +silk-create-asset-group \
+        --branch <branch>
+     ```
 - Make a PR to apply the "Update CHANGELOG.md for x.y.z" commit to the `master` branch.
 - Update the release on the [Jira releases page](https://jira.mongodb.org/projects/MONGOCRYPT/versions).
 - Record the release on [C/C++ Release Info](https://docs.google.com/spreadsheets/d/1yHfGmDnbA5-Qt8FX4tKWC5xk9AhzYZx1SKF4AD36ecY/edit?usp=sharing). This is done to meet SSDLC reporting requirements.

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -32,11 +32,14 @@ Do the following when releasing:
         --secret silk_client_id=${silk_client_id} \
         --secret silk_client_secret=${silk_client_secret} \
         +sbom-download \
-        --out cyclonedx.augmented.sbom.json
+        --out cyclonedx.augmented.sbom.json \
+        --branch <branch>
      ```
+     For a new minor release, use `master` for `--branch`. For a patch release, use the release branch (e.g. `rx.y`).
      Secrets can be obtained from [AWS Secrets Manager](https://wiki.corp.mongodb.com/display/DRIVERS/Using+AWS+Secrets+Manager+to+Store+Testing+Secrets) under `drivers/libmongocrypt`.
 
-- If this is a new minor release (e.g. `x.y.0`), file a DOCSP ticket to update the installation instructions on [Install libmongocrypt](https://www.mongodb.com/docs/manual/core/csfle/reference/libmongocrypt/). ([Example](https://jira.mongodb.org/browse/DOCSP-36863))
+- If this is a new minor release (e.g. `x.y.0`):
+   - File a DOCSP ticket to update the installation instructions on [Install libmongocrypt](https://www.mongodb.com/docs/manual/core/csfle/reference/libmongocrypt/). ([Example](https://jira.mongodb.org/browse/DOCSP-36863))
 - Make a PR to apply the "Update CHANGELOG.md for x.y.z" commit to the `master` branch.
 - Update the release on the [Jira releases page](https://jira.mongodb.org/projects/MONGOCRYPT/versions).
 - Record the release on [C/C++ Release Info](https://docs.google.com/spreadsheets/d/1yHfGmDnbA5-Qt8FX4tKWC5xk9AhzYZx1SKF4AD36ecY/edit?usp=sharing). This is done to meet SSDLC reporting requirements.

--- a/etc/silk-create-asset-group.sh
+++ b/etc/silk-create-asset-group.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Check for required commands:
+if ! command -v jq > /dev/null 2>&1; then
+    echo "jq not found. Install jq"
+    exit 1
+fi
+
+if ! command -v curl > /dev/null 2>&1; then
+    echo "curl not found. Install curl"
+    exit 1
+fi
+
+# Check for required environment variables:
+: "${silk_client_id:?}"
+: "${silk_client_secret:?}"
+: "${branch:?}"
+
+# Get Silk token:
+json_payload=$(cat <<EOF
+{
+    "client_id": "${silk_client_id}",
+    "client_secret": "${silk_client_secret}"
+}
+EOF
+)
+silk_jwt_token=$(curl -s -X POST "https://silkapi.us1.app.silk.security/api/v1/authenticate" \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
+  -d "$json_payload" \
+  | jq -r '.token')
+
+asset_id="libmongocrypt-${branch}"
+
+# Create Silk asset group:
+json_payload=$(cat <<EOF
+{
+    "active": true,
+    "name": "libmongocrypt",
+    "code_repo_url": "https://github.com/mongodb/libmongocrypt",
+    "branch": "${branch}",
+    "metadata": {
+        "sbom_lite_path": "etc/cyclonedx.sbom.json"
+    },
+    "file_paths": [],
+    "asset_id": "${asset_id}"
+}
+EOF
+)
+reply=$(curl --silent -X 'POST' \
+  'https://silkapi.us1.app.silk.security/api/v1/raw/asset_group' \
+  -H "Accept: application/json" \
+  -H "Authorization: ${silk_jwt_token}" \
+  -H 'Content-Type: application/json' \
+  -d "$json_payload")
+
+if silkid=$(echo "$reply" | jq ".silk_id"); then
+    echo "Created silk asset group with asset_id=$asset_id and silk_id=$silkid"
+else
+    echo "Reply does not contain expected 'silk_id': $reply"
+    exit 1
+fi
+


### PR DESCRIPTION
# Summary

This PR makes changes to support attaching an Augmented SBOM for all releases (not just feature releases):

- Add a release step to create a Silk asset group when doing a minor release.
- Add `--branch` argument to `sbom-download` target.

# Background & Motivation

I expect attaching the Augmented SBOM is required for all releases. I left a [suggestion](https://docs.google.com/document/d/1mXxDdY38nGVKWJhIbH83X6mcHsxllAiunH2hg-NdDsY/edit?disco=AAABOjmUj4c) in the Client Libs scope to clarify.

The naming choice of `libmongocrypt-${branch}` for the `asset_id` is arbitrary, but was met with approval in this [slack thread](https://mongodb.slack.com/archives/C05N744KWQ4/p1716297227559829?thread_ts=1716296884.511029&cid=C05N744KWQ4).


