### PR TITLE
MONGOCRYPT-760 Rename `set_error` to `kms_set_error`

### DIFF
--- a/kms-message/src/kms_message.c
+++ b/kms-message/src/kms_message.c
@@ -24,7 +24,7 @@
 #include <stdio.h>
 
 void
-set_error (char *error, size_t size, const char *fmt, ...)
+kms_set_error (char *error, size_t size, const char *fmt, ...)
 {
    va_list va;
 

--- a/kms-message/src/kms_message_private.h
+++ b/kms-message/src/kms_message_private.h
@@ -125,12 +125,12 @@ struct _kms_response_parser_t {
    } while (0)
 
 void
-set_error (char *error, size_t size, const char *fmt, ...);
+kms_set_error (char *error, size_t size, const char *fmt, ...);
 
 #define KMS_ERROR(obj, ...)                                     \
    do {                                                         \
       obj->failed = true;                                       \
-      set_error (obj->error, sizeof (obj->error), __VA_ARGS__); \
+      kms_set_error (obj->error, sizeof (obj->error), __VA_ARGS__); \
    } while (0)
 
 #define KMS_ASSERT(stmt)                      \


### PR DESCRIPTION
set_error is an awful generic name for a global function.

Sadly this easily conflicts with other libraries if you statically link this into an application.

please have us rename set_error to kms_set_error to avoid link errors with libraries/applications that also have set_error as function.