### PR TITLE
PYTHON-4670 Fix handling of AsyncMongoCryptCallback.fetch_keys

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -164,6 +164,7 @@ functions:
         binary: bash
         env:
           TOPOLOGY: replica_set
+          MONGODB_VERSION: 8.0
         args:
           - ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     - command: "subprocess.exec"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -164,7 +164,7 @@ functions:
         binary: bash
         env:
           TOPOLOGY: replica_set
-          MONGODB_VERSION: 8.0
+          MONGODB_VERSION: "8.0"
         args:
           - ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     - command: "subprocess.exec"

--- a/bindings/python/pymongocrypt/asynchronous/state_machine.py
+++ b/bindings/python/pymongocrypt/asynchronous/state_machine.py
@@ -134,7 +134,7 @@ async def run_state_machine(ctx, callback):
             ctx.complete_mongo_operation()
         elif state == lib.MONGOCRYPT_CTX_NEED_MONGO_KEYS:
             key_filter = ctx.mongo_operation()
-            for key in await callback.fetch_keys(key_filter):
+            async for key in callback.fetch_keys(key_filter):
                 ctx.add_mongo_operation_result(key)
             ctx.complete_mongo_operation()
         elif state == lib.MONGOCRYPT_CTX_NEED_KMS:

--- a/bindings/python/test/test_mongocrypt.py
+++ b/bindings/python/test/test_mongocrypt.py
@@ -478,7 +478,8 @@ class MockAsyncCallback(AsyncMongoCryptCallback):
         return self.mongocryptd_reply
 
     async def fetch_keys(self, filter):
-        return self.key_docs
+        for doc in self.key_docs:
+            yield doc
 
     async def insert_data_key(self, data_key):
         raise NotImplementedError


### PR DESCRIPTION
The signature in pymongo is `async def fetch_keys(self, filter: bytes) -> AsyncGenerator[bytes, None]`