### PR TITLE
MONGOCRYPT-685 fix disabling patching and whitespace

### DIFF
--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -6,6 +6,7 @@ set (MONGOC_FETCH_TAG_FOR_LIBBSON "1.27.1" CACHE STRING "The Git tag of mongo-c-
 
 # Add an option to disable patching if a patch command is unavailable.
 option (LIBBSON_PATCH_ENABLED "Whether to apply patches to the libbson library" ON)
+set (patch_disabled OFF)
 if (NOT LIBBSON_PATCH_ENABLED)
     set (patch_disabled ON)
 endif ()

--- a/cmake/IntelDFP.cmake
+++ b/cmake/IntelDFP.cmake
@@ -17,6 +17,7 @@ if (NOT INTEL_DFP_LIBRARY_URL_SHA256 STREQUAL "no-verify")
     set (_hash_arg URL_HASH "${INTEL_DFP_LIBRARY_URL_HASH}")
 endif ()
 
+set (patch_disabled OFF)
 if (NOT INTEL_DFP_LIBRARY_PATCH_ENABLED)
     set (patch_disabled ON)
 endif ()

--- a/cmake/Patch.cmake
+++ b/cmake/Patch.cmake
@@ -31,6 +31,8 @@ function(make_patch_command out)
         if(patch_STRIP_COMPONENTS)
             list(APPEND cmd -p${patch_STRIP_COMPONENTS})
         endif()
+        # Ignore whitespace errors to fix patch errors on Windows: The patch file may be converted to \r\n by git, but libbson fetched with \n.
+        list(APPEND cmd "--ignore-whitespace")
         # git accepts patch filepaths as positional arguments
         list(APPEND cmd ${patch_PATCHES})
     else()


### PR DESCRIPTION
# Summary

This is a follow-up to https://github.com/mongodb/libmongocrypt/pull/818 to resolve two observed issues:

- Configuring with `LIBBSON_PATCH_ENABLED=OFF` incorrectly disabled patching for IntelDFP.
- Patching libbson failed on a local Windows build in non-Cygwin shell.




