### PR TITLE
MONGOCRYPT-728 Add FLE2IndexedRangeEncryptedValueV2 serializer

### DIFF
--- a/src/mc-fle2-payload-iev-private-v2.h
+++ b/src/mc-fle2-payload-iev-private-v2.h
@@ -130,4 +130,18 @@ bool mc_FLE2IndexedRangeEncryptedValueV2_parse(mc_FLE2IndexedEncryptedValueV2_t 
                                                const _mongocrypt_buffer_t *buf,
                                                mongocrypt_status_t *status);
 
+/*
+ * Serializes an mc_FLE2IndexedEncryptedValueV2_t into a buffer.
+ *
+ * The serialized output follows the same layout as the input `buf` to
+ * mc_FLE2IndexedRangeEncryptedValueV2_parse, allowing for round-trip
+ * conversions between the serialized and parsed forms.
+ *
+ * Retuns an error if the input structure is not valid, or if the buffer
+ * provided is insufficient to hold the serialized data.
+ */
+bool mc_FLE2IndexedRangeEncryptedValueV2_serialize(const mc_FLE2IndexedEncryptedValueV2_t *iev,
+                                                   _mongocrypt_buffer_t *buf,
+                                                   mongocrypt_status_t *status);
+
 #endif /* MONGOCRYPT_INDEXED_ENCRYPTED_VALUE_PRIVATE_V2_H */

--- a/test/test-mc-fle2-payload-iev-v2.c
+++ b/test/test-mc-fle2-payload-iev-v2.c
@@ -114,6 +114,13 @@ static void _mc_fle2_iev_v2_test_run(_mongocrypt_tester_t *tester, _mc_fle2_iev_
     } else {
         ASSERT(test->type == kTypeRange);
         ASSERT_OK_STATUS(mc_FLE2IndexedRangeEncryptedValueV2_parse(iev, &test->payload, status), status);
+
+        // Reserialize and assert that the result is the same as the initial input
+        _mongocrypt_buffer_t serialized_buf;
+        _mongocrypt_buffer_init_size(&serialized_buf, test->payload.len);
+        ASSERT_OK_STATUS(mc_FLE2IndexedRangeEncryptedValueV2_serialize(iev, &serialized_buf, status), status);
+        ASSERT_CMPBUF(serialized_buf, test->payload);
+        _mongocrypt_buffer_cleanup(&serialized_buf);
     }
 
     // Validate S_KeyId as parsed.


### PR DESCRIPTION
# Summary
This PR adds `mc_FLE2IndexedRangeEncryptedValueV2_serialize` along with the appropriate testing integration. 

# Background
See [SPM-3042](https://jira.mongodb.org/browse/SPM-3042). This new function is necessary for [SERVER-95887](https://jira.mongodb.org/browse/SERVER-95887) as a part of eliminating duplicated code for FLE2 support.

# Metadata
Previously, metadata sent into the `FLE2IndexedRangeEncryptedValueV2` parser was ignored as `libmongocrypt` doesn't have a use for it. Now that it's necessary to reserialize the encrypted data for server use, a new field is added to `_mc_FLE2IndexedEncryptedValueV2_t` and the metadata is saved while parsing.

# Testing
After parsing the test's payload, we now send the parsing function output into the new serializer to ensure that the serialized output is the same as the initial payload.