### PR TITLE
MONGOCRYPT-685 update libbson to 1.27.1

### DIFF
--- a/.evergreen/linker-tests.sh
+++ b/.evergreen/linker-tests.sh
@@ -56,6 +56,8 @@ if is_true USE_NINJA; then
 fi
 
 run_chdir "$MONGOC_DIR" git apply --ignore-whitespace "$linker_tests_deps_root/bson_patches/libbson1.patch"
+# Apply patch to fix compile on RHEL 6.2.
+run_chdir "$MONGOC_DIR" git apply "$LIBMONGOCRYPT_DIR/etc/libbson-remove-GCC-diagnostic-pragma.patch"
 
 BUILD_PATH="$MONGOC_DIR/cmake-build"
 BSON1_INSTALL_PATH="$linker_tests_root/install/bson1"
@@ -71,6 +73,8 @@ run_cmake --build "$BUILD_PATH" --target install --config RelWithDebInfo
 # Prepare libbson2
 run_chdir "$MONGOC_DIR" git reset --hard
 run_chdir "$MONGOC_DIR" git apply --ignore-whitespace "$linker_tests_deps_root/bson_patches/libbson2.patch"
+# Apply patch to fix compile on RHEL 6.2.
+run_chdir "$MONGOC_DIR" git apply "$LIBMONGOCRYPT_DIR/etc/libbson-remove-GCC-diagnostic-pragma.patch"
 LIBBSON2_SRC_DIR="$MONGOC_DIR"
 
 # Build libmongocrypt, static linking against libbson2

--- a/.evergreen/linker-tests.sh
+++ b/.evergreen/linker-tests.sh
@@ -56,7 +56,7 @@ if is_true USE_NINJA; then
 fi
 
 run_chdir "$MONGOC_DIR" git apply --ignore-whitespace "$linker_tests_deps_root/bson_patches/libbson1.patch"
-# Apply patch to fix compile on RHEL 6.2.
+# Apply patch to fix compile on RHEL 6.2. TODO: try to remove once RHEL 6.2 is dropped (MONGOCRYPT-688).
 run_chdir "$MONGOC_DIR" git apply "$LIBMONGOCRYPT_DIR/etc/libbson-remove-GCC-diagnostic-pragma.patch"
 
 BUILD_PATH="$MONGOC_DIR/cmake-build"
@@ -73,7 +73,7 @@ run_cmake --build "$BUILD_PATH" --target install --config RelWithDebInfo
 # Prepare libbson2
 run_chdir "$MONGOC_DIR" git reset --hard
 run_chdir "$MONGOC_DIR" git apply --ignore-whitespace "$linker_tests_deps_root/bson_patches/libbson2.patch"
-# Apply patch to fix compile on RHEL 6.2.
+# Apply patch to fix compile on RHEL 6.2. TODO: try to remove once RHEL 6.2 is dropped (MONGOCRYPT-688).
 run_chdir "$MONGOC_DIR" git apply "$LIBMONGOCRYPT_DIR/etc/libbson-remove-GCC-diagnostic-pragma.patch"
 LIBBSON2_SRC_DIR="$MONGOC_DIR"
 

--- a/.evergreen/prep_c_driver_source.sh
+++ b/.evergreen/prep_c_driver_source.sh
@@ -7,5 +7,3 @@ MONGO_C_DRIVER_VERSION=1.27.1
 
 # Force checkout with lf endings since .sh must have lf, not crlf on Windows
 git clone https://github.com/mongodb/mongo-c-driver.git --config core.eol=lf --config core.autocrlf=false --depth=1 --branch $MONGO_C_DRIVER_VERSION
-echo $MONGO_C_DRIVER_VERSION > mongo-c-driver/VERSION_CURRENT
-

--- a/.evergreen/prep_c_driver_source.sh
+++ b/.evergreen/prep_c_driver_source.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 # Clone mongo-c-driver and check out to a tagged version.
-MONGO_C_DRIVER_VERSION=1.17.0
+MONGO_C_DRIVER_VERSION=1.27.1
 
 # Force checkout with lf endings since .sh must have lf, not crlf on Windows
 git clone https://github.com/mongodb/mongo-c-driver.git --config core.eol=lf --config core.autocrlf=false --depth=1 --branch $MONGO_C_DRIVER_VERSION

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,6 +426,9 @@ if (BUILD_TESTING)
       INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/src"
       LINK_LIBRARIES _mongocrypt::libbson_for_static
       COMPILE_FEATURES cxx_std_11
+      # Define `__STDC_LIMIT_MACROS` in libbson to define integer macros (e.g. SIZE_MAX) when including in C++ code.
+      # C99 standard notes: "C++ implementations should define these macros only when __STDC_LIMIT_MACROS is defined before <stdint.h> is included."
+      COMPILE_DEFINITIONS __STDC_LIMIT_MACROS
       PREFIX ""
       )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ option (ENABLE_PIC
    ON
 )
 option (ENABLE_BUILD_FOR_PPA "Maintainer-only option for preparing PPA build" OFF)
