### PR TITLE
MONGOCRYPT-744 modify _mongocrypt_hmac_sha_256 to accept crypto as nullptr

### DIFF
--- a/src/mongocrypt-crypto.c
+++ b/src/mongocrypt-crypto.c
@@ -299,7 +299,6 @@ bool _mongocrypt_hmac_sha_256(_mongocrypt_crypto_t *crypto,
                               const _mongocrypt_buffer_t *in,
                               _mongocrypt_buffer_t *out,
                               mongocrypt_status_t *status) {
-    BSON_ASSERT_PARAM(crypto);
     BSON_ASSERT_PARAM(key);
     BSON_ASSERT_PARAM(in);
     BSON_ASSERT_PARAM(out);
@@ -311,7 +310,7 @@ bool _mongocrypt_hmac_sha_256(_mongocrypt_crypto_t *crypto,
         return false;
     }
 
-    if (crypto->hooks_enabled) {
+    if (crypto && crypto->hooks_enabled) {
         mongocrypt_binary_t key_bin, out_bin, in_bin;
         _mongocrypt_buffer_to_binary(key, &key_bin);
         _mongocrypt_buffer_to_binary(out, &out_bin);

--- a/test/test-mongocrypt-crypto.c
+++ b/test/test-mongocrypt-crypto.c
@@ -311,10 +311,6 @@ void _test_native_crypto_hmac_sha_256(_mongocrypt_tester_t *tester) {
 #include "./data/NIST-CAVP.cstructs"
                                    {0}};
     hmac_sha_256_test_t *test;
-    mongocrypt_t *crypt;
-
-    /* Create a mongocrypt_t to call _native_crypto_init(). */
-    crypt = mongocrypt_new();
 
     for (test = tests; test->testname != NULL; test++) {
         bool ret;
@@ -341,6 +337,13 @@ void _test_native_crypto_hmac_sha_256(_mongocrypt_tester_t *tester) {
         }
         ASSERT_CMPBYTES(expect.data, expect.len, got.data, got.len);
 
+        // _mongocrypt_hmac_sha_256 requires keys to be an exact size
+        if (key.len == MONGOCRYPT_MAC_KEY_LEN) {
+            ret = _mongocrypt_hmac_sha_256(NULL, &key, &input, &got, status);
+            ASSERT_OR_PRINT(ret, status);
+            ASSERT_CMPBYTES(expect.data, expect.len, got.data, got.len);
+        }
+
         mongocrypt_status_destroy(status);
         _mongocrypt_buffer_cleanup(&got);
         _mongocrypt_buffer_cleanup(&expect);
@@ -349,8 +352,6 @@ void _test_native_crypto_hmac_sha_256(_mongocrypt_tester_t *tester) {
 
         printf("End test '%s'.\n", test->testname);
     }
-
-    mongocrypt_destroy(crypt);
 }
 
 static bool _hook_hmac_sha_256(void *ctx,


### PR DESCRIPTION
# Summary
This PR allows `_mongocrypt_hmac_sha_256` to accept `NULL` for the `crypto` parameter.

# Background
Currently, the comment above `_mongocrypt_hmac_sha_256` describes that the function will call the native implementation if there is no hook set on the `crypto` parameter.

In cases where the program desires the native implementation to be called, it is helpful to simply allow `NULL` to be passed through instead of creating a dummy crypto object.