### PR TITLE
MONGOCRYPT-708 pass environment for Alpine task

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -404,10 +404,7 @@ tasks:
   - func: "fetch source"
   - func: "earthly"
     vars:
-      args: +build --env=${earthly_env}
-  - func: "earthly"
-    vars:
-      args: --artifact +build/libmongocrypt-install ${workdir}/install
+      args: --artifact +build/libmongocrypt-install --env=${earthly_env} ${workdir}/install
   - func: "tar and upload libmongocrypt libraries"
 
 - name: build-deb-packages-with-earthly


### PR DESCRIPTION
# Summary

Follow-up to https://github.com/mongodb/libmongocrypt/pull/805. Intended to resolve issue using Alpine build reported in MONGOCRYPT-708.

The `--artifact` command was not supplied with an `--env`, resulting in use of the [default environment](https://github.com/mongodb/libmongocrypt/blob/b1753358f4e243d164f31fe31338c2ef70f3cb77/Earthfile#L375) (Ubuntu 22.04).

Removes the redundant `build` command. The `--artifact` command runs the necessary target.

# Testing

Checking the binary of a [prior task](https://spruce.mongodb.com/task/libmongocrypt_alpine_arm64_earthly_build_with_earthly_b1753358f4e243d164f31fe31338c2ef70f3cb77_24_07_31_17_07_01/files?execution=0&sortBy=STATUS&sortDir=ASC) shows a shared library dependency of `ld-linux-aarch64.so.1`:
```
mkdir libmongocrypt-alpine-before
cd libmongocrypt-alpine-before
curl -o libmongocrypt-alpine-before.tar.gz https://mciuploads.s3.amazonaws.com/libmongocrypt/alpine-arm64-earthly/master/b1753358f4e243d164f31fe31338c2ef70f3cb77/libmongocrypt.tar.gz
tar -xf libmongocrypt-alpine-before.tar.gz
readelf -d nocrypto/lib/libmongocrypt.so | grep "Shared library"
# Prints:
# 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
# 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
# 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-aarch64.so.1]
```

Checking the binary on a [this patch](https://spruce.mongodb.com/task/libmongocrypt_alpine_arm64_earthly_build_with_earthly_patch_b1753358f4e243d164f31fe31338c2ef70f3cb77_66ab9056fb29d10007814a8d_24_08_01_13_40_39/files?execution=0) with changes from this PR shows an expected dependency on `libc.musl-aarch64.so.1`:

```
mkdir libmongocrypt-alpine-after
cd libmongocrypt-alpine-after
curl -o libmongocrypt-alpine-after.tar.gz https://mciuploads.s3.amazonaws.com/libmongocrypt/alpine-arm64-earthly/master/b1753358f4e243d164f31fe31338c2ef70f3cb77/66ab9056fb29d10007814a8d/libmongocrypt.tar.gz
tar -xf libmongocrypt-alpine-after.tar.gz
readelf -d nocrypto/lib/libmongocrypt.so | grep "Shared library"
# Prints
# 0x0000000000000001 (NEEDED)             Shared library: [libc.musl-aarch64.so.1]
```

