### PR TITLE
MONGOCRYPT-743 implement token _new_from_buffer_copy 

### DIFF
--- a/src/mc-tokens-private.h
+++ b/src/mc-tokens-private.h
@@ -91,7 +91,7 @@
     extern void BSON_CONCAT(Prefix, _destroy)(T * t);                                                                  \
     /* Constructor for server to shallow copy tokens from raw buffer */                                                \
     extern T *BSON_CONCAT(Prefix, _new_from_buffer)(_mongocrypt_buffer_t * buf);                                       \
-    /* Constructor for server to deep copy tokens    from raw buffer */                                                \
+    /* Constructor for server to deep copy tokens from raw buffer */                                                   \
     extern T *BSON_CONCAT(Prefix, _new_from_buffer_copy)(_mongocrypt_buffer_t * buf);                                  \
     /* Constructor. Parameter list given as variadic args */                                                           \
     extern T *BSON_CONCAT(Prefix, _new)(_mongocrypt_crypto_t * crypto, __VA_ARGS__, mongocrypt_status_t * status)

--- a/src/mc-tokens-private.h
+++ b/src/mc-tokens-private.h
@@ -89,8 +89,10 @@
     extern const _mongocrypt_buffer_t *BSON_CONCAT(Prefix, _get)(const T *t);                                          \
     /* Destructor */                                                                                                   \
     extern void BSON_CONCAT(Prefix, _destroy)(T * t);                                                                  \
-    /* Constructor for server to create tokens from raw buffer */                                                      \
+    /* Constructor for server to shallow copy tokens from raw buffer */                                                \
     extern T *BSON_CONCAT(Prefix, _new_from_buffer)(_mongocrypt_buffer_t * buf);                                       \
+    /* Constructor for server to deep copy tokens    from raw buffer */                                                \
+    extern T *BSON_CONCAT(Prefix, _new_from_buffer_copy)(_mongocrypt_buffer_t * buf);                                  \
     /* Constructor. Parameter list given as variadic args */                                                           \
     extern T *BSON_CONCAT(Prefix, _new)(_mongocrypt_crypto_t * crypto, __VA_ARGS__, mongocrypt_status_t * status)
 

--- a/src/mc-tokens.c
+++ b/src/mc-tokens.c
@@ -29,7 +29,9 @@
         _mongocrypt_buffer_t data;                                                                                     \
     };                                                                                                                 \
     /* Data-getter */                                                                                                  \
-    const _mongocrypt_buffer_t *BSON_CONCAT(Prefix, _get)(const T *self) { return &self->data; }                       \
+    const _mongocrypt_buffer_t *BSON_CONCAT(Prefix, _get)(const T *self) {                                             \
+        return &self->data;                                                                                            \
+    }                                                                                                                  \
     /* Destructor */                                                                                                   \
     void BSON_CONCAT(Prefix, _destroy)(T * self) {                                                                     \
         if (!self) {                                                                                                   \
@@ -38,11 +40,18 @@
         _mongocrypt_buffer_cleanup(&self->data);                                                                       \
         bson_free(self);                                                                                               \
     }                                                                                                                  \
-    /* Constructor. From raw buffer */                                                                                 \
+    /* Constructor. Shallow copy from raw buffer */                                                                    \
     T *BSON_CONCAT(Prefix, _new_from_buffer)(_mongocrypt_buffer_t * buf) {                                             \
         BSON_ASSERT(buf->len == MONGOCRYPT_HMAC_SHA256_LEN);                                                           \
         T *t = bson_malloc(sizeof(T));                                                                                 \
         _mongocrypt_buffer_set_to(buf, &t->data);                                                                      \
+        return t;                                                                                                      \
+    }                                                                                                                  \
+    /* Constructor. Deep copy from raw buffer */                                                                       \
+    T *BSON_CONCAT(Prefix, _new_from_buffer_copy)(_mongocrypt_buffer_t * buf) {                                        \
+        BSON_ASSERT(buf->len == MONGOCRYPT_HMAC_SHA256_LEN);                                                           \
+        T *t = bson_malloc(sizeof(T));                                                                                 \
+        _mongocrypt_buffer_copy_to(buf, &t->data);                                                                     \
         return t;                                                                                                      \
     }                                                                                                                  \
     /* Constructor. Parameter list given as variadic args. */                                                          \

--- a/src/mc-tokens.c
+++ b/src/mc-tokens.c
@@ -29,9 +29,7 @@
         _mongocrypt_buffer_t data;                                                                                     \
     };                                                                                                                 \
     /* Data-getter */                                                                                                  \
