### PR TITLE
MONGOCRYPT-703 Error if precision-mode encoding cannot be used

### DIFF
--- a/src/mc-range-edge-generation-private.h
+++ b/src/mc-range-edge-generation-private.h
@@ -86,7 +86,7 @@ typedef struct {
     uint32_t trimFactor;
 } mc_getEdgesDecimal128_args_t;
 
-mc_edges_t *mc_getEdgesDecimal128(mc_getEdgesDecimal128_args_t args, mongocrypt_status_t *status);
+mc_edges_t *mc_getEdgesDecimal128(mc_getEdgesDecimal128_args_t args, mongocrypt_status_t *status, bool use_range_v2);
 #endif // MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
 
 BSON_STATIC_ASSERT2(ull_is_u64, sizeof(uint64_t) == sizeof(unsigned long long));

--- a/src/mc-range-edge-generation-private.h
+++ b/src/mc-range-edge-generation-private.h
@@ -75,7 +75,7 @@ typedef struct {
 
 // mc_getEdgesDouble implements the Edge Generation algorithm described in
 // SERVER-67751 for double.
-mc_edges_t *mc_getEdgesDouble(mc_getEdgesDouble_args_t args, mongocrypt_status_t *status);
+mc_edges_t *mc_getEdgesDouble(mc_getEdgesDouble_args_t args, mongocrypt_status_t *status, bool use_range_v2);
 
 #if MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
 typedef struct {

--- a/src/mc-range-edge-generation.c
+++ b/src/mc-range-edge-generation.c
@@ -182,14 +182,15 @@ mc_edges_t *mc_getEdgesInt64(mc_getEdgesInt64_args_t args, mongocrypt_status_t *
     return ret;
 }
 
-mc_edges_t *mc_getEdgesDouble(mc_getEdgesDouble_args_t args, mongocrypt_status_t *status) {
+mc_edges_t *mc_getEdgesDouble(mc_getEdgesDouble_args_t args, mongocrypt_status_t *status, bool use_range_v2) {
     mc_OSTType_Double got;
     if (!mc_getTypeInfoDouble((mc_getTypeInfoDouble_args_t){.value = args.value,
                                                             .min = args.min,
                                                             .max = args.max,
                                                             .precision = args.precision},
                               &got,
-                              status)) {
+                              status,
+                              use_range_v2)) {
         return NULL;
     }
 

--- a/src/mc-range-edge-generation.c
+++ b/src/mc-range-edge-generation.c
@@ -207,7 +207,7 @@ mc_edges_t *mc_getEdgesDouble(mc_getEdgesDouble_args_t args, mongocrypt_status_t
 }
 
 #if MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
-mc_edges_t *mc_getEdgesDecimal128(mc_getEdgesDecimal128_args_t args, mongocrypt_status_t *status) {
+mc_edges_t *mc_getEdgesDecimal128(mc_getEdgesDecimal128_args_t args, mongocrypt_status_t *status, bool use_range_v2) {
     mc_OSTType_Decimal128 got;
     if (!mc_getTypeInfoDecimal128(
             (mc_getTypeInfoDecimal128_args_t){
@@ -217,7 +217,8 @@ mc_edges_t *mc_getEdgesDecimal128(mc_getEdgesDecimal128_args_t args, mongocrypt_
                 .precision = args.precision,
             },
             &got,
-            status)) {
+            status,
+            use_range_v2)) {
         return NULL;
     }
 

--- a/src/mc-range-encoding-private.h
+++ b/src/mc-range-encoding-private.h
@@ -86,6 +86,9 @@ typedef struct {
     mc_optional_uint32_t precision;
 } mc_getTypeInfoDouble_args_t;
 
+// `mc_canUsePrecisionModeDouble` returns true if the domain can be represented in fewer than 64 bits.
+bool mc_canUsePrecisionModeDouble(double min, double max, uint32_t precision, uint32_t *maxBitsOut);
+
 /* mc_getTypeInfoDouble encodes the double `args.value` into an OSTType_Double
  * `out`. Returns false and sets `status` on error. */
 bool mc_getTypeInfoDouble(mc_getTypeInfoDouble_args_t args,
@@ -106,6 +109,9 @@ typedef struct {
     mc_optional_dec128_t min, max;
     mc_optional_uint32_t precision;
 } mc_getTypeInfoDecimal128_args_t;
+
+// `mc_canUsePrecisionModeDecimal` returns true if the domain can be represented in fewer than 128 bits.
+bool mc_canUsePrecisionModeDecimal(mc_dec128 min, mc_dec128 max, uint32_t precision, uint32_t *maxBitsOut);
 
 /**
  * @brief Obtain the OST encoding of a finite Decimal128 value.

--- a/src/mc-range-encoding-private.h
+++ b/src/mc-range-encoding-private.h
@@ -117,7 +117,8 @@ typedef struct {
  */
 bool mc_getTypeInfoDecimal128(mc_getTypeInfoDecimal128_args_t args,
                               mc_OSTType_Decimal128 *out,
-                              mongocrypt_status_t *status) MONGOCRYPT_WARN_UNUSED_RESULT;
+                              mongocrypt_status_t *status,
+                              bool use_range_v2) MONGOCRYPT_WARN_UNUSED_RESULT;
 #endif // MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
 
 #endif /* MC_RANGE_ENCODING_PRIVATE_H */

--- a/src/mc-range-encoding-private.h
+++ b/src/mc-range-encoding-private.h
@@ -90,7 +90,8 @@ typedef struct {
  * `out`. Returns false and sets `status` on error. */
 bool mc_getTypeInfoDouble(mc_getTypeInfoDouble_args_t args,
                           mc_OSTType_Double *out,
-                          mongocrypt_status_t *status) MONGOCRYPT_WARN_UNUSED_RESULT;
+                          mongocrypt_status_t *status,
+                          bool use_range_v2) MONGOCRYPT_WARN_UNUSED_RESULT;
 
 #if MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
 /**

--- a/src/mc-range-encoding.c
+++ b/src/mc-range-encoding.c
@@ -338,7 +338,8 @@ static mlib_int128 dec128_to_int128(mc_dec128 dec) {
 
 bool mc_getTypeInfoDecimal128(mc_getTypeInfoDecimal128_args_t args,
                               mc_OSTType_Decimal128 *out,
-                              mongocrypt_status_t *status) {
+                              mongocrypt_status_t *status,
+                              bool use_range_v2) {
     /// Basic param checks
     if (args.min.set != args.max.set || args.min.set != args.precision.set) {
         CLIENT_ERR("min, max, and precision must all be set or must all be unset");

--- a/src/mc-range-encoding.c
+++ b/src/mc-range-encoding.c
@@ -163,7 +163,10 @@ bool mc_getTypeInfo64(mc_getTypeInfo64_args_t args, mc_OSTType_Int64 *out, mongo
 
 #define exp10Double(x) pow(10, x)
 
-bool mc_getTypeInfoDouble(mc_getTypeInfoDouble_args_t args, mc_OSTType_Double *out, mongocrypt_status_t *status) {
+bool mc_getTypeInfoDouble(mc_getTypeInfoDouble_args_t args,
+                          mc_OSTType_Double *out,
+                          mongocrypt_status_t *status,
+                          bool use_range_v2) {
     if (args.min.set != args.max.set || args.min.set != args.precision.set) {
         CLIENT_ERR("min, max, and precision must all be set or must all be unset");
         return false;

--- a/src/mc-range-encoding.c
+++ b/src/mc-range-encoding.c
@@ -239,6 +239,15 @@ bool mc_getTypeInfoDouble(mc_getTypeInfoDouble_args_t args,
                 }
             }
         }
+
+        if (!use_precision_mode && use_range_v2) {
+            CLIENT_ERR("The domain of double values specified by the min, max, and precision cannot be represented in "
+                       "fewer than 64 bits. min: %g, max: %g, precision: %" PRIu32,
+                       args.min.value,
+                       args.max.value,
+                       args.precision.value);
+            return false;
+        }
     }
 
     if (use_precision_mode) {

--- a/src/mc-range-encoding.c
+++ b/src/mc-range-encoding.c
@@ -428,6 +428,14 @@ bool mc_getTypeInfoDecimal128(mc_getTypeInfoDecimal128_args_t args,
                 }
             }
         }
+        if (!use_precision_mode && use_range_v2) {
+            CLIENT_ERR("The domain of decimal values specified by the min, max, and precision cannot be represented in "
+                       "fewer than 128 bits. min: %s, max: %s, precision: %" PRIu32,
+                       mc_dec128_to_string(args.min.value).str,
+                       mc_dec128_to_string(args.max.value).str,
+                       args.precision.value);
+            return false;
+        }
     }
 
     // Constant zero

--- a/src/mc-range-encoding.c
+++ b/src/mc-range-encoding.c
@@ -163,6 +163,34 @@ bool mc_getTypeInfo64(mc_getTypeInfo64_args_t args, mc_OSTType_Int64 *out, mongo
 
 #define exp10Double(x) pow(10, x)
 
+bool mc_canUsePrecisionModeDouble(double min, double max, uint32_t precision, uint32_t *maxBitsOut) {
+    BSON_ASSERT_PARAM(maxBitsOut);
+
+    bool use_precision_mode = false;
+    double range = max - min;
+
+    // We can overflow if max = max double and min = min double so make sure
+    // we have finite number after we do subtraction
+    // Ignore conversion warnings to fix error with glibc.
+    if (mc_isfinite(range)) {
+        // This creates a range which is wider then we permit by our min/max
+        // bounds check with the +1 but it is as the algorithm is written in
+        // WRITING-11907.
+        double rangeAndPrecision = (range + 1) * exp10Double(precision);
+
+        if (mc_isfinite(rangeAndPrecision)) {
+            double bits_range_double = log2(rangeAndPrecision);
+            *maxBitsOut = (uint32_t)ceil(bits_range_double);
+
+            if (*maxBitsOut < 64) {
+                use_precision_mode = true;
+            }
+        }
+    }
+
+    return use_precision_mode;
+}
+
 bool mc_getTypeInfoDouble(mc_getTypeInfoDouble_args_t args,
                           mc_OSTType_Double *out,
                           mongocrypt_status_t *status,
@@ -219,27 +247,8 @@ bool mc_getTypeInfoDouble(mc_getTypeInfoDouble_args_t args,
             return false;
         }
 
-        double range = args.max.value - args.min.value;
-
-        // We can overflow if max = max double and min = min double so make sure
-        // we have finite number after we do subtraction
-        // Ignore conversion warnings to fix error with glibc.
-        if (mc_isfinite(range)) {
-            // This creates a range which is wider then we permit by our min/max
-            // bounds check with the +1 but it is as the algorithm is written in
-            // WRITING-11907.
-            double rangeAndPrecision = (range + 1) * exp10Double(args.precision.value);
-
-            if (mc_isfinite(rangeAndPrecision)) {
-                double bits_range_double = log2(rangeAndPrecision);
-                bits_range = (uint32_t)ceil(bits_range_double);
-
-                if (bits_range < 64) {
-                    use_precision_mode = true;
-                }
-            }
-        }
-
+        use_precision_mode =
+            mc_canUsePrecisionModeDouble(args.min.value, args.max.value, args.precision.value, &bits_range);
         if (!use_precision_mode && use_range_v2) {
             CLIENT_ERR("The domain of double values specified by the min, max, and precision cannot be represented in "
                        "fewer than 64 bits. min: %g, max: %g, precision: %" PRIu32,
@@ -336,6 +345,44 @@ static mlib_int128 dec128_to_int128(mc_dec128 dec) {
     return ret;
 }
 
+bool mc_canUsePrecisionModeDecimal(mc_dec128 min, mc_dec128 max, uint32_t precision, uint32_t *maxBitsOut) {
+    BSON_ASSERT_PARAM(maxBitsOut);
+
+    bool use_precision_mode = false;
+    // max - min
+    mc_dec128 bounds_n1 = mc_dec128_sub(max, min);
+    // The size of [min, max]: (max - min) + 1
+    mc_dec128 bounds = mc_dec128_add(bounds_n1, MC_DEC128_ONE);
+
+    // We can overflow if max = max_dec128 and min = min_dec128 so make sure
+    // we have finite number after we do subtraction
+    if (mc_dec128_is_finite(bounds)) {
+        // This creates a range which is wider then we permit by our min/max
+        // bounds check with the +1 but it is as the algorithm is written in
+        // WRITING-11907.
+        mc_dec128 precision_scaled_bounds = mc_dec128_scale(bounds, precision);
+        /// The number of bits required to hold the result for the given
+        /// precision (as decimal)
+        mc_dec128 bits_range_dec = mc_dec128_log2(precision_scaled_bounds);
+
+        if (mc_dec128_is_finite(bits_range_dec) && mc_dec128_less(bits_range_dec, MC_DEC128(128))) {
+            // We need fewer than 128 bits to hold the result. But round up,
+            // just to be sure:
+            int64_t r = mc_dec128_to_int64(mc_dec128_round_integral_ex(bits_range_dec, MC_DEC128_ROUND_UPWARD, NULL));
+            BSON_ASSERT(r >= 0);
+            BSON_ASSERT(r <= UINT8_MAX);
+            // We've computed the proper 'bits_range'
+            *maxBitsOut = (uint8_t)r;
+
+            if (*maxBitsOut < 128) {
+                use_precision_mode = true;
+            }
+        }
+    }
+
+    return use_precision_mode;
+}
+
 bool mc_getTypeInfoDecimal128(mc_getTypeInfoDecimal128_args_t args,
                               mc_OSTType_Decimal128 *out,
                               mongocrypt_status_t *status,
@@ -389,7 +436,7 @@ bool mc_getTypeInfoDecimal128(mc_getTypeInfoDecimal128_args_t args,
     // full range.
     bool use_precision_mode = false;
     // The number of bits required to hold the result (used for precision mode)
-    uint8_t bits_range = 0;
+    uint32_t bits_range = 0;
     if (args.precision.set) {
         // Subnormal representations can support up to 5x10^-6182 as a number
         if (args.precision.value > 6182) {
@@ -397,37 +444,9 @@ bool mc_getTypeInfoDecimal128(mc_getTypeInfoDecimal128_args_t args,
             return false;
         }
 
-        // max - min
-        mc_dec128 bounds_n1 = mc_dec128_sub(args.max.value, args.min.value);
-        // The size of [min, max]: (max - min) + 1
-        mc_dec128 bounds = mc_dec128_add(bounds_n1, MC_DEC128_ONE);
+        use_precision_mode =
+            mc_canUsePrecisionModeDecimal(args.min.value, args.max.value, args.precision.value, &bits_range);
 
-        // We can overflow if max = max_dec128 and min = min_dec128 so make sure
-        // we have finite number after we do subtraction
-        if (mc_dec128_is_finite(bounds)) {
-            // This creates a range which is wider then we permit by our min/max
-            // bounds check with the +1 but it is as the algorithm is written in
-            // WRITING-11907.
-            mc_dec128 precision_scaled_bounds = mc_dec128_scale(bounds, args.precision.value);
-            /// The number of bits required to hold the result for the given
-            /// precision (as decimal)
-            mc_dec128 bits_range_dec = mc_dec128_log2(precision_scaled_bounds);
-
-            if (mc_dec128_is_finite(bits_range_dec) && mc_dec128_less(bits_range_dec, MC_DEC128(128))) {
-                // We need fewer than 128 bits to hold the result. But round up,
-                // just to be sure:
-                int64_t r =
-                    mc_dec128_to_int64(mc_dec128_round_integral_ex(bits_range_dec, MC_DEC128_ROUND_UPWARD, NULL));
-                BSON_ASSERT(r >= 0);
-                BSON_ASSERT(r <= UINT8_MAX);
-                // We've computed the proper 'bits_range'
-                bits_range = (uint8_t)r;
-
-                if (bits_range < 128) {
-                    use_precision_mode = true;
-                }
-            }
-        }
         if (!use_precision_mode && use_range_v2) {
             CLIENT_ERR("The domain of decimal values specified by the min, max, and precision cannot be represented in "
                        "fewer than 128 bits. min: %s, max: %s, precision: %" PRIu32,
@@ -478,9 +497,9 @@ bool mc_getTypeInfoDecimal128(mc_getTypeInfoDecimal128_args_t args,
         v_prime2 = mc_dec128_round_integral_ex(v_prime2, MC_DEC128_ROUND_TOWARD_ZERO, NULL);
 
         BSON_ASSERT(mc_dec128_less(mc_dec128_log2(v_prime2), MC_DEC128(128)));
-
+        BSON_ASSERT(bits_range < 128);
         // Resulting OST maximum
-        mlib_int128 ost_max = mlib_int128_sub(mlib_int128_pow2(bits_range), i128_one);
+        mlib_int128 ost_max = mlib_int128_sub(mlib_int128_pow2((uint8_t)bits_range), i128_one);
 
         // Now we need to get the Decimal128 out as a 128-bit integer
         // But Decimal128 does not support conversion to Int128.

--- a/src/mc-range-mincover-private.h
+++ b/src/mc-range-mincover-private.h
@@ -83,7 +83,8 @@ typedef struct {
 // mc_getMincoverDouble implements the Mincover Generation algorithm described
 // in SERVER-68600 for double.
 mc_mincover_t *mc_getMincoverDouble(mc_getMincoverDouble_args_t args,
-                                    mongocrypt_status_t *status) MONGOCRYPT_WARN_UNUSED_RESULT;
+                                    mongocrypt_status_t *status,
+                                    bool use_range_v2) MONGOCRYPT_WARN_UNUSED_RESULT;
 
 #if MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
 typedef struct {

--- a/src/mc-range-mincover-private.h
+++ b/src/mc-range-mincover-private.h
@@ -101,7 +101,8 @@ typedef struct {
 // mc_getMincoverDecimal128 implements the Mincover Generation algorithm
 // described in SERVER-68600 for Decimal128 (as mc_dec128).
 mc_mincover_t *mc_getMincoverDecimal128(mc_getMincoverDecimal128_args_t args,
-                                        mongocrypt_status_t *status) MONGOCRYPT_WARN_UNUSED_RESULT;
+                                        mongocrypt_status_t *status,
+                                        bool use_range_v2) MONGOCRYPT_WARN_UNUSED_RESULT;
 #endif // MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
 
 #endif /* MC_RANGE_MINCOVER_PRIVATE_H */

--- a/src/mc-range-mincover.c
+++ b/src/mc-range-mincover.c
@@ -235,7 +235,8 @@ mc_mincover_t *mc_getMincoverDouble(mc_getMincoverDouble_args_t args, mongocrypt
 }
 
 #if MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
-mc_mincover_t *mc_getMincoverDecimal128(mc_getMincoverDecimal128_args_t args, mongocrypt_status_t *status) {
+mc_mincover_t *
+mc_getMincoverDecimal128(mc_getMincoverDecimal128_args_t args, mongocrypt_status_t *status, bool use_range_v2) {
     BSON_ASSERT_PARAM(status);
 #define ToString(Dec) (mc_dec128_to_string(Dec).str)
     CHECK_BOUNDS(args, "s", ToString, mc_dec128_less);
@@ -246,7 +247,8 @@ mc_mincover_t *mc_getMincoverDecimal128(mc_getMincoverDecimal128_args_t args, mo
                                                                     .max = args.max,
                                                                     .precision = args.precision},
                                   &a,
-                                  status)) {
+                                  status,
+                                  use_range_v2)) {
         return NULL;
     }
     if (!mc_getTypeInfoDecimal128((mc_getTypeInfoDecimal128_args_t){.value = args.upperBound,
@@ -254,7 +256,8 @@ mc_mincover_t *mc_getMincoverDecimal128(mc_getMincoverDecimal128_args_t args, mo
                                                                     .max = args.max,
                                                                     .precision = args.precision},
                                   &b,
-                                  status)) {
+                                  status,
+                                  use_range_v2)) {
         return NULL;
     }
 

--- a/src/mc-range-mincover.c
+++ b/src/mc-range-mincover.c
@@ -193,7 +193,7 @@ mc_mincover_t *mc_getMincoverInt64(mc_getMincoverInt64_args_t args, mongocrypt_s
 
 // mc_getMincoverDouble implements the Mincover Generation algorithm described
 // in SERVER-68600 for double.
-mc_mincover_t *mc_getMincoverDouble(mc_getMincoverDouble_args_t args, mongocrypt_status_t *status) {
+mc_mincover_t *mc_getMincoverDouble(mc_getMincoverDouble_args_t args, mongocrypt_status_t *status, bool use_range_v2) {
     BSON_ASSERT_PARAM(status);
     CHECK_BOUNDS(args, "g", IDENTITY, LESSTHAN);
 
@@ -203,7 +203,8 @@ mc_mincover_t *mc_getMincoverDouble(mc_getMincoverDouble_args_t args, mongocrypt
                                                             .max = args.max,
                                                             .precision = args.precision},
                               &a,
-                              status)) {
+                              status,
+                              use_range_v2)) {
         return NULL;
     }
     if (!mc_getTypeInfoDouble((mc_getTypeInfoDouble_args_t){.value = args.upperBound,
@@ -211,7 +212,8 @@ mc_mincover_t *mc_getMincoverDouble(mc_getMincoverDouble_args_t args, mongocrypt
                                                             .max = args.max,
                                                             .precision = args.precision},
                               &b,
-                              status)) {
+                              status,
+                              use_range_v2)) {
         return NULL;
     }
 

--- a/src/mc-rangeopts-private.h
+++ b/src/mc-rangeopts-private.h
@@ -99,7 +99,8 @@ bool mc_RangeOpts_appendTrimFactor(const mc_RangeOpts_t *ro,
                                    bson_type_t valueType,
                                    const char *fieldName,
                                    bson_t *out,
-                                   mongocrypt_status_t *status);
+                                   mongocrypt_status_t *status,
+                                   bool use_range_v2);
 
 void mc_RangeOpts_cleanup(mc_RangeOpts_t *ro);
 

--- a/src/mc-rangeopts.c
+++ b/src/mc-rangeopts.c
@@ -249,7 +249,7 @@ bool mc_RangeOpts_to_FLE2RangeInsertSpec(const mc_RangeOpts_t *ro,
     }
 
     if (use_range_v2) {
-        if (!mc_RangeOpts_appendTrimFactor(ro, bson_iter_type(&v_iter), "trimFactor", &child, status)) {
+        if (!mc_RangeOpts_appendTrimFactor(ro, bson_iter_type(&v_iter), "trimFactor", &child, status, use_range_v2)) {
             return false;
         }
     }
@@ -378,7 +378,8 @@ bool mc_RangeOpts_appendMax(const mc_RangeOpts_t *ro,
 bool mc_getNumberOfBits(const mc_RangeOpts_t *ro,
                         bson_type_t valueType,
                         uint32_t *bitsOut,
-                        mongocrypt_status_t *status) {
+                        mongocrypt_status_t *status,
+                        bool use_range_v2) {
     BSON_ASSERT_PARAM(ro);
     BSON_ASSERT_PARAM(bitsOut);
 
@@ -445,7 +446,7 @@ bool mc_getNumberOfBits(const mc_RangeOpts_t *ro,
         }
         mc_getTypeInfoDouble_args_t args = {value, rmin, rmax, prec};
         mc_OSTType_Double out;
-        if (!mc_getTypeInfoDouble(args, &out, status)) {
+        if (!mc_getTypeInfoDouble(args, &out, status, use_range_v2)) {
             return false;
         }
         *bitsOut = 64 - (uint32_t)mc_count_leading_zeros_u64(out.max);
@@ -482,7 +483,8 @@ bool mc_RangeOpts_appendTrimFactor(const mc_RangeOpts_t *ro,
                                    bson_type_t valueType,
                                    const char *fieldName,
                                    bson_t *out,
-                                   mongocrypt_status_t *status) {
+                                   mongocrypt_status_t *status,
+                                   bool use_range_v2) {
     BSON_ASSERT_PARAM(ro);
     BSON_ASSERT_PARAM(fieldName);
     BSON_ASSERT_PARAM(out);
@@ -498,7 +500,7 @@ bool mc_RangeOpts_appendTrimFactor(const mc_RangeOpts_t *ro,
     BSON_ASSERT(ro->trimFactor.value <= INT32_MAX);
 
     uint32_t nbits;
-    if (!mc_getNumberOfBits(ro, valueType, &nbits, status)) {
+    if (!mc_getNumberOfBits(ro, valueType, &nbits, status, use_range_v2)) {
         return false;
     }
     // if nbits = 0, we want to allow trim factor = 0.

--- a/src/mc-rangeopts.c
+++ b/src/mc-rangeopts.c
@@ -465,7 +465,7 @@ bool mc_getNumberOfBits(const mc_RangeOpts_t *ro,
         }
         mc_getTypeInfoDecimal128_args_t args = {value, rmin, rmax, prec};
         mc_OSTType_Decimal128 out;
-        if (!mc_getTypeInfoDecimal128(args, &out, status)) {
+        if (!mc_getTypeInfoDecimal128(args, &out, status, use_range_v2)) {
             return false;
         }
         *bitsOut = 128 - (uint32_t)mc_count_leading_zeros_u128(out.max);

--- a/src/mongocrypt-marking-private.h
+++ b/src/mongocrypt-marking-private.h
@@ -63,6 +63,7 @@ bool _mongocrypt_marking_to_ciphertext(void *ctx,
 
 mc_mincover_t *mc_get_mincover_from_FLE2RangeFindSpec(mc_FLE2RangeFindSpec_t *findSpec,
                                                       size_t sparsity,
-                                                      mongocrypt_status_t *status) MONGOCRYPT_WARN_UNUSED_RESULT;
+                                                      mongocrypt_status_t *status,
+                                                      bool use_range_v2) MONGOCRYPT_WARN_UNUSED_RESULT;
 
 #endif /* MONGOCRYPT_MARKING_PRIVATE_H */

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -962,7 +962,7 @@ get_edges(mc_FLE2RangeInsertSpec_t *insertSpec, size_t sparsity, mongocrypt_stat
             args.max = OPT_MC_DEC128(max);
             args.precision = insertSpec->precision;
         }
-        return mc_getEdgesDecimal128(args, status);
+        return mc_getEdgesDecimal128(args, status, use_range_v2);
 #else // ↑↑↑↑↑↑↑↑ With Decimal128 / Without ↓↓↓↓↓↓↓↓↓↓
         CLIENT_ERR("unsupported BSON type (Decimal128) for range: libmongocrypt "
                    "was built without extended Decimal128 support");
@@ -1530,7 +1530,7 @@ mc_mincover_t *mc_get_mincover_from_FLE2RangeFindSpec(mc_FLE2RangeFindSpec_t *fi
             args.max = OPT_MC_DEC128(mc_dec128_from_bson_iter(&findSpec->edgesInfo.value.indexMax));
             args.precision = findSpec->edgesInfo.value.precision;
         }
-        return mc_getMincoverDecimal128(args, status);
+        return mc_getMincoverDecimal128(args, status, use_range_v2);
 #else // ↑↑↑↑↑↑↑↑ With Decimal128 / Without ↓↓↓↓↓↓↓↓↓↓
         CLIENT_ERR("FLE2 find is not supported for Decimal128: libmongocrypt "
                    "was built without Decimal128 support");

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -896,7 +896,8 @@ fail:
 
 // get_edges creates and returns edges from an FLE2RangeInsertSpec. Returns NULL
 // on error.
-static mc_edges_t *get_edges(mc_FLE2RangeInsertSpec_t *insertSpec, size_t sparsity, mongocrypt_status_t *status) {
+static mc_edges_t *
+get_edges(mc_FLE2RangeInsertSpec_t *insertSpec, size_t sparsity, mongocrypt_status_t *status, bool use_range_v2) {
     BSON_ASSERT_PARAM(insertSpec);
 
     bson_type_t value_type = bson_iter_type(&insertSpec->v);
@@ -943,7 +944,7 @@ static mc_edges_t *get_edges(mc_FLE2RangeInsertSpec_t *insertSpec, size_t sparsi
             args.precision = insertSpec->precision;
         }
 
-        return mc_getEdgesDouble(args, status);
+        return mc_getEdgesDouble(args, status, use_range_v2);
     }
 
     else if (value_type == BSON_TYPE_DECIMAL128) {
@@ -1025,7 +1026,7 @@ static bool _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange_v1(
     // g:= array<EdgeTokenSet>
     {
         BSON_ASSERT(placeholder->sparsity >= 0 && (uint64_t)placeholder->sparsity <= (uint64_t)SIZE_MAX);
-        edges = get_edges(&insertSpec, (size_t)placeholder->sparsity, status);
+        edges = get_edges(&insertSpec, (size_t)placeholder->sparsity, status, kb->crypt->opts.use_range_v2);
         if (!edges) {
             goto fail;
         }
@@ -1159,7 +1160,7 @@ static bool _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForRange(_mo
     // g:= array<EdgeTokenSetV2>
     {
         BSON_ASSERT(placeholder->sparsity >= 0 && (uint64_t)placeholder->sparsity <= (uint64_t)SIZE_MAX);
-        edges = get_edges(&insertSpec, (size_t)placeholder->sparsity, status);
+        edges = get_edges(&insertSpec, (size_t)placeholder->sparsity, status, kb->crypt->opts.use_range_v2);
         if (!edges) {
             goto fail;
         }
@@ -1390,8 +1391,10 @@ static bool isInfinite(bson_iter_t *iter) {
 
 // mc_get_mincover_from_FLE2RangeFindSpec creates and returns a mincover from an
 // FLE2RangeFindSpec. Returns NULL on error.
-mc_mincover_t *
-mc_get_mincover_from_FLE2RangeFindSpec(mc_FLE2RangeFindSpec_t *findSpec, size_t sparsity, mongocrypt_status_t *status) {
+mc_mincover_t *mc_get_mincover_from_FLE2RangeFindSpec(mc_FLE2RangeFindSpec_t *findSpec,
+                                                      size_t sparsity,
+                                                      mongocrypt_status_t *status,
+                                                      bool use_range_v2) {
     BSON_ASSERT_PARAM(findSpec);
     BSON_ASSERT(findSpec->edgesInfo.set);
 
@@ -1505,7 +1508,7 @@ mc_get_mincover_from_FLE2RangeFindSpec(mc_FLE2RangeFindSpec_t *findSpec, size_t 
             args.max = OPT_DOUBLE(bson_iter_double(&findSpec->edgesInfo.value.indexMax));
             args.precision = findSpec->edgesInfo.value.precision;
         }
-        return mc_getMincoverDouble(args, status);
+        return mc_getMincoverDouble(args, status, use_range_v2);
     }
     case BSON_TYPE_DECIMAL128: {
 #if MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
@@ -1571,6 +1574,7 @@ static bool _mongocrypt_fle2_placeholder_to_find_ciphertextForRange_v1(_mongocry
     BSON_ASSERT_PARAM(ciphertext);
     BSON_ASSERT(kb->crypt);
 
+    const bool use_range_v2 = kb->crypt->opts.use_range_v2;
     _mongocrypt_crypto_t *crypto = kb->crypt->crypto;
     mc_FLE2EncryptionPlaceholder_t *placeholder = &marking->fle2;
     mc_FLE2FindRangePayload_t payload;
@@ -1588,7 +1592,7 @@ static bool _mongocrypt_fle2_placeholder_to_find_ciphertextForRange_v1(_mongocry
     // Parse the query bounds and index bounds from FLE2EncryptionPlaceholder for
     // range find.
     mc_FLE2RangeFindSpec_t findSpec;
-    if (!mc_FLE2RangeFindSpec_parse(&findSpec, &placeholder->v_iter, kb->crypt->opts.use_range_v2, status)) {
+    if (!mc_FLE2RangeFindSpec_parse(&findSpec, &placeholder->v_iter, use_range_v2, status)) {
         goto fail;
     }
 
@@ -1615,7 +1619,8 @@ static bool _mongocrypt_fle2_placeholder_to_find_ciphertextForRange_v1(_mongocry
         // g:= array<EdgeFindTokenSet>
         {
             BSON_ASSERT(placeholder->sparsity >= 0 && (uint64_t)placeholder->sparsity <= (uint64_t)SIZE_MAX);
-            mincover = mc_get_mincover_from_FLE2RangeFindSpec(&findSpec, (size_t)placeholder->sparsity, status);
+            mincover =
+                mc_get_mincover_from_FLE2RangeFindSpec(&findSpec, (size_t)placeholder->sparsity, status, use_range_v2);
             if (!mincover) {
                 goto fail;
             }
@@ -1709,6 +1714,7 @@ static bool _mongocrypt_fle2_placeholder_to_find_ciphertextForRange(_mongocrypt_
         return _mongocrypt_fle2_placeholder_to_find_ciphertextForRange_v1(kb, marking, ciphertext, status);
     }
 
+    const bool use_range_v2 = kb->crypt->opts.use_range_v2;
     mc_FLE2EncryptionPlaceholder_t *placeholder = &marking->fle2;
     mc_FLE2FindRangePayloadV2_t payload;
     bool res = false;
@@ -1724,7 +1730,7 @@ static bool _mongocrypt_fle2_placeholder_to_find_ciphertextForRange(_mongocrypt_
     // Parse the query bounds and index bounds from FLE2EncryptionPlaceholder for
     // range find.
     mc_FLE2RangeFindSpec_t findSpec;
-    if (!mc_FLE2RangeFindSpec_parse(&findSpec, &placeholder->v_iter, kb->crypt->opts.use_range_v2, status)) {
+    if (!mc_FLE2RangeFindSpec_parse(&findSpec, &placeholder->v_iter, use_range_v2, status)) {
         goto fail;
     }
 
@@ -1735,7 +1741,8 @@ static bool _mongocrypt_fle2_placeholder_to_find_ciphertextForRange(_mongocrypt_
         // g:= array<EdgeFindTokenSet>
         {
             BSON_ASSERT(placeholder->sparsity >= 0 && (uint64_t)placeholder->sparsity <= (uint64_t)SIZE_MAX);
-            mincover = mc_get_mincover_from_FLE2RangeFindSpec(&findSpec, (size_t)placeholder->sparsity, status);
+            mincover =
+                mc_get_mincover_from_FLE2RangeFindSpec(&findSpec, (size_t)placeholder->sparsity, status, use_range_v2);
             if (!mincover) {
                 goto fail;
             }

--- a/test/test-mc-range-edge-generation.c
+++ b/test/test-mc-range-edge-generation.c
@@ -327,7 +327,8 @@ static void _test_getEdgesDecimal128(_mongocrypt_tester_t *tester) {
             //  .max = test->max,
             .sparsity = (size_t)test->sparsity,
         };
-        mc_edges_t *got = mc_getEdgesDecimal128(args, status);
+        const bool use_range_v2 = true;
+        mc_edges_t *got = mc_getEdgesDecimal128(args, status, use_range_v2);
 
         if (test->expectError != NULL) {
             if (NULL != got) {

--- a/test/test-mc-range-edge-generation.c
+++ b/test/test-mc-range-edge-generation.c
@@ -259,7 +259,8 @@ static void _test_getEdgesDouble(_mongocrypt_tester_t *tester) {
         mongocrypt_status_t *const status = mongocrypt_status_new();
         const DoubleTest *test = tests + i;
         mc_getEdgesDouble_args_t args = {.value = test->value, .sparsity = test->sparsity};
-        mc_edges_t *got = mc_getEdgesDouble(args, status);
+        const bool use_range_v2 = true;
+        mc_edges_t *got = mc_getEdgesDouble(args, status, use_range_v2);
 
         if (test->expectError != NULL) {
             if (NULL != got) {

--- a/test/test-mc-range-encoding.c
+++ b/test/test-mc-range-encoding.c
@@ -771,12 +771,17 @@ static void _test_RangeTest_Encode_Decimal128(_mongocrypt_tester_t *tester) {
         }
         fflush(stdout);
         mc_OSTType_Decimal128 got;
-        const bool ok = mc_getTypeInfoDecimal128((mc_getTypeInfoDecimal128_args_t){.value = test->value,
-                                                                                   .min = test->min,
-                                                                                   .max = test->max,
-                                                                                   .precision = test->precision},
-                                                 &got,
-                                                 status);
+        const bool use_range_v2 = true;
+        const bool ok = mc_getTypeInfoDecimal128(
+            (mc_getTypeInfoDecimal128_args_t){
+                .value = test->value,
+                .min = test->min,
+                .max = test->max,
+                .precision = test->precision,
+            },
+            &got,
+            status,
+            use_range_v2);
         if (test->expectError) {
             ASSERT_OR_PRINT_MSG(!ok, "expected error, but got none");
             ASSERT_STATUS_CONTAINS(status, test->expectError);

--- a/test/test-mc-range-encoding.c
+++ b/test/test-mc-range-encoding.c
@@ -482,6 +482,7 @@ typedef struct {
     mc_optional_uint32_t precision;
     mlib_int128 expect;
     const char *expectError;
+    bool use_range_v1; // By default, use range v2.
 } Decimal128Test;
 
 static void _test_RangeTest_Encode_Decimal128(_mongocrypt_tester_t *tester) {
@@ -697,11 +698,24 @@ static void _test_RangeTest_Encode_Decimal128(_mongocrypt_tester_t *tester) {
         .expect = MLIB_INT128_CAST(Expect),                                                                            \
     }
 
+// ASSERT_EIBB_OVERFLOW defines cases where applying min/max/precision result in a domain needing >= 128 bits.
+// For range v1, expect precision to be ignored.
+// For range v2, expect an error.
 #define ASSERT_EIBB_OVERFLOW(Val, Max, Min, Precision, Expect)                                                         \
-    (Decimal128Test) {                                                                                                 \
-        .value = mc_dec128_from_string(#Val), .min = OPT_MC_DEC128(mc_dec128_from_string(#Min)),                       \
-        .max = OPT_MC_DEC128(mc_dec128_from_string(#Max)), .precision = OPT_U32(Precision), .expect = Expect,          \
-    }
+    (Decimal128Test){                                                                                                  \
+        .value = mc_dec128_from_string(#Val),                                                                          \
+        .min = OPT_MC_DEC128(mc_dec128_from_string(#Min)),                                                             \
+        .max = OPT_MC_DEC128(mc_dec128_from_string(#Max)),                                                             \
+        .precision = OPT_U32(Precision),                                                                               \
+        .expect = Expect,                                                                                              \
+        .use_range_v1 = true,                                                                                          \
+    },                                                                                                                 \
+        (Decimal128Test){.value = mc_dec128_from_string(#Val),                                                         \
+                         .min = OPT_MC_DEC128(mc_dec128_from_string(#Min)),                                            \
+                         .max = OPT_MC_DEC128(mc_dec128_from_string(#Max)),                                            \
+                         .precision = OPT_U32(Precision),                                                              \
+                         .expectError = "The domain of decimal values specified by the min, max, and precision "       \
+                                        "cannot be represented in fewer than 128 bits"}
 
         ASSERT_EIBB(0, 1, -1, 3, 1000),
         ASSERT_EIBB(0, 1, -1E5, 3, 100000000),
@@ -771,7 +785,7 @@ static void _test_RangeTest_Encode_Decimal128(_mongocrypt_tester_t *tester) {
         }
         fflush(stdout);
         mc_OSTType_Decimal128 got;
-        const bool use_range_v2 = true;
+        const bool use_range_v2 = !test->use_range_v1;
         const bool ok = mc_getTypeInfoDecimal128(
             (mc_getTypeInfoDecimal128_args_t){
                 .value = test->value,

--- a/test/test-mc-range-encoding.c
+++ b/test/test-mc-range-encoding.c
@@ -427,7 +427,8 @@ static void _test_RangeTest_Encode_Double(_mongocrypt_tester_t *tester) {
                                                                            .max = test->max,
                                                                            .precision = test->precision},
                                              &got,
-                                             status);
+                                             status,
+                                             use_range_v2);
         if (test->expectError) {
             ASSERT_OR_PRINT_MSG(!ok, "expected error, but got none");
             ASSERT_STATUS_CONTAINS(status, test->expectError);

--- a/test/test-mc-range-encoding.c
+++ b/test/test-mc-range-encoding.c
@@ -710,12 +710,12 @@ static void _test_RangeTest_Encode_Decimal128(_mongocrypt_tester_t *tester) {
         .expect = Expect,                                                                                              \
         .use_range_v1 = true,                                                                                          \
     },                                                                                                                 \
-        (Decimal128Test){.value = mc_dec128_from_string(#Val),                                                         \
-                         .min = OPT_MC_DEC128(mc_dec128_from_string(#Min)),                                            \
-                         .max = OPT_MC_DEC128(mc_dec128_from_string(#Max)),                                            \
-                         .precision = OPT_U32(Precision),                                                              \
-                         .expectError = "The domain of decimal values specified by the min, max, and precision "       \
-                                        "cannot be represented in fewer than 128 bits"}
+        (Decimal128Test) {                                                                                             \
+        .value = mc_dec128_from_string(#Val), .min = OPT_MC_DEC128(mc_dec128_from_string(#Min)),                       \
+        .max = OPT_MC_DEC128(mc_dec128_from_string(#Max)), .precision = OPT_U32(Precision),                            \
+        .expectError = "The domain of decimal values specified by the min, max, and precision "                        \
+                       "cannot be represented in fewer than 128 bits"                                                  \
+    }
 
         ASSERT_EIBB(0, 1, -1, 3, 1000),
         ASSERT_EIBB(0, 1, -1E5, 3, 100000000),

--- a/test/test-mc-range-mincover.c
+++ b/test/test-mc-range-mincover.c
@@ -123,6 +123,7 @@ static mc_mincover_t *_test_getMincover64(void *tests, size_t idx, mongocrypt_st
 static mc_mincover_t *_test_getMincoverDouble_helper(void *tests, size_t idx, mongocrypt_status_t *status) {
     BSON_ASSERT_PARAM(tests);
 
+    const bool use_range_v2 = true;
     DoubleTest *const test = (DoubleTest *)tests + idx;
 
     return mc_getMincoverDouble(
@@ -134,7 +135,8 @@ static mc_mincover_t *_test_getMincoverDouble_helper(void *tests, size_t idx, mo
                                       .min = test->precision.set ? test->min : (mc_optional_double_t){0},
                                       .max = test->precision.set ? test->max : (mc_optional_double_t){0},
                                       .precision = test->precision},
-        status);
+        status,
+        use_range_v2);
 }
 
 #if MONGOCRYPT_HAVE_DECIMAL128_SUPPORT

--- a/test/test-mc-range-mincover.c
+++ b/test/test-mc-range-mincover.c
@@ -145,6 +145,7 @@ static mc_mincover_t *_test_getMincoverDecimal128_helper(void *tests, size_t idx
 
     Decimal128Test *const test = (Decimal128Test *)tests + idx;
 
+    const bool use_range_v2 = true;
     return mc_getMincoverDecimal128(
         (mc_getMincoverDecimal128_args_t){.lowerBound = test->lowerBound,
                                           .includeLowerBound = test->includeLowerBound,
@@ -154,7 +155,8 @@ static mc_mincover_t *_test_getMincoverDecimal128_helper(void *tests, size_t idx
                                           .min = test->precision.set ? test->min : (mc_optional_dec128_t){0},
                                           .max = test->precision.set ? test->max : (mc_optional_dec128_t){0},
                                           .precision = test->precision},
-        status);
+        status,
+        use_range_v2);
 }
 #endif // MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
 

--- a/test/test-mongocrypt-marking.c
+++ b/test/test-mongocrypt-marking.c
@@ -885,7 +885,8 @@ static void test_mc_get_mincover_from_FLE2RangeFindSpec(_mongocrypt_tester_t *te
             sparsity = (size_t)test->sparsity.value;
         }
 
-        mc_mincover_t *mc = mc_get_mincover_from_FLE2RangeFindSpec(&findSpec, sparsity, status);
+        const bool use_range_v2 = true;
+        mc_mincover_t *mc = mc_get_mincover_from_FLE2RangeFindSpec(&findSpec, sparsity, status, use_range_v2);
 
         if (test->expectedError) {
             ASSERT(NULL == mc);


### PR DESCRIPTION
# Summary

Error if precision-mode encoding cannot be used when precision is specified.

Patch build: https://spruce.mongodb.com/version/66849c9eb759740007686794

# Background & Motivation

Applies similar changes from https://github.com/10gen/mongo/pull/23753. See SERVER-91571 for motivation.

The server validates in `validateEncryptedFieldConfig` to prevent creating a collection with an invalid `min/max/precision`. This PR proposes adding the validation in the `mc_getTypeInfo*` functions. This is intended to validate regardless of how `min/max/precision` was specified (manually for explicit encryption or from placeholders for automatic encryption).

The error check is only applied for rangev2 to match server behavior. This motivated passing a `use_range_v2` argument to multiple functions. The argument may be removed once rangev2 is made the default in MONGOCRYPT-661.
