### PR TITLE
MONGOCRYPT-706 clear `BUILD_VERSION` before including C driver

### DIFF
--- a/cmake/ImportBSON.cmake
+++ b/cmake/ImportBSON.cmake
@@ -142,9 +142,16 @@ function (_import_bson)
       set (ENABLE_EXTRA_ALIGNMENT ${_extra_alignment_default} CACHE BOOL "Toggle extra alignment of bson_t")
       # We don't want the subproject to find libmongocrypt
       set (ENABLE_CLIENT_SIDE_ENCRYPTION OFF CACHE BOOL "Disable client-side encryption for the libmongoc subproject")
-      # Set `BUILD_VERSION` so C driver does not use a `BUILD_VERSION` meant for libmongocrypt.
+      # Clear `BUILD_VERSION` so C driver does not use a `BUILD_VERSION` meant for libmongocrypt.
       # Both libmongocrypt and C driver support setting a `BUILD_VERSION` to override the version.
-      set (BUILD_VERSION ${MONGOC_FETCH_TAG_FOR_LIBBSON})
+      if (DEFINED CACHE{BUILD_VERSION})
+         set (SAVED_CACHED_BUILD_VERSION "${BUILD_VERSION}")
+         unset (BUILD_VERSION CACHE) # Undefine cache variable.
+      endif ()
+      if (DEFINED BUILD_VERSION)
+         set (SAVED_BUILD_VERSION "${BUILD_VERSION}")
+         unset (BUILD_VERSION) # Undefine normal variable.
+      endif ()
       # Disable building tests in C driver:
       set (ENABLE_TESTS OFF)
       set (BUILD_TESTING OFF)
@@ -156,6 +163,12 @@ function (_import_bson)
          add_subdirectory ("${MONGOCRYPT_MONGOC_DIR}" _mongo-c-driver EXCLUDE_FROM_ALL SYSTEM)
       else ()
          add_subdirectory ("${MONGOCRYPT_MONGOC_DIR}" _mongo-c-driver EXCLUDE_FROM_ALL)
+      endif ()
+      if (DEFINED SAVED_CACHED_BUILD_VERSION)
+         set (BUILD_VERSION "${SAVED_CACHED_BUILD_VERSION}" CACHE STRING "Library version")
+      endif ()
+      if (DEFINED SAVED_BUILD_VERSION)
+         set (BUILD_VERSION "${SAVED_BUILD_VERSION}")
       endif ()
       if (TARGET mongoc_static)
          # Workaround: Embedded mongoc_static does not set its INCLUDE_DIRECTORIES for user targets

--- a/cmake/ImportBSON.cmake
+++ b/cmake/ImportBSON.cmake
@@ -145,11 +145,11 @@ function (_import_bson)
       # Clear `BUILD_VERSION` so C driver does not use a `BUILD_VERSION` meant for libmongocrypt.
       # Both libmongocrypt and C driver support setting a `BUILD_VERSION` to override the version.
       if (DEFINED CACHE{BUILD_VERSION})
-         set (SAVED_CACHED_BUILD_VERSION "${BUILD_VERSION}")
+         set (saved_cached_build_version "${BUILD_VERSION}")
          unset (BUILD_VERSION CACHE) # Undefine cache variable.
       endif ()
       if (DEFINED BUILD_VERSION)
-         set (SAVED_BUILD_VERSION "${BUILD_VERSION}")
+         set (saved_build_version "${BUILD_VERSION}")
          unset (BUILD_VERSION) # Undefine normal variable.
       endif ()
       # Disable building tests in C driver:
@@ -164,11 +164,11 @@ function (_import_bson)
       else ()
          add_subdirectory ("${MONGOCRYPT_MONGOC_DIR}" _mongo-c-driver EXCLUDE_FROM_ALL)
       endif ()
-      if (DEFINED SAVED_CACHED_BUILD_VERSION)
-         set (BUILD_VERSION "${SAVED_CACHED_BUILD_VERSION}" CACHE STRING "Library version")
+      if (DEFINED saved_cached_build_version)
+         set (BUILD_VERSION "${saved_cached_build_version}" CACHE STRING "Library version")
       endif ()
-      if (DEFINED SAVED_BUILD_VERSION)
-         set (BUILD_VERSION "${SAVED_BUILD_VERSION}")
+      if (DEFINED saved_build_version)
+         set (BUILD_VERSION "${saved_build_version}")
       endif ()
       if (TARGET mongoc_static)
          # Workaround: Embedded mongoc_static does not set its INCLUDE_DIRECTORIES for user targets


### PR DESCRIPTION
# Summary

Save and restore `BUILD_VERSION` before adding C driver project in CMake.

# Background & Motivation

Intended to resolve an observed error building libmongocrypt with `MONGOCRYPT_MONGOC_DIR` specified: https://github.com/mongodb/mongo-c-driver/pull/1656#discussion_r1657626974. The `BUILD_VERSION` intended for libmongocrypt was incorrectly applied to the C driver subproject.

`MONGOC_FETCH_TAG_FOR_LIBBSON` is only defined when `FetchMongoC.cmake` is loaded. When `MONGOCRYPT_MONGOC_DIR` is used, libbson is not fetched, and `MONGOC_FETCH_TAG_FOR_LIBBSON` is not defined.

This PR clears and restores the normal and cache variable for `BUILD_VERSION`. An attempt was made to set `BUILD_VERSION` to an empty string unconditionally. [CMake unset](https://cmake.org/cmake/help/latest/command/unset.html) notes:
> **unsetting a normal variable can expose a cache variable that was previously hidden**. To force a variable reference of the form ${VAR} to return an empty string, use set(<variable> ""), which clears the normal variable but leaves it defined.

However, the C driver only checks if `BUILD_VERSION` is [DEFINED](https://github.com/mongodb/mongo-c-driver/blob/fed2beb1b025c9ad2414f3e6070d09dc0e63f885/build/cmake/BuildVersion.cmake#L50) (rather than defined and not a false constant). Setting
`BUILD_VERSION` to an empty string results in the C driver attempting to use an empty string and failing to parse.
