### PR TITLE
MONGOCRYPT-599 retry oauth requests

### DIFF
--- a/src/mongocrypt-key-broker.c
+++ b/src/mongocrypt-key-broker.c
@@ -807,6 +807,13 @@ mongocrypt_kms_ctx_t *_mongocrypt_key_broker_next_kms(_mongocrypt_key_broker_t *
         // Return the first not-yet-returned auth request.
         for (size_t i = 0; i < mc_mapof_kmsid_to_authrequest_len(kb->auth_requests); i++) {
             auth_request_t *ar = mc_mapof_kmsid_to_authrequest_at(kb->auth_requests, i);
+
+            if (ar->kms.should_retry) {
+                ar->kms.should_retry = false;
+                ar->returned = true;
+                return &ar->kms;
+            }
+
             if (ar->returned) {
                 continue;
             }

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -5508,6 +5508,12 @@ static void _test_encrypt_retry_provider(_responses r, _mongocrypt_tester_t *tes
         ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_KMS);
         mongocrypt_kms_ctx_t *kctx = mongocrypt_ctx_next_kms_ctx(ctx);
         ASSERT(kctx);
+        // Feed a retryable HTTP error.
+        ASSERT_OK(mongocrypt_kms_ctx_feed(kctx, TEST_FILE("./test/data/rmd/kms-decrypt-reply-429.txt")), kctx);
+        // Expect KMS request is returned again for a retry.
+        kctx = mongocrypt_ctx_next_kms_ctx(ctx);
+        ASSERT_OK(kctx, ctx);
+        ASSERT_CMPINT64(mongocrypt_kms_ctx_usleep(kctx), >, 0);
         ASSERT_OK(mongocrypt_kms_ctx_feed(kctx, TEST_FILE(r.oauth_response)), kctx);
         ASSERT_OK(mongocrypt_ctx_kms_done(ctx), ctx);
     }

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -5557,6 +5557,7 @@ static void _test_encrypt_retry(_mongocrypt_tester_t *tester) {
         ASSERT_OK(mongocrypt_ctx_kms_done(ctx), ctx);
         _mongocrypt_tester_run_ctx_to(tester, ctx, MONGOCRYPT_CTX_DONE);
         mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
     }
     // Azure
     {

--- a/test/test-mongocrypt-datakey.c
+++ b/test/test-mongocrypt-datakey.c
@@ -453,6 +453,108 @@ static void _test_create_datakey_with_retry(_mongocrypt_tester_t *tester) {
         mongocrypt_ctx_destroy(ctx);
         mongocrypt_destroy(crypt);
     }
+
+    // Test that an oauth request is retried for a network error.
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+        ASSERT_OK(mongocrypt_ctx_setopt_key_encryption_key(
+                      ctx,
+                      TEST_BSON("{'provider': 'azure', 'keyVaultEndpoint': 'example.com', 'keyName': 'foo' }")),
+                  ctx);
+        ASSERT_OK(mongocrypt_ctx_datakey_init(ctx), ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_KMS);
+        mongocrypt_kms_ctx_t *kms_ctx = mongocrypt_ctx_next_kms_ctx(ctx);
+        ASSERT_OK(kms_ctx, ctx);
+        // Expect an oauth request.
+        {
+            mongocrypt_binary_t *bin = mongocrypt_binary_new();
+            ASSERT_OK(mongocrypt_kms_ctx_message(kms_ctx, bin), kms_ctx);
+            const char *str = (const char *)mongocrypt_binary_data(bin);
+            ASSERT_STRCONTAINS(str, "oauth2");
+            mongocrypt_binary_destroy(bin);
+        }
+        // Expect no sleep is requested before any error.
+        ASSERT_CMPINT64(mongocrypt_kms_ctx_usleep(kms_ctx), ==, 0);
+        // Mark a network error.
+        ASSERT_OK(mongocrypt_kms_ctx_fail(kms_ctx), kms_ctx);
+        // Expect KMS request is returned again for a retry.
+        kms_ctx = mongocrypt_ctx_next_kms_ctx(ctx);
+        ASSERT_OK(kms_ctx, ctx);
+        // Expect an oauth request.
+        {
+            mongocrypt_binary_t *bin = mongocrypt_binary_new();
+            ASSERT_OK(mongocrypt_kms_ctx_message(kms_ctx, bin), kms_ctx);
+            const char *str = (const char *)mongocrypt_binary_data(bin);
+            ASSERT_STRCONTAINS(str, "oauth2");
+            mongocrypt_binary_destroy(bin);
+        }
+        // Feed a successful response.
+        ASSERT_OK(mongocrypt_kms_ctx_feed(kms_ctx, TEST_FILE("./test/data/kms-azure/oauth-response.txt")), kms_ctx);
+        ASSERT_OK(mongocrypt_ctx_kms_done(ctx), ctx);
+
+        // Expect KMS request for encrypt.
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_KMS);
+        kms_ctx = mongocrypt_ctx_next_kms_ctx(ctx);
+        ASSERT_OK(kms_ctx, ctx);
+        // Feed a successful response.
+        ASSERT_OK(mongocrypt_kms_ctx_feed(kms_ctx, TEST_FILE("./test/data/kms-azure/encrypt-response.txt")), kms_ctx);
+        ASSERT_OK(mongocrypt_ctx_kms_done(ctx), ctx);
+        _mongocrypt_tester_run_ctx_to(tester, ctx, MONGOCRYPT_CTX_DONE);
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+
+    // Test that an oauth request is retried for an HTTP error.
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+        ASSERT_OK(mongocrypt_ctx_setopt_key_encryption_key(
+                      ctx,
+                      TEST_BSON("{'provider': 'azure', 'keyVaultEndpoint': 'example.com', 'keyName': 'foo' }")),
+                  ctx);
+        ASSERT_OK(mongocrypt_ctx_datakey_init(ctx), ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_KMS);
+        mongocrypt_kms_ctx_t *kms_ctx = mongocrypt_ctx_next_kms_ctx(ctx);
+        ASSERT_OK(kms_ctx, ctx);
+        // Expect an oauth request.
+        {
+            mongocrypt_binary_t *bin = mongocrypt_binary_new();
+            ASSERT_OK(mongocrypt_kms_ctx_message(kms_ctx, bin), kms_ctx);
+            const char *str = (const char *)mongocrypt_binary_data(bin);
+            ASSERT_STRCONTAINS(str, "oauth2");
+            mongocrypt_binary_destroy(bin);
+        }
+        // Expect no sleep is requested before any error.
+        ASSERT_CMPINT64(mongocrypt_kms_ctx_usleep(kms_ctx), ==, 0);
+        // Feed a retryable HTTP error.
+        ASSERT_OK(mongocrypt_kms_ctx_feed(kms_ctx, TEST_FILE("./test/data/rmd/kms-decrypt-reply-429.txt")), kms_ctx);
+        // Expect KMS request is returned again for a retry.
+        kms_ctx = mongocrypt_ctx_next_kms_ctx(ctx);
+        ASSERT_OK(kms_ctx, ctx);
+        // Expect an oauth request.
+        {
+            mongocrypt_binary_t *bin = mongocrypt_binary_new();
+            ASSERT_OK(mongocrypt_kms_ctx_message(kms_ctx, bin), kms_ctx);
+            const char *str = (const char *)mongocrypt_binary_data(bin);
+            ASSERT_STRCONTAINS(str, "oauth2");
+            mongocrypt_binary_destroy(bin);
+        };
+
+        // Feed a successful response.
+        ASSERT_OK(mongocrypt_kms_ctx_feed(kms_ctx, TEST_FILE("./test/data/kms-azure/oauth-response.txt")), kms_ctx);
+        ASSERT_OK(mongocrypt_ctx_kms_done(ctx), ctx);
+
+        // Expect KMS request for encrypt.
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_KMS);
+        kms_ctx = mongocrypt_ctx_next_kms_ctx(ctx);
+        ASSERT_OK(kms_ctx, ctx);
+        // Feed a successful response.
+        ASSERT_OK(mongocrypt_kms_ctx_feed(kms_ctx, TEST_FILE("./test/data/kms-azure/encrypt-response.txt")), kms_ctx);
+        ASSERT_OK(mongocrypt_ctx_kms_done(ctx), ctx);
+        _mongocrypt_tester_run_ctx_to(tester, ctx, MONGOCRYPT_CTX_DONE);
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
     }
 }
 

