### PR TITLE
MONGOCRYPT-625 address Coverity issues

### DIFF
--- a/src/mc-fle2-rfds.c
+++ b/src/mc-fle2-rfds.c
@@ -264,7 +264,7 @@ bool mc_FLE2RangeFindDriverSpec_parse(mc_FLE2RangeFindDriverSpec_t *spec,
             }
         }
 
-        operator_value_t op;
+        operator_value_t op = {0};
         switch (arg_type) {
         case AGGREGATE_EXPRESSION:
             if (!parse_aggregate_expression(in, &doc, &op, status)) {

--- a/src/mc-fle2-rfds.c
+++ b/src/mc-fle2-rfds.c
@@ -217,7 +217,7 @@ bool mc_FLE2RangeFindDriverSpec_parse(mc_FLE2RangeFindDriverSpec_t *spec,
     // {$and: [{$gt: ["$age", 5]}, {$lt:["$age", 50]}]}
     // Or `in` may be a Match Expression with this form:
     // {$and: [{age: {$gt: 5}}, {age: {$lt: 50}} ]}
-    bson_iter_t and, array;
+    bson_iter_t and = {0}, array = {0};
     bool ok = false;
 
     if (!parse_and(in, &and, status)) {

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -1434,7 +1434,7 @@ static bool _fle2_append_compactionTokens(mongocrypt_t *crypt,
                                           const char *command_name,
                                           bson_t *out,
                                           mongocrypt_status_t *status) {
-    bson_t result_compactionTokens;
+    bson_t result_compactionTokens = BSON_INITIALIZER;
     bool ret = false;
 
     BSON_ASSERT_PARAM(crypt);


### PR DESCRIPTION
# Summary

Addresses additional issues reported in Coverity. All three issues appear to be false positives due. Coverity appears not to realize the values are initialized as out-params of other functions calls. This PR proposes initializing to resolve the Coverity issues.