### PR TITLE
MONGOCRYPT-695 Remove upper bound assertions on FLE2 range precision

### DIFF
--- a/src/mc-range-encoding.c
+++ b/src/mc-range-encoding.c
@@ -225,7 +225,7 @@ bool mc_getTypeInfoDouble(mc_getTypeInfoDouble_args_t args,
         }
 
         if (args.precision.set && args.precision.value > INT32_MAX) {
-            CLIENT_ERR("Precision cannot be greater than %d, got %u", INT32_MAX, args.precision.value);
+            CLIENT_ERR("Precision cannot be greater than %" PRId32 ", got %" PRIu32, INT32_MAX, args.precision.value);
             return false;
         }
     }
@@ -393,7 +393,7 @@ bool mc_getTypeInfoDecimal128(mc_getTypeInfoDecimal128_args_t args,
     }
 
     if (args.precision.set && args.precision.value > INT32_MAX) {
-        CLIENT_ERR("Precision cannot be greater than %d, got %u", INT32_MAX, args.precision.value);
+        CLIENT_ERR("Precision cannot be greater than %" PRId32 ", got %" PRIu32, INT32_MAX, args.precision.value);
         return false;
     }
 

--- a/src/mc-range-encoding.c
+++ b/src/mc-range-encoding.c
@@ -391,7 +391,7 @@ bool mc_getTypeInfoDecimal128(mc_getTypeInfoDecimal128_args_t args,
         CLIENT_ERR("min, max, and precision must all be set or must all be unset");
         return false;
     }
-    
+
     if (args.precision.set && args.precision.value > INT32_MAX) {
         CLIENT_ERR("Precision cannot be greater than %d, got %u", INT32_MAX, args.precision.value);
         return false;

--- a/src/mc-range-encoding.c
+++ b/src/mc-range-encoding.c
@@ -391,6 +391,11 @@ bool mc_getTypeInfoDecimal128(mc_getTypeInfoDecimal128_args_t args,
         CLIENT_ERR("min, max, and precision must all be set or must all be unset");
         return false;
     }
+    
+    if (args.precision.set && args.precision.value > INT32_MAX) {
+        CLIENT_ERR("Precision cannot be greater than %d, got %u", INT32_MAX, args.precision.value);
+        return false;
+    }
 
     // We only accept normal numbers
     if (mc_dec128_is_inf(args.value) || mc_dec128_is_nan(args.value)) {

--- a/src/mc-range-encoding.c
+++ b/src/mc-range-encoding.c
@@ -223,6 +223,11 @@ bool mc_getTypeInfoDouble(mc_getTypeInfoDouble_args_t args,
                        args.value);
             return false;
         }
+
+        if (args.precision.set && args.precision.value > INT32_MAX) {
+            CLIENT_ERR("Precision cannot be greater than %d, got %u", INT32_MAX, args.precision.value);
+            return false;
+        }
     }
 
     const bool is_neg = args.value < 0.0;

