### PR TITLE
MONGOCRYPT-725 fix UBSan alignment errors

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -436,6 +436,17 @@ tasks:
         # Add detect_odr_violation=0 to ASAN_OPTIONS to ignore odr-violation in IntelDFP symbol: __dpml_bid_globals_table
         ASAN_OPTIONS="detect_leaks=1 detect_odr_violation=0"
 
+- name: build-and-test-ubsan
+  commands:
+  - func: "fetch source"
+  - func: "build and test"
+    vars:
+      compile_env: >-
+        ${compile_env|}
+        LIBMONGOCRYPT_EXTRA_CFLAGS="-fsanitize=undefined -fno-omit-frame-pointer"
+        UBSAN_OPTIONS="halt_on_error=1,print_stacktrace=1"
+        
+
 - name: build-and-test-asan-mac
   commands:
   - func: "fetch source"
@@ -1498,6 +1509,7 @@ buildvariants:
   - build-and-test-and-upload
   - build-and-test-shared-bson
   - build-and-test-asan
+  - build-and-test-ubsan
   - test-java
   - upload-java
   - name: publish-packages

--- a/src/mc-fle2-encryption-placeholder-private.h
+++ b/src/mc-fle2-encryption-placeholder-private.h
@@ -54,6 +54,11 @@ typedef struct {
     mc_optional_int32_t trimFactor;
 } mc_FLE2RangeFindSpecEdgesInfo_t;
 
