### PR TITLE
MONGOCRYPT-726 Remove/replace unnecessary memset calls.

### DIFF
--- a/src/mongocrypt-ciphertext.c
+++ b/src/mongocrypt-ciphertext.c
@@ -92,7 +92,7 @@ bool _mongocrypt_ciphertext_parse_unowned(_mongocrypt_buffer_t *in,
     ciphertext->original_bson_type = in->data[offset];
     offset += 1;
 
-    memset(&ciphertext->data, 0, sizeof(ciphertext->data));
+    _mongocrypt_buffer_init(&ciphertext->data);
     ciphertext->data.data = in->data + offset;
     ciphertext->data.len = in->len - offset;
 

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -1214,13 +1214,11 @@ fail:
 
 static bool
 _replace_marking_with_ciphertext(void *ctx, _mongocrypt_buffer_t *in, bson_value_t *out, mongocrypt_status_t *status) {
-    _mongocrypt_marking_t marking;
+    _mongocrypt_marking_t marking = {0};
     bool ret;
 
     BSON_ASSERT_PARAM(ctx);
     BSON_ASSERT_PARAM(in);
-
-    memset(&marking, 0, sizeof(marking));
 
     if (!_mongocrypt_marking_parse_unowned(in, &marking, status)) {
         _mongocrypt_marking_cleanup(&marking);
@@ -2425,7 +2423,7 @@ static bool explicit_encrypt_init(mongocrypt_ctx_t *ctx, mongocrypt_binary_t *ms
     _mongocrypt_ctx_encrypt_t *ectx;
     bson_t as_bson;
     bson_iter_t iter;
-    _mongocrypt_ctx_opts_spec_t opts_spec;
+    _mongocrypt_ctx_opts_spec_t opts_spec = {0};
 
     if (!ctx) {
         return false;

--- a/src/mongocrypt-key-broker.c
+++ b/src/mongocrypt-key-broker.c
@@ -1155,6 +1155,7 @@ void _mongocrypt_key_broker_add_test_key(_mongocrypt_key_broker_t *kb, const _mo
     key_returned->decrypted = true;
     _mongocrypt_buffer_init(&key_returned->decrypted_key_material);
     _mongocrypt_buffer_resize(&key_returned->decrypted_key_material, MONGOCRYPT_KEY_LEN);
+    // Initialize test key material with all zeros.
     memset(key_returned->decrypted_key_material.data, 0, MONGOCRYPT_KEY_LEN);
     _mongocrypt_key_destroy(key_doc);
     /* Hijack state and move directly to DONE. */

--- a/src/mongocrypt-log.c
+++ b/src/mongocrypt-log.c
@@ -37,7 +37,6 @@ void _mongocrypt_log_cleanup(_mongocrypt_log_t *log) {
     }
 
     _mongocrypt_mutex_cleanup(&log->mutex);
-    memset(log, 0, sizeof(*log));
 }
 
 void _mongocrypt_stdout_log_fn(mongocrypt_log_level_t level, const char *message, uint32_t message_len, void *ctx) {

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -461,7 +461,7 @@ static void _FLE2EncryptedPayloadCommon_cleanup(_FLE2EncryptedPayloadCommon_t *c
     _mongocrypt_buffer_cleanup(&common->eccDerivedToken);
     _mongocrypt_buffer_cleanup(&common->serverDerivedFromDataToken);
     // Zero out memory so `_FLE2EncryptedPayloadCommon_cleanup` is safe to call twice.
-    *common = (_FLE2EncryptedPayloadCommon_t){0};
+    *common = (_FLE2EncryptedPayloadCommon_t){{0}};
 }
 
 // _get_tokenKey returns the tokenKey identified by indexKeyId.

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -460,7 +460,8 @@ static void _FLE2EncryptedPayloadCommon_cleanup(_FLE2EncryptedPayloadCommon_t *c
     _mongocrypt_buffer_cleanup(&common->escDerivedToken);
     _mongocrypt_buffer_cleanup(&common->eccDerivedToken);
     _mongocrypt_buffer_cleanup(&common->serverDerivedFromDataToken);
-    memset(common, 0, sizeof(*common));
+    // Zero out memory so `_FLE2EncryptedPayloadCommon_cleanup` is safe to call twice.
+    *common = (_FLE2EncryptedPayloadCommon_t){0};
 }
 
 // _get_tokenKey returns the tokenKey identified by indexKeyId.


### PR DESCRIPTION
Remove/replace unnecessary memset calls.

Verified by [this patch](https://spruce.mongodb.com/version/67041413723f3f000708f57e)

**Background & Motivation**

This PR is intended to address point 5 in audit identified in MONGOCRYPT-686. The memset calls are not intended to securely zero out memory. Securing process memory is a non-goal of libmongocrypt (per MONGOCRYPT-89). This PR was motivated by [discussion addressing the audit](https://docs.google.com/document/d/1vEifWIhZrwJjiS4WrVo7ZI09kpZJH1a0gOTEVJPeobE/edit?disco=AAABWsDJGHk).

