### PR TITLE
Fix format script

### DIFF
--- a/.evergreen/init.sh
+++ b/.evergreen/init.sh
@@ -222,6 +222,7 @@ run_ctest() {
 
 run_python() {
     pys=(
+        "${MONGOCRYPT_PYTHON:-}"
         py
         python3.14
         python3.13

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Formatting
+
+To format, install `pipx` and run:
+```bash
+./etc/format-all.sh
+```
+
+To use a specified python install, set `MONGOCRYPT_PYTHON`:
+
+```bash
+# Set MONGOCRYPT_PYTHON to a python install with pipx installed.
+export MONGOCRYPT_PYTHON=python
+./etc/format-all.sh
+```

--- a/etc/format.sh
+++ b/etc/format.sh
@@ -9,8 +9,6 @@ if ! run_python -c ''; then
   fail "No Python found?"
 fi
 
-# Check that we have a pipx of the proper version:
-run_python -c 'import pkg_resources; pkg_resources.require("pipx>=0.17.0,<2.0")'
 
 # Give default clang-format an empty string on stdin if there are no inputs files
 printf '' | run_python -m pipx run "clang-format==${CLANG_FORMAT_VERSION:?}" "$@"


### PR DESCRIPTION
# Summary
- Update formatting script for Python 3.12
- Add CONTRIBUTING.md
- Relocate design rationale from README.md to integrating.md

# Details
The formatting script is updated to address an observed error on Python 3.12:

```
$ bash etc/format-all.sh
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'pkg_resources'
```

The error comes from this check:
```
run_python -c 'import pkg_resources; pkg_resources.require("pipx>=0.17.0,<2.0")'
```

`pkg_resources` is removed in Python 3.12. I expect that check is not strictly needed. This check has been removed.

A `MONGOCRYPT_PYTHON` environment variable is added to specify an override python version. This is documented in a new CONTRIBUTING.md document.