+// `mc_FLE2RangeFindSpecEdgesInfo_t` inherits extended alignment from libbson. To dynamically allocate, use
+// aligned allocation (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof_mc_FLE2RangeFindSpecEdgesInfo_t,
+                    BSON_ALIGNOF(mc_FLE2RangeFindSpecEdgesInfo_t) >= BSON_ALIGNOF(bson_iter_t));
+
 /** FLE2RangeFindSpec represents the range find specification that is encoded
  * inside of a FLE2EncryptionPlaceholder. See
  * https://github.com/mongodb/mongo/blob/master/src/mongo/crypto/fle_field_schema.idl
@@ -75,6 +80,10 @@ typedef struct {
     // was generated. Only populated for two-sided ranges. It is 0 if unset.
     mc_FLE2RangeOperator_t secondOperator;
 } mc_FLE2RangeFindSpec_t;
+
+// `mc_FLE2RangeFindSpec_t` inherits extended alignment from libbson. To dynamically allocate, use
+// aligned allocation (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof_mc_FLE2RangeFindSpec_t, BSON_ALIGNOF(mc_FLE2RangeFindSpec_t) >= BSON_ALIGNOF(bson_iter_t));
 
 bool mc_FLE2RangeFindSpec_parse(mc_FLE2RangeFindSpec_t *out,
                                 const bson_iter_t *in,
@@ -98,6 +107,11 @@ typedef struct {
     // trimFactor determines how many root levels of the hypergraph to trim.
     mc_optional_int32_t trimFactor;
 } mc_FLE2RangeInsertSpec_t;
+
+// `mc_FLE2RangeInsertSpec_t` inherits extended alignment from libbson. To dynamically allocate, use
+// aligned allocation (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof_mc_FLE2RangeInsertSpec_t,
+                    BSON_ALIGNOF(mc_FLE2RangeInsertSpec_t) >= BSON_ALIGNOF(bson_iter_t));
 
 bool mc_FLE2RangeInsertSpec_parse(mc_FLE2RangeInsertSpec_t *out,
                                   const bson_iter_t *in,
@@ -130,6 +144,11 @@ typedef struct {
     // sparsity is the Queryable Encryption range hypergraph sparsity factor
     int64_t sparsity;
 } mc_FLE2EncryptionPlaceholder_t;
+
+// `mc_FLE2EncryptionPlaceholder_t` inherits extended alignment from libbson. To dynamically allocate, use
+// aligned allocation (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof_mc_FLE2EncryptionPlaceholder_t,
+                    BSON_ALIGNOF(mc_FLE2EncryptionPlaceholder_t) >= BSON_ALIGNOF(bson_iter_t));
 
 void mc_FLE2EncryptionPlaceholder_init(mc_FLE2EncryptionPlaceholder_t *placeholder);
 

--- a/src/mc-fle2-encryption-placeholder-private.h
+++ b/src/mc-fle2-encryption-placeholder-private.h
@@ -83,7 +83,8 @@ typedef struct {
 
 // `mc_FLE2RangeFindSpec_t` inherits extended alignment from libbson. To dynamically allocate, use
 // aligned allocation (e.g. BSON_ALIGNED_ALLOC)
-BSON_STATIC_ASSERT2(alignof_mc_FLE2RangeFindSpec_t, BSON_ALIGNOF(mc_FLE2RangeFindSpec_t) >= BSON_ALIGNOF(bson_iter_t));
+BSON_STATIC_ASSERT2(alignof_mc_FLE2RangeFindSpec_t,
+                    BSON_ALIGNOF(mc_FLE2RangeFindSpec_t) >= BSON_ALIGNOF(mc_FLE2RangeFindSpecEdgesInfo_t));
 
 bool mc_FLE2RangeFindSpec_parse(mc_FLE2RangeFindSpec_t *out,
                                 const bson_iter_t *in,

--- a/src/mc-fle2-find-range-payload-private-v2.h
+++ b/src/mc-fle2-find-range-payload-private-v2.h
@@ -78,6 +78,11 @@ typedef struct {
     bson_value_t indexMax;          // mx
 } mc_FLE2FindRangePayloadV2_t;
 
+// `mc_FLE2FindRangePayloadV2_t` inherits extended alignment from libbson. To dynamically allocate, use aligned
+// allocation (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof_mc_FLE2FindRangePayloadV2_t,
+                    BSON_ALIGNOF(mc_FLE2FindRangePayloadV2_t) >= BSON_ALIGNOF(bson_value_t));
+
 /**
  * EdgeFindTokenSetV2 is the following BSON document:
  * d: <binary> // EDCDerivedFromDataTokenAndContentionFactor

--- a/src/mc-fle2-insert-update-payload-private-v2.h
+++ b/src/mc-fle2-insert-update-payload-private-v2.h
@@ -87,6 +87,11 @@ typedef struct {
     _mongocrypt_buffer_t userKeyId;
 } mc_FLE2InsertUpdatePayloadV2_t;
 
+// `mc_FLE2InsertUpdatePayloadV2_t` inherits extended alignment from libbson. To dynamically allocate, use
+// aligned allocation (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof_mc_FLE2InsertUpdatePayloadV2_t,
+                    BSON_ALIGNOF(mc_FLE2InsertUpdatePayloadV2_t) >= BSON_ALIGNOF(bson_value_t));
+
 /**
  * EdgeTokenSetV2 is the following BSON document:
  * d: <binary> // EDCDerivedFromDataTokenAndContentionFactor

--- a/src/mc-fle2-rfds-private.h
+++ b/src/mc-fle2-rfds-private.h
@@ -41,6 +41,11 @@ typedef struct {
     mc_FLE2RangeOperator_t secondOp;
 } mc_FLE2RangeFindDriverSpec_t;
 
+// `mc_FLE2RangeFindDriverSpec_t` inherits extended alignment from libbson. To dynamically allocate, use
+// aligned allocation (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof_mc_FLE2RangeFindDriverSpec_t,
+                    BSON_ALIGNOF(mc_FLE2RangeFindDriverSpec_t) >= BSON_ALIGNOF(bson_iter_t));
+
 // mc_FLE2RangeFindDriverSpec_parse parses a FLE2RangeFindDriverSpec document.
 bool mc_FLE2RangeFindDriverSpec_parse(mc_FLE2RangeFindDriverSpec_t *spec,
                                       const bson_t *in,
@@ -78,6 +83,11 @@ typedef struct {
     mc_optional_int32_t precision;
     mc_optional_int32_t trimFactor;
 } mc_makeRangeFindPlaceholder_args_t;
+
+// `mc_makeRangeFindPlaceholder_args_t` inherits extended alignment from libbson. To dynamically allocate, use
+// aligned allocation (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof_mc_makeRangeFindPlaceholder_args_t,
+                    BSON_ALIGNOF(mc_makeRangeFindPlaceholder_args_t) >= BSON_ALIGNOF(bson_iter_t));
 
 // mc_makeRangeFindPlaceholder creates a placeholder to be consumed by
 // libmongocrypt to encrypt a range find query. It is included in the header to

--- a/src/mc-rangeopts-private.h
+++ b/src/mc-rangeopts-private.h
@@ -40,6 +40,10 @@ typedef struct {
     mc_optional_int32_t trimFactor;
 } mc_RangeOpts_t;
 
+// `mc_RangeOpts_t` inherits extended alignment from libbson. To dynamically allocate, use
+// aligned allocation (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof_mc_RangeOpts_t, BSON_ALIGNOF(mc_RangeOpts_t) >= BSON_ALIGNOF(bson_iter_t));
+
 /* mc_RangeOpts_parse parses a BSON document into mc_RangeOpts_t.
  * The document is expected to have the form:
  * {

--- a/src/mc-rangeopts-private.h
+++ b/src/mc-rangeopts-private.h
@@ -42,7 +42,8 @@ typedef struct {
 
 // `mc_RangeOpts_t` inherits extended alignment from libbson. To dynamically allocate, use
 // aligned allocation (e.g. BSON_ALIGNED_ALLOC)
-BSON_STATIC_ASSERT2(alignof_mc_RangeOpts_t, BSON_ALIGNOF(mc_RangeOpts_t) >= BSON_ALIGNOF(bson_iter_t));
+BSON_STATIC_ASSERT2(alignof_mc_RangeOpts_t,
+                    BSON_ALIGNOF(mc_RangeOpts_t) >= BSON_MAX(BSON_ALIGNOF(bson_t), BSON_ALIGNOF(bson_iter_t)));
 
 /* mc_RangeOpts_parse parses a BSON document into mc_RangeOpts_t.
  * The document is expected to have the form:

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -88,6 +88,10 @@ typedef struct __mongocrypt_ctx_opts_t {
     } rangeopts;
 } _mongocrypt_ctx_opts_t;
 
+// `_mongocrypt_ctx_opts_t` inherits extended alignment from libbson. To dynamically allocate, use
+// aligned allocation (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof__mongocrypt_ctx_opts_t, BSON_ALIGNOF(_mongocrypt_ctx_opts_t) >= BSON_ALIGNOF(bson_iter_t));
+
 /* All derived contexts may override these methods. */
 typedef struct {
     const char *(*mongo_db_collinfo)(mongocrypt_ctx_t *ctx);
@@ -126,6 +130,10 @@ struct _mongocrypt_ctx_t {
      */
     bool nothing_to_do;
 };
+
+// `_mongocrypt_ctx_t` inherits extended alignment from libbson. To dynamically allocate, use
+// aligned allocation (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof_mongocrypt_ctx_t, BSON_ALIGNOF(mongocrypt_ctx_t) >= BSON_ALIGNOF(bson_iter_t));
 
 /* Transition to the error state. An error status must have been set. */
 bool _mongocrypt_ctx_fail(mongocrypt_ctx_t *ctx);
@@ -203,6 +211,11 @@ typedef struct {
     const char *cmd_name;
 } _mongocrypt_ctx_encrypt_t;
 
+// `_mongocrypt_ctx_encrypt_t` inherits extended alignment from libbson. To dynamically allocate, use
+// aligned allocation (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof__mongocrypt_ctx_encrypt_t,
+                    BSON_ALIGNOF(_mongocrypt_ctx_encrypt_t) >= BSON_ALIGNOF(bson_iter_t));
+
 typedef struct {
     mongocrypt_ctx_t parent;
     /* TODO CDRIVER-3150: audit + rename these buffers.
@@ -212,6 +225,11 @@ typedef struct {
     _mongocrypt_buffer_t original_doc;
     _mongocrypt_buffer_t decrypted_doc;
 } _mongocrypt_ctx_decrypt_t;
+
+// `_mongocrypt_ctx_datakey_t` inherits extended alignment from libbson. To dynamically allocate, use
+// aligned allocation (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof__mongocrypt_ctx_decrypt_t,
+                    BSON_ALIGNOF(_mongocrypt_ctx_decrypt_t) >= BSON_ALIGNOF(bson_iter_t));
 
 typedef struct {
     mongocrypt_ctx_t parent;
@@ -225,6 +243,11 @@ typedef struct {
     bool kmip_activated;
     _mongocrypt_buffer_t kmip_secretdata;
 } _mongocrypt_ctx_datakey_t;
+
+// `_mongocrypt_ctx_datakey_t` inherits extended alignment from libbson. To dynamically allocate, use
+// aligned allocation (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof__mongocrypt_ctx_datakey_t,
+                    BSON_ALIGNOF(_mongocrypt_ctx_datakey_t) >= BSON_ALIGNOF(bson_iter_t));
 
 typedef struct _mongocrypt_ctx_rmd_datakey_t _mongocrypt_ctx_rmd_datakey_t;
 
@@ -243,11 +266,21 @@ typedef struct {
     _mongocrypt_buffer_t results;
 } _mongocrypt_ctx_rewrap_many_datakey_t;
 
+// `_mongocrypt_ctx_rewrap_many_datakey_t` inherits extended alignment from libbson. To dynamically allocate, use
+// aligned allocation (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof__mongocrypt_ctx_rewrap_many_datakey_t,
+                    BSON_ALIGNOF(_mongocrypt_ctx_rewrap_many_datakey_t) >= BSON_ALIGNOF(bson_iter_t));
+
 typedef struct {
     mongocrypt_ctx_t parent;
     _mongocrypt_buffer_t result;
     mc_EncryptedFieldConfig_t efc;
 } _mongocrypt_ctx_compact_t;
+
+// `_mongocrypt_ctx_compact_t` inherits extended alignment from libbson. To dynamically allocate, use aligned
+// allocation (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof__mongocrypt_ctx_compact_t,
+                    BSON_ALIGNOF(_mongocrypt_ctx_compact_t) >= BSON_ALIGNOF(bson_iter_t));
 
 /* Used for option validation. True means required. False means prohibited. */
 typedef enum { OPT_PROHIBITED = 0, OPT_REQUIRED, OPT_OPTIONAL } _mongocrypt_ctx_opt_spec_t;

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -90,7 +90,9 @@ typedef struct __mongocrypt_ctx_opts_t {
 
 // `_mongocrypt_ctx_opts_t` inherits extended alignment from libbson. To dynamically allocate, use
 // aligned allocation (e.g. BSON_ALIGNED_ALLOC)
-BSON_STATIC_ASSERT2(alignof__mongocrypt_ctx_opts_t, BSON_ALIGNOF(_mongocrypt_ctx_opts_t) >= BSON_ALIGNOF(bson_iter_t));
+BSON_STATIC_ASSERT2(alignof__mongocrypt_ctx_opts_t,
+                    BSON_ALIGNOF(_mongocrypt_ctx_opts_t)
+                        >= BSON_MAX(BSON_ALIGNOF(_mongocrypt_key_alt_name_t), BSON_ALIGNOF(mc_RangeOpts_t)));
 
 /* All derived contexts may override these methods. */
 typedef struct {
@@ -214,7 +216,7 @@ typedef struct {
 // `_mongocrypt_ctx_encrypt_t` inherits extended alignment from libbson. To dynamically allocate, use
 // aligned allocation (e.g. BSON_ALIGNED_ALLOC)
 BSON_STATIC_ASSERT2(alignof__mongocrypt_ctx_encrypt_t,
-                    BSON_ALIGNOF(_mongocrypt_ctx_encrypt_t) >= BSON_ALIGNOF(bson_iter_t));
+                    BSON_ALIGNOF(_mongocrypt_ctx_encrypt_t) >= BSON_ALIGNOF(mongocrypt_ctx_t));
 
 typedef struct {
     mongocrypt_ctx_t parent;
@@ -229,7 +231,7 @@ typedef struct {
 // `_mongocrypt_ctx_datakey_t` inherits extended alignment from libbson. To dynamically allocate, use
 // aligned allocation (e.g. BSON_ALIGNED_ALLOC)
 BSON_STATIC_ASSERT2(alignof__mongocrypt_ctx_decrypt_t,
-                    BSON_ALIGNOF(_mongocrypt_ctx_decrypt_t) >= BSON_ALIGNOF(bson_iter_t));
+                    BSON_ALIGNOF(_mongocrypt_ctx_decrypt_t) >= BSON_ALIGNOF(mongocrypt_ctx_t));
 
 typedef struct {
     mongocrypt_ctx_t parent;
@@ -247,7 +249,7 @@ typedef struct {
 // `_mongocrypt_ctx_datakey_t` inherits extended alignment from libbson. To dynamically allocate, use
 // aligned allocation (e.g. BSON_ALIGNED_ALLOC)
 BSON_STATIC_ASSERT2(alignof__mongocrypt_ctx_datakey_t,
-                    BSON_ALIGNOF(_mongocrypt_ctx_datakey_t) >= BSON_ALIGNOF(bson_iter_t));
+                    BSON_ALIGNOF(_mongocrypt_ctx_datakey_t) >= BSON_ALIGNOF(mongocrypt_ctx_t));
 
 typedef struct _mongocrypt_ctx_rmd_datakey_t _mongocrypt_ctx_rmd_datakey_t;
 
@@ -269,7 +271,7 @@ typedef struct {
 // `_mongocrypt_ctx_rewrap_many_datakey_t` inherits extended alignment from libbson. To dynamically allocate, use
 // aligned allocation (e.g. BSON_ALIGNED_ALLOC)
 BSON_STATIC_ASSERT2(alignof__mongocrypt_ctx_rewrap_many_datakey_t,
-                    BSON_ALIGNOF(_mongocrypt_ctx_rewrap_many_datakey_t) >= BSON_ALIGNOF(bson_iter_t));
+                    BSON_ALIGNOF(_mongocrypt_ctx_rewrap_many_datakey_t) >= BSON_ALIGNOF(mongocrypt_ctx_t));
 
 typedef struct {
     mongocrypt_ctx_t parent;
@@ -280,7 +282,7 @@ typedef struct {
 // `_mongocrypt_ctx_compact_t` inherits extended alignment from libbson. To dynamically allocate, use aligned
 // allocation (e.g. BSON_ALIGNED_ALLOC)
 BSON_STATIC_ASSERT2(alignof__mongocrypt_ctx_compact_t,
-                    BSON_ALIGNOF(_mongocrypt_ctx_compact_t) >= BSON_ALIGNOF(bson_iter_t));
+                    BSON_ALIGNOF(_mongocrypt_ctx_compact_t) >= BSON_ALIGNOF(mongocrypt_ctx_t));
 
 /* Used for option validation. True means required. False means prohibited. */
 typedef enum { OPT_PROHIBITED = 0, OPT_REQUIRED, OPT_OPTIONAL } _mongocrypt_ctx_opt_spec_t;

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -133,10 +133,6 @@ struct _mongocrypt_ctx_t {
     bool nothing_to_do;
 };
 
-// `_mongocrypt_ctx_t` inherits extended alignment from libbson. To dynamically allocate, use
-// aligned allocation (e.g. BSON_ALIGNED_ALLOC)
-BSON_STATIC_ASSERT2(alignof_mongocrypt_ctx_t, BSON_ALIGNOF(mongocrypt_ctx_t) >= BSON_ALIGNOF(bson_iter_t));
-
 /* Transition to the error state. An error status must have been set. */
 bool _mongocrypt_ctx_fail(mongocrypt_ctx_t *ctx);
 
@@ -283,6 +279,24 @@ typedef struct {
 // allocation (e.g. BSON_ALIGNED_ALLOC)
 BSON_STATIC_ASSERT2(alignof__mongocrypt_ctx_compact_t,
                     BSON_ALIGNOF(_mongocrypt_ctx_compact_t) >= BSON_ALIGNOF(mongocrypt_ctx_t));
+
+#define MONGOCRYPT_CTX_ALLOC_SIZE                                                                                      \
+    BSON_MAX(sizeof(_mongocrypt_ctx_encrypt_t),                                                                        \
+             BSON_MAX(sizeof(_mongocrypt_ctx_decrypt_t),                                                               \
+                      BSON_MAX(sizeof(_mongocrypt_ctx_datakey_t),                                                      \
+                               BSON_MAX(sizeof(_mongocrypt_ctx_rewrap_many_datakey_t),                                 \
+                                        sizeof(_mongocrypt_ctx_compact_t)))))
+
+#define MONGOCRYPT_CTX_ALLOC_ALIGNMENT                                                                                 \
+    BSON_MAX(BSON_ALIGNOF(_mongocrypt_ctx_encrypt_t),                                                                  \
+             BSON_MAX(BSON_ALIGNOF(_mongocrypt_ctx_decrypt_t),                                                         \
+                      BSON_MAX(BSON_ALIGNOF(_mongocrypt_ctx_datakey_t),                                                \
+                               BSON_MAX(BSON_ALIGNOF(_mongocrypt_ctx_rewrap_many_datakey_t),                           \
+                                        BSON_ALIGNOF(_mongocrypt_ctx_compact_t)))))
+
+// `_mongocrypt_ctx_t` inherits extended alignment from libbson. To dynamically allocate, use
+// aligned allocation (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof_mongocrypt_ctx_t, BSON_ALIGNOF(mongocrypt_ctx_t) >= MONGOCRYPT_CTX_ALLOC_ALIGNMENT);
 
 /* Used for option validation. True means required. False means prohibited. */
 typedef enum { OPT_PROHIBITED = 0, OPT_REQUIRED, OPT_OPTIONAL } _mongocrypt_ctx_opt_spec_t;

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -295,7 +295,9 @@ mongocrypt_ctx_t *mongocrypt_ctx_new(mongocrypt_t *crypt) {
     }
 
     // Allocate with memory and alignment large enough for any possible context type.
-    ctx = bson_aligned_alloc0(MONGOCRYPT_CTX_ALLOC_ALIGNMENT, MONGOCRYPT_CTX_ALLOC_SIZE);
+    static const size_t ctx_alignment = MONGOCRYPT_CTX_ALLOC_ALIGNMENT;
+    static const size_t ctx_size = MONGOCRYPT_CTX_ALLOC_SIZE;
+    ctx = bson_aligned_alloc0(ctx_alignment, ctx_size);
     BSON_ASSERT(ctx);
 
     ctx->crypt = crypt;

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -294,22 +294,8 @@ mongocrypt_ctx_t *mongocrypt_ctx_new(mongocrypt_t *crypt) {
         return NULL;
     }
 
-    // Allocate enough memory for any possible context type.
-    static const size_t ctx_size = BSON_MAX(
-        sizeof(_mongocrypt_ctx_encrypt_t),
-        BSON_MAX(sizeof(_mongocrypt_ctx_decrypt_t),
-                 BSON_MAX(sizeof(_mongocrypt_ctx_datakey_t),
-                          BSON_MAX(sizeof(_mongocrypt_ctx_rewrap_many_datakey_t), sizeof(_mongocrypt_ctx_compact_t)))));
-
-    // Use an alignment that is enough for any possible context type.
-    static const size_t ctx_alignment =
-        BSON_MAX(BSON_ALIGNOF(_mongocrypt_ctx_encrypt_t),
-                 BSON_MAX(BSON_ALIGNOF(_mongocrypt_ctx_decrypt_t),
-                          BSON_MAX(BSON_ALIGNOF(_mongocrypt_ctx_datakey_t),
-                                   BSON_MAX(BSON_ALIGNOF(_mongocrypt_ctx_rewrap_many_datakey_t),
-                                            BSON_ALIGNOF(_mongocrypt_ctx_compact_t)))));
-
-    ctx = bson_aligned_alloc0(ctx_alignment, ctx_size);
+    // Allocate with memory and alignment large enough for any possible context type.
+    ctx = bson_aligned_alloc0(MONGOCRYPT_CTX_ALLOC_ALIGNMENT, MONGOCRYPT_CTX_ALLOC_SIZE);
     BSON_ASSERT(ctx);
 
     ctx->crypt = crypt;

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -293,19 +293,22 @@ mongocrypt_ctx_t *mongocrypt_ctx_new(mongocrypt_t *crypt) {
         CLIENT_ERR("cannot create context from uninitialized crypt");
         return NULL;
     }
-    // Allocate with maximum size and alignment of any of the possible context types.
-    size_t ctx_size = 0;
-    ctx_size = BSON_MAX(ctx_size, sizeof(_mongocrypt_ctx_encrypt_t));
-    ctx_size = BSON_MAX(ctx_size, sizeof(_mongocrypt_ctx_decrypt_t));
-    ctx_size = BSON_MAX(ctx_size, sizeof(_mongocrypt_ctx_datakey_t));
-    ctx_size = BSON_MAX(ctx_size, sizeof(_mongocrypt_ctx_rewrap_many_datakey_t));
-    ctx_size = BSON_MAX(ctx_size, sizeof(_mongocrypt_ctx_compact_t));
-    size_t ctx_alignment = 0;
-    ctx_alignment = BSON_MAX(ctx_alignment, BSON_ALIGNOF(_mongocrypt_ctx_encrypt_t));
-    ctx_alignment = BSON_MAX(ctx_alignment, BSON_ALIGNOF(_mongocrypt_ctx_decrypt_t));
-    ctx_alignment = BSON_MAX(ctx_alignment, BSON_ALIGNOF(_mongocrypt_ctx_datakey_t));
-    ctx_alignment = BSON_MAX(ctx_alignment, BSON_ALIGNOF(_mongocrypt_ctx_rewrap_many_datakey_t));
-    ctx_alignment = BSON_MAX(ctx_alignment, BSON_ALIGNOF(_mongocrypt_ctx_compact_t));
+
+    // Allocate enough memory for any possible context type.
+    static const size_t ctx_size = BSON_MAX(
+        sizeof(_mongocrypt_ctx_encrypt_t),
+        BSON_MAX(sizeof(_mongocrypt_ctx_decrypt_t),
+                 BSON_MAX(sizeof(_mongocrypt_ctx_datakey_t),
+                          BSON_MAX(sizeof(_mongocrypt_ctx_rewrap_many_datakey_t), sizeof(_mongocrypt_ctx_compact_t)))));
+
+    // Use an alignment that is enough for any possible context type.
+    static const size_t ctx_alignment =
+        BSON_MAX(BSON_ALIGNOF(_mongocrypt_ctx_encrypt_t),
+                 BSON_MAX(BSON_ALIGNOF(_mongocrypt_ctx_decrypt_t),
+                          BSON_MAX(BSON_ALIGNOF(_mongocrypt_ctx_datakey_t),
+                                   BSON_MAX(BSON_ALIGNOF(_mongocrypt_ctx_rewrap_many_datakey_t),
+                                            BSON_ALIGNOF(_mongocrypt_ctx_compact_t)))));
+
     ctx = bson_aligned_alloc0(ctx_alignment, ctx_size);
     BSON_ASSERT(ctx);
 

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -282,7 +282,6 @@ bool mongocrypt_ctx_setopt_algorithm(mongocrypt_ctx_t *ctx, const char *algorith
 
 mongocrypt_ctx_t *mongocrypt_ctx_new(mongocrypt_t *crypt) {
     mongocrypt_ctx_t *ctx;
-    size_t ctx_size;
 
     if (!crypt) {
         return NULL;
@@ -294,13 +293,13 @@ mongocrypt_ctx_t *mongocrypt_ctx_new(mongocrypt_t *crypt) {
         CLIENT_ERR("cannot create context from uninitialized crypt");
         return NULL;
     }
-    ctx_size = sizeof(_mongocrypt_ctx_encrypt_t);
-    if (sizeof(_mongocrypt_ctx_decrypt_t) > ctx_size) {
-        ctx_size = sizeof(_mongocrypt_ctx_decrypt_t);
-    }
-    if (sizeof(_mongocrypt_ctx_datakey_t) > ctx_size) {
-        ctx_size = sizeof(_mongocrypt_ctx_datakey_t);
-    }
+    // Allocate with maximum size of any of the possible context types.
+    size_t ctx_size = 0;
+    ctx_size = BSON_MAX(ctx_size, sizeof(_mongocrypt_ctx_encrypt_t));
+    ctx_size = BSON_MAX(ctx_size, sizeof(_mongocrypt_ctx_decrypt_t));
+    ctx_size = BSON_MAX(ctx_size, sizeof(_mongocrypt_ctx_datakey_t));
+    ctx_size = BSON_MAX(ctx_size, sizeof(_mongocrypt_ctx_rewrap_many_datakey_t));
+    ctx_size = BSON_MAX(ctx_size, sizeof(_mongocrypt_ctx_compact_t));
     ctx = bson_malloc0(ctx_size);
     BSON_ASSERT(ctx);
 

--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -293,14 +293,20 @@ mongocrypt_ctx_t *mongocrypt_ctx_new(mongocrypt_t *crypt) {
         CLIENT_ERR("cannot create context from uninitialized crypt");
         return NULL;
     }
-    // Allocate with maximum size of any of the possible context types.
+    // Allocate with maximum size and alignment of any of the possible context types.
     size_t ctx_size = 0;
     ctx_size = BSON_MAX(ctx_size, sizeof(_mongocrypt_ctx_encrypt_t));
     ctx_size = BSON_MAX(ctx_size, sizeof(_mongocrypt_ctx_decrypt_t));
     ctx_size = BSON_MAX(ctx_size, sizeof(_mongocrypt_ctx_datakey_t));
     ctx_size = BSON_MAX(ctx_size, sizeof(_mongocrypt_ctx_rewrap_many_datakey_t));
     ctx_size = BSON_MAX(ctx_size, sizeof(_mongocrypt_ctx_compact_t));
-    ctx = bson_malloc0(ctx_size);
+    size_t ctx_alignment = 0;
+    ctx_alignment = BSON_MAX(ctx_alignment, BSON_ALIGNOF(_mongocrypt_ctx_encrypt_t));
+    ctx_alignment = BSON_MAX(ctx_alignment, BSON_ALIGNOF(_mongocrypt_ctx_decrypt_t));
+    ctx_alignment = BSON_MAX(ctx_alignment, BSON_ALIGNOF(_mongocrypt_ctx_datakey_t));
+    ctx_alignment = BSON_MAX(ctx_alignment, BSON_ALIGNOF(_mongocrypt_ctx_rewrap_many_datakey_t));
+    ctx_alignment = BSON_MAX(ctx_alignment, BSON_ALIGNOF(_mongocrypt_ctx_compact_t));
+    ctx = bson_aligned_alloc0(ctx_alignment, ctx_size);
     BSON_ASSERT(ctx);
 
     ctx->crypt = crypt;

--- a/src/mongocrypt-key-private.h
+++ b/src/mongocrypt-key-private.h
@@ -27,6 +27,11 @@ typedef struct __mongocrypt_key_alt_name_t {
     bson_value_t value;
 } _mongocrypt_key_alt_name_t;
 
+// `_mongocrypt_key_alt_name_t` inherits extended alignment from libbson. To dynamically allocate, use aligned
+// allocation (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof__mongocrypt_key_alt_name_t,
+                    BSON_ALIGNOF(_mongocrypt_key_alt_name_t) >= BSON_ALIGNOF(bson_value_t));
+
 typedef struct {
     bson_t bson; /* original BSON for this key. */
     _mongocrypt_buffer_t id;
@@ -36,6 +41,10 @@ typedef struct {
     int64_t update_date;
     _mongocrypt_kek_t kek;
 } _mongocrypt_key_doc_t;
+
+// `_mongocrypt_key_doc_t` inherits extended alignment from libbson. To dynamically allocate, use aligned allocation
+// (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof__mongocrypt_key_doc_t, BSON_ALIGNOF(_mongocrypt_key_doc_t) >= BSON_ALIGNOF(bson_t));
 
 _mongocrypt_key_alt_name_t *_mongocrypt_key_alt_name_new(const bson_value_t *value);
 

--- a/src/mongocrypt-key.c
+++ b/src/mongocrypt-key.c
@@ -272,7 +272,9 @@ _mongocrypt_key_doc_t *_mongocrypt_key_new(void) {
     _mongocrypt_key_doc_t *key_doc;
 
     key_doc = BSON_ALIGNED_ALLOC(_mongocrypt_key_doc_t);
-    *key_doc = (_mongocrypt_key_doc_t){0};
+    // Use two sets of braces to avoid erroneous missing-braces warning in GCC. Refer:
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53119
+    *key_doc = (_mongocrypt_key_doc_t){{0}};
     bson_init(&key_doc->bson);
 
     return key_doc;

--- a/src/mongocrypt-key.c
+++ b/src/mongocrypt-key.c
@@ -271,7 +271,7 @@ bool _mongocrypt_key_parse_owned(const bson_t *bson, _mongocrypt_key_doc_t *out,
 _mongocrypt_key_doc_t *_mongocrypt_key_new(void) {
     _mongocrypt_key_doc_t *key_doc;
 
-    key_doc = (_mongocrypt_key_doc_t *)bson_malloc0(sizeof *key_doc);
+    key_doc = BSON_ALIGNED_ALLOC0(_mongocrypt_key_doc_t);
     bson_init(&key_doc->bson);
 
     return key_doc;

--- a/src/mongocrypt-key.c
+++ b/src/mongocrypt-key.c
@@ -389,7 +389,8 @@ _mongocrypt_key_alt_name_t *_mongocrypt_key_alt_name_create(const char *name, ..
 _mongocrypt_key_alt_name_t *_mongocrypt_key_alt_name_new(const bson_value_t *value) {
     BSON_ASSERT_PARAM(value);
 
-    _mongocrypt_key_alt_name_t *name = bson_malloc0(sizeof(*name));
+    _mongocrypt_key_alt_name_t *name = BSON_ALIGNED_ALLOC(_mongocrypt_key_alt_name_t);
+    *name = (_mongocrypt_key_alt_name_t){0};
     BSON_ASSERT(name);
 
     bson_value_copy(value, &name->value);

--- a/src/mongocrypt-key.c
+++ b/src/mongocrypt-key.c
@@ -271,7 +271,8 @@ bool _mongocrypt_key_parse_owned(const bson_t *bson, _mongocrypt_key_doc_t *out,
 _mongocrypt_key_doc_t *_mongocrypt_key_new(void) {
     _mongocrypt_key_doc_t *key_doc;
 
-    key_doc = BSON_ALIGNED_ALLOC0(_mongocrypt_key_doc_t);
+    key_doc = BSON_ALIGNED_ALLOC(_mongocrypt_key_doc_t);
+    *key_doc = (_mongocrypt_key_doc_t){0};
     bson_init(&key_doc->bson);
 
     return key_doc;

--- a/src/mongocrypt-marking-private.h
+++ b/src/mongocrypt-marking-private.h
@@ -45,6 +45,10 @@ typedef struct {
     };
 } _mongocrypt_marking_t;
 
+// `_mongocrypt_marking_t` inherits extended alignment from libbson. To dynamically allocate, use aligned allocation
+// (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof__mongocrypt_marking_t, BSON_ALIGNOF(_mongocrypt_marking_t) >= BSON_ALIGNOF(bson_iter_t));
+
 void _mongocrypt_marking_init(_mongocrypt_marking_t *marking);
 
 void _mongocrypt_marking_cleanup(_mongocrypt_marking_t *marking);

--- a/test/test-mongocrypt.h
+++ b/test/test-mongocrypt.h
@@ -79,6 +79,10 @@ typedef struct __mongocrypt_tester_t {
     _mongocrypt_buffer_t encrypted_doc;
 } _mongocrypt_tester_t;
 
+// `_mongocrypt_tester_t` inherits extended alignment from libbson. To dynamically allocate, use aligned allocation
+// (e.g. BSON_ALIGNED_ALLOC)
+BSON_STATIC_ASSERT2(alignof__mongocrypt_tester_t, BSON_ALIGNOF(_mongocrypt_tester_t) >= BSON_ALIGNOF(bson_t));
+
 /* Load a .json file as bson */
 void _load_json_as_bson(const char *path, bson_t *out);
 


### PR DESCRIPTION
# Summary

- Fix alignment errors reported by UBSan.
- Add a UBSan task to Evergreen.

# Details

This PR is hopefully intended to address the reported errors in MONGOCRYPT-725 by addressing reported UBSan errors like the following:
```
cmake-build/_deps/embedded_mcd-src/src/libbson/src/bson/bson.c:1778:10: runtime error: member access within misaligned address 0x000131f052b0 for type 'bson_impl_inline_t', which requires 128 byte alignment
0x000131f052b0: note: pointer points here
 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00
              ^
```

The UBSan errors appear due to dynamic allocation of structs containing libbson types defined with a default 128-byte alignment: `bson_t` and `bson_iter_t`. This only appeared to impact `mongocrypt_ctx_t` and `_mongocrypt_key_doc_t`. Utilities added in https://github.com/mongodb/mongo-c-driver/pull/1072 are used to do aligned allocation.

As an added fix, the allocation of `mongocrypt_ctx_t` is updated to account for all possible context implementations.

The new UBSan task was run without the fix to ensure it fails: [failing patch](https://spruce.mongodb.com/version/672255573428fc0007163971). With the fix, the task succeeds: [passing patch](https://spruce.mongodb.com/version/672258362cd0820007527938).
