### PR TITLE
PYTHON-5017 Fix handling of post-publish step again

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -81,7 +81,7 @@ jobs:
           name: all-dist-${{ github.run_id }}
           path: dist/
       - name: Publish package distributions to PyPI
-        if: inputs.dry_run == 'false'
+        if: startsWith(inputs.dry_run, 'false')
         uses: pypa/gh-action-pypi-publish@release/v1
 
   post-publish:


### PR DESCRIPTION
We had the environment name wrong, and we need to coerce the dry_run flag to a string for comparision.