-option (ENABLE_ONLINE_TESTS "Enable online tests and the csfle utility" ON)
+option (ENABLE_ONLINE_TESTS "Enable online tests and the csfle utility. Requires libmongoc." ON)
 # TODO MONGOCRYPT-661 When range V2 is default, remove this option.
 option (ENABLE_USE_RANGE_V2 "Enable the use_range_v2 flag by default for queryable encryption" OFF)
 if (ENABLE_USE_RANGE_V2)

--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -13,6 +13,7 @@ endif ()
 include (Patch)
 make_patch_command (patch_command
     STRIP_COMPONENTS 1
+    DIRECTORY "<SOURCE_DIR>"
     PATCHES
         ${PROJECT_SOURCE_DIR}/etc/libbson-remove-GCC-diagnostic-pragma.patch
     )

--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -2,7 +2,7 @@ include (FetchContent)
 
 # Set the tag that we will fetch.
 # When updating the version of libbson, also update the version in etc/purls.txt
-set (MONGOC_FETCH_TAG_FOR_LIBBSON "1.17.7" CACHE STRING "The Git tag of mongo-c-driver that will be fetched to obtain libbson")
+set (MONGOC_FETCH_TAG_FOR_LIBBSON "1.27.1" CACHE STRING "The Git tag of mongo-c-driver that will be fetched to obtain libbson")
 
 # Fetch the source archive for the requested tag from GitHub
 FetchContent_Declare (

--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -9,17 +9,19 @@ option (LIBBSON_PATCH_ENABLED "Whether to apply patches to the libbson library" 
 if (NOT LIBBSON_PATCH_ENABLED)
     set (patch_disabled ON)
 endif ()
-include (Patch) # defines `patch_command` and `patch_input_opt`.
+
+include (Patch)
+make_patch_command (patch_command
+    STRIP_COMPONENTS 1
+    PATCHES
+        ${PROJECT_SOURCE_DIR}/etc/libbson-remove-GCC-diagnostic-pragma.patch
+    )
 
 # Fetch the source archive for the requested tag from GitHub
 FetchContent_Declare (
     embedded_mcd
     URL "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/${MONGOC_FETCH_TAG_FOR_LIBBSON}.tar.gz"
-    PATCH_COMMAND
-        ${patch_command}
-            -p 1 # Strip one path component
-            ${patch_input_opt} "${PROJECT_SOURCE_DIR}/etc/libbson-remove-GCC-diagnostic-pragma.patch" # TODO: try to remove once RHEL 6.2 is dropped (MONGOCRYPT-688).
-            --verbose
+    PATCH_COMMAND ${patch_command} --verbose
     )
 # Populate it:
 FetchContent_GetProperties (embedded_mcd)

--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -4,10 +4,22 @@ include (FetchContent)
 # When updating the version of libbson, also update the version in etc/purls.txt
 set (MONGOC_FETCH_TAG_FOR_LIBBSON "1.27.1" CACHE STRING "The Git tag of mongo-c-driver that will be fetched to obtain libbson")
 
+# Add an option to disable patching if a patch command is unavailable.
+option (LIBBSON_PATCH_ENABLED "Whether to apply patches to the libbson library" ON)
+if (NOT LIBBSON_PATCH_ENABLED)
+    set (patch_disabled ON)
+endif ()
+include (Patch) # defines `patch_command` and `patch_input_opt`.
+
 # Fetch the source archive for the requested tag from GitHub
 FetchContent_Declare (
     embedded_mcd
     URL "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/${MONGOC_FETCH_TAG_FOR_LIBBSON}.tar.gz"
+    PATCH_COMMAND
+        ${patch_command}
+            -p 1 # Strip one path component
+            ${patch_input_opt} "${PROJECT_SOURCE_DIR}/etc/libbson-remove-GCC-diagnostic-pragma.patch" # TODO: try to remove once RHEL 6.2 is dropped.
+            --verbose
     )
 # Populate it:
 FetchContent_GetProperties (embedded_mcd)

--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -14,6 +14,7 @@ include (Patch)
 make_patch_command (patch_command
     STRIP_COMPONENTS 1
     DIRECTORY "<SOURCE_DIR>"
+    DISABLED "${patch_disabled}"
     PATCHES
         ${PROJECT_SOURCE_DIR}/etc/libbson-remove-GCC-diagnostic-pragma.patch
     )

--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -18,7 +18,7 @@ FetchContent_Declare (
     PATCH_COMMAND
         ${patch_command}
             -p 1 # Strip one path component
-            ${patch_input_opt} "${PROJECT_SOURCE_DIR}/etc/libbson-remove-GCC-diagnostic-pragma.patch" # TODO: try to remove once RHEL 6.2 is dropped.
+            ${patch_input_opt} "${PROJECT_SOURCE_DIR}/etc/libbson-remove-GCC-diagnostic-pragma.patch" # TODO: try to remove once RHEL 6.2 is dropped (MONGOCRYPT-688).
             --verbose
     )
 # Populate it:

--- a/cmake/ImportBSON.cmake
+++ b/cmake/ImportBSON.cmake
@@ -142,6 +142,11 @@ function (_import_bson)
       set (ENABLE_EXTRA_ALIGNMENT ${_extra_alignment_default} CACHE BOOL "Toggle extra alignment of bson_t")
       # We don't want the subproject to find libmongocrypt
       set (ENABLE_CLIENT_SIDE_ENCRYPTION OFF CACHE BOOL "Disable client-side encryption for the libmongoc subproject")
+      if (BUILD_VERSION)
+         # Both libmongocrypt and C driver support setting a `BUILD_VERSION`. Do not reuse the `BUILD_VERSION` for libmongocrypt when building the C driver.
+         # Set the `BUILD_VERSION` in this file to only apply to the C driver subproject.
+         set (BUILD_VERSION ${MONGOC_FETCH_TAG_FOR_LIBBSON})
+      endif()
       # Add the subdirectory as a project. EXCLUDE_FROM_ALL to inhibit building and installing of components unless requested
       # SYSTEM (on applicable CMake versions) to prevent warnings (particularly from -Wconversion/-Wsign-conversion) from the C driver code
       if (CMAKE_VERSION VERSION_GREATER 3.25)

--- a/cmake/ImportBSON.cmake
+++ b/cmake/ImportBSON.cmake
@@ -150,6 +150,8 @@ function (_import_bson)
       # Disable building tests in C driver:
       set (ENABLE_TESTS OFF)
       set (BUILD_TESTING OFF)
+      # Disable counters in C driver. Counters are not supported on all platforms.
+      set (ENABLE_SHM_COUNTERS OFF)
       # Add the subdirectory as a project. EXCLUDE_FROM_ALL to inhibit building and installing of components unless requested
       # SYSTEM (on applicable CMake versions) to prevent warnings (particularly from -Wconversion/-Wsign-conversion) from the C driver code
       if (CMAKE_VERSION VERSION_GREATER 3.25)

--- a/cmake/ImportBSON.cmake
+++ b/cmake/ImportBSON.cmake
@@ -142,11 +142,9 @@ function (_import_bson)
       set (ENABLE_EXTRA_ALIGNMENT ${_extra_alignment_default} CACHE BOOL "Toggle extra alignment of bson_t")
       # We don't want the subproject to find libmongocrypt
       set (ENABLE_CLIENT_SIDE_ENCRYPTION OFF CACHE BOOL "Disable client-side encryption for the libmongoc subproject")
-      if (BUILD_VERSION)
-         # Both libmongocrypt and C driver support setting a `BUILD_VERSION`. Do not reuse the `BUILD_VERSION` for libmongocrypt when building the C driver.
-         # Set the `BUILD_VERSION` in this file to only apply to the C driver subproject.
-         set (BUILD_VERSION ${MONGOC_FETCH_TAG_FOR_LIBBSON})
-      endif()
+      # Set `BUILD_VERSION` so C driver does not use a `BUILD_VERSION` meant for libmongocrypt.
+      # Both libmongocrypt and C driver support setting a `BUILD_VERSION` to override the version.
+      set (BUILD_VERSION ${MONGOC_FETCH_TAG_FOR_LIBBSON})
       # Disable building tests in C driver:
       set (ENABLE_TESTS OFF)
       set (BUILD_TESTING OFF)

--- a/cmake/ImportBSON.cmake
+++ b/cmake/ImportBSON.cmake
@@ -147,6 +147,9 @@ function (_import_bson)
          # Set the `BUILD_VERSION` in this file to only apply to the C driver subproject.
          set (BUILD_VERSION ${MONGOC_FETCH_TAG_FOR_LIBBSON})
       endif()
+      # Disable building tests in C driver:
+      set (ENABLE_TESTS OFF)
+      set (BUILD_TESTING OFF)
       # Add the subdirectory as a project. EXCLUDE_FROM_ALL to inhibit building and installing of components unless requested
       # SYSTEM (on applicable CMake versions) to prevent warnings (particularly from -Wconversion/-Wsign-conversion) from the C driver code
       if (CMAKE_VERSION VERSION_GREATER 3.25)

--- a/cmake/IntelDFP.cmake
+++ b/cmake/IntelDFP.cmake
@@ -20,7 +20,16 @@ endif ()
 if (NOT INTEL_DFP_LIBRARY_PATCH_ENABLED)
     set (patch_disabled ON)
 endif ()
-include (Patch) # defines `patch_command` and `patch_input_opt`.
+
+include (Patch)
+make_patch_command (patch_command
+    STRIP_COMPONENTS 4
+    PATCHES
+        "${PROJECT_SOURCE_DIR}/etc/mongo-inteldfp-s390x.patch"
+        "${PROJECT_SOURCE_DIR}/etc/mongo-inteldfp-MONGOCRYPT-571.patch"
+        "${PROJECT_SOURCE_DIR}/etc/mongo-inteldfp-libmongocrypt-pr-625.patch"
+        "${PROJECT_SOURCE_DIR}/etc/mongo-inteldfp-alpine-arm-fix.patch"
+    )
 
 # NOTE: The applying of the patch expects the correct input directly from the
 #       expanded archive. If the patch needs to be reapplied, you may see errors
@@ -31,14 +40,7 @@ FetchContent_Declare (
     intel_dfp
     URL "${_default_url}"
     ${_hash_arg}
-    PATCH_COMMAND
-        ${patch_command}
-            -p 4 # Strip four path components
-            ${patch_input_opt} "${PROJECT_SOURCE_DIR}/etc/mongo-inteldfp-s390x.patch"
-            ${patch_input_opt} "${PROJECT_SOURCE_DIR}/etc/mongo-inteldfp-MONGOCRYPT-571.patch"
-            ${patch_input_opt} "${PROJECT_SOURCE_DIR}/etc/mongo-inteldfp-libmongocrypt-pr-625.patch"
-            ${patch_input_opt} "${PROJECT_SOURCE_DIR}/etc/mongo-inteldfp-alpine-arm-fix.patch"
-            --verbose
+    PATCH_COMMAND ${patch_command} --verbose
     )
 
 FetchContent_GetProperties (intel_dfp)

--- a/cmake/IntelDFP.cmake
+++ b/cmake/IntelDFP.cmake
@@ -25,6 +25,7 @@ include (Patch)
 make_patch_command (patch_command
     STRIP_COMPONENTS 4
     DIRECTORY "<SOURCE_DIR>"
+    DISABLED "${patch_disabled}"
     PATCHES
         "${PROJECT_SOURCE_DIR}/etc/mongo-inteldfp-s390x.patch"
         "${PROJECT_SOURCE_DIR}/etc/mongo-inteldfp-MONGOCRYPT-571.patch"

--- a/cmake/IntelDFP.cmake
+++ b/cmake/IntelDFP.cmake
@@ -1,7 +1,5 @@
 
 include (FetchContent)
-find_program (GIT_EXECUTABLE git)
-find_program (PATCH_EXECUTABLE patch)
 
 # When updating the version of IntelDFP, also update the version in etc/purls.txt
 set (_default_url "${PROJECT_SOURCE_DIR}/third-party/IntelRDFPMathLib20U2.tar.xz")
@@ -19,17 +17,10 @@ if (NOT INTEL_DFP_LIBRARY_URL_SHA256 STREQUAL "no-verify")
     set (_hash_arg URL_HASH "${INTEL_DFP_LIBRARY_URL_HASH}")
 endif ()
 
-# Make the PATCH_COMMAND a no-op if it was disabled
-set (patch_command)
-set (patch_input_opt)
 if (NOT INTEL_DFP_LIBRARY_PATCH_ENABLED)
-    set (patch_command "${CMAKE_COMMAND}" -E true)
-elseif (GIT_EXECUTABLE)
-    set (patch_command "${GIT_EXECUTABLE}" --work-tree=<SOURCE_DIR> apply)
-else ()
-    set (patch_command "${PATCH_EXECUTABLE}" --dir=<SOURCE_DIR>)
-    set (patch_input_opt -i)
+    set (patch_disabled ON)
 endif ()
+include (Patch) # defines `patch_command` and `patch_input_opt`.
 
 # NOTE: The applying of the patch expects the correct input directly from the
 #       expanded archive. If the patch needs to be reapplied, you may see errors

--- a/cmake/IntelDFP.cmake
+++ b/cmake/IntelDFP.cmake
@@ -24,6 +24,7 @@ endif ()
 include (Patch)
 make_patch_command (patch_command
     STRIP_COMPONENTS 4
+    DIRECTORY "<SOURCE_DIR>"
     PATCHES
         "${PROJECT_SOURCE_DIR}/etc/mongo-inteldfp-s390x.patch"
         "${PROJECT_SOURCE_DIR}/etc/mongo-inteldfp-MONGOCRYPT-571.patch"

--- a/cmake/Patch.cmake
+++ b/cmake/Patch.cmake
@@ -1,0 +1,14 @@
+find_program (GIT_EXECUTABLE git)
+find_program (PATCH_EXECUTABLE patch)
+
+set (patch_command)
+set (patch_input_opt)
+if (patch_disabled)
+    # Make `patch_command` a no-op if it was disabled.
+    set (patch_command "${CMAKE_COMMAND}" -E true)
+elseif (GIT_EXECUTABLE)
+    set (patch_command "${GIT_EXECUTABLE}" --work-tree=<SOURCE_DIR> apply)
+else ()
+    set (patch_command "${PATCH_EXECUTABLE}" --dir=<SOURCE_DIR>)
+    set (patch_input_opt -i)
+endif ()

--- a/cmake/Patch.cmake
+++ b/cmake/Patch.cmake
@@ -6,14 +6,18 @@ find_program(PATCH_EXECUTABLE patch)
 
     make_patch_command(
         <outvar>
+        [DISABLED <bool>]
         [DIRECTORY <dir>]
         [STRIP_COMPONENTS <N>]
         PATCHES [<file> ...]
     )
 ]]
 function(make_patch_command out)
-    cmake_parse_arguments(PARSE_ARGV 1 patch "" "DIRECTORY;STRIP_COMPONENTS" "PATCHES")
-    if(GIT_EXECUTABLE)
+    cmake_parse_arguments(PARSE_ARGV 1 patch "" "DIRECTORY;STRIP_COMPONENTS;DISABLED" "PATCHES")
+    if(patch_DISABLED)
+        # Use a placeholder "no-op" patch command.
+        set(cmd "${CMAKE_COMMAND}" "-E" "true")
+    elseif(GIT_EXECUTABLE)
         # git ...
         set(cmd ${GIT_EXECUTABLE})
 

--- a/cmake/Patch.cmake
+++ b/cmake/Patch.cmake
@@ -31,11 +31,8 @@ function(make_patch_command out)
         if(patch_STRIP_COMPONENTS)
             list(APPEND cmd -p${patch_STRIP_COMPONENTS})
         endif()
-        # git ... apply ...
-        foreach(p IN LISTS patch_PATCHES)
-            # git ... apply ... <file>
-            list(APPEND cmd ${p})
-        endforeach()
+        # git accepts patch filepaths as positional arguments
+        list(APPEND cmd ${patch_PATCHES})
     else()
         # patch ...
         set(cmd ${PATCH_EXECUTABLE})
@@ -47,10 +44,9 @@ function(make_patch_command out)
         if(patch_STRIP_COMPONENTS)
             list(APPEND cmd -p${patch_STRIP_COMPONENTS})
         endif()
-        foreach(p IN LISTS patch_PATCHES)
-            # patch ... ---input=<file>
-            list(APPEND cmd --input=${p})
-        endforeach()
+        # Prepend "--input=" to each patch filepath and add them to the argv
+        list(TRANSFORM patch_PATCHES PREPEND "--input=")
+        list(APPEND cmd ${patch_PATCHES})
     endif()
     set("${out}" "${cmd}" PARENT_SCOPE)
 endfunction()

--- a/cmake/Patch.cmake
+++ b/cmake/Patch.cmake
@@ -1,14 +1,52 @@
-find_program (GIT_EXECUTABLE git)
-find_program (PATCH_EXECUTABLE patch)
+find_program(GIT_EXECUTABLE git)
+find_program(PATCH_EXECUTABLE patch)
 
-set (patch_command)
-set (patch_input_opt)
-if (patch_disabled)
-    # Make `patch_command` a no-op if it was disabled.
-    set (patch_command "${CMAKE_COMMAND}" -E true)
-elseif (GIT_EXECUTABLE)
-    set (patch_command "${GIT_EXECUTABLE}" --work-tree=<SOURCE_DIR> apply)
-else ()
-    set (patch_command "${PATCH_EXECUTABLE}" --dir=<SOURCE_DIR>)
-    set (patch_input_opt -i)
-endif ()
+#[[
+    Form a new Patch-applying command for the given inputs
+
+    make_patch_command(
+        <outvar>
+        [DIRECTORY <dir>]
+        [STRIP_COMPONENTS <N>]
+        PATCHES [<file> ...]
+    )
+]]
+function(make_patch_command out)
+    cmake_parse_arguments(PARSE_ARGV 1 patch "" "DIRECTORY;STRIP_COMPONENTS" "PATCHES")
+    if(GIT_EXECUTABLE)
+        # git ...
+        set(cmd ${GIT_EXECUTABLE})
+
+        if(patch_DIRECTORY)
+            # git --work-tree=...
+            list(APPEND cmd --work-tree=${patch_DIRECTORY})
+        endif()
+        # git ... apply ...
+        list(APPEND cmd apply)
+        # git ... apply -pN ...
+        if(patch_STRIP_COMPONENTS)
+            list(APPEND cmd -p${patch_STRIP_COMPONENTS})
+        endif()
+        # git ... apply ...
+        foreach(p IN LISTS patch_PATCHES)
+            # git ... apply ... <file>
+            list(APPEND cmd ${p})
+        endforeach()
+    else()
+        # patch ...
+        set(cmd ${PATCH_EXECUTABLE})
+        if(patch_DIRECTORY)
+            # patch --dir=...
+            list(APPEND cmd --dir=${patch_DIRECTORY})
+        endif()
+        # patch ... -pN ...
+        if(patch_STRIP_COMPONENTS)
+            list(APPEND cmd -p${patch_STRIP_COMPONENTS})
+        endif()
+        foreach(p IN LISTS patch_PATCHES)
+            # patch ... ---input=<file>
+            list(APPEND cmd --input=${p})
+        endforeach()
+    endif()
+    set("${out}" "${cmd}" PARENT_SCOPE)
+endfunction()

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -1,16 +1,16 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.17.0#src/libbson",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.27.1#src/libbson",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/v1.17.0.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/v1.27.1.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/v1.17.0"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/v1.27.1"
         }
       ],
       "group": "mongodb",
