### PR TITLE
Set status if `mongocrypt_kms_ctx_fail` called with retry disabled

### DIFF
--- a/src/mongocrypt-kms-ctx.c
+++ b/src/mongocrypt-kms-ctx.c
@@ -1121,7 +1121,7 @@ done:
 }
 
 bool mongocrypt_kms_ctx_fail(mongocrypt_kms_ctx_t *kms) {
-    if (!kms || !kms->retry_enabled) {
+    if (!kms) {
         return false;
     }
 


### PR DESCRIPTION
Calling `mongocrypt_kms_ctx_fail` with retry disabled is expected to result in an error.

An early return in `mongocrypt_kms_ctx_fail` returns `false` to indicate error, but [does not set the status](https://github.com/mongodb/libmongocrypt/blob/43a44227b1b22adec6ea8d0273d7e7746fadc7bc/src/mongocrypt-kms-ctx.c#L1124):

```c
if (!kms && !kms->retry_enabled) {
    return false;
}
```

This PR removes the `!kms->retry_enabled` condition to fall through to the intended error check below:

```c
if (!kms->retry_enabled) {
    CLIENT_ERR("KMS request failed due to network error");
    return false;
}
```
