### PR TITLE
clarify lifetime of returned `mongocrypt_kms_ctx_t`

### DIFF
--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -1082,6 +1082,8 @@ typedef struct _mongocrypt_kms_ctx_t mongocrypt_kms_ctx_t;
  * If KMS handles are being handled synchronously, the driver can reuse the same
  * TLS socket to send HTTP requests and receive responses.
  *
+ * The returned KMS handle must not outlive `ctx`.
+ *
  * @param[in] ctx A @ref mongocrypt_ctx_t.
  * @returns a new @ref mongocrypt_kms_ctx_t or NULL.
  */

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -1082,7 +1082,7 @@ typedef struct _mongocrypt_kms_ctx_t mongocrypt_kms_ctx_t;
  * If KMS handles are being handled synchronously, the driver can reuse the same
  * TLS socket to send HTTP requests and receive responses.
  *
- * The returned KMS handle must not outlive `ctx`.
+ * The returned KMS handle does not outlive `ctx`.
  *
  * @param[in] ctx A @ref mongocrypt_ctx_t.
  * @returns a new @ref mongocrypt_kms_ctx_t or NULL.


### PR DESCRIPTION
Motivated by question about expected lifetime of `mongocrypt_kms_ctx_t` with respect to `mongocrypt_ctx_t` ([see slack](https://mongodb.slack.com/archives/C0668RJBA0J/p1724089719861209)).

Calling `mongocrypt_ctx_destroy (ctx)` [frees](https://github.com/mongodb/libmongocrypt/blob/d05dbf3c0d6e03da8c0b25a6fd0214c1165f9214/src/mongocrypt-key-broker.c#L1117) associated `mongocrypt_kms_ctx`'s.