### PR TITLE
add release instruction to update webhook

### DIFF
--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -130,6 +130,10 @@ Do the following when releasing:
       --remote-repo-url=https://github.com/mongodb/libmongocrypt.git
      ```
      Snyk reference targets for older release branches may be removed if no further releases are expected on the branch.
+   - Update the [Github Webhook](https://wiki.corp.mongodb.com/display/INTX/Githook) to include the new branch.
+     - Navigate to the [Webhook Settings](https://github.com/mongodb/libmongocrypt/settings/hooks).
+     - Click `Edit` on the hook for `https://githook.mongodb.com/`.
+     - Add the new release branch to the `Payload URL`. Remove unmaintained release branches.
 - Make a PR to apply the "Update CHANGELOG.md for x.y.z" commit to the `master` branch.
 - Update the release on the [Jira releases page](https://jira.mongodb.org/projects/MONGOCRYPT/versions).
 - Record the release on [C/C++ Release Info](https://docs.google.com/spreadsheets/d/1yHfGmDnbA5-Qt8FX4tKWC5xk9AhzYZx1SKF4AD36ecY/edit?usp=sharing). This is done to meet SSDLC reporting requirements.


### PR DESCRIPTION
Applies similar changes from https://github.com/mongodb/mongo-cxx-driver/pull/1282: Add release process step to update the GitHub Webhook.

**Background**

Updating the `debian/unstable` branch may result in Jira ticket comments for commits added to the branch ([example](https://jira.mongodb.org/browse/MONGOCRYPT-696?focusedCommentId=6633671&focusedId=6633671&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-6633671)). I expect this is not helpful, and results in unnecessary emails.

The [webhook](https://github.com/mongodb/libmongocrypt/settings/hooks) is now updated to limit updates to `master` and `r1.12`:

```
https://githook.mongodb.com?branches=master..r1.29
```

Consequently, the webhook must be updated when new release branches are created.
