### PR TITLE
Use Artifactory for image registry

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -929,7 +929,7 @@ tasks:
   tags: [packaging]
   run_on: &docker-distros
     # * The RHEL76-docker distro runs an old and unsupported version of Docker.
-    # * (We requires the --mount parameter)
+    # * (We require the --mount parameter)
     - ubuntu1804
     - ubuntu1804-medium
     - debian10

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -346,7 +346,9 @@ functions:
       params:
         shell: bash
         working_dir: ${working_dir|libmongocrypt}
-        script: bash ${workdir}/libmongocrypt/.evergreen/earthly.sh ${args}
+        script: |
+          echo "${docker_password}" | docker login --username "${docker_username}" --password-stdin
+          bash ${workdir}/libmongocrypt/.evergreen/earthly.sh ${args}
 
 tasks:
 - name: build-and-test-and-upload

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -930,8 +930,7 @@ tasks:
   run_on: &docker-distros
     # * The RHEL76-docker distro runs an old and unsupported version of Docker.
     # * (We require the --mount parameter)
-    - ubuntu1804
-    - ubuntu1804-medium
+    - ubuntu2204-large
     - debian10
     - debian11
     - amazon2

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -930,8 +930,6 @@ tasks:
   run_on: &docker-distros
     # * The RHEL76-docker distro runs an old and unsupported version of Docker.
     # * (We requires the --mount parameter)
-    - ubuntu2004-small
-    - ubuntu2004
     - ubuntu1804
     - ubuntu1804-medium
     - debian10

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -346,9 +346,7 @@ functions:
       params:
         shell: bash
         working_dir: ${working_dir|libmongocrypt}
-        script: |
-          echo "${docker_password}" | docker login --username "${docker_username}" --password-stdin
-          bash ${workdir}/libmongocrypt/.evergreen/earthly.sh ${args}
+        script: bash ${workdir}/libmongocrypt/.evergreen/earthly.sh ${args}
 
 tasks:
 - name: build-and-test-and-upload

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -349,7 +349,10 @@ functions:
         script: |
           # Authenticate to artifactory.
           echo "${artifactory_password}" | docker login --password-stdin --username "${artifactory_username}" artifactory.corp.mongodb.com
-          bash ${workdir}/libmongocrypt/.evergreen/earthly.sh ${args}
+          # TODO(MONGOCRYPT-747): remove `--persist-build=false`. 
+          # Pass `--persist-build=false` to avoid using Docker Hub.
+          # Earthly hardcodes use of docker/dockerfile-copy:v0.1.9 for the CACHE command.
+          bash ${workdir}/libmongocrypt/.evergreen/earthly.sh ${args} --persist-build=false
 
 tasks:
 - name: build-and-test-and-upload

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -346,7 +346,10 @@ functions:
       params:
         shell: bash
         working_dir: ${working_dir|libmongocrypt}
-        script: bash ${workdir}/libmongocrypt/.evergreen/earthly.sh ${args}
+        script: |
+          # Authenticate to artifactory.
+          echo "${artifactory_password}" | docker login --password-stdin --username "${artifactory_username}" artifactory.corp.mongodb.com
+          bash ${workdir}/libmongocrypt/.evergreen/earthly.sh ${args}
 
 tasks:
 - name: build-and-test-and-upload

--- a/.evergreen/earthly.sh
+++ b/.evergreen/earthly.sh
@@ -48,4 +48,4 @@ fi
 
 chmod a+x "$exe_path"
 
-"$exe_path" "$@"
+"$exe_path" --buildkit-image "artifactory.corp.mongodb.com/dockerhub/earthly/buildkitd:v${EARTHLY_VERSION}" "$@"

--- a/Earthfile
+++ b/Earthfile
@@ -354,7 +354,8 @@ packaging-full-test:
     BUILD +rpm-runtime-test
 
 check-format:
-    FROM artifactory.corp.mongodb.com/dockerhub/python:3.11.2-slim-buster
+    FROM +init --base=artifactory.corp.mongodb.com/dockerhub/python:3.11.2-slim-buster
+    RUN __install build-essential # To install `make` to install clang-format.
     RUN pip install pipx
     COPY etc/format* /X/etc/
     COPY .evergreen/init.sh /X/.evergreen/

--- a/Earthfile
+++ b/Earthfile
@@ -54,11 +54,11 @@
     #   • DO NOT: "ubuntu"
     #   • DO NOT: "ubuntu:latest"
     #   • DO NOT: "ubuntu:22.10"
-    #   • DO: "docker.io/library/ubuntu:22.10"
+    #   • DO: "artifactory.corp.mongodb.com/dockerhub/library/ubuntu:22.10"
 # ###
 
 VERSION --use-cache-command 0.6
-FROM docker.io/library/alpine:3.16
+FROM artifactory.corp.mongodb.com/dockerhub/library/alpine:3.16
 WORKDIR /s
 
 init:
@@ -125,24 +125,24 @@ ALPINE_SETUP:
 
 env.c6:
     # A CentOS 6 environment.
-    FROM +init --base=docker.io/library/centos:6
+    FROM +init --base=artifactory.corp.mongodb.com/dockerhub/library/centos:6
     DO +CENTOS6_SETUP
 
 env.c7:
     # A CentOS 7 environment.
-    FROM +init --base=docker.io/library/centos:7
+    FROM +init --base=artifactory.corp.mongodb.com/dockerhub/library/centos:7
     DO +REDHAT_SETUP
 
 env.rl8:
     # CentOS 8 is cancelled. Use RockyLinux 8 for our RHEL 8 environment.
-    FROM +init --base=docker.io/library/rockylinux:8
+    FROM +init --base=artifactory.corp.mongodb.com/dockerhub/library/rockylinux:8
     DO +REDHAT_SETUP
 
 # Utility command for Ubuntu environments
 ENV_UBUNTU:
     COMMAND
     ARG --required version
