### PR TITLE
disable zlib in mongoc subproject

### DIFF
--- a/cmake/ImportBSON.cmake
+++ b/cmake/ImportBSON.cmake
@@ -132,6 +132,8 @@ function (_import_bson)
       set (ENABLE_MONGODB_AWS_AUTH OFF CACHE BOOL "Disable kms-message content in mongoc for libmongocrypt" FORCE)
       # Disable install() for the libbson static library. We'll do it ourselves
       set (ENABLE_STATIC BUILD_ONLY)
+      # Disable zlib, which isn't necessary for libmongocrypt and isn't necessarily available.
+      set (ENABLE_ZLIB OFF CACHE BOOL "Toggle zlib for the mongoc subproject (not required by libmongocrypt)")
       # Disable libzstd, which isn't necessary for libmongocrypt and isn't necessarily available.
       set (ENABLE_ZSTD OFF CACHE BOOL "Toggle libzstd for the mongoc subproject (not required by libmongocrypt)")
       # Disable snappy, which isn't necessary for libmongocrypt and isn't necessarily available.


### PR DESCRIPTION
zlib is not needed in libmongocrypt. Disabling addresses local build failures with zlib 1.2.13 on Homebrew clang version 18.1.8:

```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/stdio.h:225:7: error: expected identifier or '('
  225 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_3_2, __DARWIN_EXTSN(fdopen));
      |          ^
/Users/kevin.albertson/code/libmongocrypt/cmake-build/_deps/embedded_mcd-src/src/zlib-1.2.13/zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
```

The build failure appears resolved when using newer versions of zlib. Building newer versions of the C driver with zlib 1.3.1 (due to https://github.com/mongodb/mongo-c-driver/pull/1651) succeeds.