### PR TITLE
Add fetch source to upload-java for tag-based uploads.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -570,6 +570,7 @@ tasks:
     - variant: macos
       name: build-and-test-and-upload
   commands:
+    - func: "fetch source"
     - command: shell.exec
       params:
         script: mkdir all

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -570,7 +570,7 @@ tasks:
     - variant: macos
       name: build-and-test-and-upload
   commands:
-    - func: "fetch source"
+    - func: "fetch source" # To set `tag_upload_location` expansion.
     - command: shell.exec
       params:
         script: mkdir all


### PR DESCRIPTION
**Description:** 
This PR adds tag-based publishing to the `upload-java`, matching the functionality of the `upload-all` task. It integrates the "fetch source" function to assign release tags properly to the "use-tag" variable.

As we move the Java binding into the `mongo-java-driver` repository, using release tags to locate binaries will help ensure that we depend on the correct binaries. This approach is clearer and more informative than specifying revisions in build scripts of `mongo-java-driver`.

Links:
Current publishing demonstration: [Evergreen release task](https://parsley.mongodb.com/evergreen/libmongocrypt_release_ubuntu2004_64_upload_java_9a88ac5698e8e3ffcd6580b98c247f0126f26c40_24_08_01_18_30_17/0/task?bookmarks=0,61&shareLine=49)

JAVA-5590