### PR TITLE
Address memory leaks in test suite

### DIFF
--- a/test/test-mc-fle2-payload-iup-v2.c
+++ b/test/test-mc-fle2-payload-iup-v2.c
@@ -238,6 +238,8 @@ static void _test_mc_FLE2InsertUpdatePayloadV2_parses_crypto_params(_mongocrypt_
 
     ASSERT(got.indexMax.value_type == BSON_TYPE_INT32);
     ASSERT_CMPINT32(got.indexMax.value.v_int32, ==, 1234567);
+
+    mc_FLE2InsertUpdatePayloadV2_cleanup(&got);
 }
 
 void _mongocrypt_tester_install_fle2_payload_iup_v2(_mongocrypt_tester_t *tester) {

--- a/test/test-mongocrypt-ctx-rewrap-many-datakey.c
+++ b/test/test-mongocrypt-ctx-rewrap-many-datakey.c
@@ -571,6 +571,7 @@ static void _test_rewrap_many_datakey_need_kms_retry(_mongocrypt_tester_t *teste
     ASSERT_OK(mongocrypt_ctx_kms_done(ctx), ctx);
     ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_KMS); // To encrypt.
     mongocrypt_ctx_destroy(ctx);
+    mongocrypt_destroy(crypt);
 }
 
 static void _test_rewrap_many_datakey_need_kms_encrypt(_mongocrypt_tester_t *tester) {


### PR DESCRIPTION
Observed when running the test suite locally while reviewing https://github.com/mongodb/libmongocrypt/pull/901. It is unclear why these are not being caught by the sanitizer tasks on Evergreen.