-    FROM +init --base=docker.io/library/ubuntu:$version
+    FROM +init --base=artifactory.corp.mongodb.com/dockerhub/library/ubuntu:$version
     DO +DEBIAN_SETUP
 
 env.u14:
@@ -167,19 +167,19 @@ env.u22:
 
 env.amzn1:
     # An Amazon "1" environment. (AmazonLinux 2018)
-    FROM +init --base=docker.io/library/amazonlinux:2018.03
+    FROM +init --base=artifactory.corp.mongodb.com/dockerhub/library/amazonlinux:2018.03
     DO +AMZ_SETUP
 
 env.amzn2:
     # An AmazonLinux 2 environment
-    FROM +init --base=docker.io/library/amazonlinux:2
+    FROM +init --base=artifactory.corp.mongodb.com/dockerhub/library/amazonlinux:2
     DO +AMZ_SETUP
 
 # Utility command for Debian setup
 ENV_DEBIAN:
     COMMAND
     ARG --required version
-    FROM +init --base=docker.io/library/debian:$version
+    FROM +init --base=artifactory.corp.mongodb.com/dockerhub/library/debian:$version
     IF [ $version = "9.2" ]
         # Update source list for archived Debian stretch packages.
         # Refer: https://unix.stackexchange.com/a/743865/260858
@@ -208,11 +208,11 @@ env.deb12:
 
 env.sles15:
     # An OpenSUSE Leap 15.0 environment.
-    FROM +init --base=docker.io/opensuse/leap:15.0
+    FROM +init --base=artifactory.corp.mongodb.com/dockerhub/opensuse/leap:15.0
     DO +SLES_SETUP
 
 env.alpine:
-    FROM +init --base=docker.io/library/alpine:3.18
+    FROM +init --base=artifactory.corp.mongodb.com/dockerhub/library/alpine:3.18
     DO +ALPINE_SETUP
 
 # Utility: Warm-up obtaining CMake and Ninja for the build. This is usually
@@ -259,7 +259,7 @@ BUILD_EXAMPLE_STATE_MACHINE:
     RUN cd /s && /s/example-state-machine
 
 rpm-build:
-    FROM +init --base fedora:38
+    FROM +init --base artifactory.corp.mongodb.com/dockerhub/fedora:38
     GIT CLONE https://src.fedoraproject.org/rpms/libmongocrypt.git /R
     # Install the packages listed by "BuildRequires" and rpm-build:
     RUN __install $(awk '/^BuildRequires:/ { print $2 }' /R/libmongocrypt.spec) \
@@ -275,7 +275,7 @@ rpm-build:
 
 rpm-install-runtime:
     # Install the runtime RPM
-    FROM +init --base fedora:38
+    FROM +init --base artifactory.corp.mongodb.com/dockerhub/fedora:38
     COPY +rpm-build/RPMS /tmp/libmongocrypt-rpm/
     RUN dnf makecache
     RUN __install $(find /tmp/libmongocrypt-rpm/ -name 'libmongocrypt-1.*.rpm')
@@ -325,7 +325,7 @@ deb-build:
 
 deb-install-runtime:
     # Install the runtime deb package
-    FROM +init --base=docker.io/library/debian:unstable
+    FROM +init --base=artifactory.corp.mongodb.com/dockerhub/library/debian:unstable
     COPY +deb-build/debs/libmongocrypt0*.deb /tmp/lmc.deb
     RUN __install /tmp/lmc.deb
 
@@ -354,7 +354,7 @@ packaging-full-test:
     BUILD +rpm-runtime-test
 
 check-format:
-    FROM python:3.11.2-slim-buster
+    FROM artifactory.corp.mongodb.com/dockerhub/python:3.11.2-slim-buster
     RUN pip install pipx
     COPY etc/format* /X/etc/
     COPY .evergreen/init.sh /X/.evergreen/


### PR DESCRIPTION
This PR is intended to address rate-limiting errors pulling from dockerhub causing task failures on Evergreen. [Example](https://spruce.mongodb.com/task/libmongocrypt_alpine_amd64_earthly_build_with_earthly_b150e745c573793e7d27568f4be2d6f83d879f82_24_11_15_14_38_07/logs?execution=0):

> docker: Error response from daemon: toomanyrequests: Too Many Requests (HAP429).

[DEVPROD-12779](https://jira.mongodb.org/browse/DEVPROD-12779) [notes](https://jira.mongodb.org/browse/DEVPROD-12779?focusedCommentId=6856395&focusedId=6856395&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-6856395):

> In the meantime there is an artifactory mirror for dockerhub that can be used for pull containers.

Running `docker pull artifactory.corp.mongodb.com/dockerhub/<DOCKER_IMAGE>:<DOCKER_TAG>` appears to pull and add the image to the artifactory registry. DEVPROD-12779 [also notes](https://jira.mongodb.org/browse/DEVPROD-12779?focusedCommentId=6856869&focusedId=6856869&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-6856869):

> The proper long term solution seems to be to use authentication for pull requests as suggested by the Docker support.

Getting credentials is tracked in DRIVERS-3047.

As an added fix, the `check-format` target is updated to install `make` to address an observed error:

```
+check-format *failed* | Some possibly relevant errors from pip install:
+check-format *failed* |     error: subprocess-exited-with-error
+check-format *failed* |     CMake Error: CMake was unable to find a build program corresponding to "Unix Makefiles".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.
+check-format *failed* |     ERROR: ERROR: Failed to build installable wheels for some pyproject.toml based projects (clang-format)
```

Verified with [this patch build](https://spruce.mongodb.com/version/673b690551cfa80007577948/)