### PR TITLE
MONGOCRYPT-699 Omit `encryptionInformation` in compact if no range fields are used

### DIFF
--- a/bindings/python/test/data/compact/success/encrypted-payload.json
+++ b/bindings/python/test/data/compact/success/encrypted-payload.json
@@ -1,55 +1,5 @@
 {
   "compactStructuredEncryptionData": "test",
-  "encryptionInformation": {
-    "type": 1,
-    "schema": {
-      "db.test": {
-        "escCollection": "esc",
-        "eccCollection": "ecc",
-        "ecocCollection": "ecoc",
-        "fields": [
-          {
-            "keyId": {
-              "$binary": {
-                "base64": "EjRWeBI0mHYSNBI0VniQEg==",
-                "subType": "04"
-              }
-            },
-            "path": "encrypted",
-            "bsonType": "string",
-            "queries": {
-              "queryType": "equality",
-              "contention": 0
-            }
-          },
-          {
-            "keyId": {
-              "$binary": {
-                "base64": "q83vqxI0mHYSNBI0VniQEg==",
-                "subType": "04"
-              }
-            },
-            "path": "nested.encrypted",
-            "bsonType": "string",
-            "queries": {
-              "queryType": "equality",
-              "contention": 0
-            }
-          },
-          {
-            "keyId": {
-              "$binary": {
-                "base64": "EjRWeBI0mHYSNBI0VniQEw==",
-                "subType": "04"
-              }
-            },
-            "path": "nested.notindexed",
-            "bsonType": "string"
-          }
-        ]
-      }
-    }
-  },
   "compactionTokens": {
     "nested.notindexed": {
       "$binary": {

--- a/test/data/compact/no-range/cmd.json
+++ b/test/data/compact/no-range/cmd.json
@@ -1,0 +1,1 @@
+{ "compactStructuredEncryptionData": "test" }

--- a/test/data/compact/no-range/collinfo.json
+++ b/test/data/compact/no-range/collinfo.json
@@ -1,0 +1,49 @@
+{
+    "options": {
+        "encryptedFields": {
+            "escCollection": "esc",
+            "eccCollection": "ecc",
+            "ecocCollection": "ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "encrypted",
+                    "bsonType": "string",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": 0
+                    }
+                },
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "nested.encrypted",
+                    "bsonType": "string",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": 0
+                    }
+                },
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "EjRWeBI0mHYSNBI0VniQEw==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "nested.notindexed",
+                    "bsonType": "string"
+                }
+            ]
+        }
+    }
+}

--- a/test/data/compact/no-range/encrypted-field-config-map.json
+++ b/test/data/compact/no-range/encrypted-field-config-map.json
@@ -1,0 +1,47 @@
+{
+    "db.test": {
+        "escCollection": "esc",
+        "eccCollection": "ecc",
+        "ecocCollection": "ecoc",
+        "fields": [
+            {
+                "keyId": {
+                    "$binary": {
+                        "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                        "subType": "04"
+                    }
+                },
+                "path": "encrypted",
+                "bsonType": "string",
+                "queries": {
+                    "queryType": "equality",
+                    "contention": 0
+                }
+            },
+            {
+                "keyId": {
+                    "$binary": {
+                        "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                        "subType": "04"
+                    }
+                },
+                "path": "nested.encrypted",
+                "bsonType": "string",
+                "queries": {
+                    "queryType": "equality",
+                    "contention": 0
+                }
+            },
+            {
+                "keyId": {
+                    "$binary": {
+                        "base64": "EjRWeBI0mHYSNBI0VniQEw==",
+                        "subType": "04"
+                    }
+                },
+                "path": "nested.notindexed",
+                "bsonType": "string"
+            }
+        ]
+    }
+}

--- a/test/data/compact/no-range/encrypted-payload.json
+++ b/test/data/compact/no-range/encrypted-payload.json
@@ -1,0 +1,23 @@
+{
+   "compactStructuredEncryptionData": "test",
+   "compactionTokens": {
+      "nested.notindexed": {
+         "$binary": {
+            "base64": "27J6DZqcjkRzZ3lWEsxH7CsQHr4CZirrGmuPS8ZkRO0=",
+            "subType": "00"
+         }
+      },
+      "nested.encrypted": {
+         "$binary": {
+            "base64": "SWO8WEoZ2r2Kx/muQKb7+COizy85nIIUFiHh4K9kcvA=",
+            "subType": "00"
+         }
+      },
+      "encrypted": {
+         "$binary": {
+            "base64": "noN+05JsuO1oDg59yypIGj45i+eFH6HOTXOPpeZ//Mk=",
+            "subType": "00"
+         }
+      }
+   }
+}

--- a/test/test-mongocrypt-compact.c
+++ b/test/test-mongocrypt-compact.c
@@ -81,6 +81,64 @@ static void _test_compact_success(_mongocrypt_tester_t *tester) {
             mongocrypt_destroy(crypt);
         }
     }
+
+    // Test `compactStructuredEncryptionData` without range fields omits encryptionInformation.
+    // This is a regression test for MONGOCRYPT-699.
+    for (int use_range_v2 = 0; use_range_v2 <= 1; use_range_v2++) {
+        datapath[nullb] = 0;
+        strcat(datapath, "no-range/");
+        strcpy(cmdfile, datapath);
+        strcat(cmdfile, "cmd.json");
+        strcpy(collfile, datapath);
+        strcat(collfile, "collinfo.json");
+        strcpy(payloadfile, datapath);
+        strcat(payloadfile, "encrypted-payload.json"); // Expect same result regardless of range v2.
+
+        mongocrypt_t *crypt;
+        mongocrypt_ctx_t *ctx;
+
+        crypt =
+            _mongocrypt_tester_mongocrypt(use_range_v2 ? TESTER_MONGOCRYPT_WITH_RANGE_V2 : TESTER_MONGOCRYPT_DEFAULT);
+        ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TEST_FILE(cmdfile)), ctx);
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TEST_FILE(collfile)), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_KEYS);
+        {
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx,
+                                                TEST_FILE("./test/data/keys/"
+                                                          "12345678123498761234123456789012-local-document.json")),
+                      ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx,
+                                                TEST_FILE("./test/data/keys/"
+                                                          "ABCDEFAB123498761234123456789012-local-document.json")),
+                      ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx,
+                                                TEST_FILE("./test/data/keys/"
+                                                          "12345678123498761234123456789013-local-document.json")),
+                      ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_READY);
+        {
+            mongocrypt_binary_t *out = mongocrypt_binary_new();
+            ASSERT_OK(mongocrypt_ctx_finalize(ctx, out), ctx);
+            ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON(TEST_FILE(payloadfile), out);
+            mongocrypt_binary_destroy(out);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_DONE);
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
 }
 
 static void _test_compact_nonlocal_kms(_mongocrypt_tester_t *tester) {


### PR DESCRIPTION
See MONGOCRYPT-699. Bug was discovered by a PHP driver test receiving an error running `compactStructuredEncryptionData` on non-range fields in server 7.0 after upgrading libmongocrypt:

```
Command 'compactStructuredEncryptionData' requires field 'encryptionInformation' when range fields are present
```

A drivers integration test for running compact with range fields is proposed in https://github.com/mongodb/specifications/pull/1605
