### PR TITLE
enable policy CMP0135

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ elseif (DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
    message (WARNING "The CMAKE_MSVC_RUNTIME_LIBRARY variable is set, but CMake is too old to understand it")
 endif ()
 
+if (POLICY CMP0135)
+   cmake_policy (SET CMP0135 NEW)
+endif ()
+
 project (mongocrypt C)
 
 # Used for the csfle-markup util:


### PR DESCRIPTION
Intended to address this warning when running CMake:

```
CMake Warning (dev) at C:/Program Files/CMake/share/cmake-3.28/Modules/FetchContent.cmake:1331 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is 
  not set.  The policy's OLD behavior will be used.  When using a URL       
  download, the timestamps of extracted files should preferably be that of  
  the time of extraction, otherwise code that depends on the extracted      
  contents might not be rebuilt if the URL changes.  The OLD behavior       
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the    
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this      
  robustness issue.
Call Stack (most recent call first):
  cmake/FetchMongoC.cmake:23 (FetchContent_Declare)
  cmake/ImportBSON.cmake:105 (include)
  CMakeLists.txt:52 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```