### PR TITLE
JAVA-5321: Enable Query Encryption V2 as fixed default.

### DIFF
--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/CAPI.java
@@ -583,8 +583,8 @@ public class CAPI {
     mongocrypt_ctx_setopt_query_type (mongocrypt_ctx_t ctx, cstring query_type, int len);
 
     /**
-     * Set options for explicit encryption with the "rangePreview" algorithm.
-     * NOTE: The RangePreview algorithm is experimental only. It is not intended for
+     * Set options for explicit encryption with the "range" algorithm.
+     * NOTE: The range algorithm is unstable. It is not intended for
      * public use.
      *
      * opts is a BSON document of the form:
@@ -603,6 +603,17 @@ public class CAPI {
      */
     public static native boolean
     mongocrypt_ctx_setopt_algorithm_range (mongocrypt_ctx_t ctx, mongocrypt_binary_t opts);
+
+    /**
+     * Opt-into use of Queryable Encryption Range V2 protocol.
+     * NOTE: "range" is currently unstable API and subject to backwards breaking changes.
+     *
+     * @param crypt  The @ref mongocrypt_t object.
+     * @return A boolean indicating success. If false, an error status is set.
+     * @since 1.10
+     */
+    public static native boolean
+    mongocrypt_setopt_use_range_v2(mongocrypt_t crypt);
 
     /**
      * Initialize new @ref mongocrypt_t object.
@@ -887,8 +898,8 @@ public class CAPI {
     /**
      * Explicit helper method to encrypt a Match Expression or Aggregate Expression.
      * Contexts created for explicit encryption will not go through mongocryptd.
-     * Requires query_type to be "rangePreview".
-     * NOTE: The RangePreview algorithm is experimental only. It is not intended for
+     * Requires query_type to be "range".
+     * NOTE: The range algorithm is unstable. It is not intended for
      * public use.
      *
      * This method expects the passed-in BSON to be of the form:

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoCryptImpl.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoCryptImpl.java
@@ -72,6 +72,7 @@ import static com.mongodb.crypt.capi.CAPI.mongocrypt_setopt_log_handler;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_setopt_schema_map;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_setopt_set_crypt_shared_lib_path_override;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_setopt_use_need_kms_credentials_state;
+import static com.mongodb.crypt.capi.CAPI.mongocrypt_setopt_use_range_v2;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_status;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_status_destroy;
 import static com.mongodb.crypt.capi.CAPI.mongocrypt_status_new;
@@ -202,6 +203,7 @@ class MongoCryptImpl implements MongoCrypt {
             mongocrypt_setopt_set_crypt_shared_lib_path_override(wrapped, new cstring(options.getExtraOptions().getString("cryptSharedLibPath").getValue()));
         }
 
+        configure(() -> mongocrypt_setopt_use_range_v2(wrapped));
         configure(() -> mongocrypt_init(wrapped));
     }
 

--- a/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoExplicitEncryptOptions.java
+++ b/bindings/java/mongocrypt/src/main/java/com/mongodb/crypt/capi/MongoExplicitEncryptOptions.java
@@ -114,7 +114,7 @@ public class MongoExplicitEncryptOptions {
         /**
          * The Range Options.
          *
-         * <p>It is an error to set rangeOptions when the algorithm is not "rangePreview".</p>
+         * <p>It is an error to set rangeOptions when the algorithm is not "range".</p>
          *
          * @param rangeOptions the range options
          * @return this
@@ -202,11 +202,11 @@ public class MongoExplicitEncryptOptions {
         this.contentionFactor = builder.contentionFactor;
         this.queryType = builder.queryType;
         this.rangeOptions = builder.rangeOptions;
-        if (!(Objects.equals(algorithm, "Indexed") || Objects.equals(algorithm, "RangePreview"))) {
+        if (!(Objects.equals(algorithm, "Indexed") || Objects.equals(algorithm, "Range"))) {
             if (contentionFactor != null) {
-                throw new IllegalStateException("Invalid configuration, contentionFactor can only be set if algorithm is 'Indexed' or 'RangePreview'");
+                throw new IllegalStateException("Invalid configuration, contentionFactor can only be set if algorithm is 'Indexed' or 'Range'");
             } else if (queryType != null) {
-                throw new IllegalStateException("Invalid configuration, queryType can only be set if algorithm is 'Indexed'  or 'RangePreview'");
+                throw new IllegalStateException("Invalid configuration, queryType can only be set if algorithm is 'Indexed'  or 'Range'");
             }
         }
     }

--- a/bindings/java/mongocrypt/src/test/java/com/mongodb/crypt/capi/MongoCryptTest.java
+++ b/bindings/java/mongocrypt/src/test/java/com/mongodb/crypt/capi/MongoCryptTest.java
@@ -23,7 +23,6 @@ import org.bson.BsonBinarySubType;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
 import org.bson.RawBsonDocument;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
@@ -44,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 @SuppressWarnings("SameParameterValue")
@@ -210,8 +210,8 @@ public class MongoCryptTest {
 
         MongoExplicitEncryptOptions options = MongoExplicitEncryptOptions.builder()
                 .keyId(new BsonBinary(BsonBinarySubType.UUID_STANDARD, Base64.getDecoder().decode("q83vqxI0mHYSNBI0VniQEg==")))
-                .algorithm("RangePreview")
-                .queryType("rangePreview")
+                .algorithm("Range")
+                .queryType("range")
                 .contentionFactor(4L)
                 .rangeOptions(rangeOptions)
                 .build();
@@ -227,6 +227,46 @@ public class MongoCryptTest {
         assertEquals(expectedEncryptedPayload, actualEncryptedPayload);
 
         encryptor.close();
+        mongoCrypt.close();
+    }
+
+    @Test
+    public void testRangePreviewQueryTypeIsNotSupported() {
+        MongoCrypt mongoCrypt = createMongoCrypt();
+        assertNotNull(mongoCrypt);
+
+        BsonDocument valueToEncrypt = getResourceAsDocument("fle2-find-range-explicit-v2/int32/value-to-encrypt.json");
+        BsonDocument rangeOptions = getResourceAsDocument("fle2-find-range-explicit-v2/int32/rangeopts.json");
+
+        MongoExplicitEncryptOptions options = MongoExplicitEncryptOptions.builder()
+                .keyId(new BsonBinary(BsonBinarySubType.UUID_STANDARD, Base64.getDecoder().decode("q83vqxI0mHYSNBI0VniQEg==")))
+                .algorithm("Range")
+                .queryType("rangePreview")
+                .contentionFactor(4L)
+                .rangeOptions(rangeOptions)
+                .build();
+
+        assertThrows(MongoCryptException.class, () -> mongoCrypt.createEncryptExpressionContext(valueToEncrypt, options));
+        mongoCrypt.close();
+    }
+
+    @Test
+    public void testRangePreviewAlgorithmIsNotSupported() {
+        MongoCrypt mongoCrypt = createMongoCrypt();
+        assertNotNull(mongoCrypt);
+
+        BsonDocument rangeOptions = getResourceAsDocument("fle2-find-range-explicit-v2/int32/rangeopts.json");
+
+        IllegalStateException illegalStateException = assertThrows(IllegalStateException.class, () -> MongoExplicitEncryptOptions.builder()
+                .keyId(new BsonBinary(BsonBinarySubType.UUID_STANDARD, Base64.getDecoder().decode("q83vqxI0mHYSNBI0VniQEg==")))
+                .algorithm("RangePreview")
+                .queryType("range")
+                .contentionFactor(4L)
+                .rangeOptions(rangeOptions)
+                .build());
+
+        assertEquals("Invalid configuration, contentionFactor can only be set if algorithm is 'Indexed' or 'Range'",
+                illegalStateException.getMessage());
         mongoCrypt.close();
     }
 

--- a/bindings/java/mongocrypt/src/test/resources/fle2-find-range-explicit-v2/int32/rangeopts.json
+++ b/bindings/java/mongocrypt/src/test/resources/fle2-find-range-explicit-v2/int32/rangeopts.json
@@ -7,5 +7,8 @@
     },
     "sparsity": {
         "$numberLong": "1"
+    },
+    "trimFactor": {
+        "$numberInt": "1"
     }
 }


### PR DESCRIPTION
"rangePreview" is deprecated and no longer used starting from server version 8.0.

[JAVA-5321](https://jira.mongodb.org/browse/JAVA-5521)