### PR TITLE
MONGOCRYPT-688 drop RHEL 6 packaging task

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1255,17 +1255,10 @@ buildvariants:
 - name: rhel-62-64-bit
   display_name: "RHEL 6.2 64-bit"
   run_on: rhel62-small
-  expansions:
-    has_packages: true
-    packager_distro: rhel62
-    packager_arch: x86_64
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
   - test-java
-  - name: publish-packages
-    distros:
-    - rhel70-small
 - name: rhel-70-64-bit
   display_name: "RHEL 7.0 64-bit"
   run_on: rhel70-small

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # ChangeLog
 ## 1.12.0
 ### Removed
-- libmongocrypt is no longer published in the PPA for RHEL 6. libmongocrypt may instead be built from source on RHEL 6, but support for RHEL 6 will be dropped in a future release.
+- libmongocrypt is no longer published in the MongoDB package repository for RHEL 6. libmongocrypt may instead be built from source on RHEL 6, but support for RHEL 6 will be dropped in a future release.
 
 ## 1.11.0
 ### New features
@@ -79,7 +79,7 @@ This release makes backwards breaking changes to Queryable Encryption (QE) behav
 - Set context error state during KMS provider validation.
 ## 1.6.1
 ## Fixed
-- Fix libbson dependency in pkg-config for PPA.
+- Fix libbson dependency in pkg-config for MongoDB repository package.
 ## 1.6.0
 ## New Features
 - Support accessToken to authenticate with Azure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # ChangeLog
+## 1.12.0
+### Removed
+- libmongocrypt is no longer published in the PPA for RHEL 6. libmongocrypt may instead be built from source on RHEL 6, but support for RHEL 6 will be dropped in a future release.
+
 ## 1.11.0
 ### New features
 - Support `range` algorithm as stable.


### PR DESCRIPTION
# Summary

Partially resolves MONGOCRYPT-688. Drop PPA packaging task RHEL 6.

# Background & Motivation

The `publish-packages` task is failing on RHEL 6. Publishing to RHEL 6 is disabled ([see slack thread](https://mongodb.slack.com/archives/C04LGNQV4M7/p1730404465788919)). Re-enabling can be requested, but this PR takes the opportunity to drop PPA packages for RHEL 6.

As a result users will be unable to install [with these steps](https://www.mongodb.com/docs/manual/core/csfle/reference/libmongocrypt/#redhat) on RHEL 6. But they can still build from source (at least until MONGOCRYPT-688 is fully resolved).

This PR does not-yet drop support for building on RHEL 6. Users can continue to build from source. CHANGELOG.md is updated to warn about dropping support of RHEL 6 entirely in the future.
