### PR TITLE
PYTHON-4459 Prep for PyMongoCrypt 1.9.2 Release

### DIFF
--- a/bindings/python/CHANGELOG.rst
+++ b/bindings/python/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Changes in Version 1.9.2
+------------------------
+
+- Fix support for building source distributions with setuptools >= 70.
+
+
 Changes in Version 1.9.1
 ------------------------
 

--- a/bindings/python/pymongocrypt/version.py
+++ b/bindings/python/pymongocrypt/version.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '1.9.1'
+__version__ = '1.9.2'
 
 _MIN_LIBMONGOCRYPT_VERSION = '1.8.0'


### PR DESCRIPTION
Patch build: https://spruce.mongodb.com/version/6655b963736e870007224561/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC