### PR TITLE
MONGOCRYPT-724 remove use of `bson_as_json`

### DIFF
--- a/src/mongocrypt-opts.c
+++ b/src/mongocrypt-opts.c
@@ -990,7 +990,7 @@ bool _mongocrypt_parse_kms_providers(mongocrypt_binary_t *kms_providers_definiti
     }
 
     if (log && log->trace_enabled) {
-        char *as_str = bson_as_json(&as_bson, NULL);
+        char *as_str = bson_as_relaxed_extended_json(&as_bson, NULL);
         _mongocrypt_log(log, MONGOCRYPT_LOG_LEVEL_TRACE, "%s (%s=\"%s\")", BSON_FUNC, "kms_providers", as_str);
         bson_free(as_str);
     }

--- a/test/example-state-machine.c
+++ b/test/example-state-machine.c
@@ -108,7 +108,7 @@ static void _print_binary_as_bson(mongocrypt_binary_t *binary) {
     BSON_ASSERT(binary);
 
     bson_init_static(&as_bson, mongocrypt_binary_data(binary), mongocrypt_binary_len(binary));
-    str = bson_as_json(&as_bson, NULL);
+    str = bson_as_relaxed_extended_json(&as_bson, NULL);
     printf("%s\n", str);
     bson_free(str);
 }

--- a/test/test-mongocrypt-assert-match-bson.h
+++ b/test/test-mongocrypt-assert-match-bson.h
@@ -26,8 +26,8 @@ bool _check_match_bson(const bson_t *doc, const bson_t *pattern, char *errmsg, s
     if (1) {                                                                                                           \
         char errmsg[1024] = "";                                                                                        \
         if (!_check_match_bson(doc, pattern, errmsg, sizeof(errmsg))) {                                                \
-            char *doc_str = bson_as_json(doc, NULL);                                                                   \
-            char *pattern_str = bson_as_json(pattern, NULL);                                                           \
+            char *doc_str = bson_as_relaxed_extended_json(doc, NULL);                                                  \
+            char *pattern_str = bson_as_relaxed_extended_json(pattern, NULL);                                          \
                                                                                                                        \
             TEST_ERROR("ASSERT_MATCH failed with document:\n\n"                                                        \
                        "%s\n"                                                                                          \

--- a/test/test-mongocrypt-kek.c
+++ b/test/test-mongocrypt-kek.c
@@ -45,7 +45,7 @@ static void _run_one_test(_mongocrypt_tester_t *tester, bson_t *test) {
         expect_append = expect;
     }
 
-    input_str = bson_as_json(&input, NULL);
+    input_str = bson_as_relaxed_extended_json(&input, NULL);
     printf("- testcase: %s\n", input_str);
     bson_free(input_str);
 

--- a/test/test-mongocrypt-key-cache.c
+++ b/test/test-mongocrypt-key-cache.c
@@ -268,7 +268,7 @@ static void _match_cache_entry(_mongocrypt_tester_t *tester, mongocrypt_ctx_t *c
     while (pair) {
         if (_match_one_cache_entry(pair, expected_entry)) {
             if (matched) {
-                printf("double matched entry: %s\n", bson_as_json(expected_entry, NULL));
+                printf("double matched entry: %s\n", bson_as_relaxed_extended_json(expected_entry, NULL));
                 BSON_ASSERT(false);
             }
             matched = true;
@@ -278,7 +278,7 @@ static void _match_cache_entry(_mongocrypt_tester_t *tester, mongocrypt_ctx_t *c
     }
 
     if (!matched) {
-        printf("could not match entry: %s\n", bson_as_json(expected_entry, NULL));
+        printf("could not match entry: %s\n", bson_as_relaxed_extended_json(expected_entry, NULL));
         BSON_ASSERT(false);
     }
 }


### PR DESCRIPTION
# Summary

Replace use of the soon-to-be-deprecated `bson_as_json` with `bson_as_relaxed_extended_json`.

# Background & Motivation

CDRIVER-5700 plans to deprecate `bson_as_json` due to producing Legacy Extended JSON by default. libmongocrypt's use of `bson_as_json` appears limited to logging and tests. Calls are updated to use the portable Relaxed Extended JSON format (rather than preserve the Legacy Extended JSON format).