@@ -22,9 +22,9 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@v1.17.0#src/libbson",
+      "purl": "pkg:github/mongodb/mongo-c-driver@v1.27.1#src/libbson",
       "type": "library",
-      "version": "v1.17.0"
+      "version": "v1.27.1"
     },
     {
       "bom-ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz",
@@ -53,11 +53,11 @@
       "ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz"
     },
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@v1.17.0#src/libbson"
+      "ref": "pkg:github/mongodb/mongo-c-driver@v1.27.1#src/libbson"
     }
   ],
   "metadata": {
-    "timestamp": "2024-05-09T14:53:50.877648+00:00",
+    "timestamp": "2024-05-10T12:07:55.084050+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/libbson-remove-GCC-diagnostic-pragma.patch
+++ b/etc/libbson-remove-GCC-diagnostic-pragma.patch
@@ -1,0 +1,27 @@
+diff --git a/src/common/bson-dsl.h b/src/common/bson-dsl.h
+index 58a14e28e..3341e603f 100644
+--- a/src/common/bson-dsl.h
++++ b/src/common/bson-dsl.h
+@@ -29,6 +29,13 @@ enum {
+    BSON_IF_WINDOWS (__declspec (selectany)) \
+    BSON_IF_POSIX (__attribute__ ((weak)))
+ 
++#if defined(__GNUC__) && !defined(__clang__) && ((__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ < 6))
++// Using GCC < 4.6
++// Do not define `GCC diagnostic` pragma for GCC < 4.6.
++#define _bsonDSL_disableWarnings() ((void) 0)
++#define _bsonDSL_restoreWarnings() ((void) 0)
++#else
++// Not using GCC < 4.6
+ #ifdef __GNUC__
+ // GCC has a bug handling pragma statements that disable warnings within complex
+ // nested macro expansions. If we're GCC, just disable -Wshadow outright:
+@@ -47,7 +54,7 @@ BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
+       BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic pop");) \
+    } else                                                \
+       ((void) 0)
+-
++#endif
+ /**
+  * @brief Parse the given BSON document.
+  *

--- a/etc/purls.txt
+++ b/etc/purls.txt
@@ -8,7 +8,7 @@
 # `copyright` property. This information can be manually added.
 
 # libbson is obtained via `cmake/FetchMongoC.cmake`.
-pkg:github/mongodb/mongo-c-driver@v1.17.0?#src/libbson
+pkg:github/mongodb/mongo-c-driver@v1.27.1?#src/libbson
 
 # IntelDFP is obtained via `cmake/IntelDFP.cmake`
 pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz

--- a/src/mc-range-mincover-generator.template.h
+++ b/src/mc-range-mincover-generator.template.h
@@ -17,18 +17,6 @@
 // mc-range-mincover-generator.template.h is meant to be included in another
 // source file.
 
-// TODO: replace `CONCAT` with `BSON_CONCAT` after libbson dependency is
-// upgraded to 1.20.0 or higher.
-#ifndef CONCAT
-#define CONCAT_1(a, b) a##b
-#define CONCAT(a, b) CONCAT_1(a, b)
-#endif
-// TODO: replace `CONCAT3` with `BSON_CONCAT3` after libbson dependency is
-// upgraded to 1.20.0 or higher.
-#ifndef CONCAT3
-#define CONCAT3(a, b, c) CONCAT(a, CONCAT(b, c))
-#endif
-
 #if !(defined(UINT_T) && defined(UINT_C) && defined(UINT_FMT_S) && defined(DECORATE_NAME))
 #ifdef __INTELLISENSE__
 #define UINT_T uint32_t

--- a/src/mc-tokens-private.h
+++ b/src/mc-tokens-private.h
@@ -76,35 +76,23 @@
  * ======================== End: FLE 2 Token Reference ========================
  */
 
-// TODO: replace `CONCAT` with `BSON_CONCAT` after libbson dependency is
-// upgraded to 1.20.0 or higher.
-#ifndef CONCAT
-#define CONCAT_1(a, b) a##b
-#define CONCAT(a, b) CONCAT_1(a, b)
-#endif
-// TODO: replace `CONCAT3` with `BSON_CONCAT3` after libbson dependency is
-// upgraded to 1.20.0 or higher.
-#ifndef CONCAT3
-#define CONCAT3(a, b, c) CONCAT(a, CONCAT(b, c))
-#endif
-
 /// Declare a token type named 'Name', with constructor parameters given by the
 /// remaining arguments. Each constructor will also have the implicit first
 /// argument '_mongocrypt_crypto_t* crypto' and a final argument
 /// 'mongocrypt_status_t* status'
-#define DECL_TOKEN_TYPE(Name, ...) DECL_TOKEN_TYPE_1(Name, CONCAT(Name, _t), __VA_ARGS__)
+#define DECL_TOKEN_TYPE(Name, ...) DECL_TOKEN_TYPE_1(Name, BSON_CONCAT(Name, _t), __VA_ARGS__)
 
 #define DECL_TOKEN_TYPE_1(Prefix, T, ...)                                                                              \
     /* Opaque typedef the struct */                                                                                    \
     typedef struct T T;                                                                                                \
     /* Data-getter */                                                                                                  \
-    extern const _mongocrypt_buffer_t *CONCAT(Prefix, _get)(const T *t);                                               \
+    extern const _mongocrypt_buffer_t *BSON_CONCAT(Prefix, _get)(const T *t);                                          \
     /* Destructor */                                                                                                   \
-    extern void CONCAT(Prefix, _destroy)(T * t);                                                                       \
+    extern void BSON_CONCAT(Prefix, _destroy)(T * t);                                                                  \
     /* Constructor for server to create tokens from raw buffer */                                                      \
-    extern T *CONCAT(Prefix, _new_from_buffer)(_mongocrypt_buffer_t * buf);                                            \
+    extern T *BSON_CONCAT(Prefix, _new_from_buffer)(_mongocrypt_buffer_t * buf);                                       \
     /* Constructor. Parameter list given as variadic args */                                                           \
-    extern T *CONCAT(Prefix, _new)(_mongocrypt_crypto_t * crypto, __VA_ARGS__, mongocrypt_status_t * status)
+    extern T *BSON_CONCAT(Prefix, _new)(_mongocrypt_crypto_t * crypto, __VA_ARGS__, mongocrypt_status_t * status)
 
 DECL_TOKEN_TYPE(mc_CollectionsLevel1Token, const _mongocrypt_buffer_t *);
 DECL_TOKEN_TYPE(mc_ServerTokenDerivationLevel1Token, const _mongocrypt_buffer_t *);

--- a/src/mc-tokens.c
+++ b/src/mc-tokens.c
@@ -21,7 +21,7 @@
 /// the remaining arguments. This macro usage should be followed by the
 /// constructor body, with the implicit first argument '_mongocrypt_crypto_t*
 /// crypto' and final argument 'mongocrypt_status_t* status'
-#define DEF_TOKEN_TYPE(Name, ...) DEF_TOKEN_TYPE_1(Name, CONCAT(Name, _t), __VA_ARGS__)
+#define DEF_TOKEN_TYPE(Name, ...) DEF_TOKEN_TYPE_1(Name, BSON_CONCAT(Name, _t), __VA_ARGS__)
 
 #define DEF_TOKEN_TYPE_1(Prefix, T, ...)                                                                               \
     /* Define the struct for the token */                                                                              \
@@ -29,9 +29,9 @@
         _mongocrypt_buffer_t data;                                                                                     \
     };                                                                                                                 \
     /* Data-getter */                                                                                                  \
-    const _mongocrypt_buffer_t *CONCAT(Prefix, _get)(const T *self) { return &self->data; }                            \
+    const _mongocrypt_buffer_t *BSON_CONCAT(Prefix, _get)(const T *self) { return &self->data; }                       \
     /* Destructor */                                                                                                   \
-    void CONCAT(Prefix, _destroy)(T * self) {                                                                          \
+    void BSON_CONCAT(Prefix, _destroy)(T * self) {                                                                     \
         if (!self) {                                                                                                   \
             return;                                                                                                    \
         }                                                                                                              \
@@ -39,23 +39,23 @@
         bson_free(self);                                                                                               \
     }                                                                                                                  \
     /* Constructor. From raw buffer */                                                                                 \
-    T *CONCAT(Prefix, _new_from_buffer)(_mongocrypt_buffer_t * buf) {                                                  \
+    T *BSON_CONCAT(Prefix, _new_from_buffer)(_mongocrypt_buffer_t * buf) {                                             \
         BSON_ASSERT(buf->len == MONGOCRYPT_HMAC_SHA256_LEN);                                                           \
         T *t = bson_malloc(sizeof(T));                                                                                 \
         _mongocrypt_buffer_set_to(buf, &t->data);                                                                      \
         return t;                                                                                                      \
     }                                                                                                                  \
     /* Constructor. Parameter list given as variadic args. */                                                          \
-    T *CONCAT(Prefix, _new)(_mongocrypt_crypto_t * crypto, __VA_ARGS__, mongocrypt_status_t * status)
+    T *BSON_CONCAT(Prefix, _new)(_mongocrypt_crypto_t * crypto, __VA_ARGS__, mongocrypt_status_t * status)
 
 #define IMPL_TOKEN_NEW_1(Name, Key, Arg, Clean)                                                                        \
     {                                                                                                                  \
-        CONCAT(Name, _t) *t = bson_malloc(sizeof(CONCAT(Name, _t)));                                                   \
+        BSON_CONCAT(Name, _t) *t = bson_malloc(sizeof(BSON_CONCAT(Name, _t)));                                         \
         _mongocrypt_buffer_init(&t->data);                                                                             \
         _mongocrypt_buffer_resize(&t->data, MONGOCRYPT_HMAC_SHA256_LEN);                                               \
                                                                                                                        \
         if (!_mongocrypt_hmac_sha_256(crypto, Key, Arg, &t->data, status)) {                                           \
-            CONCAT(Name, _destroy)(t);                                                                                 \
+            BSON_CONCAT(Name, _destroy)(t);                                                                            \
             Clean;                                                                                                     \
             return NULL;                                                                                               \
         }                                                                                                              \

--- a/src/mongocrypt-buffer.c
+++ b/src/mongocrypt-buffer.c
@@ -19,6 +19,11 @@
 #include "mongocrypt-util-private.h"
 #include <bson/bson.h>
 
+// Require libbson 1.16.0 or newer. Fix for CDRIVER-3360 is needed.
+#if !BSON_CHECK_VERSION(1, 16, 0)
+#error "libbson 1.16.0 or newer is required."
+#endif
+
 #define INT32_LEN 4
 #define TYPE_LEN 1
 #define NULL_BYTE_LEN 1
@@ -305,13 +310,6 @@ bool _mongocrypt_buffer_to_bson_value(_mongocrypt_buffer_t *plaintext, uint8_t t
         goto fail;
     }
     bson_value_copy(bson_iter_value(&iter), out);
-
-    /* Due to an open libbson bug (CDRIVER-3340), give an empty
-     * binary payload a real address. TODO: remove this after
-     * CDRIVER-3340 is fixed. */
-    if (out->value_type == BSON_TYPE_BINARY && 0 == out->value.v_binary.data_len) {
-        out->value.v_binary.data = bson_malloc(1); /* Freed in bson_value_destroy */
-    }
 
     ret = true;
 fail:

--- a/src/mongocrypt-private.h
+++ b/src/mongocrypt-private.h
@@ -49,9 +49,6 @@
 
 #define MONGOCRYPT_DATA_AND_LEN(x) ((uint8_t *)x), (sizeof(x) / sizeof((x)[0]) - 1)
 
-/* TODO: remove after integrating into libmongoc */
-#define BSON_SUBTYPE_ENCRYPTED 6
-
 /* TODO: Move these to mongocrypt-log-private.h? */
 const char *tmp_json(const bson_t *bson);
 


### PR DESCRIPTION
# Summary

Update bundled libbson to 1.27.1

Apply workarounds to resolve errors on RHEL 6.2 with gcc 4.4.7:
- Define `__STDC_LIMIT_MACROS` when compiling with C++.
- Disable GCC diagnostic macros in functions for gcc < 4.6.

Remove workarounds for older libbson:
- Replace `CONCAT` macro with `BSON_CONCAT`.
- Remove `BSON_SUBTYPE_ENCRYPTED` (now defined in libbson).
- Remove workaround for CDRIVER-3340.

Verified with this patch build: https://spruce.mongodb.com/version/6650b53f05094a0007522646

# Background

## Motivation

Updating bundled libbson is to address an issue reported in Skyk that was fixed in libbson 1.25.0: https://security.snyk.io/vuln/SNYK-UNMANAGED-MONGODBMONGOCDRIVER-6156642

## Workaround: define `__STDC_LIMIT_MACROS` for C++ targets

Defining `__STDC_LIMIT_MACROS` resolves an error on [this patch](https://parsley.mongodb.com/evergreen/libmongocrypt_rhel_62_64_bit_build_and_test_and_upload_patch_6b328b46d2489526b7cc013a9b3d36eddfe3ab62_6647a9b5a30c2b00076ff94f_24_05_17_19_02_14/0/task?bookmarks=0,705) when compiling a C++ test target: `bson-cmp.h:144: error: 'INT8_MIN' was not declared in this scope`. The stdint.h header on a spawned RHEL 6.2 host includes:
```c
/* The ISO C99 standard specifies that in C++ implementations these
   macros should only be defined if explicitly requested.  */
#if !defined __cplusplus || defined __STDC_LIMIT_MACROS
```

## Workaround: remove diagnostic pragma on old GCC

Removing the `GCC diagnostic` pragma resolves an error on [this patch](https://spruce.mongodb.com/task/libmongocrypt_rhel_62_64_bit_build_and_test_and_upload_patch_6b328b46d2489526b7cc013a9b3d36eddfe3ab62_664ea13f2a08f80007e8b58f_24_05_23_01_51_59/logs?execution=0): `mongoc-aggregate.c:97: error: #pragma GCC diagnostic not allowed inside functions`. I expect this is unavailable on GCC 4.6 and older. [GCC 4.6 changelog](https://gcc.gnu.org/gcc-4.6/changes.html) notes:
> Support for selectively enabling and disabling warnings via #pragma GCC diagnostic has been added

Due to the workarounds, MONGOCRYPT-688 was filed to propose dropping RHEL 6.2 support for libmongocrypt.

## Adding a runtime check

Removing the workaround of CDRIVER-3340 motivated adding a compile-time check to ensure libbson is newer than 1.16.0 (to include fix of CDRIVER-3340). The check for 1.16.0 is a precaution to ensure using a system install of libbson is 1.16.0 or newer. When libbson is loaded from the system, [a version check is not performed](https://github.com/mongodb/libmongocrypt/blob/7f396b84308ae0428bcdf4f55f9b387ecfe24981/cmake/ImportBSON.cmake#L110-L128).

