### PR TITLE
Update references to Markdown MongoDB specifications

### DIFF
--- a/integrating.md
+++ b/integrating.md
@@ -63,7 +63,7 @@ Seek help in the slack channel \#drivers-fle.
 After you have a binding, integrate libmongocrypt in your driver to
 support client side encryption.
 
-See the [driver spec](https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst)
+See the [driver spec](https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.md)
 for a reference of the user-facing API. libmongocrypt is needed for:
 
 -   Automatic encryption/decryption
@@ -243,7 +243,7 @@ Credentials for one or more KMS providers.
 
 **Driver needs to...**
 
-Fetch credentials for supported KMS providers. See the [Client Side Encryption specification](https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials) for details.
+Fetch credentials for supported KMS providers. See the [Client Side Encryption specification](https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.md#automatic-credentials) for details.
 
 Pass credentials to libmongocrypt using `mongocrypt_ctx_provide_kms_providers`.
 

--- a/kms-message/README.md
+++ b/kms-message/README.md
@@ -11,7 +11,7 @@ implements the request format.
 - `test_kms_azure_online` makes live requests, and has additional requirements (must have working credentials).
 
 ### Requirements
-- A complete installation of the C driver. (libbson is needed for parsing JSON, and libmongoc is used for creating TLS streams). See http://mongoc.org/libmongoc/current/installing.html for installation instructions. For macOS, `brew install mongo-c-driver` will suffice.
+- A complete installation of the C driver. (libbson is needed for parsing JSON, and libmongoc is used for creating TLS streams). See the [C Driver Manual](https://www.mongodb.com/docs/languages/c/c-driver/current/libmongoc/tutorials/obtaining-libraries/) for installation instructions. For macOS, `brew install mongo-c-driver` will suffice.
 - An Azure key vault, and a service principal with an access policy allowing encrypt / decrypt key operations. The following environment variables must be set:
     - AZURE_TENANT_ID
     - AZURE_CLIENT_ID

--- a/src/mc-fle-blob-subtype-private.h
+++ b/src/mc-fle-blob-subtype-private.h
@@ -19,7 +19,7 @@
 
 /* FLE Blob Subtype is the first byte of a BSON Binary Subtype 6.
  * FLE1 Blob Subtypes are defined in:
- * https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/subtype6.rst
+ * https://github.com/mongodb/specifications/blob/master/source/bson-binary-encrypted/binary-encrypted.md
  * FLE2 Blob Subtypes are currently defined in:
  * https://github.com/markbenvenuto/mongo-enterprise-modules/blob/fle2/fle_protocol.md#reference-bindata-6-subtypes.
  */


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1746 which address kms-divergence-check task failure in C Driver EVG builds + similar updates to specification links.