### PR TITLE
DEVPROD-6063: update to macos 11

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1017,8 +1017,8 @@ buildvariants:
     distros:
     - ubuntu2004-small
 - name: macos_x86_64
-  display_name: "macOS (x86_64) 10.14"
-  run_on: macos-1014
+  display_name: "macOS (x86_64) 11"
+  run_on: macos-1100
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # ChangeLog
+## 1.13.0 (Not yet released)
+### Removed
+- Support for macOS versions older than 11. libmongocrypt is supported and tested with macOS 11+.
+
 ## 1.12.0
 ### New features
 - Add option to configure Data Encryption Key cache lifetime (`mongocrypt_setopt_key_expiration`)


### PR DESCRIPTION
This commit bumps our builds from MacOS 10.14 to MacOS 11. 10.14 has been
unsupported for several years. MacOS 11 is also EOL, but it seems to pass
all of our tests and isn't quite as old as 10.14. I tried to bump all the
way to MacOS 14, but ran into some kind of linking error. I think we can
return to that upgrade at a different time.