### PR TITLE
MONGOCRYPT-661 document "range" as stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # ChangeLog
 ## (Next)
+### New features
+- Support `range` algorithm as stable.
 ### Deprecated
 - The Windows download URLs for [stable](https://s3.amazonaws.com/mciuploads/libmongocrypt/windows/latest_release/libmongocrypt.tar.gz) and [unstable](https://s3.amazonaws.com/mciuploads/libmongocrypt/windows/latest_release/libmongocrypt_unstable.tar.gz) are now deprecated. See the GitHub Release page for Windows downloads.
 ## 1.10.1

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -688,7 +688,6 @@ bool mongocrypt_ctx_setopt_algorithm(mongocrypt_ctx_t *ctx, const char *algorith
 #define MONGOCRYPT_ALGORITHM_UNINDEXED_STR "Unindexed"
 // DEPRECATED: support "RangePreview" has been removed in favor of "range".
 #define MONGOCRYPT_ALGORITHM_RANGEPREVIEW_DEPRECATED_STR "RangePreview"
-// NOTE: "Range" is currently unstable API and subject to backwards breaking changes.
 #define MONGOCRYPT_ALGORITHM_RANGE_STR "Range"
 
 /**
@@ -879,8 +878,6 @@ bool mongocrypt_ctx_explicit_encrypt_init(mongocrypt_ctx_t *ctx, mongocrypt_bina
  * Explicit helper method to encrypt a Match Expression or Aggregate Expression.
  * Contexts created for explicit encryption will not go through mongocryptd.
  * Requires query_type to be "range".
- *
- * NOTE: "range" is currently unstable API and subject to backwards breaking changes.
  *
  * This method expects the passed-in BSON to be of the form:
  * { "v" : FLE2RangeFindDriverSpec }
@@ -1416,7 +1413,6 @@ void mongocrypt_setopt_bypass_query_analysis(mongocrypt_t *crypt);
 
 /**
  * DEPRECATED: Use of `mongocrypt_setopt_use_range_v2` is deprecated. Range V2 is always enabled.
- * NOTE: "range" is currently unstable API and subject to backwards breaking changes.
  *
  * @param[in] crypt The @ref mongocrypt_t object.
  *
@@ -1472,7 +1468,6 @@ bool mongocrypt_ctx_setopt_query_type(mongocrypt_ctx_t *ctx, const char *query_t
 
 /**
  * Set options for explicit encryption with the "range" algorithm.
- * NOTE: "range" is currently unstable API and subject to backwards breaking changes.
  *
  * @p opts is a BSON document of the form:
  * {
@@ -1496,7 +1491,6 @@ bool mongocrypt_ctx_setopt_algorithm_range(mongocrypt_ctx_t *ctx, mongocrypt_bin
 #define MONGOCRYPT_QUERY_TYPE_EQUALITY_STR "equality"
 // DEPRECATED: Support "rangePreview" has been removed in favor of "range".
 #define MONGOCRYPT_QUERY_TYPE_RANGEPREVIEW_DEPRECATED_STR "rangePreview"
-/// NOTE: "range" is currently unstable API and subject to backwards breaking changes.
 #define MONGOCRYPT_QUERY_TYPE_RANGE_STR "range"
 
 #endif /* MONGOCRYPT_H */


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/libmongocrypt/pull/861.

~~This PR is not-yet ready to merge. It is awaiting pending [protocol changes](https://jira.mongodb.org/issues/?jql=project%3DMONGOCRYPT%20and%20labels%3D%22range-ga-drivers%22%20and%20status%20!%3D%20closed).~~