--- a/test/test-mongocrypt-datakey.c
+++ b/test/test-mongocrypt-datakey.c
@@ -424,6 +424,7 @@ static void _test_create_datakey_with_retry(_mongocrypt_tester_t *tester) {
         ASSERT_OK(mongocrypt_ctx_kms_done(ctx), ctx);
         _mongocrypt_tester_run_ctx_to(tester, ctx, MONGOCRYPT_CTX_DONE);
         mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
     }
 
     // Test that a network error is retried.
@@ -450,6 +451,8 @@ static void _test_create_datakey_with_retry(_mongocrypt_tester_t *tester) {
         ASSERT_OK(mongocrypt_ctx_kms_done(ctx), ctx);
         _mongocrypt_tester_run_ctx_to(tester, ctx, MONGOCRYPT_CTX_DONE);
         mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
     }
 }
 


### PR DESCRIPTION
# Summary
Follow-up to https://github.com/mongodb/libmongocrypt/pull/783. Retry oauth requests on network or transient HTTP errors.

Verified by this patch build: https://spruce.mongodb.com/version/66fefa4733b962000781f45c

# Background

Retrying oauth requests was a [non-goal of the scope](https://jira.mongodb.org/browse/WRITING-18063). However, extending the retry mechanism to oauth requests was not much effort. It may further improve the success rate of KMS requests. I expect oauth requests are safe to retry.