### PR TITLE
MONGOCRYPT-724 remove use of `bson_string_t` in tests

### DIFF
--- a/test/test-mongocrypt-kms-responses.c
+++ b/test/test-mongocrypt-kms-responses.c
@@ -142,13 +142,14 @@ static void _test_one_kms_response(_mongocrypt_tester_t *tester, bson_t *test) {
         BSON_ASSERT(bson_iter_init_find(&iter, test, "expect"));
         if (BSON_ITER_HOLDS_ARRAY(&iter)) {
             // Concatenate array into one string.
-            bson_string_t *builder = bson_string_new(NULL);
+            expect = bson_strdup("");
             bson_iter_recurse(&iter, &iter);
             while (bson_iter_next(&iter)) {
                 ASSERT(BSON_ITER_HOLDS_UTF8(&iter));
-                bson_string_append(builder, bson_iter_utf8(&iter, NULL));
+                char *previous = expect;
+                expect = bson_strdup_printf("%s%s", expect, bson_iter_utf8(&iter, NULL));
+                bson_free(previous);
             }
-            expect = bson_string_free(builder, false /* free segment */);
         } else {
             expect = bson_strdup(bson_iter_utf8(&iter, NULL));
         }

--- a/test/test-mongocrypt-marking.c
+++ b/test/test-mongocrypt-marking.c
@@ -173,12 +173,14 @@ static void test_mongocrypt_marking_parse(_mongocrypt_tester_t *tester) {
 
 #define ASSERT_MINCOVER_EQ(got, expectString)                                                                          \
     if (1) {                                                                                                           \
-        bson_string_t *gotStr = bson_string_new("");                                                                   \
+        char *gotStr = bson_strdup("");                                                                                \
         for (size_t i = 0; i < mc_mincover_len(got); i++) {                                                            \
-            bson_string_append_printf(gotStr, "%s\n", mc_mincover_get(got, i));                                        \
+            char *previous = gotStr;                                                                                   \
+            gotStr = bson_strdup_printf("%s%s\n", gotStr, mc_mincover_get(got, i));                                    \
+            bson_free(previous);                                                                                       \
         }                                                                                                              \
-        ASSERT_STREQUAL(gotStr->str, expectString);                                                                    \
-        bson_string_free(gotStr, true);                                                                                \
+        ASSERT_STREQUAL(gotStr, expectString);                                                                         \
+        bson_free(gotStr);                                                                                             \
     } else                                                                                                             \
         ((void)0)
 


### PR DESCRIPTION
# Summary

Remove use of `bson_string_t`. Partially resolves MONGOCRYPT-724.

Verified with [this patch build](https://spruce.mongodb.com/version/66faaf9b91ae7f0007d25720).

# Background & Motivation

`bson_string_t` is planned to be deprecated in CDRIVER-5697.

Deprecating results in warnings from the C driver tasks [building libmongocrypt](https://spruce.mongodb.com/task/mongo_c_driver_power8_rhel81_debug_compile_nosasl_nossl_patch_57f5be6ee79f13a4d9b0a2fd9de8487b89c17619_66f55d1ead09cf00077b34b2_24_09_26_13_09_52/logs?execution=0):

```
../../../src/libbson/src/bson/bson-string.c:276:7: error: ‘bson_string_append’ is deprecated [-Werror=deprecated-declarations]
       bson_string_append (string, cc);
       ^~~~~~~~~~~~~~~~~~
```

This PR changes to use non-deprecated string functions. libmongocrypt only uses `bson_string_t` in tests.