--- a/src/mc-range-encoding.c
+++ b/src/mc-range-encoding.c
@@ -241,12 +241,6 @@ bool mc_getTypeInfoDouble(mc_getTypeInfoDouble_args_t args,
     bool use_precision_mode = false;
     uint32_t bits_range;
     if (args.precision.set) {
-        // Subnormal representations can support up to 5x10^-324 as a number
-        if (args.precision.value > 324) {
-            CLIENT_ERR("Precision must be between 0 and 324 inclusive, got: %" PRIu32, args.precision.value);
-            return false;
-        }
-
         use_precision_mode =
             mc_canUsePrecisionModeDouble(args.min.value, args.max.value, args.precision.value, &bits_range);
         if (!use_precision_mode && use_range_v2) {
@@ -438,12 +432,6 @@ bool mc_getTypeInfoDecimal128(mc_getTypeInfoDecimal128_args_t args,
     // The number of bits required to hold the result (used for precision mode)
     uint32_t bits_range = 0;
     if (args.precision.set) {
-        // Subnormal representations can support up to 5x10^-6182 as a number
-        if (args.precision.value > 6182) {
-            CLIENT_ERR("Precision must be between 0 and 6182 inclusive, got: %" PRIu32, args.precision.value);
-            return false;
-        }
-
         use_precision_mode =
             mc_canUsePrecisionModeDecimal(args.min.value, args.max.value, args.precision.value, &bits_range);
 

--- a/test/test-mc-range-encoding.c
+++ b/test/test-mc-range-encoding.c
@@ -426,14 +426,6 @@ static void _test_RangeTest_Encode_Double(_mongocrypt_tester_t *tester) {
                            // For range v2, expect an error.
                            .expectError = "The domain of double values specified by the min, max, and precision cannot "
                                           "be represented in fewer than 64 bits"},
-                          {.value = 1,
-                           .max = OPT_DOUBLE_C(2),
-                           .min = OPT_DOUBLE_C(1),
-                           .precision = OPT_U32_C(309),
-                           // Applying min/max/precision result in a domain needing >= 64 bits to represent.
-                           // For range v2, expect an error.
-                           .expectError = "The domain of double values specified by the min, max, and precision cannot "
-                                          "be represented in fewer than 64 bits"},
                           /* Test cases copied from Double_Bounds_Precision ... end */
                           {.value = -1,
                            .min = OPT_DOUBLE_C(0),
@@ -658,12 +650,6 @@ static void _test_RangeTest_Encode_Decimal128(_mongocrypt_tester_t *tester) {
                    OPT_NULLOPT,
                    "Infinity and Nan Decimal128 values are not supported."),
 
-        ERROR_CASE(MC_DEC128_C(1),
-                   OPT_MC_DEC128(MC_DEC128_C(0)),
-                   OPT_MC_DEC128(MC_DEC128_C(1)),
-                   OPT_U32((uint32_t)INT32_MAX + 1),
-                   "cannot be greater than"),
-
 /* Test cases copied from Decimal128_Bounds_Precision ... begin */
 #define ASSERT_EIBP(Value, Precision, Expect)                                                                          \
     (Decimal128Test){                                                                                                  \
@@ -790,9 +776,6 @@ static void _test_RangeTest_Encode_Decimal128(_mongocrypt_tester_t *tester) {
         // Test a range that requires > 64 bits.
         // min has more places after the decimal than precision.
         ASSERT_EIBB(5, 18446744073709551616, .01, 1, 49),
-
-        // NOTE: largest value representable in Decimal128 is 9.999..*10^6144
-        ASSERT_EIBB_OVERFLOW(1, 2, 1, 6145, mlib_int128_from_string("231572183460469231731687303715884099585", NULL)),
 
 #undef ASSERT_EIBB
 #undef ASSERT_EIBB_OVERFLOW

--- a/test/test-mc-range-encoding.c
+++ b/test/test-mc-range-encoding.c
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "stdint.h"
 #include "test-mongocrypt.h"
 
 #include "mc-check-conversions-private.h"
@@ -21,6 +20,7 @@
 
 #include <float.h> // DBL_MAX
 #include <math.h>  // INFINITY, NAN
+#include <stdint.h>
 
 typedef struct {
     mc_getTypeInfo32_args_t args;

--- a/test/test-mc-range-encoding.c
+++ b/test/test-mc-range-encoding.c
@@ -754,7 +754,6 @@ static void _test_RangeTest_Encode_Decimal128(_mongocrypt_tester_t *tester) {
                              DBL_MIN,
                              3,
                              mlib_int128_from_string("170141183460469231731687303715884105728", NULL)),
-        ASSERT_EIBB_OVERFLOW(1, 2, 1, 6145, mlib_int128_from_string("231572183460469231731687303715884099585", NULL)),
 
         ASSERT_EIBB(3.141592653589, 5, 0, 0, 3),
         ASSERT_EIBB(3.141592653589, 5, 0, 1, 31),

--- a/test/test-mc-range-encoding.c
+++ b/test/test-mc-range-encoding.c
@@ -435,7 +435,13 @@ static void _test_RangeTest_Encode_Double(_mongocrypt_tester_t *tester) {
                            .min = OPT_DOUBLE_C(0),
                            .max = OPT_DOUBLE_C(201),
                            .precision = OPT_U32_C(1),
-                           .expectError = "less than or equal to the maximum value"}};
+                           .expectError = "less than or equal to the maximum value"},
+                          {.value = 1,
+                           .min = OPT_DOUBLE_C(1),
+                           .max = OPT_DOUBLE_C(2),
+                           .precision = OPT_U32_C(309),
+                           .expect = 13381399884061196960ULL,
+                           .expectMax = OPT_U64_C(UINT64_MAX)}};
 
     for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
         DoubleTest *test = tests + i;
@@ -732,6 +738,7 @@ static void _test_RangeTest_Encode_Decimal128(_mongocrypt_tester_t *tester) {
                              DBL_MIN,
                              3,
                              mlib_int128_from_string("170141183460469231731687303715884105728", NULL)),
+        ASSERT_EIBB_OVERFLOW(1, 2, 1, 6145, mlib_int128_from_string("231572183460469231731687303715884099585", NULL)),
 
         ASSERT_EIBB(3.141592653589, 5, 0, 0, 3),
         ASSERT_EIBB(3.141592653589, 5, 0, 1, 31),

--- a/test/test-mc-range-encoding.c
+++ b/test/test-mc-range-encoding.c
@@ -792,8 +792,7 @@ static void _test_RangeTest_Encode_Decimal128(_mongocrypt_tester_t *tester) {
          .min = OPT_MC_DEC128(MC_DEC128_C(0)),
          .max = OPT_MC_DEC128(MC_DEC128_C(1)),
          .precision = OPT_U32(6145),
-         .expectError = "Precision is too large"}
-    };
+         .expectError = "Precision is too large"}};
 
     for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
         Decimal128Test *test = tests + i;

--- a/test/test-mc-range-encoding.c
+++ b/test/test-mc-range-encoding.c
@@ -434,14 +434,6 @@ static void _test_RangeTest_Encode_Double(_mongocrypt_tester_t *tester) {
                            // For range v2, expect an error.
                            .expectError = "The domain of double values specified by the min, max, and precision cannot "
                                           "be represented in fewer than 64 bits"},
-                          {.value = 1,
-                           .max = OPT_DOUBLE_C(2),
-                           .min = OPT_DOUBLE_C(1),
-                           .precision = OPT_U32_C(325),
-                           // Applying min/max/precision result in a domain needing >= 64 bits to represent.
-                           // For range v2, expect an error.
-                           .expectError = "The domain of double values specified by the min, max, and precision cannot "
-                                          "be represented in fewer than 64 bits"},
                           /* Test cases copied from Double_Bounds_Precision ... end */
                           {.value = -1,
                            .min = OPT_DOUBLE_C(0),
@@ -657,6 +649,12 @@ static void _test_RangeTest_Encode_Decimal128(_mongocrypt_tester_t *tester) {
                    OPT_NULLOPT,
                    OPT_NULLOPT,
                    "Infinity and Nan Decimal128 values are not supported."),
+
+        ERROR_CASE(MC_DEC128_C(1),
+                   OPT_MC_DEC128(MC_DEC128_C(0)),
+                   OPT_MC_DEC128(MC_DEC128_C(1)),
+                   OPT_U32((uint32_t)INT32_MAX + 1),
+                   "cannot be greater than"),
 
 /* Test cases copied from Decimal128_Bounds_Precision ... begin */
 #define ASSERT_EIBP(Value, Precision, Expect)                                                                          \

--- a/test/test-mc-range-encoding.c
+++ b/test/test-mc-range-encoding.c
@@ -456,9 +456,8 @@ static void _test_RangeTest_Encode_Double(_mongocrypt_tester_t *tester) {
                           {.value = 1,
                            .min = OPT_DOUBLE_C(1),
                            .max = OPT_DOUBLE_C(2),
-                           .precision = OPT_U32_C((uint32_t) INT32_MAX + 1),
+                           .precision = OPT_U32_C((uint32_t)INT32_MAX + 1),
                            .expectError = "cannot be greater than"}};
-
 
     for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
         DoubleTest *test = tests + i;

--- a/test/test-mc-range-encoding.c
+++ b/test/test-mc-range-encoding.c
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "stdint.h"
 #include "test-mongocrypt.h"
 
 #include "mc-check-conversions-private.h"
@@ -425,6 +426,22 @@ static void _test_RangeTest_Encode_Double(_mongocrypt_tester_t *tester) {
                            // For range v2, expect an error.
                            .expectError = "The domain of double values specified by the min, max, and precision cannot "
                                           "be represented in fewer than 64 bits"},
+                          {.value = 1,
+                           .max = OPT_DOUBLE_C(2),
+                           .min = OPT_DOUBLE_C(1),
+                           .precision = OPT_U32_C(309),
+                           // Applying min/max/precision result in a domain needing >= 64 bits to represent.
+                           // For range v2, expect an error.
+                           .expectError = "The domain of double values specified by the min, max, and precision cannot "
+                                          "be represented in fewer than 64 bits"},
+                          {.value = 1,
+                           .max = OPT_DOUBLE_C(2),
+                           .min = OPT_DOUBLE_C(1),
+                           .precision = OPT_U32_C(325),
+                           // Applying min/max/precision result in a domain needing >= 64 bits to represent.
+                           // For range v2, expect an error.
+                           .expectError = "The domain of double values specified by the min, max, and precision cannot "
+                                          "be represented in fewer than 64 bits"},
                           /* Test cases copied from Double_Bounds_Precision ... end */
                           {.value = -1,
                            .min = OPT_DOUBLE_C(0),
@@ -439,9 +456,9 @@ static void _test_RangeTest_Encode_Double(_mongocrypt_tester_t *tester) {
                           {.value = 1,
                            .min = OPT_DOUBLE_C(1),
                            .max = OPT_DOUBLE_C(2),
-                           .precision = OPT_U32_C(309),
-                           .expect = 13381399884061196960ULL,
-                           .expectMax = OPT_U64_C(UINT64_MAX)}};
+                           .precision = OPT_U32_C((uint32_t) INT32_MAX + 1),
+                           .expectError = "cannot be greater than"}};
+
 
     for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
         DoubleTest *test = tests + i;
@@ -769,6 +786,9 @@ static void _test_RangeTest_Encode_Decimal128(_mongocrypt_tester_t *tester) {
         // Test a range that requires > 64 bits.
         // min has more places after the decimal than precision.
         ASSERT_EIBB(5, 18446744073709551616, .01, 1, 49),
+
+        // NOTE: largest value representable in Decimal128 is 9.999..*10^6144
+        ASSERT_EIBB_OVERFLOW(1, 2, 1, 6145, mlib_int128_from_string("231572183460469231731687303715884099585", NULL)),
 
 #undef ASSERT_EIBB
 #undef ASSERT_EIBB_OVERFLOW


### PR DESCRIPTION
Removes maximum precision assertions.

Corresponding server PR:https://github.com/10gen/mongo/pull/24903