### PR TITLE
MONGOCRYPT-661 improve unsupported error for "rangePreview"

### DIFF
--- a/src/mc-efc-private.h
+++ b/src/mc-efc-private.h
@@ -48,7 +48,10 @@ typedef struct {
  * into @efc. Fields are copied from @efc_bson. It is OK to free efc_bson after
  * this call. Fields are appended in reverse order to @efc->fields. Extra
  * unrecognized fields are not considered an error for forward compatibility. */
-bool mc_EncryptedFieldConfig_parse(mc_EncryptedFieldConfig_t *efc, const bson_t *efc_bson, mongocrypt_status_t *status);
+bool mc_EncryptedFieldConfig_parse(mc_EncryptedFieldConfig_t *efc,
+                                   const bson_t *efc_bson,
+                                   mongocrypt_status_t *status,
+                                   bool use_range_v2);
 
 void mc_EncryptedFieldConfig_cleanup(mc_EncryptedFieldConfig_t *efc);
 

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -416,7 +416,7 @@ static bool _set_schema_from_collinfo(mongocrypt_ctx_t *ctx, bson_t *collinfo) {
         if (!_mongocrypt_buffer_to_bson(&ectx->encrypted_field_config, &efc_bson)) {
             return _mongocrypt_ctx_fail_w_msg(ctx, "unable to create BSON from encrypted_field_config");
         }
-        if (!mc_EncryptedFieldConfig_parse(&ectx->efc, &efc_bson, ctx->status)) {
+        if (!mc_EncryptedFieldConfig_parse(&ectx->efc, &efc_bson, ctx->status, ctx->crypt->opts.use_range_v2)) {
             _mongocrypt_ctx_fail(ctx);
             return false;
         }
@@ -447,7 +447,10 @@ static bool _set_schema_from_collinfo(mongocrypt_ctx_t *ctx, bson_t *collinfo) {
             bson_free(ecocCollection);
         }
 
-        if (!mc_EncryptedFieldConfig_parse(&ectx->efc, &empty_encryptedFields, ctx->status)) {
+        if (!mc_EncryptedFieldConfig_parse(&ectx->efc,
+                                           &empty_encryptedFields,
+                                           ctx->status,
+                                           ctx->crypt->opts.use_range_v2)) {
             bson_destroy(&empty_encryptedFields);
             _mongocrypt_ctx_fail(ctx);
             return false;
@@ -2219,7 +2222,7 @@ static bool _fle2_try_encrypted_field_config_from_map(mongocrypt_ctx_t *ctx) {
         if (!_mongocrypt_buffer_to_bson(&ectx->encrypted_field_config, &efc_bson)) {
             return _mongocrypt_ctx_fail_w_msg(ctx, "unable to create BSON from encrypted_field_config");
         }
-        if (!mc_EncryptedFieldConfig_parse(&ectx->efc, &efc_bson, ctx->status)) {
+        if (!mc_EncryptedFieldConfig_parse(&ectx->efc, &efc_bson, ctx->status, ctx->crypt->opts.use_range_v2)) {
             _mongocrypt_ctx_fail(ctx);
             return false;
         }

--- a/test/test-mc-efc.c
+++ b/test/test-mc-efc.c
@@ -34,9 +34,11 @@ static void _test_efc(_mongocrypt_tester_t *tester) {
     _mongocrypt_buffer_copy_from_hex(&expect_keyId1, "12345678123498761234123456789012");
     _mongocrypt_buffer_copy_from_hex(&expect_keyId2, "abcdefab123498761234123456789012");
 
+    const bool use_range_v2 = false;
+
     {
         _load_test_file(tester, "./test/data/efc/efc-oneField.json", &efc_bson);
-        ASSERT_OK_STATUS(mc_EncryptedFieldConfig_parse(&efc, &efc_bson, status), status);
+        ASSERT_OK_STATUS(mc_EncryptedFieldConfig_parse(&efc, &efc_bson, status, use_range_v2), status);
         ptr = efc.fields;
         ASSERT(ptr);
         ASSERT_STREQUAL(ptr->path, "firstName");
@@ -47,7 +49,7 @@ static void _test_efc(_mongocrypt_tester_t *tester) {
 
     {
         _load_test_file(tester, "./test/data/efc/efc-extraField.json", &efc_bson);
-        ASSERT_OK_STATUS(mc_EncryptedFieldConfig_parse(&efc, &efc_bson, status), status);
+        ASSERT_OK_STATUS(mc_EncryptedFieldConfig_parse(&efc, &efc_bson, status, use_range_v2), status);
         ptr = efc.fields;
         ASSERT(ptr);
         ASSERT_STREQUAL(ptr->path, "firstName");
@@ -58,7 +60,7 @@ static void _test_efc(_mongocrypt_tester_t *tester) {
 
     {
         _load_test_file(tester, "./test/data/efc/efc-twoFields.json", &efc_bson);
-        ASSERT_OK_STATUS(mc_EncryptedFieldConfig_parse(&efc, &efc_bson, status), status);
+        ASSERT_OK_STATUS(mc_EncryptedFieldConfig_parse(&efc, &efc_bson, status, use_range_v2), status);
         ptr = efc.fields;
         ASSERT(ptr);
         ASSERT_STREQUAL(ptr->path, "lastName");
@@ -73,7 +75,7 @@ static void _test_efc(_mongocrypt_tester_t *tester) {
 
     {
         _load_test_file(tester, "./test/data/efc/efc-missingKeyId.json", &efc_bson);
-        ASSERT_FAILS_STATUS(mc_EncryptedFieldConfig_parse(&efc, &efc_bson, status),
+        ASSERT_FAILS_STATUS(mc_EncryptedFieldConfig_parse(&efc, &efc_bson, status, use_range_v2),
                             status,
                             "unable to find 'keyId' in 'field' document");
         mc_EncryptedFieldConfig_cleanup(&efc);


### PR DESCRIPTION
# Summary

Error earlier if "rangePreview" is used with auto encryption with rangeV2 enabled.

Evergreen patch: https://spruce.mongodb.com/version/668ffe0531e5a60007090e86

# Background & Motivation

Partially resolves MONGOCRYPT-661. Intended to improve the error if "rangePreview" is used when rangeV2 is enabled.

Prior to this PR, auto encryption with "rangePreview" and rangeV2 enabled results in an error parsing payloads from query analysis (mongocryptd or crypt_shared). Example:

```
Error parsing FLE2RangeInsertSpec: Missing field 'trimFactor' in placeholder
```

This PR proposes erroring earlier. If libmongocrypt receives an `encryptedFields` with "rangePreview" specified, return an error like the following:

```
Cannot use field 'foo' with 'rangePreview' queries. 'rangePreview' is unsupported. Use 'range' instead. 'range' is not compatible with 'rangePreview' and requires recreating the collection.
```

This is intended to match similar messaging produced by the server 8.0. Sending `encryptionInformation` with "rangePreview" to server 8.0.0-rc11 results in this error:
```
Collection contains the 'rangePreview' query type which is deprecated. Please recreate the collection with the 'range' query type.
```