-    const _mongocrypt_buffer_t *BSON_CONCAT(Prefix, _get)(const T *self) {                                             \
-        return &self->data;                                                                                            \
-    }                                                                                                                  \
+    const _mongocrypt_buffer_t *BSON_CONCAT(Prefix, _get)(const T *self) { return &self->data; }                       \
     /* Destructor */                                                                                                   \
     void BSON_CONCAT(Prefix, _destroy)(T * self) {                                                                     \
         if (!self) {                                                                                                   \

--- a/src/mc-tokens.c
+++ b/src/mc-tokens.c
@@ -51,6 +51,7 @@
     T *BSON_CONCAT(Prefix, _new_from_buffer_copy)(_mongocrypt_buffer_t * buf) {                                        \
         BSON_ASSERT(buf->len == MONGOCRYPT_HMAC_SHA256_LEN);                                                           \
         T *t = bson_malloc(sizeof(T));                                                                                 \
+        _mongocrypt_buffer_init(&t->data);                                                                             \
         _mongocrypt_buffer_copy_to(buf, &t->data);                                                                     \
         return t;                                                                                                      \
     }                                                                                                                  \

--- a/test/test-mc-tokens.c
+++ b/test/test-mc-tokens.c
@@ -259,14 +259,17 @@ static void _test_mc_tokens_error(_mongocrypt_tester_t *tester) {
 }
 
 static void _test_mc_tokens_raw_buffer(_mongocrypt_tester_t *tester) {
-    mc_ServerDataEncryptionLevel1Token_t *token;
+    mc_ServerDataEncryptionLevel1Token_t *token1;
+    mc_ServerDataEncryptionLevel1Token_t *token2;
     _mongocrypt_buffer_t test_input;
+    _mongocrypt_buffer_t original_test_input;
     _mongocrypt_buffer_t expected;
 
     _mongocrypt_buffer_copy_from_hex(&test_input, "6c6a349956c19f9c5e638e612011a71fbb71921edb540310c17cd0208b7f548b");
 
     /* Make a token from a raw buffer */
-    token = mc_ServerDataEncryptionLevel1Token_new_from_buffer(&test_input);
+    token1 = mc_ServerDataEncryptionLevel1Token_new_from_buffer(&test_input);
+    token2 = mc_ServerDataEncryptionLevel1Token_new_from_buffer_copy(&test_input);
 
     /* Assert new_from_buffer did not steal ownership. */
     ASSERT(test_input.owned);
@@ -274,16 +277,21 @@ static void _test_mc_tokens_raw_buffer(_mongocrypt_tester_t *tester) {
 
     _mongocrypt_buffer_copy_from_hex(&expected, "6c6a349956c19f9c5e638e612011a71fbb71921edb540310c17cd0208b7f548b");
 
-    ASSERT_CMPBUF(*mc_ServerDataEncryptionLevel1Token_get(token), expected);
+    ASSERT_CMPBUF(*mc_ServerDataEncryptionLevel1Token_get(token1), expected);
+    ASSERT_CMPBUF(*mc_ServerDataEncryptionLevel1Token_get(token2), expected);
 
     /* Assert new_from_buffer references original buffer instead of a copy. */
+    _mongocrypt_buffer_copy_to(&test_input, &original_test_input);
     test_input.data[0] = '0';
     expected.data[0] = '0';
-    ASSERT_CMPBUF(*mc_ServerDataEncryptionLevel1Token_get(token), expected);
+    ASSERT_CMPBUF(*mc_ServerDataEncryptionLevel1Token_get(token1), expected);
+    ASSERT_CMPBUF(*mc_ServerDataEncryptionLevel1Token_get(token2), original_test_input);
 
     _mongocrypt_buffer_cleanup(&test_input);
+    _mongocrypt_buffer_cleanup(&original_test_input);
     _mongocrypt_buffer_cleanup(&expected);
-    mc_ServerDataEncryptionLevel1Token_destroy(token);
+    mc_ServerDataEncryptionLevel1Token_destroy(token1);
+    mc_ServerDataEncryptionLevel1Token_destroy(token2);
 }
 
 void _mongocrypt_tester_install_mc_tokens(_mongocrypt_tester_t *tester) {

--- a/test/test-mc-tokens.c
+++ b/test/test-mc-tokens.c
@@ -281,6 +281,7 @@ static void _test_mc_tokens_raw_buffer(_mongocrypt_tester_t *tester) {
     ASSERT_CMPBUF(*mc_ServerDataEncryptionLevel1Token_get(token2), expected);
 
     /* Assert new_from_buffer references original buffer instead of a copy. */
+    _mongocrypt_buffer_init(&original_test_input);
     _mongocrypt_buffer_copy_to(&test_input, &original_test_input);
     test_input.data[0] = '0';
     expected.data[0] = '0';

--- a/test/test-mc-tokens.c
+++ b/test/test-mc-tokens.c
@@ -262,7 +262,6 @@ static void _test_mc_tokens_raw_buffer(_mongocrypt_tester_t *tester) {
     mc_ServerDataEncryptionLevel1Token_t *token1;
     mc_ServerDataEncryptionLevel1Token_t *token2;
     _mongocrypt_buffer_t test_input;
-    _mongocrypt_buffer_t original_test_input;
     _mongocrypt_buffer_t expected;
 
     _mongocrypt_buffer_copy_from_hex(&test_input, "6c6a349956c19f9c5e638e612011a71fbb71921edb540310c17cd0208b7f548b");
@@ -281,15 +280,14 @@ static void _test_mc_tokens_raw_buffer(_mongocrypt_tester_t *tester) {
     ASSERT_CMPBUF(*mc_ServerDataEncryptionLevel1Token_get(token2), expected);
 
     /* Assert new_from_buffer references original buffer instead of a copy. */
-    _mongocrypt_buffer_init(&original_test_input);
-    _mongocrypt_buffer_copy_to(&test_input, &original_test_input);
     test_input.data[0] = '0';
     expected.data[0] = '0';
     ASSERT_CMPBUF(*mc_ServerDataEncryptionLevel1Token_get(token1), expected);
-    ASSERT_CMPBUF(*mc_ServerDataEncryptionLevel1Token_get(token2), original_test_input);
+
+    // Assert new_from_buffer_copy references a new buffer.
+    ASSERT_CMPUINT8(mc_ServerDataEncryptionLevel1Token_get(token2)->data[0], !=, expected.data[0]);
 
     _mongocrypt_buffer_cleanup(&test_input);
-    _mongocrypt_buffer_cleanup(&original_test_input);
     _mongocrypt_buffer_cleanup(&expected);
     mc_ServerDataEncryptionLevel1Token_destroy(token1);
     mc_ServerDataEncryptionLevel1Token_destroy(token2);


### PR DESCRIPTION
# Summary 
This PR adds a new function `_new_from_buffer_copy` to `mc-tokens`. 

# Background
The existing function `_new_from_buffer` performs a shallow copy on the `src` buffer where the data pointer value is simply copied to the `dst` buffer. This seems to be an explicit decision according the [PR](https://github.com/mongodb/libmongocrypt/pull/514) where this function was added.

Part of the [`FLEToken` refactor ](https://jira.mongodb.org/browse/SERVER-96316) in the server necessitates a constructor that creates a token from a buffer. Because we cannot guarantee that the buffer passed in won't be deleted throughout the lifetime of the program, we must deep copy it to ensure that there isn't an access of stale/deleted data in the token object.