### PR TITLE
MONGOCRYPT-683 add SSDLC report

### DIFF
--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -20,7 +20,8 @@ For a patch release (e.g. x.y.z) check the rx.y reference target. For a minor re
 ### Release
 
 Do the following when releasing:
-- Ensure `etc/purls.txt` is up-to-date. 
+- Ensure `etc/purls.txt` is up-to-date.
+- Update `etc/third_party_vulnerabilities.md` with any updates to new or known vulnerabilities for third party dependencies that must be reported.
 - If this is a feature release (e.g. `x.y.0` or `x.0.0`), follow these steps: [Creating SSDLC static analysis reports](https://docs.google.com/document/d/1rkFL8ymbkc0k8Apky9w5pTPbvKRm68wj17mPJt2_0yo/edit).
 - Update CHANGELOG.md with the version being released.
 - Check out the release branch. For a release `x.y.z`, the release branch is `rx.y`. If this is a new minor release (`x.y.0`), create the release branch.
@@ -50,6 +51,8 @@ Do the following when releasing:
      ```
      For a new minor release, use `master` for `--branch`. For a patch release, use the release branch (e.g. `rx.y`).
      Secrets can be obtained from [AWS Secrets Manager](https://wiki.corp.mongodb.com/display/DRIVERS/Using+AWS+Secrets+Manager+to+Store+Testing+Secrets) under `drivers/libmongocrypt`.
+   - Attach `etc/third_party_vulnerabilities.md` to the release.
+   - Attach `ssdlc_compliance_report.md` to the release.
 
 - If this is a new minor release (e.g. `x.y.0`):
    - File a DOCSP ticket to update the installation instructions on [Install libmongocrypt](https://www.mongodb.com/docs/manual/core/csfle/reference/libmongocrypt/). ([Example](https://jira.mongodb.org/browse/DOCSP-36863))

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -7,15 +7,31 @@ Version numbers of libmongocrypt must follow the format 1.[0-9].[0-9] for releas
 
 ## Steps to release ##
 
-### Check Snyk
+### Check for Vulnerabilities
 
-Snyk is used to satisfy vulnerability scanning requirements of [DRIVERS-714](https://jira.mongodb.org/browse/DRIVERS-714). Prior to releasing, ensure necessary Snyk reported vulnerabilities meet requirements described in: [MongoDB Software Security Development Lifecycle Policy](https://docs.google.com/document/d/1u0m4Kj2Ny30zU74KoEFCN4L6D_FbEYCaJ3CQdCYXTMc/edit?tab=t.0#bookmark=id.l09k96qt24jm).
+Snyk and Silk are used to satisfy vulnerability scanning requirements of [DRIVERS-714](https://jira.mongodb.org/browse/DRIVERS-714). Prior to releasing, ensure necessary reported vulnerabilities meet requirements described in: [MongoDB Software Security Development Lifecycle Policy](https://docs.google.com/document/d/1u0m4Kj2Ny30zU74KoEFCN4L6D_FbEYCaJ3CQdCYXTMc/edit?tab=t.0#bookmark=id.l09k96qt24jm).
+
+#### Check Snyk
 
 Go to [Snyk](https://app.snyk.io/) and select the `dev-prod` organization. If access is needed, see [Snyk Onboarding](https://docs.google.com/document/d/1A38HvDvVFOwLtJQfQwIGcy5amAIpDwHUkNInwezLwXY/edit#heading=h.9ayipd2nt7xg). Check the CLI target named `mongodb/libmongocrypt`. The CLI targets may be identified by this icon: ![CLI icon](img/cli-icon.png). There are reference targets for each tracked branch:
 
 ![Reference Targets](img/reference-targets.png)
 
 For a patch release (e.g. x.y.z) check the rx.y reference target. For a minor release (e.g. x.y.0) check the master reference target.
+
+#### Check Silk
+
+Download the Augmented SBOM using:
+```bash
+./.evergreen/earthly.sh \
+   --secret silk_client_id=${silk_client_id} \
+   --secret silk_client_secret=${silk_client_secret} \
+   +sbom-download \
+   --out cyclonedx.augmented.sbom.json \
+   --branch <branch>
+```
+
+Check the Augmented SBOM for the "vulnerabilities" field.
 
 ### Release
 

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -31,7 +31,7 @@ Download the Augmented SBOM using:
    --branch <branch>
 ```
 
-Check the Augmented SBOM for the "vulnerabilities" field.
+Check the contents of the "vulnerabilities" field (if present) in the Augmented SBOM.
 
 ### Release
 

--- a/etc/silk-create-asset-group.sh
+++ b/etc/silk-create-asset-group.sh
@@ -40,7 +40,7 @@ asset_id="libmongocrypt-${branch}"
 json_payload=$(cat <<EOF
 {
     "active": true,
-    "name": "libmongocrypt",
+    "name": "${asset_id}",
     "code_repo_url": "https://github.com/mongodb/libmongocrypt",
     "branch": "${branch}",
     "metadata": {

--- a/etc/ssdlc_compliance_report.md
+++ b/etc/ssdlc_compliance_report.md
@@ -1,0 +1,37 @@
+# libmongocrypt SSDLC Compliance Report
+
+## Release Creator
+
+See [C/CXX Release Info](https://docs.google.com/spreadsheets/d/1yHfGmDnbA5-Qt8FX4tKWC5xk9AhzYZx1SKF4AD36ecY/edit?usp=sharing) (internal).
+
+## Process Document
+
+Not available. <!-- DRIVERS-2892: replace with link to public-facing document once available. -->
+
+## Tool used to track third party vulnerabilities
+
+Silk and Snyk.
+
+## Third-Party Dependency Information
+
+See `cyclonedx.augmented.sbom.json` attached to release.
+
+## Static Analysis Findings
+
+See [SSDLC Static Analysis Reports](https://drive.google.com/drive/folders/17bjBnQ3mhEXvs6IK1rrTphJr0CUO2qZh?usp=sharing) (internal) for release-specific reports.
+
+## Security Testing Report
+
+See [libmongocrypt Security Testing Summary](https://docs.google.com/document/d/1dc7uvBzu3okAIsA8LSW5sVQGkYIvwpBVdg5v4wb4c4s?usp=sharing) (internal). Available as needed from the libmongocrypt team.
+
+## Security Assessment Report
+
+Not applicable to libmongocrypt.
+
+## Signature Information
+
+Signatures for Windows binaries are attached to this release and may be verified with `gpg`. The public key for `libmongocrypt` is available on https://pgp.mongodb.com/.
+
+## Known Vulnerabilities
+
+Any vulnerabilities that may be shown in the links referenced above have been reviewed and accepted by the appropriate approvers. For detailed information, see `third_party_vulnerabilities.md` attached to release.

--- a/etc/third_party_vulnerabilities.md
+++ b/etc/third_party_vulnerabilities.md
@@ -25,7 +25,17 @@ This section provides a template that may be used for actual vulnerability repor
 
 ## libbson
 
-None.
+### CVE-2023-0437
+
+- **Date Detected:** 2024-05-20
+- **Severity:** Medium
+- **Detector:** Snyk
+- **Description:** Loop with Unreachable Exit Condition ('Infinite Loop')
+- **Dependency:** libbson 1.17.0
+- **Upstream Status:** Fix Available (1.25.0, 2023-11-01).
+- **Fix Status:** Fix Committed.
+- **For Release:** The libmongocrypt release version for which the "Fix Status" above was last updated.
+- **Notes:** Fixed in libbson 1.25.0 ([CDRIVER-4747](https://jira.mongodb.org/browse/CDRIVER-4747)). Fixed in libmongocrypt by upgrading libbson to 1.27.1.
 
 ## IntelDFP
 

--- a/etc/third_party_vulnerabilities.md
+++ b/etc/third_party_vulnerabilities.md
@@ -34,7 +34,7 @@ This section provides a template that may be used for actual vulnerability repor
 - **Dependency:** mongodb/mongo-c-driver@1.17.7
 - **Upstream Status:** Fix Available (1.25.0, 2023-11-01).
 - **Fix Status:** Fix Committed.
-- **For Release:** The libmongocrypt release version for which the "Fix Status" above was last updated.
+- **For Release:** 1.10.1
 - **Notes:** Fixed in libbson 1.25.0 ([CDRIVER-4747](https://jira.mongodb.org/browse/CDRIVER-4747)). Fixed in libmongocrypt by upgrading libbson to 1.27.1.
 
 ## IntelDFP

--- a/etc/third_party_vulnerabilities.md
+++ b/etc/third_party_vulnerabilities.md
@@ -35,7 +35,7 @@ This section provides a template that may be used for actual vulnerability repor
 - **Upstream Status:** Fix Available (1.25.0, 2023-11-01).
 - **Fix Status:** Fix Committed.
 - **For Release:** 1.10.1
-- **Notes:** Fixed in libbson 1.25.0 ([CDRIVER-4747](https://jira.mongodb.org/browse/CDRIVER-4747)). Fixed in libmongocrypt by upgrading libbson to 1.27.1.
+- **Notes:** Fixed in libbson 1.25.0 ([CDRIVER-4747](https://jira.mongodb.org/browse/CDRIVER-4747)). Fixed in libmongocrypt by upgrading libbson to 1.27.1 ([MONGOCRYPT-685](https://jira.mongodb.org/browse/MONGOCRYPT-685)).
 
 ## IntelDFP
 

--- a/etc/third_party_vulnerabilities.md
+++ b/etc/third_party_vulnerabilities.md
@@ -1,0 +1,32 @@
+# 3rd Party Dependency Vulnerabilities
+
+This document tracks vulnerabilities in 3rd party dependencies that directly affect the standard release product of libmongocrypt.
+
+> [!IMPORTANT]
+> The "standard release product" is defined as the set of files which are _installed_ by a configuration, build, and install of libmongocrypt. This includes static/shared library files, header files, and packaging files for supported build configurations. Vulnerabilities for 3rd party dependencies that are bundled with the standard release product are reported in this document.
+>
+> Language bindings (in the `bindings` directory), test files, utility scripts, documentation generators, and other miscellaneous files and artifacts are NOT considered part of the standard release product, even if they are included in the release distribution tarball. Vulnerabilities for such 3rd party dependencies are NOT reported in this document.
+
+## Template
+
+This section provides a template that may be used for actual vulnerability reports further below.
+
+### CVE-YYYY-NNNNNN
+
+- **Date Detected:** YYYY-MM-DD
+- **Severity:** Low, Medium, High, or Critical
+- **Detector:** Silk or Snyk
+- **Description:** A short vulnerability description.
+- **Dependency:** Name and version of the 3rd party dependency.
+- **Upstream Status:** False Positive, Won't Fix, Fix Pending, or Fix Available. This is the fix status for the 3rd party dependency, not libmongocrypt. "Fix Available" should include the version and/or date when the fix was released, e.g. "Fix Available (1.2.3, 1970-01-01)".
+- **Fix Status:** False Positive, Won't Fix, Fix Pending, or Fix Committed. This is the fix status for the libmongocrypt. "False Positive" and "Won't Fix" must include rationale in notes below.
+- **For Release:** The libmongocrypt release version for which the "Fix Status" above was last updated.
+- **Notes:** Context or rationale for remediation, references to relevant issue trackers, etc.
+
+## libbson
+
+None.
+
+## IntelDFP
+
+None.

--- a/etc/third_party_vulnerabilities.md
+++ b/etc/third_party_vulnerabilities.md
@@ -31,7 +31,7 @@ This section provides a template that may be used for actual vulnerability repor
 - **Severity:** Medium
 - **Detector:** Snyk
 - **Description:** Loop with Unreachable Exit Condition ('Infinite Loop')
-- **Dependency:** libbson 1.17.0
+- **Dependency:** mongodb/mongo-c-driver@1.17.7
 - **Upstream Status:** Fix Available (1.25.0, 2023-11-01).
 - **Fix Status:** Fix Committed.
 - **For Release:** The libmongocrypt release version for which the "Fix Status" above was last updated.


### PR DESCRIPTION
# Summary

- Add release steps to attach `ssdlc_compliance_report.md`.
- Add release steps to check Silk.

As a drive-by improvement, update the Silk asset group name to include the branch suffix to ease locating in the [Silk web UI](https://us1.app.silk.security/inventory/asset-group?assetId=&assets-filters=%5B%7B%22filterCriteria%22%3A%22startsWith%22%2C%22filterField%22%3A%22name%22%2C%22filterString%22%3A%5B%22libmongocrypt%22%5D%2C%22filterType%22%3A%22string%22%7D%5D&assets-page=1).

# Background & Motivation

`ssdlc_compliance_report.md` is based off the [template](https://gist.github.com/rtimmons/8253d1dfcc5f233bdb2d9c73b8e5c129#file-minimal-md) referenced in [Proposal: SSDLC Compliance Verification Flow](https://docs.google.com/document/d/1yRbq_LZLn9vq4PzqWFqe9-zyhC97B3-mr_LiCKVuJrc/edit) and the report [proposed for the C++ driver](https://github.com/mongodb/mongo-cxx-driver/pull/1149).

`third_party_vulnerabilities.md` is inspired by the [same-named file](https://github.com/mongodb/mongo-cxx-driver/blob/61191579820637dad4d0faf59e28f04e2439891f/etc/third_party_vulnerabilities.md) in the C++ driver.

