### PR TITLE
CDRIVER-5702 remove use of `bson-cmp.h`

### DIFF
--- a/src/mc-range-edge-generation.c
+++ b/src/mc-range-edge-generation.c
@@ -20,6 +20,7 @@
 #include "mc-array-private.h"
 #include "mc-check-conversions-private.h"
 #include "mc-range-encoding-private.h"
+#include "mlib/cmp.h"
 #include "mongocrypt-private.h"
 
 struct _mc_edges_t {
@@ -47,7 +48,7 @@ static mc_edges_t *mc_edges_new(const char *leaf,
 
     const size_t leaf_len = strlen(leaf);
     const int32_t trimFactor = trimFactorDefault(leaf_len, opt_trimFactor, use_range_v2);
-    if (trimFactor != 0 && bson_cmp_greater_equal_su(trimFactor, leaf_len)) {
+    if (trimFactor != 0 && mlib_cmp_greater_equal_su(trimFactor, leaf_len)) {
         // We append a total of leaf_len + 1 (for the root) - trimFactor edges. When this number is equal to 1, we
         // degenerate into equality, which is not desired, so trimFactor must be less than leaf_len.
         CLIENT_ERR("trimFactor must be less than the number of bits (%ld) used to represent an element of the domain, "
@@ -76,7 +77,7 @@ static mc_edges_t *mc_edges_new(const char *leaf,
     _mc_array_append_val(&edges->edges, leaf_copy);
 
     // Start loop at max(trimFactor, 1). The full leaf is unconditionally appended after loop.
-    BSON_ASSERT(bson_in_range_size_t_signed(trimFactor));
+    BSON_ASSERT(mlib_in_range_size_t_signed(trimFactor));
     size_t trimFactor_sz = (size_t)trimFactor;
     size_t startLevel = trimFactor > 0 ? trimFactor_sz : 1;
     for (size_t i = startLevel; i < leaf_len; i++) {

--- a/src/mc-range-encoding.c
+++ b/src/mc-range-encoding.c
@@ -16,6 +16,7 @@
 
 #include "mc-check-conversions-private.h"
 #include "mc-range-encoding-private.h"
+#include "mlib/cmp.h"
 #include "mongocrypt-private.h"
 #include "mongocrypt-util-private.h" // mc_isinf
 
@@ -863,7 +864,7 @@ int32_t trimFactorDefault(size_t maxlen, mc_optional_int32_t trimFactor, bool us
         return 0;
     }
 
-    if (bson_cmp_greater_su(mc_FLERangeTrimFactorDefault, maxlen - 1)) {
+    if (mlib_cmp_greater_su(mc_FLERangeTrimFactorDefault, maxlen - 1)) {
         return (int32_t)(maxlen - 1);
     } else {
         return mc_FLERangeTrimFactorDefault;

--- a/src/mc-range-mincover-generator.template.h
+++ b/src/mc-range-mincover-generator.template.h
@@ -124,7 +124,7 @@ static inline DECORATE_NAME(MinCoverGenerator)
     }
     size_t maxlen = (size_t)BITS - DECORATE_NAME(mc_count_leading_zeros)(max);
     int32_t trimFactor = trimFactorDefault(maxlen, opt_trimFactor, use_range_v2);
-    if (trimFactor != 0 && bson_cmp_greater_equal_su(trimFactor, maxlen)) {
+    if (trimFactor != 0 && mlib_cmp_greater_equal_su(trimFactor, maxlen)) {
         CLIENT_ERR("Trim factor must be less than the number of bits (%ld) used to represent an element of the domain, "
                    "but got %" PRId32,
                    maxlen,
@@ -169,7 +169,7 @@ static inline bool DECORATE_NAME(MinCoverGenerator_isLevelStored)(DECORATE_NAME(
                                                                   size_t maskedBits) {
     BSON_ASSERT_PARAM(mcg);
     size_t level = mcg->_maxlen - maskedBits;
-    BSON_ASSERT(bson_in_range_size_t_signed(mcg->_trimFactor));
+    BSON_ASSERT(mlib_in_range_size_t_signed(mcg->_trimFactor));
     size_t trimFactor_sz = (size_t)mcg->_trimFactor;
     return 0 == maskedBits || (level >= trimFactor_sz && 0 == (level % mcg->_sparsity));
 }

--- a/src/mc-range-mincover.c
+++ b/src/mc-range-mincover.c
@@ -22,6 +22,7 @@
 #include "mc-range-edge-generation-private.h" // mc_count_leading_zeros_u32
 #include "mc-range-encoding-private.h"        // mc_getTypeInfo32, trimFactorDefault
 #include "mc-range-mincover-private.h"
+#include "mlib/cmp.h"
 #include "mongocrypt-private.h"
 
 struct _mc_mincover_t {

--- a/src/mc-rangeopts.c
+++ b/src/mc-rangeopts.c
@@ -19,6 +19,7 @@
 #include "mc-check-conversions-private.h"
 #include "mc-range-edge-generation-private.h" // mc_count_leading_zeros_XX
 #include "mc-range-encoding-private.h"        // mc_getTypeInfoXX
+#include "mlib/cmp.h"
 #include "mongocrypt-private.h"
 #include "mongocrypt-util-private.h" // mc_bson_type_to_string
 
@@ -504,7 +505,7 @@ bool mc_RangeOpts_appendTrimFactor(const mc_RangeOpts_t *ro,
     }
     // if nbits = 0, we want to allow trim factor = 0.
     uint32_t test = nbits ? nbits : 1;
-    if (bson_cmp_greater_equal_su(ro->trimFactor.value, test)) {
+    if (mlib_cmp_greater_equal_su(ro->trimFactor.value, test)) {
         CLIENT_ERR_PREFIXED("Trim factor (%d) must be less than the total number of bits (%d) used to represent "
                             "any element in the domain.",
                             ro->trimFactor.value,

--- a/src/mlib/cmp.h
+++ b/src/mlib/cmp.h
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2009-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bson/bson-prelude.h>
+
+
+#ifndef BSON_CMP_H
+#define BSON_CMP_H
+
+
+#include <bson/bson-compat.h> /* ssize_t */
+#include <bson/bson-macros.h> /* BSON_CONCAT */
+
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+
+BSON_BEGIN_DECLS
+
+
+/* Based on the "Safe Integral Comparisons" proposal merged in C++20:
+ * http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p0586r2.html
+ *
+ * Due to lack of type deduction in C, relational comparison functions (e.g.
+ * `cmp_less`) are defined in sets of four "functions" according to the
+ * signedness of each value argument, e.g.:
+ *  - bson_cmp_less_ss (signed-value, signed-value)
+ *  - bson_cmp_less_uu (unsigned-value, unsigned-value)
+ *  - bson_cmp_less_su (signed-value, unsigned-value)
+ *  - bson_cmp_less_us (unsigned-value, signed-value)
+ *
+ * Similarly, the `in_range` function is defined as a set of two "functions"
+ * according to the signedness of the value argument:
+ *  - bson_in_range_signed (Type, signed-value)
+ *  - bson_in_range_unsigned (Type, unsigned-value)
+ *
+ * The user must take care to use the correct signedness for the provided
+ * argument(s). Enabling compiler warnings for implicit sign conversions is
+ * recommended.
+ */
+
+
+#define BSON_CMP_SET(op, ss, uu, su, us)                                              \
+   static BSON_INLINE bool BSON_CONCAT3 (bson_cmp_, op, _ss) (int64_t t, int64_t u)   \
+   {                                                                                  \
+      return (ss);                                                                    \
+   }                                                                                  \
+                                                                                      \
+   static BSON_INLINE bool BSON_CONCAT3 (bson_cmp_, op, _uu) (uint64_t t, uint64_t u) \
+   {                                                                                  \
+      return (uu);                                                                    \
+   }                                                                                  \
+                                                                                      \
+   static BSON_INLINE bool BSON_CONCAT3 (bson_cmp_, op, _su) (int64_t t, uint64_t u)  \
+   {                                                                                  \
+      return (su);                                                                    \
+   }                                                                                  \
+                                                                                      \
+   static BSON_INLINE bool BSON_CONCAT3 (bson_cmp_, op, _us) (uint64_t t, int64_t u)  \
+   {                                                                                  \
+      return (us);                                                                    \
+   }
+
+BSON_CMP_SET (equal, t == u, t == u, t < 0 ? false : (uint64_t) (t) == u, u < 0 ? false : t == (uint64_t) (u))
+
+BSON_CMP_SET (not_equal,
+              !bson_cmp_equal_ss (t, u),
+              !bson_cmp_equal_uu (t, u),
+              !bson_cmp_equal_su (t, u),
+              !bson_cmp_equal_us (t, u))
+
+BSON_CMP_SET (less, t < u, t < u, t < 0 ? true : (uint64_t) (t) < u, u < 0 ? false : t < (uint64_t) (u))
+
+BSON_CMP_SET (
+   greater, bson_cmp_less_ss (u, t), bson_cmp_less_uu (u, t), bson_cmp_less_us (u, t), bson_cmp_less_su (u, t))
+
+BSON_CMP_SET (less_equal,
+              !bson_cmp_greater_ss (t, u),
+              !bson_cmp_greater_uu (t, u),
+              !bson_cmp_greater_su (t, u),
+              !bson_cmp_greater_us (t, u))
+
+BSON_CMP_SET (greater_equal,
+              !bson_cmp_less_ss (t, u),
+              !bson_cmp_less_uu (t, u),
+              !bson_cmp_less_su (t, u),
+              !bson_cmp_less_us (t, u))
+
+#undef BSON_CMP_SET
+
+
+/* Return true if the given value is within the range of the corresponding
+ * signed type. The suffix must match the signedness of the given value. */
+#define BSON_IN_RANGE_SET_SIGNED(Type, min, max)                                             \
+   static BSON_INLINE bool BSON_CONCAT3 (bson_in_range, _##Type, _signed) (int64_t value)    \
+   {                                                                                         \
+      return bson_cmp_greater_equal_ss (value, min) && bson_cmp_less_equal_ss (value, max);  \
+   }                                                                                         \
+                                                                                             \
+   static BSON_INLINE bool BSON_CONCAT3 (bson_in_range, _##Type, _unsigned) (uint64_t value) \
+   {                                                                                         \
+      return bson_cmp_greater_equal_us (value, min) && bson_cmp_less_equal_us (value, max);  \
+   }
+
+/* Return true if the given value is within the range of the corresponding
+ * unsigned type. The suffix must match the signedness of the given value. */
+#define BSON_IN_RANGE_SET_UNSIGNED(Type, max)                                                \
+   static BSON_INLINE bool BSON_CONCAT3 (bson_in_range, _##Type, _signed) (int64_t value)    \
+   {                                                                                         \
+      return bson_cmp_greater_equal_su (value, 0u) && bson_cmp_less_equal_su (value, max);   \
+   }                                                                                         \
+                                                                                             \
+   static BSON_INLINE bool BSON_CONCAT3 (bson_in_range, _##Type, _unsigned) (uint64_t value) \
+   {                                                                                         \
+      return bson_cmp_less_equal_uu (value, max);                                            \
+   }
+
+BSON_IN_RANGE_SET_SIGNED (signed_char, SCHAR_MIN, SCHAR_MAX)
+BSON_IN_RANGE_SET_SIGNED (short, SHRT_MIN, SHRT_MAX)
+BSON_IN_RANGE_SET_SIGNED (int, INT_MIN, INT_MAX)
+BSON_IN_RANGE_SET_SIGNED (long, LONG_MIN, LONG_MAX)
+BSON_IN_RANGE_SET_SIGNED (long_long, LLONG_MIN, LLONG_MAX)
+
+BSON_IN_RANGE_SET_UNSIGNED (unsigned_char, UCHAR_MAX)
+BSON_IN_RANGE_SET_UNSIGNED (unsigned_short, USHRT_MAX)
+BSON_IN_RANGE_SET_UNSIGNED (unsigned_int, UINT_MAX)
+BSON_IN_RANGE_SET_UNSIGNED (unsigned_long, ULONG_MAX)
+BSON_IN_RANGE_SET_UNSIGNED (unsigned_long_long, ULLONG_MAX)
+
+BSON_IN_RANGE_SET_SIGNED (int8_t, INT8_MIN, INT8_MAX)
+BSON_IN_RANGE_SET_SIGNED (int16_t, INT16_MIN, INT16_MAX)
+BSON_IN_RANGE_SET_SIGNED (int32_t, INT32_MIN, INT32_MAX)
+BSON_IN_RANGE_SET_SIGNED (int64_t, INT64_MIN, INT64_MAX)
+
+BSON_IN_RANGE_SET_UNSIGNED (uint8_t, UINT8_MAX)
+BSON_IN_RANGE_SET_UNSIGNED (uint16_t, UINT16_MAX)
+BSON_IN_RANGE_SET_UNSIGNED (uint32_t, UINT32_MAX)
+BSON_IN_RANGE_SET_UNSIGNED (uint64_t, UINT64_MAX)
+
+BSON_IN_RANGE_SET_SIGNED (ssize_t, SSIZE_MIN, SSIZE_MAX)
+BSON_IN_RANGE_SET_UNSIGNED (size_t, SIZE_MAX)
+
+#undef BSON_IN_RANGE_SET_SIGNED
+#undef BSON_IN_RANGE_SET_UNSIGNED
+
+
+/* Return true if the value with *signed* type is in the representable range of
+ * Type and false otherwise. */
+#define bson_in_range_signed(Type, value) BSON_CONCAT3 (bson_in_range, _##Type, _signed) (value)
+
+/* Return true if the value with *unsigned* type is in the representable range
+ * of Type and false otherwise. */
+#define bson_in_range_unsigned(Type, value) BSON_CONCAT3 (bson_in_range, _##Type, _unsigned) (value)
+
+
+BSON_END_DECLS
+
+
+#endif /* BSON_CMP_H */

--- a/src/mlib/cmp.h
+++ b/src/mlib/cmp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-present MongoDB, Inc.
+ * Copyright 2018-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/mlib/cmp.h
+++ b/src/mlib/cmp.h
@@ -33,122 +33,122 @@ BSON_BEGIN_DECLS
  * Due to lack of type deduction in C, relational comparison functions (e.g.
  * `cmp_less`) are defined in sets of four "functions" according to the
  * signedness of each value argument, e.g.:
- *  - bson_cmp_less_ss (signed-value, signed-value)
- *  - bson_cmp_less_uu (unsigned-value, unsigned-value)
- *  - bson_cmp_less_su (signed-value, unsigned-value)
- *  - bson_cmp_less_us (unsigned-value, signed-value)
+ *  - mlib_cmp_less_ss (signed-value, signed-value)
+ *  - mlib_cmp_less_uu (unsigned-value, unsigned-value)
+ *  - mlib_cmp_less_su (signed-value, unsigned-value)
+ *  - mlib_cmp_less_us (unsigned-value, signed-value)
  *
  * Similarly, the `in_range` function is defined as a set of two "functions"
  * according to the signedness of the value argument:
- *  - bson_in_range_signed (Type, signed-value)
- *  - bson_in_range_unsigned (Type, unsigned-value)
+ *  - mlib_in_range_signed (Type, signed-value)
+ *  - mlib_in_range_unsigned (Type, unsigned-value)
  *
  * The user must take care to use the correct signedness for the provided
  * argument(s). Enabling compiler warnings for implicit sign conversions is
  * recommended.
  */
 
-#define BSON_CMP_SET(op, ss, uu, su, us)                                                                               \
-    static BSON_INLINE bool BSON_CONCAT3(bson_cmp_, op, _ss)(int64_t t, int64_t u) {                                   \
+#define MLIB_CMP_SET(op, ss, uu, su, us)                                                                               \
+    static BSON_INLINE bool BSON_CONCAT3(mlib_cmp_, op, _ss)(int64_t t, int64_t u) {                                   \
         return (ss);                                                                                                   \
     }                                                                                                                  \
                                                                                                                        \
-    static BSON_INLINE bool BSON_CONCAT3(bson_cmp_, op, _uu)(uint64_t t, uint64_t u) {                                 \
+    static BSON_INLINE bool BSON_CONCAT3(mlib_cmp_, op, _uu)(uint64_t t, uint64_t u) {                                 \
         return (uu);                                                                                                   \
     }                                                                                                                  \
                                                                                                                        \
-    static BSON_INLINE bool BSON_CONCAT3(bson_cmp_, op, _su)(int64_t t, uint64_t u) {                                  \
+    static BSON_INLINE bool BSON_CONCAT3(mlib_cmp_, op, _su)(int64_t t, uint64_t u) {                                  \
         return (su);                                                                                                   \
     }                                                                                                                  \
                                                                                                                        \
-    static BSON_INLINE bool BSON_CONCAT3(bson_cmp_, op, _us)(uint64_t t, int64_t u) {                                  \
+    static BSON_INLINE bool BSON_CONCAT3(mlib_cmp_, op, _us)(uint64_t t, int64_t u) {                                  \
         return (us);                                                                                                   \
     }
 
-BSON_CMP_SET(equal, t == u, t == u, t < 0 ? false : (uint64_t)(t) == u, u < 0 ? false : t == (uint64_t)(u))
+MLIB_CMP_SET(equal, t == u, t == u, t < 0 ? false : (uint64_t)(t) == u, u < 0 ? false : t == (uint64_t)(u))
 
-BSON_CMP_SET(not_equal,
-             !bson_cmp_equal_ss(t, u),
-             !bson_cmp_equal_uu(t, u),
-             !bson_cmp_equal_su(t, u),
-             !bson_cmp_equal_us(t, u))
+MLIB_CMP_SET(not_equal,
+             !mlib_cmp_equal_ss(t, u),
+             !mlib_cmp_equal_uu(t, u),
+             !mlib_cmp_equal_su(t, u),
+             !mlib_cmp_equal_us(t, u))
 
-BSON_CMP_SET(less, t < u, t < u, t < 0 ? true : (uint64_t)(t) < u, u < 0 ? false : t < (uint64_t)(u))
+MLIB_CMP_SET(less, t < u, t < u, t < 0 ? true : (uint64_t)(t) < u, u < 0 ? false : t < (uint64_t)(u))
 
-BSON_CMP_SET(greater, bson_cmp_less_ss(u, t), bson_cmp_less_uu(u, t), bson_cmp_less_us(u, t), bson_cmp_less_su(u, t))
+MLIB_CMP_SET(greater, mlib_cmp_less_ss(u, t), mlib_cmp_less_uu(u, t), mlib_cmp_less_us(u, t), mlib_cmp_less_su(u, t))
 
-BSON_CMP_SET(less_equal,
-             !bson_cmp_greater_ss(t, u),
-             !bson_cmp_greater_uu(t, u),
-             !bson_cmp_greater_su(t, u),
-             !bson_cmp_greater_us(t, u))
+MLIB_CMP_SET(less_equal,
+             !mlib_cmp_greater_ss(t, u),
+             !mlib_cmp_greater_uu(t, u),
+             !mlib_cmp_greater_su(t, u),
+             !mlib_cmp_greater_us(t, u))
 
-BSON_CMP_SET(greater_equal,
-             !bson_cmp_less_ss(t, u),
-             !bson_cmp_less_uu(t, u),
-             !bson_cmp_less_su(t, u),
-             !bson_cmp_less_us(t, u))
+MLIB_CMP_SET(greater_equal,
+             !mlib_cmp_less_ss(t, u),
+             !mlib_cmp_less_uu(t, u),
+             !mlib_cmp_less_su(t, u),
+             !mlib_cmp_less_us(t, u))
 
-#undef BSON_CMP_SET
+#undef MLIB_CMP_SET
 
 /* Return true if the given value is within the range of the corresponding
  * signed type. The suffix must match the signedness of the given value. */
-#define BSON_IN_RANGE_SET_SIGNED(Type, min, max)                                                                       \
-    static BSON_INLINE bool BSON_CONCAT3(bson_in_range, _##Type, _signed)(int64_t value) {                             \
-        return bson_cmp_greater_equal_ss(value, min) && bson_cmp_less_equal_ss(value, max);                            \
+#define MLIB_IN_RANGE_SET_SIGNED(Type, min, max)                                                                       \
+    static BSON_INLINE bool BSON_CONCAT3(mlib_in_range, _##Type, _signed)(int64_t value) {                             \
+        return mlib_cmp_greater_equal_ss(value, min) && mlib_cmp_less_equal_ss(value, max);                            \
     }                                                                                                                  \
                                                                                                                        \
-    static BSON_INLINE bool BSON_CONCAT3(bson_in_range, _##Type, _unsigned)(uint64_t value) {                          \
-        return bson_cmp_greater_equal_us(value, min) && bson_cmp_less_equal_us(value, max);                            \
+    static BSON_INLINE bool BSON_CONCAT3(mlib_in_range, _##Type, _unsigned)(uint64_t value) {                          \
+        return mlib_cmp_greater_equal_us(value, min) && mlib_cmp_less_equal_us(value, max);                            \
     }
 
 /* Return true if the given value is within the range of the corresponding
  * unsigned type. The suffix must match the signedness of the given value. */
-#define BSON_IN_RANGE_SET_UNSIGNED(Type, max)                                                                          \
-    static BSON_INLINE bool BSON_CONCAT3(bson_in_range, _##Type, _signed)(int64_t value) {                             \
-        return bson_cmp_greater_equal_su(value, 0u) && bson_cmp_less_equal_su(value, max);                             \
+#define MLIB_IN_RANGE_SET_UNSIGNED(Type, max)                                                                          \
+    static BSON_INLINE bool BSON_CONCAT3(mlib_in_range, _##Type, _signed)(int64_t value) {                             \
+        return mlib_cmp_greater_equal_su(value, 0u) && mlib_cmp_less_equal_su(value, max);                             \
     }                                                                                                                  \
                                                                                                                        \
-    static BSON_INLINE bool BSON_CONCAT3(bson_in_range, _##Type, _unsigned)(uint64_t value) {                          \
-        return bson_cmp_less_equal_uu(value, max);                                                                     \
+    static BSON_INLINE bool BSON_CONCAT3(mlib_in_range, _##Type, _unsigned)(uint64_t value) {                          \
+        return mlib_cmp_less_equal_uu(value, max);                                                                     \
     }
 
-BSON_IN_RANGE_SET_SIGNED(signed_char, SCHAR_MIN, SCHAR_MAX)
-BSON_IN_RANGE_SET_SIGNED(short, SHRT_MIN, SHRT_MAX)
-BSON_IN_RANGE_SET_SIGNED(int, INT_MIN, INT_MAX)
-BSON_IN_RANGE_SET_SIGNED(long, LONG_MIN, LONG_MAX)
-BSON_IN_RANGE_SET_SIGNED(long_long, LLONG_MIN, LLONG_MAX)
+MLIB_IN_RANGE_SET_SIGNED(signed_char, SCHAR_MIN, SCHAR_MAX)
+MLIB_IN_RANGE_SET_SIGNED(short, SHRT_MIN, SHRT_MAX)
+MLIB_IN_RANGE_SET_SIGNED(int, INT_MIN, INT_MAX)
+MLIB_IN_RANGE_SET_SIGNED(long, LONG_MIN, LONG_MAX)
+MLIB_IN_RANGE_SET_SIGNED(long_long, LLONG_MIN, LLONG_MAX)
 
-BSON_IN_RANGE_SET_UNSIGNED(unsigned_char, UCHAR_MAX)
-BSON_IN_RANGE_SET_UNSIGNED(unsigned_short, USHRT_MAX)
-BSON_IN_RANGE_SET_UNSIGNED(unsigned_int, UINT_MAX)
-BSON_IN_RANGE_SET_UNSIGNED(unsigned_long, ULONG_MAX)
-BSON_IN_RANGE_SET_UNSIGNED(unsigned_long_long, ULLONG_MAX)
+MLIB_IN_RANGE_SET_UNSIGNED(unsigned_char, UCHAR_MAX)
+MLIB_IN_RANGE_SET_UNSIGNED(unsigned_short, USHRT_MAX)
+MLIB_IN_RANGE_SET_UNSIGNED(unsigned_int, UINT_MAX)
+MLIB_IN_RANGE_SET_UNSIGNED(unsigned_long, ULONG_MAX)
+MLIB_IN_RANGE_SET_UNSIGNED(unsigned_long_long, ULLONG_MAX)
 
-BSON_IN_RANGE_SET_SIGNED(int8_t, INT8_MIN, INT8_MAX)
-BSON_IN_RANGE_SET_SIGNED(int16_t, INT16_MIN, INT16_MAX)
-BSON_IN_RANGE_SET_SIGNED(int32_t, INT32_MIN, INT32_MAX)
-BSON_IN_RANGE_SET_SIGNED(int64_t, INT64_MIN, INT64_MAX)
+MLIB_IN_RANGE_SET_SIGNED(int8_t, INT8_MIN, INT8_MAX)
+MLIB_IN_RANGE_SET_SIGNED(int16_t, INT16_MIN, INT16_MAX)
+MLIB_IN_RANGE_SET_SIGNED(int32_t, INT32_MIN, INT32_MAX)
+MLIB_IN_RANGE_SET_SIGNED(int64_t, INT64_MIN, INT64_MAX)
 
-BSON_IN_RANGE_SET_UNSIGNED(uint8_t, UINT8_MAX)
-BSON_IN_RANGE_SET_UNSIGNED(uint16_t, UINT16_MAX)
-BSON_IN_RANGE_SET_UNSIGNED(uint32_t, UINT32_MAX)
-BSON_IN_RANGE_SET_UNSIGNED(uint64_t, UINT64_MAX)
+MLIB_IN_RANGE_SET_UNSIGNED(uint8_t, UINT8_MAX)
+MLIB_IN_RANGE_SET_UNSIGNED(uint16_t, UINT16_MAX)
+MLIB_IN_RANGE_SET_UNSIGNED(uint32_t, UINT32_MAX)
+MLIB_IN_RANGE_SET_UNSIGNED(uint64_t, UINT64_MAX)
 
-BSON_IN_RANGE_SET_SIGNED(ssize_t, SSIZE_MIN, SSIZE_MAX)
-BSON_IN_RANGE_SET_UNSIGNED(size_t, SIZE_MAX)
+MLIB_IN_RANGE_SET_SIGNED(ssize_t, SSIZE_MIN, SSIZE_MAX)
+MLIB_IN_RANGE_SET_UNSIGNED(size_t, SIZE_MAX)
 
-#undef BSON_IN_RANGE_SET_SIGNED
-#undef BSON_IN_RANGE_SET_UNSIGNED
+#undef MLIB_IN_RANGE_SET_SIGNED
+#undef MLIB_IN_RANGE_SET_UNSIGNED
 
 /* Return true if the value with *signed* type is in the representable range of
  * Type and false otherwise. */
-#define bson_in_range_signed(Type, value) BSON_CONCAT3(bson_in_range, _##Type, _signed)(value)
+#define mlib_in_range_signed(Type, value) BSON_CONCAT3(mlib_in_range, _##Type, _signed)(value)
 
 /* Return true if the value with *unsigned* type is in the representable range
  * of Type and false otherwise. */
-#define bson_in_range_unsigned(Type, value) BSON_CONCAT3(bson_in_range, _##Type, _unsigned)(value)
+#define mlib_in_range_unsigned(Type, value) BSON_CONCAT3(mlib_in_range, _##Type, _unsigned)(value)
 
 BSON_END_DECLS
 
-#endif /* BSON_CMP_H */
+#endif /* MLIB_CMP_H */

--- a/src/mlib/cmp.h
+++ b/src/mlib/cmp.h
@@ -24,8 +24,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-BSON_BEGIN_DECLS
-
 /* Based on the "Safe Integral Comparisons" proposal merged in C++20:
  * http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p0586r2.html
  *
@@ -147,7 +145,5 @@ MLIB_IN_RANGE_SET_UNSIGNED(size_t, SIZE_MAX)
 /* Return true if the value with *unsigned* type is in the representable range
  * of Type and false otherwise. */
 #define mlib_in_range_unsigned(Type, value) BSON_CONCAT3(mlib_in_range, _##Type, _unsigned)(value)
-
-BSON_END_DECLS
 
 #endif /* MLIB_CMP_H */

--- a/src/mlib/cmp.h
+++ b/src/mlib/cmp.h
@@ -18,8 +18,7 @@
 #ifndef MLIB_CMP_H
 #define MLIB_CMP_H
 
-#include <bson/bson-compat.h> /* ssize_t */
-#include <bson/bson-macros.h> /* BSON_CONCAT */
+#include <bson/bson.h> /* ssize_t + BSON_CONCAT */
 
 #include <limits.h>
 #include <stdbool.h>

--- a/src/mlib/cmp.h
+++ b/src/mlib/cmp.h
@@ -16,10 +16,8 @@
 
 #include <bson/bson-prelude.h>
 
-
 #ifndef BSON_CMP_H
 #define BSON_CMP_H
-
 
 #include <bson/bson-compat.h> /* ssize_t */
 #include <bson/bson-macros.h> /* BSON_CONCAT */
@@ -28,9 +26,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-
 BSON_BEGIN_DECLS
-
 
 /* Based on the "Safe Integral Comparisons" proposal merged in C++20:
  * http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p0586r2.html
@@ -53,121 +49,107 @@ BSON_BEGIN_DECLS
  * recommended.
  */
 
+#define BSON_CMP_SET(op, ss, uu, su, us)                                                                               \
+    static BSON_INLINE bool BSON_CONCAT3(bson_cmp_, op, _ss)(int64_t t, int64_t u) {                                   \
+        return (ss);                                                                                                   \
+    }                                                                                                                  \
+                                                                                                                       \
+    static BSON_INLINE bool BSON_CONCAT3(bson_cmp_, op, _uu)(uint64_t t, uint64_t u) {                                 \
+        return (uu);                                                                                                   \
+    }                                                                                                                  \
+                                                                                                                       \
+    static BSON_INLINE bool BSON_CONCAT3(bson_cmp_, op, _su)(int64_t t, uint64_t u) {                                  \
+        return (su);                                                                                                   \
+    }                                                                                                                  \
+                                                                                                                       \
+    static BSON_INLINE bool BSON_CONCAT3(bson_cmp_, op, _us)(uint64_t t, int64_t u) {                                  \
+        return (us);                                                                                                   \
+    }
 
-#define BSON_CMP_SET(op, ss, uu, su, us)                                              \
-   static BSON_INLINE bool BSON_CONCAT3 (bson_cmp_, op, _ss) (int64_t t, int64_t u)   \
-   {                                                                                  \
-      return (ss);                                                                    \
-   }                                                                                  \
-                                                                                      \
-   static BSON_INLINE bool BSON_CONCAT3 (bson_cmp_, op, _uu) (uint64_t t, uint64_t u) \
-   {                                                                                  \
-      return (uu);                                                                    \
-   }                                                                                  \
-                                                                                      \
-   static BSON_INLINE bool BSON_CONCAT3 (bson_cmp_, op, _su) (int64_t t, uint64_t u)  \
-   {                                                                                  \
-      return (su);                                                                    \
-   }                                                                                  \
-                                                                                      \
-   static BSON_INLINE bool BSON_CONCAT3 (bson_cmp_, op, _us) (uint64_t t, int64_t u)  \
-   {                                                                                  \
-      return (us);                                                                    \
-   }
+BSON_CMP_SET(equal, t == u, t == u, t < 0 ? false : (uint64_t)(t) == u, u < 0 ? false : t == (uint64_t)(u))
 
-BSON_CMP_SET (equal, t == u, t == u, t < 0 ? false : (uint64_t) (t) == u, u < 0 ? false : t == (uint64_t) (u))
+BSON_CMP_SET(not_equal,
+             !bson_cmp_equal_ss(t, u),
+             !bson_cmp_equal_uu(t, u),
+             !bson_cmp_equal_su(t, u),
+             !bson_cmp_equal_us(t, u))
 
-BSON_CMP_SET (not_equal,
-              !bson_cmp_equal_ss (t, u),
-              !bson_cmp_equal_uu (t, u),
-              !bson_cmp_equal_su (t, u),
-              !bson_cmp_equal_us (t, u))
+BSON_CMP_SET(less, t < u, t < u, t < 0 ? true : (uint64_t)(t) < u, u < 0 ? false : t < (uint64_t)(u))
 
-BSON_CMP_SET (less, t < u, t < u, t < 0 ? true : (uint64_t) (t) < u, u < 0 ? false : t < (uint64_t) (u))
+BSON_CMP_SET(greater, bson_cmp_less_ss(u, t), bson_cmp_less_uu(u, t), bson_cmp_less_us(u, t), bson_cmp_less_su(u, t))
 
-BSON_CMP_SET (
-   greater, bson_cmp_less_ss (u, t), bson_cmp_less_uu (u, t), bson_cmp_less_us (u, t), bson_cmp_less_su (u, t))
+BSON_CMP_SET(less_equal,
+             !bson_cmp_greater_ss(t, u),
+             !bson_cmp_greater_uu(t, u),
+             !bson_cmp_greater_su(t, u),
+             !bson_cmp_greater_us(t, u))
 
-BSON_CMP_SET (less_equal,
-              !bson_cmp_greater_ss (t, u),
-              !bson_cmp_greater_uu (t, u),
-              !bson_cmp_greater_su (t, u),
-              !bson_cmp_greater_us (t, u))
-
-BSON_CMP_SET (greater_equal,
-              !bson_cmp_less_ss (t, u),
-              !bson_cmp_less_uu (t, u),
-              !bson_cmp_less_su (t, u),
-              !bson_cmp_less_us (t, u))
+BSON_CMP_SET(greater_equal,
+             !bson_cmp_less_ss(t, u),
+             !bson_cmp_less_uu(t, u),
+             !bson_cmp_less_su(t, u),
+             !bson_cmp_less_us(t, u))
 
 #undef BSON_CMP_SET
 
-
 /* Return true if the given value is within the range of the corresponding
  * signed type. The suffix must match the signedness of the given value. */
-#define BSON_IN_RANGE_SET_SIGNED(Type, min, max)                                             \
-   static BSON_INLINE bool BSON_CONCAT3 (bson_in_range, _##Type, _signed) (int64_t value)    \
-   {                                                                                         \
-      return bson_cmp_greater_equal_ss (value, min) && bson_cmp_less_equal_ss (value, max);  \
-   }                                                                                         \
-                                                                                             \
-   static BSON_INLINE bool BSON_CONCAT3 (bson_in_range, _##Type, _unsigned) (uint64_t value) \
-   {                                                                                         \
-      return bson_cmp_greater_equal_us (value, min) && bson_cmp_less_equal_us (value, max);  \
-   }
+#define BSON_IN_RANGE_SET_SIGNED(Type, min, max)                                                                       \
+    static BSON_INLINE bool BSON_CONCAT3(bson_in_range, _##Type, _signed)(int64_t value) {                             \
+        return bson_cmp_greater_equal_ss(value, min) && bson_cmp_less_equal_ss(value, max);                            \
+    }                                                                                                                  \
+                                                                                                                       \
+    static BSON_INLINE bool BSON_CONCAT3(bson_in_range, _##Type, _unsigned)(uint64_t value) {                          \
+        return bson_cmp_greater_equal_us(value, min) && bson_cmp_less_equal_us(value, max);                            \
+    }
 
 /* Return true if the given value is within the range of the corresponding
  * unsigned type. The suffix must match the signedness of the given value. */
-#define BSON_IN_RANGE_SET_UNSIGNED(Type, max)                                                \
-   static BSON_INLINE bool BSON_CONCAT3 (bson_in_range, _##Type, _signed) (int64_t value)    \
-   {                                                                                         \
-      return bson_cmp_greater_equal_su (value, 0u) && bson_cmp_less_equal_su (value, max);   \
-   }                                                                                         \
-                                                                                             \
-   static BSON_INLINE bool BSON_CONCAT3 (bson_in_range, _##Type, _unsigned) (uint64_t value) \
-   {                                                                                         \
-      return bson_cmp_less_equal_uu (value, max);                                            \
-   }
+#define BSON_IN_RANGE_SET_UNSIGNED(Type, max)                                                                          \
+    static BSON_INLINE bool BSON_CONCAT3(bson_in_range, _##Type, _signed)(int64_t value) {                             \
+        return bson_cmp_greater_equal_su(value, 0u) && bson_cmp_less_equal_su(value, max);                             \
+    }                                                                                                                  \
+                                                                                                                       \
+    static BSON_INLINE bool BSON_CONCAT3(bson_in_range, _##Type, _unsigned)(uint64_t value) {                          \
+        return bson_cmp_less_equal_uu(value, max);                                                                     \
+    }
 
-BSON_IN_RANGE_SET_SIGNED (signed_char, SCHAR_MIN, SCHAR_MAX)
-BSON_IN_RANGE_SET_SIGNED (short, SHRT_MIN, SHRT_MAX)
-BSON_IN_RANGE_SET_SIGNED (int, INT_MIN, INT_MAX)
-BSON_IN_RANGE_SET_SIGNED (long, LONG_MIN, LONG_MAX)
-BSON_IN_RANGE_SET_SIGNED (long_long, LLONG_MIN, LLONG_MAX)
+BSON_IN_RANGE_SET_SIGNED(signed_char, SCHAR_MIN, SCHAR_MAX)
+BSON_IN_RANGE_SET_SIGNED(short, SHRT_MIN, SHRT_MAX)
+BSON_IN_RANGE_SET_SIGNED(int, INT_MIN, INT_MAX)
+BSON_IN_RANGE_SET_SIGNED(long, LONG_MIN, LONG_MAX)
+BSON_IN_RANGE_SET_SIGNED(long_long, LLONG_MIN, LLONG_MAX)
 
-BSON_IN_RANGE_SET_UNSIGNED (unsigned_char, UCHAR_MAX)
-BSON_IN_RANGE_SET_UNSIGNED (unsigned_short, USHRT_MAX)
-BSON_IN_RANGE_SET_UNSIGNED (unsigned_int, UINT_MAX)
-BSON_IN_RANGE_SET_UNSIGNED (unsigned_long, ULONG_MAX)
-BSON_IN_RANGE_SET_UNSIGNED (unsigned_long_long, ULLONG_MAX)
+BSON_IN_RANGE_SET_UNSIGNED(unsigned_char, UCHAR_MAX)
+BSON_IN_RANGE_SET_UNSIGNED(unsigned_short, USHRT_MAX)
+BSON_IN_RANGE_SET_UNSIGNED(unsigned_int, UINT_MAX)
+BSON_IN_RANGE_SET_UNSIGNED(unsigned_long, ULONG_MAX)
+BSON_IN_RANGE_SET_UNSIGNED(unsigned_long_long, ULLONG_MAX)
 
-BSON_IN_RANGE_SET_SIGNED (int8_t, INT8_MIN, INT8_MAX)
-BSON_IN_RANGE_SET_SIGNED (int16_t, INT16_MIN, INT16_MAX)
-BSON_IN_RANGE_SET_SIGNED (int32_t, INT32_MIN, INT32_MAX)
-BSON_IN_RANGE_SET_SIGNED (int64_t, INT64_MIN, INT64_MAX)
+BSON_IN_RANGE_SET_SIGNED(int8_t, INT8_MIN, INT8_MAX)
+BSON_IN_RANGE_SET_SIGNED(int16_t, INT16_MIN, INT16_MAX)
+BSON_IN_RANGE_SET_SIGNED(int32_t, INT32_MIN, INT32_MAX)
+BSON_IN_RANGE_SET_SIGNED(int64_t, INT64_MIN, INT64_MAX)
 
-BSON_IN_RANGE_SET_UNSIGNED (uint8_t, UINT8_MAX)
-BSON_IN_RANGE_SET_UNSIGNED (uint16_t, UINT16_MAX)
-BSON_IN_RANGE_SET_UNSIGNED (uint32_t, UINT32_MAX)
-BSON_IN_RANGE_SET_UNSIGNED (uint64_t, UINT64_MAX)
+BSON_IN_RANGE_SET_UNSIGNED(uint8_t, UINT8_MAX)
+BSON_IN_RANGE_SET_UNSIGNED(uint16_t, UINT16_MAX)
+BSON_IN_RANGE_SET_UNSIGNED(uint32_t, UINT32_MAX)
+BSON_IN_RANGE_SET_UNSIGNED(uint64_t, UINT64_MAX)
 
-BSON_IN_RANGE_SET_SIGNED (ssize_t, SSIZE_MIN, SSIZE_MAX)
-BSON_IN_RANGE_SET_UNSIGNED (size_t, SIZE_MAX)
+BSON_IN_RANGE_SET_SIGNED(ssize_t, SSIZE_MIN, SSIZE_MAX)
+BSON_IN_RANGE_SET_UNSIGNED(size_t, SIZE_MAX)
 
 #undef BSON_IN_RANGE_SET_SIGNED
 #undef BSON_IN_RANGE_SET_UNSIGNED
 
-
 /* Return true if the value with *signed* type is in the representable range of
  * Type and false otherwise. */
-#define bson_in_range_signed(Type, value) BSON_CONCAT3 (bson_in_range, _##Type, _signed) (value)
+#define bson_in_range_signed(Type, value) BSON_CONCAT3(bson_in_range, _##Type, _signed)(value)
 
 /* Return true if the value with *unsigned* type is in the representable range
  * of Type and false otherwise. */
-#define bson_in_range_unsigned(Type, value) BSON_CONCAT3 (bson_in_range, _##Type, _unsigned) (value)
-
+#define bson_in_range_unsigned(Type, value) BSON_CONCAT3(bson_in_range, _##Type, _unsigned)(value)
 
 BSON_END_DECLS
-
 
 #endif /* BSON_CMP_H */

--- a/src/mlib/cmp.h
+++ b/src/mlib/cmp.h
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-#ifndef BSON_CMP_H
-#define BSON_CMP_H
+// `cmp.h` is a modified copy of `bson-cmp.h` from libbson 1.28.0.
+#ifndef MLIB_CMP_H
+#define MLIB_CMP_H
 
 #include <bson/bson-compat.h> /* ssize_t */
 #include <bson/bson-macros.h> /* BSON_CONCAT */

--- a/src/mlib/cmp.h
+++ b/src/mlib/cmp.h
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include <bson/bson-prelude.h>
-
 #ifndef BSON_CMP_H
 #define BSON_CMP_H
 


### PR DESCRIPTION
# Summary

Remove use of `bson-cmp.h`. Partially resolves MONGOCRYPT-724.

Verified with [this patch build](https://spruce.mongodb.com/version/66fd4469a87c330007048826).

# Background & Motivation

CDRIVER-5703 plans to make libbson's `bson-cmp.h` private. libmongocrypt supports using a system install of libbson (via `USE_SHARED_LIBBSON`). I expect this is needed to support the Debian package [libmongocrypt-dev](https://packages.debian.org/trixie/libmongocrypt-dev), which [depends on libbson-dev](https://github.com/mongodb/libmongocrypt/blob/e98085b8e1de1803b3ceb827a03924cfb8985de3/debian/control#L11). I expect the Debian package cannot use private API of the libbson source through that package. Therefore, this PR adds a modified copy of `bson-cmp.h` to `mlib/cmp.h`.
