### PR TITLE
MONGOCRYPT-599 document need to call `mongocrypt_setopt_retry_kms`

### DIFF
--- a/integrating.md
+++ b/integrating.md
@@ -197,6 +197,8 @@ All contexts except for create data key.
 
 The responses from one or more messages to KMS.
 
+Ensure `mongocrypt_setopt_retry_kms` is called on the `mongocrypt_t` to enable retry.
+
 **Driver needs to...**
 
 1.  For each context returned by `mongocrypt_ctx_next_kms_ctx`:
@@ -223,7 +225,7 @@ The responses from one or more messages to KMS.
 
 2.  When done feeding all replies, call `mongocrypt_ctx_kms_done`.
 
-Note, the driver MAY fan out KMS requests in parallel.
+Note, the driver MAY fan out KMS requests in parallel. More KMS requests may be added when processing responses to retry.
 
 **Applies to...**
 

--- a/integrating.md
+++ b/integrating.md
@@ -219,9 +219,9 @@ Ensure `mongocrypt_setopt_retry_kms` is called on the `mongocrypt_t` to enable r
     d.  Feed the reply back with `mongocrypt_kms_ctx_feed`. Repeat
         > until `mongocrypt_kms_ctx_bytes_needed` returns 0.
 
-    If any step encounters a network error, continue to the next KMS context if
-    `mongocrypt_kms_ctx_fail` returns true. Otherwise, abort and report an
-    error.
+    If any step encounters a network error, call `mongocrypt_kms_ctx_fail`.
+    If `mongocrypt_kms_ctx_fail` returns true, continue to the next KMS context.
+    If `mongocrypt_kms_ctx_fail` returns false, abort and report an error.
 
 2.  When done feeding all replies, call `mongocrypt_ctx_kms_done`.
 

--- a/integrating.md
+++ b/integrating.md
@@ -199,9 +199,7 @@ The responses from one or more messages to KMS.
 
 **Driver needs to...**
 
-1.  Iterate all KMS requests using `mongocrypt_ctx_next_kms_ctx`.
-    (Note, the driver MAY fan out all requests at the same time).
-2.  For each context:
+1.  For each context returned by `mongocrypt_ctx_next_kms_ctx`:
 
     a.  Delay the message by the time in microseconds indicated by
         `mongocrypt_kms_ctx_usleep` if returned value is greater than 0.
@@ -223,7 +221,9 @@ The responses from one or more messages to KMS.
     `mongocrypt_kms_ctx_fail` returns true. Otherwise, abort and report an
     error.
 
-3.  When done feeding all replies, call `mongocrypt_ctx_kms_done`.
+2.  When done feeding all replies, call `mongocrypt_ctx_kms_done`.
+
+Note, the driver MAY fan out KMS requests in parallel.
 
 **Applies to...**
 

--- a/integrating.md
+++ b/integrating.md
@@ -195,12 +195,12 @@ All contexts except for create data key.
 
 **libmongocrypt needs**...
 
-The responses from one or more HTTP messages to KMS.
+The responses from one or more messages to KMS.
 
 **Driver needs to...**
 
 1.  Iterate all KMS requests using `mongocrypt_ctx_next_kms_ctx`.
-    (Note, the driver MAY fan out all HTTP requests at the same time).
+    (Note, the driver MAY fan out all requests at the same time).
 2.  For each context:
 
     a.  Delay the message by the time in microseconds indicated by


### PR DESCRIPTION
Updates integrating instructions for `MONGOCRYPT_CTX_NEED_KMS` state following the retry protocol added in https://github.com/mongodb/libmongocrypt/pull/783.

Motivated by [slack thread](https://mongodb.slack.com/archives/C0406ECL478/p1731590347866929) indicating unawareness of `mongocrypt_setopt_retry_kms`.