### PR TITLE
Use native cryptography where available

### DIFF
--- a/bindings/java/mongocrypt/build.gradle.kts
+++ b/bindings/java/mongocrypt/build.gradle.kts
@@ -139,7 +139,7 @@ tasks.register<Copy>("unzipJava") {
     outputs.upToDateWhen { false }
     from(tarTree(resources.gzip("${jnaDownloadsDir}/libmongocrypt-java.tar.gz")))
     include(jnaMapping.keys.flatMap {
-        listOf("${it}/nocrypto/**/libmongocrypt.so", "${it}/nocrypto/**/libmongocrypt.dylib", "${it}/nocrypto/**/mongocrypt.dll" )
+        listOf("${it}/nocrypto/**/libmongocrypt.so", "${it}/lib/**/libmongocrypt.dylib", "${it}/lib/**/mongocrypt.dll" )
     })
     eachFile {
         path = "${jnaMapping[path.substringBefore("/")]}/${name}"

--- a/bindings/java/mongocrypt/build.gradle.kts
+++ b/bindings/java/mongocrypt/build.gradle.kts
@@ -139,7 +139,7 @@ tasks.register<Copy>("unzipJava") {
     outputs.upToDateWhen { false }
     from(tarTree(resources.gzip("${jnaDownloadsDir}/libmongocrypt-java.tar.gz")))
     include(jnaMapping.keys.flatMap {
-        listOf("${it}/nocrypto/**/libmongocrypt.so", "${it}/lib/**/libmongocrypt.dylib", "${it}/lib/**/mongocrypt.dll" )
+        listOf("${it}/nocrypto/**/libmongocrypt.so", "${it}/lib/**/libmongocrypt.dylib", "${it}/bin/**/mongocrypt.dll" )
     })
     eachFile {
         path = "${jnaMapping[path.substringBefore("/")]}/${name}"

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
@@ -624,6 +624,17 @@ public class CAPI {
     public static native boolean
     mongocrypt_status(mongocrypt_t crypt, mongocrypt_status_t status);
 
+    /**
+     * Returns true if libmongocrypt was built with native crypto support.
+     *
+     * <p>
+     * If libmongocrypt was not built with native crypto support, setting crypto hooks is required.
+     * </p>
+     *
+     * @return true if libmongocrypt was built with native crypto support
+     */
+    public static native boolean
+    mongocrypt_is_crypto_available();
 
     /**
      * Destroy the @ref mongocrypt_t object.


### PR DESCRIPTION
* Only register crypto Java callbacks if mongocrypt_is_crypto_available returns false
* Package crypto-enabled shared libraries on Mac and Windows
* Continue to package crypto-disabled shared libraries on Linux due to OpenSSL incompatibilities. Applications can force use of a crypto-enabled shared library by manually installing it in the system path or else specify the path via jna.library.path system variable.

JAVA-5306