### PR TITLE
increase sleep time in cache test and flush test output

### DIFF
--- a/kms-message/test/test_kmip_reader_writer.c
+++ b/kms-message/test/test_kmip_reader_writer.c
@@ -42,11 +42,11 @@ kms_kmip_writer_test_evaluate (kmip_writer_t *writer,
    actual_hex = data_to_hex (actual_buf, actual_len);
 
    if (0 != strcmp (expected_hex, actual_hex)) {
-      fprintf (stderr,
-               "expected '%s' but got '%s' for test description: %s\n",
-               expected_hex,
-               actual_hex,
-               desc);
+      TEST_STDERR_PRINTF (
+         "expected '%s' but got '%s' for test description: %s\n",
+         expected_hex,
+         actual_hex,
+         desc);
       abort ();
    }
 

--- a/kms-message/test/test_kms_assert.h
+++ b/kms-message/test/test_kms_assert.h
@@ -41,14 +41,13 @@
    } else                            \
       ((void) 0)
 
-#define TEST_ERROR(...)                                                        \
-   do {                                                                        \
-      fprintf (                                                                \
-         stderr, "test error %s:%d %s(): ", __FILE__, __LINE__, __FUNCTION__); \
-      fprintf (stderr, __VA_ARGS__);                                           \
-      fprintf (stderr, "\n");                                                  \
-      fflush (stderr);                                                         \
-      abort ();                                                                \
+#define TEST_ERROR(...)                                                \
+   do {                                                                \
+      TEST_STDERR_PRINTF (                                             \
+         "test error %s:%d %s(): ", __FILE__, __LINE__, __FUNCTION__); \
+      TEST_STDERR_PRINTF (__VA_ARGS__);                                \
+      TEST_STDERR_PRINTF ("\n");                                       \
+      abort ();                                                        \
    } while (0)
 
 #define ASSERT(stmt)                             \

--- a/kms-message/test/test_kms_assert.h
+++ b/kms-message/test/test_kms_assert.h
@@ -23,6 +23,24 @@
 #include <stdio.h>
 #include <string.h>
 
+// TEST_PRINTF ensures stdout and stderr are flushed.
+#define TEST_PRINTF(...)             \
+   if (1) {                          \
+      fflush (stderr);               \
+      fprintf (stdout, __VA_ARGS__); \
+      fflush (stdout);               \
+   } else                            \
+      ((void) 0)
+
+// TEST_STDERR_PRINTF ensures stdout and stderr are flushed.
+#define TEST_STDERR_PRINTF(...)      \
+   if (1) {                          \
+      fflush (stdout);               \
+      fprintf (stderr, __VA_ARGS__); \
+      fflush (stderr);               \
+   } else                            \
+      ((void) 0)
+
 #define TEST_ERROR(...)                                                        \
    do {                                                                        \
       fprintf (                                                                \

--- a/kms-message/test/test_kms_azure_online.c
+++ b/kms-message/test/test_kms_azure_online.c
@@ -56,7 +56,7 @@ test_getenv (const char *key)
 {
    char *value = getenv (key);
    if (!value) {
-      TEST_STDERR_PRINTF ("Environment variable: %s not set (@@ctest-skip@@)",
+      TEST_STDERR_PRINTF ("Environment variable: %s not set (@@ctest-skip@@)\n",
                           key);
       exit (2);
    }

--- a/kms-message/test/test_kms_azure_online.c
+++ b/kms-message/test/test_kms_azure_online.c
@@ -56,8 +56,8 @@ test_getenv (const char *key)
 {
    char *value = getenv (key);
    if (!value) {
-      fprintf (
-         stderr, "Environment variable: %s not set (@@ctest-skip@@)", key);
+      TEST_STDERR_PRINTF ("Environment variable: %s not set (@@ctest-skip@@)",
+                          key);
       exit (2);
    }
    TEST_TRACE ("Env: %s = %s", key, value);

--- a/kms-message/test/test_kms_gcp_online.c
+++ b/kms-message/test/test_kms_gcp_online.c
@@ -56,7 +56,7 @@ test_getenv (const char *key)
 {
    char *value = getenv (key);
    if (!value) {
-      TEST_STDERR_PRINTF ("Environment variable: %s not set (@@ctest-skip@@)",
+      TEST_STDERR_PRINTF ("Environment variable: %s not set (@@ctest-skip@@)\n",
                           key);
       exit (2);
    }

--- a/kms-message/test/test_kms_gcp_online.c
+++ b/kms-message/test/test_kms_gcp_online.c
@@ -56,8 +56,8 @@ test_getenv (const char *key)
 {
    char *value = getenv (key);
    if (!value) {
-      fprintf (
-         stderr, "Environment variable: %s not set (@@ctest-skip@@)", key);
+      TEST_STDERR_PRINTF ("Environment variable: %s not set (@@ctest-skip@@)",
+                          key);
       exit (2);
    }
    TEST_TRACE ("Env: %s = %s", key, value);
@@ -185,7 +185,7 @@ test_gcp (void)
                                       opt);
    ASSERT (req);
    if (kms_request_get_error (req)) {
-      printf ("error: %s\n", kms_request_get_error (req));
+      TEST_STDERR_PRINTF ("error: %s\n", kms_request_get_error (req));
       ASSERT (false);
    }
    req_str = kms_request_to_string (req);

--- a/kms-message/test/test_kms_request.c
+++ b/kms-message/test/test_kms_request.c
@@ -383,7 +383,7 @@ all_aws_sig_v4_tests (const char *path, const char *selected)
    }
 
    if (skip_aws_test (test_name) && !selected) {
-      printf ("SKIP: %s\n", test_name);
+      TEST_PRINTF ("SKIP: %s\n", test_name);
       goto done;
    }
 
@@ -407,7 +407,7 @@ all_aws_sig_v4_tests (const char *path, const char *selected)
          continue;
       }
 
-      printf ("%s\n", path);
+      TEST_PRINTF ("%s\n", path);
       aws_sig_v4_test (path);
       ran_tests = true;
    }
@@ -903,7 +903,7 @@ parser_testcase_run (parser_testcase_t *testcase)
       size_t ret = fread (buf, 1, (size_t) bytes_to_read, response_file);
 
       if (!kms_response_parser_feed (parser, buf, (int) ret)) {
-         printf ("feed error: %s\n", parser->error);
+         TEST_PRINTF ("feed error: %s\n", parser->error);
          ASSERT (false);
       }
    }
@@ -945,7 +945,7 @@ kms_response_parser_files (void)
    size_t i;
 
    for (i = 0; i < sizeof (tests) / sizeof (tests[0]); i++) {
-      printf (" parser testcase: %d\n", (int) i);
+      TEST_PRINTF (" parser testcase: %d\n", (int) i);
       parser_testcase_run (tests + i);
    }
 }
@@ -1081,8 +1081,8 @@ kms_signature_test (void)
    signature_b64 = kms_message_raw_to_b64 (signature_raw, 256);
 
    if (0 != strcmp (signature_b64, expected_signature)) {
-      printf ("generated signature: %s\n", signature_b64);
-      printf ("but expected signature: %s\n", expected_signature);
+      TEST_PRINTF ("generated signature: %s\n", signature_b64);
+      TEST_PRINTF ("but expected signature: %s\n", expected_signature);
       abort ();
    }
 
@@ -1240,7 +1240,7 @@ main (int argc, char *argv[])
 
    int ret = kms_message_init ();
    if (ret != 0) {
-      printf ("kms_message_init failed: 0x%x\n", ret);
+      TEST_PRINTF ("kms_message_init failed: 0x%x\n", ret);
       abort ();
    }
 

--- a/kms-message/test/test_kms_request.c
+++ b/kms-message/test/test_kms_request.c
@@ -1232,7 +1232,7 @@ main (int argc, char *argv[])
    help = "Usage: test_kms_request [TEST_NAME]";
 
    if (argc > 2) {
-      fprintf (stderr, "%s\n", help);
+      TEST_STDERR_PRINTF ("%s\n", help);
       abort ();
    } else if (argc == 2) {
       selector = argv[1];
@@ -1292,7 +1292,7 @@ main (int argc, char *argv[])
 
    if (!ran_tests) {
       KMS_ASSERT (argc == 2);
-      fprintf (stderr, "No such test: \"%s\"\n", argv[1]);
+      TEST_STDERR_PRINTF ("No such test: \"%s\"\n", argv[1]);
       abort ();
    }
 

--- a/kms-message/test/test_kms_request.c
+++ b/kms-message/test/test_kms_request.c
@@ -1197,7 +1197,7 @@ test_request_newlines (void)
 #define RUN_TEST(_func)                                          \
    do {                                                          \
       if (!selector || 0 == kms_strcasecmp (#_func, selector)) { \
-         printf ("%s\n", #_func);                                \
+         TEST_PRINTF ("%s\n", #_func);                           \
          _func ();                                               \
          ran_tests = true;                                       \
       }                                                          \

--- a/test/test-mc-fle2-payload-iev-v2.c
+++ b/test/test-mc-fle2-payload-iev-v2.c
@@ -379,7 +379,7 @@ cleanup:
 }
 
 static void test_fle2_iev_v2_test(_mongocrypt_tester_t *tester, const char *path) {
-    printf("Loading test from %s...\n", path);
+    TEST_PRINTF("Loading test from %s...\n", path);
 
     mongocrypt_binary_t *test_bin = TEST_FILE(path);
     if (!test_bin) {
@@ -405,7 +405,7 @@ static void test_fle2_iev_v2_test(_mongocrypt_tester_t *tester, const char *path
 
 static void test_fle2_iev_v2(_mongocrypt_tester_t *tester) {
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 

--- a/test/test-mc-fle2-payload-iev.c
+++ b/test/test-mc-fle2-payload-iev.c
@@ -171,7 +171,7 @@ static void test_FLE2IndexedEqualityEncryptedValue_decrypt(_mongocrypt_tester_t 
     mongocrypt_t *crypt;
 
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 

--- a/test/test-mc-fle2-payload-iup-v2.c
+++ b/test/test-mc-fle2-payload-iup-v2.c
@@ -107,7 +107,7 @@ static void _test_mc_FLE2InsertUpdatePayloadV2_decrypt(_mongocrypt_tester_t *tes
     mongocrypt_t *crypt;
 
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 

--- a/test/test-mc-fle2-payload-iup.c
+++ b/test/test-mc-fle2-payload-iup.c
@@ -100,7 +100,7 @@ static void test_FLE2InsertUpdatePayload_decrypt(_mongocrypt_tester_t *tester) {
     mongocrypt_t *crypt;
 
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 

--- a/test/test-mc-fle2-payload-uev.c
+++ b/test/test-mc-fle2-payload-uev.c
@@ -125,7 +125,7 @@ static void test_FLE2UnindexedEncryptedValue_decrypt(_mongocrypt_tester_t *teste
     mongocrypt_t *crypt;
 
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 
@@ -201,7 +201,7 @@ static void test_FLE2UnindexedEncryptedValue_decrypt(_mongocrypt_tester_t *teste
 
 static void test_FLE2UnindexedEncryptedValue_encrypt(_mongocrypt_tester_t *tester) {
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 

--- a/test/test-mc-fle2-rfds.c
+++ b/test/test-mc-fle2-rfds.c
@@ -92,7 +92,7 @@ static void test_mc_FLE2RangeFindDriverSpec_parse(_mongocrypt_tester_t *tester) 
         testcase *test = tests + i;
         mongocrypt_status_t *status = mongocrypt_status_new();
         mc_FLE2RangeFindDriverSpec_t rfds;
-        printf("running subtest: %s\n", test->desc);
+        TEST_PRINTF("running subtest: %s\n", test->desc);
         bool ret = mc_FLE2RangeFindDriverSpec_parse(&rfds, TMP_BSON(test->in), status);
         if (!test->expectError) {
             ASSERT_OK_STATUS(ret, status);
@@ -329,7 +329,7 @@ static void test_mc_FLE2RangeFindDriverSpec_to_placeholders(_mongocrypt_tester_t
 
     for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
         testcase_t *test = tests + i;
-        printf("running subtest: %s : %s\n", test->desc, test->in);
+        TEST_PRINTF("running subtest: %s : %s\n", test->desc, test->in);
         ASSERT_OK_STATUS(mc_FLE2RangeFindDriverSpec_parse(&spec, TMP_BSON(test->in), status), status);
 
         // Create the expected document.

--- a/test/test-mc-range-edge-generation.c
+++ b/test/test-mc-range-edge-generation.c
@@ -38,7 +38,6 @@ typedef struct {
 #undef MAX_INT32_EDGES
 
 static void print_edges_compared(mc_edges_t *edgesGot, const char *const *edgesExpected) {
-    fflush(stdout); // Avoid incomplete stdout output from prior tests on error
     TEST_STDERR_PRINTF("edges got ... begin\n");
     for (size_t i = 0; i < mc_edges_len(edgesGot); i++) {
         TEST_STDERR_PRINTF("  %s\n", mc_edges_get(edgesGot, i));

--- a/test/test-mc-range-edge-generation.c
+++ b/test/test-mc-range-edge-generation.c
@@ -39,19 +39,19 @@ typedef struct {
 
 static void print_edges_compared(mc_edges_t *edgesGot, const char *const *edgesExpected) {
     fflush(stdout); // Avoid incomplete stdout output from prior tests on error
-    fprintf(stderr, "edges got ... begin\n");
+    TEST_STDERR_PRINTF("edges got ... begin\n");
     for (size_t i = 0; i < mc_edges_len(edgesGot); i++) {
-        fprintf(stderr, "  %s\n", mc_edges_get(edgesGot, i));
+        TEST_STDERR_PRINTF("  %s\n", mc_edges_get(edgesGot, i));
     }
-    fprintf(stderr, "edges got ... end\n");
+    TEST_STDERR_PRINTF("edges got ... end\n");
 
-    fprintf(stderr, "edges expected ... begin\n");
+    TEST_STDERR_PRINTF("edges expected ... begin\n");
     const char *const *iter = edgesExpected;
     while (*iter != NULL) {
-        fprintf(stderr, "  %s\n", *iter);
+        TEST_STDERR_PRINTF("  %s\n", *iter);
         iter++;
     }
-    fprintf(stderr, "edges expected ... end\n");
+    TEST_STDERR_PRINTF("edges expected ... end\n");
 }
 
 static void _test_getEdgesInt32(_mongocrypt_tester_t *tester) {

--- a/test/test-mc-range-encoding.c
+++ b/test/test-mc-range-encoding.c
@@ -83,14 +83,14 @@ static void _test_RangeTest_Encode_Int32(_mongocrypt_tester_t *tester) {
         mongocrypt_status_t *const status = mongocrypt_status_new();
 
         // Print a description of the test case.
-        printf("_test_RangeTest_Encode_Int32: value=%" PRId32, test->args.value);
+        TEST_PRINTF("_test_RangeTest_Encode_Int32: value=%" PRId32, test->args.value);
         if (test->args.min.set) {
-            printf(" min=%" PRId32, test->args.min.value);
+            TEST_PRINTF(" min=%" PRId32, test->args.min.value);
         }
         if (test->args.max.set) {
-            printf(" max=%" PRId32, test->args.max.value);
+            TEST_PRINTF(" max=%" PRId32, test->args.max.value);
         }
-        printf("\n");
+        TEST_PRINTF("\n");
         mc_OSTType_Int32 got;
         const bool ok = mc_getTypeInfo32(test->args, &got, status);
         if (test->expectError) {
@@ -171,14 +171,14 @@ static void _test_RangeTest_Encode_Int64(_mongocrypt_tester_t *tester) {
         mongocrypt_status_t *const status = mongocrypt_status_new();
 
         // Print a description of the test case.
-        printf("_test_RangeTest_Encode_Int64: value=%" PRId64, test->args.value);
+        TEST_PRINTF("_test_RangeTest_Encode_Int64: value=%" PRId64, test->args.value);
         if (test->args.min.set) {
-            printf(" min=%" PRId64, test->args.min.value);
+            TEST_PRINTF(" min=%" PRId64, test->args.min.value);
         }
         if (test->args.max.set) {
-            printf(" max=%" PRId64, test->args.max.value);
+            TEST_PRINTF(" max=%" PRId64, test->args.max.value);
         }
-        printf("\n");
+        TEST_PRINTF("\n");
         mc_OSTType_Int64 got;
         const bool ok = mc_getTypeInfo64(test->args, &got, status);
         if (test->expectError) {
@@ -201,7 +201,7 @@ static void _test_canUsePrecisionModeDouble(_mongocrypt_tester_t *tester) {
     {                                                                                                                  \
         uint32_t bits_out = 0;                                                                                         \
         mongocrypt_status_t *const status = mongocrypt_status_new();                                                   \
-        printf("_test_canUsePrecisionModeDecimal, min: %f, max: %f, prc: %" PRIu32, lb, ub, prc);                      \
+        TEST_PRINTF("_test_canUsePrecisionModeDecimal, min: %f, max: %f, prc: %" PRIu32, lb, ub, prc);                 \
         bool result = mc_canUsePrecisionModeDouble(lb, ub, prc, &bits_out, status);                                    \
         ASSERT_OK_STATUS(mongocrypt_status_ok(status), status);                                                        \
         ASSERT(result == expected);                                                                                    \
@@ -212,7 +212,7 @@ static void _test_canUsePrecisionModeDouble(_mongocrypt_tester_t *tester) {
 #define CAN_USE_PRECISION_MODE_ERRORS(lb, ub, prc, error)                                                              \
     {                                                                                                                  \
         mongocrypt_status_t *const status = mongocrypt_status_new();                                                   \
-        printf("_test_canUsePrecisionModeDecimal errors, min: %f, max: %f, prc: %" PRIu32, lb, ub, prc);               \
+        TEST_PRINTF("_test_canUsePrecisionModeDecimal errors, min: %f, max: %f, prc: %" PRIu32, lb, ub, prc);          \
         uint32_t bits_out = 0;                                                                                         \
         bool result = mc_canUsePrecisionModeDouble(lb, ub, prc, &bits_out, status);                                    \
         ASSERT_OR_PRINT_MSG(!result, "expected error, but got none");                                                  \
@@ -551,14 +551,14 @@ static void _test_RangeTest_Encode_Double(_mongocrypt_tester_t *tester) {
         mongocrypt_status_t *const status = mongocrypt_status_new();
 
         if (test->min.set && test->max.set && test->precision.set) {
-            printf("_test_RangeTest_Encode_Double: value=%f, min=%f, max=%f, "
-                   "precision=%" PRIu32 "\n",
-                   test->value,
-                   test->min.value,
-                   test->max.value,
-                   test->precision.value);
+            TEST_PRINTF("_test_RangeTest_Encode_Double: value=%f, min=%f, max=%f, "
+                        "precision=%" PRIu32 "\n",
+                        test->value,
+                        test->min.value,
+                        test->max.value,
+                        test->precision.value);
         } else {
-            printf("_test_RangeTest_Encode_Double: value=%f\n", test->value);
+            TEST_PRINTF("_test_RangeTest_Encode_Double: value=%f\n", test->value);
         }
 
         const bool use_range_v2 = !test->use_range_v1;
@@ -599,10 +599,10 @@ static void _test_canUsePrecisionModeDecimal(_mongocrypt_tester_t *tester) {
     {                                                                                                                  \
         uint32_t bits_out = 0;                                                                                         \
         mongocrypt_status_t *const status = mongocrypt_status_new();                                                   \
-        printf("_test_canUsePrecisionModeDecimal, min: %s, max: %s, prc: %" PRIu32,                                    \
-               mc_dec128_to_string(lb).str,                                                                            \
-               mc_dec128_to_string(ub).str,                                                                            \
-               prc);                                                                                                   \
+        TEST_PRINTF("_test_canUsePrecisionModeDecimal, min: %s, max: %s, prc: %" PRIu32,                               \
+                    mc_dec128_to_string(lb).str,                                                                       \
+                    mc_dec128_to_string(ub).str,                                                                       \
+                    prc);                                                                                              \
         bool result = mc_canUsePrecisionModeDecimal(lb, ub, prc, &bits_out, status);                                   \
         ASSERT_OK_STATUS(mongocrypt_status_ok(status), status);                                                        \
         ASSERT(result == expected);                                                                                    \
@@ -613,10 +613,10 @@ static void _test_canUsePrecisionModeDecimal(_mongocrypt_tester_t *tester) {
 #define CAN_USE_PRECISION_MODE_ERRORS(lb, ub, prc, error)                                                              \
     {                                                                                                                  \
         mongocrypt_status_t *const status = mongocrypt_status_new();                                                   \
-        printf("_test_canUsePrecisionModeDecimal errors, min: %s, max: %s, prc: %" PRIu32,                             \
-               mc_dec128_to_string(lb).str,                                                                            \
-               mc_dec128_to_string(ub).str,                                                                            \
-               prc);                                                                                                   \
+        TEST_PRINTF("_test_canUsePrecisionModeDecimal errors, min: %s, max: %s, prc: %" PRIu32,                        \
+                    mc_dec128_to_string(lb).str,                                                                       \
+                    mc_dec128_to_string(ub).str,                                                                       \
+                    prc);                                                                                              \
         uint32_t bits_out = 0;                                                                                         \
         bool result = mc_canUsePrecisionModeDecimal(lb, ub, prc, &bits_out, status);                                   \
         ASSERT_OR_PRINT_MSG(!result, "expected error, but got none");                                                  \
@@ -986,14 +986,14 @@ static void _test_RangeTest_Encode_Decimal128(_mongocrypt_tester_t *tester) {
         mongocrypt_status_t *const status = mongocrypt_status_new();
 
         if (test->min.set && test->max.set && test->precision.set) {
-            printf("_test_RangeTest_Encode_Decimal128: value=%s, min=%s, max=%s, "
-                   "precision=%" PRIu32 "\n",
-                   mc_dec128_to_string(test->value).str,
-                   mc_dec128_to_string(test->min.value).str,
-                   mc_dec128_to_string(test->max.value).str,
-                   test->precision.value);
+            TEST_PRINTF("_test_RangeTest_Encode_Decimal128: value=%s, min=%s, max=%s, "
+                        "precision=%" PRIu32 "\n",
+                        mc_dec128_to_string(test->value).str,
+                        mc_dec128_to_string(test->min.value).str,
+                        mc_dec128_to_string(test->max.value).str,
+                        test->precision.value);
         } else {
-            printf("_test_RangeTest_Encode_Decimal128: value=%s\n", mc_dec128_to_string(test->value).str);
+            TEST_PRINTF("_test_RangeTest_Encode_Decimal128: value=%s\n", mc_dec128_to_string(test->value).str);
         }
         fflush(stdout);
         mc_OSTType_Decimal128 got;

--- a/test/test-mc-range-encoding.c
+++ b/test/test-mc-range-encoding.c
@@ -995,7 +995,6 @@ static void _test_RangeTest_Encode_Decimal128(_mongocrypt_tester_t *tester) {
         } else {
             TEST_PRINTF("_test_RangeTest_Encode_Decimal128: value=%s\n", mc_dec128_to_string(test->value).str);
         }
-        fflush(stdout);
         mc_OSTType_Decimal128 got;
         const bool use_range_v2 = !test->use_range_v1;
         const bool ok = mc_getTypeInfoDecimal128(

--- a/test/test-mc-range-mincover.c
+++ b/test/test-mc-range-mincover.c
@@ -248,7 +248,6 @@ static const char *const *_test_expectMincoverDecimal128(void *tests, size_t idx
 static void _test_dump_32(void *tests, size_t idx, mc_mincover_t *got) {
     BSON_ASSERT_PARAM(tests);
     Int32Test *const test = (Int32Test *)tests + idx;
-    fflush(stdout); // Avoid incomplete stdout output from prior tests on error
     TEST_STDERR_PRINTF("testcase: lowerBound=%" PRId32 " (%s) upperBound=%" PRId32 " (%s)",
                        test->lowerBound,
                        test->includeLowerBound ? "inclusive" : "exclusive",
@@ -276,7 +275,6 @@ static void _test_dump_32(void *tests, size_t idx, mc_mincover_t *got) {
 static void _test_dump_64(void *tests, size_t idx, mc_mincover_t *got) {
     BSON_ASSERT_PARAM(tests);
     Int64Test *const test = (Int64Test *)tests + idx;
-    fflush(stdout); // Avoid incomplete stdout output from prior tests on error
     TEST_STDERR_PRINTF("testcase: lowerBound=%" PRId64 " (%s) upperBound=%" PRId64 " (%s)",
                        test->lowerBound,
                        test->includeLowerBound ? "inclusive" : "exclusive",
@@ -304,7 +302,6 @@ static void _test_dump_64(void *tests, size_t idx, mc_mincover_t *got) {
 static void _test_dump_Double(void *tests, size_t idx, mc_mincover_t *got) {
     BSON_ASSERT_PARAM(tests);
     DoubleTest *const test = (DoubleTest *)tests + idx;
-    fflush(stdout); // Avoid incomplete stdout output from prior tests on error
     TEST_STDERR_PRINTF("testcase: lowerBound=%f (%s) upperBound=%f (%s)",
                        test->lowerBound,
                        test->includeLowerBound ? "inclusive" : "exclusive",
@@ -336,7 +333,6 @@ static void _test_dump_Double(void *tests, size_t idx, mc_mincover_t *got) {
 static void _test_dump_Decimal128(void *tests, size_t idx, mc_mincover_t *got) {
     BSON_ASSERT_PARAM(tests);
     Decimal128Test *const test = (Decimal128Test *)tests + idx;
-    fflush(stdout); // Avoid incomplete stdout output from prior tests on error
     TEST_STDERR_PRINTF("testcase: lowerBound=%s (%s) upperBound=%s (%s)",
                        mc_dec128_to_string(test->lowerBound).str,
                        test->includeLowerBound ? "inclusive" : "exclusive",

--- a/test/test-mc-range-mincover.c
+++ b/test/test-mc-range-mincover.c
@@ -249,90 +249,87 @@ static void _test_dump_32(void *tests, size_t idx, mc_mincover_t *got) {
     BSON_ASSERT_PARAM(tests);
     Int32Test *const test = (Int32Test *)tests + idx;
     fflush(stdout); // Avoid incomplete stdout output from prior tests on error
-    fprintf(stderr,
-            "testcase: lowerBound=%" PRId32 " (%s) upperBound=%" PRId32 " (%s)",
-            test->lowerBound,
-            test->includeLowerBound ? "inclusive" : "exclusive",
-            test->upperBound,
-            test->includeUpperBound ? "inclusive" : "exclusive");
+    TEST_STDERR_PRINTF("testcase: lowerBound=%" PRId32 " (%s) upperBound=%" PRId32 " (%s)",
+                       test->lowerBound,
+                       test->includeLowerBound ? "inclusive" : "exclusive",
+                       test->upperBound,
+                       test->includeUpperBound ? "inclusive" : "exclusive");
     if (test->min.set) {
-        fprintf(stderr, " min=%" PRId32, test->min.value);
+        TEST_STDERR_PRINTF(" min=%" PRId32, test->min.value);
     }
     if (test->max.set) {
-        fprintf(stderr, " max=%" PRId32, test->max.value);
+        TEST_STDERR_PRINTF(" max=%" PRId32, test->max.value);
     }
-    fprintf(stderr, " sparsity=%zu\n", test->sparsity);
-    fprintf(stderr, "mincover expected ... begin\n");
+    TEST_STDERR_PRINTF(" sparsity=%zu\n", test->sparsity);
+    TEST_STDERR_PRINTF("mincover expected ... begin\n");
     for (const char **p = test->expectMincoverStrings; *p; ++p) {
-        fprintf(stderr, "  %s\n", *p);
+        TEST_STDERR_PRINTF("  %s\n", *p);
     }
-    fprintf(stderr, "mincover expected ... end\n");
-    fprintf(stderr, "mincover got ... begin\n");
+    TEST_STDERR_PRINTF("mincover expected ... end\n");
+    TEST_STDERR_PRINTF("mincover got ... begin\n");
     for (size_t i = 0; i < mc_mincover_len(got); i++) {
-        fprintf(stderr, "  %s\n", mc_mincover_get(got, i));
+        TEST_STDERR_PRINTF("  %s\n", mc_mincover_get(got, i));
     }
-    fprintf(stderr, "mincover got ... end\n");
+    TEST_STDERR_PRINTF("mincover got ... end\n");
 }
 
 static void _test_dump_64(void *tests, size_t idx, mc_mincover_t *got) {
     BSON_ASSERT_PARAM(tests);
     Int64Test *const test = (Int64Test *)tests + idx;
     fflush(stdout); // Avoid incomplete stdout output from prior tests on error
-    fprintf(stderr,
-            "testcase: lowerBound=%" PRId64 " (%s) upperBound=%" PRId64 " (%s)",
-            test->lowerBound,
-            test->includeLowerBound ? "inclusive" : "exclusive",
-            test->upperBound,
-            test->includeUpperBound ? "inclusive" : "exclusive");
+    TEST_STDERR_PRINTF("testcase: lowerBound=%" PRId64 " (%s) upperBound=%" PRId64 " (%s)",
+                       test->lowerBound,
+                       test->includeLowerBound ? "inclusive" : "exclusive",
+                       test->upperBound,
+                       test->includeUpperBound ? "inclusive" : "exclusive");
     if (test->min.set) {
-        fprintf(stderr, " min=%" PRId64, test->min.value);
+        TEST_STDERR_PRINTF(" min=%" PRId64, test->min.value);
     }
     if (test->max.set) {
-        fprintf(stderr, " max=%" PRId64, test->max.value);
+        TEST_STDERR_PRINTF(" max=%" PRId64, test->max.value);
     }
-    fprintf(stderr, " sparsity=%zu\n", test->sparsity);
-    fprintf(stderr, "mincover expected ... begin\n");
+    TEST_STDERR_PRINTF(" sparsity=%zu\n", test->sparsity);
+    TEST_STDERR_PRINTF("mincover expected ... begin\n");
     for (const char **p = test->expectMincoverStrings; *p; ++p) {
-        fprintf(stderr, "  %s\n", *p);
+        TEST_STDERR_PRINTF("  %s\n", *p);
     }
-    fprintf(stderr, "mincover expected ... end\n");
-    fprintf(stderr, "mincover got ... begin\n");
+    TEST_STDERR_PRINTF("mincover expected ... end\n");
+    TEST_STDERR_PRINTF("mincover got ... begin\n");
     for (size_t i = 0; i < mc_mincover_len(got); i++) {
-        fprintf(stderr, "  %s\n", mc_mincover_get(got, i));
+        TEST_STDERR_PRINTF("  %s\n", mc_mincover_get(got, i));
     }
-    fprintf(stderr, "mincover got ... end\n");
+    TEST_STDERR_PRINTF("mincover got ... end\n");
 }
 
 static void _test_dump_Double(void *tests, size_t idx, mc_mincover_t *got) {
     BSON_ASSERT_PARAM(tests);
     DoubleTest *const test = (DoubleTest *)tests + idx;
     fflush(stdout); // Avoid incomplete stdout output from prior tests on error
-    fprintf(stderr,
-            "testcase: lowerBound=%f (%s) upperBound=%f (%s)",
-            test->lowerBound,
-            test->includeLowerBound ? "inclusive" : "exclusive",
-            test->upperBound,
-            test->includeUpperBound ? "inclusive" : "exclusive");
+    TEST_STDERR_PRINTF("testcase: lowerBound=%f (%s) upperBound=%f (%s)",
+                       test->lowerBound,
+                       test->includeLowerBound ? "inclusive" : "exclusive",
+                       test->upperBound,
+                       test->includeUpperBound ? "inclusive" : "exclusive");
     if (test->min.set) {
-        fprintf(stderr, " min=%f", test->min.value);
+        TEST_STDERR_PRINTF(" min=%f", test->min.value);
     }
     if (test->max.set) {
-        fprintf(stderr, " max=%f", test->max.value);
+        TEST_STDERR_PRINTF(" max=%f", test->max.value);
     }
     if (test->precision.set) {
-        fprintf(stderr, " precision=%" PRIu32, test->precision.value);
+        TEST_STDERR_PRINTF(" precision=%" PRIu32, test->precision.value);
     }
-    fprintf(stderr, " sparsity=%zu\n", test->sparsity);
-    fprintf(stderr, "mincover expected ... begin\n");
+    TEST_STDERR_PRINTF(" sparsity=%zu\n", test->sparsity);
+    TEST_STDERR_PRINTF("mincover expected ... begin\n");
     for (const char **p = test->expectMincoverStrings; *p; ++p) {
-        fprintf(stderr, "  %s\n", *p);
+        TEST_STDERR_PRINTF("  %s\n", *p);
     }
-    fprintf(stderr, "mincover expected ... end\n");
-    fprintf(stderr, "mincover got ... begin\n");
+    TEST_STDERR_PRINTF("mincover expected ... end\n");
+    TEST_STDERR_PRINTF("mincover got ... begin\n");
     for (size_t i = 0; i < mc_mincover_len(got); i++) {
-        fprintf(stderr, "  %s\n", mc_mincover_get(got, i));
+        TEST_STDERR_PRINTF("  %s\n", mc_mincover_get(got, i));
     }
-    fprintf(stderr, "mincover got ... end\n");
+    TEST_STDERR_PRINTF("mincover got ... end\n");
 }
 
 #if MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
@@ -340,32 +337,31 @@ static void _test_dump_Decimal128(void *tests, size_t idx, mc_mincover_t *got) {
     BSON_ASSERT_PARAM(tests);
     Decimal128Test *const test = (Decimal128Test *)tests + idx;
     fflush(stdout); // Avoid incomplete stdout output from prior tests on error
-    fprintf(stderr,
-            "testcase: lowerBound=%s (%s) upperBound=%s (%s)",
-            mc_dec128_to_string(test->lowerBound).str,
-            test->includeLowerBound ? "inclusive" : "exclusive",
-            mc_dec128_to_string(test->upperBound).str,
-            test->includeUpperBound ? "inclusive" : "exclusive");
+    TEST_STDERR_PRINTF("testcase: lowerBound=%s (%s) upperBound=%s (%s)",
+                       mc_dec128_to_string(test->lowerBound).str,
+                       test->includeLowerBound ? "inclusive" : "exclusive",
+                       mc_dec128_to_string(test->upperBound).str,
+                       test->includeUpperBound ? "inclusive" : "exclusive");
     if (test->min.set) {
-        fprintf(stderr, " min=%s", mc_dec128_to_string(test->min.value).str);
+        TEST_STDERR_PRINTF(" min=%s", mc_dec128_to_string(test->min.value).str);
     }
     if (test->max.set) {
-        fprintf(stderr, " max=%s", mc_dec128_to_string(test->max.value).str);
+        TEST_STDERR_PRINTF(" max=%s", mc_dec128_to_string(test->max.value).str);
     }
     if (test->precision.set) {
-        fprintf(stderr, " precision=%" PRIu32, test->precision.value);
+        TEST_STDERR_PRINTF(" precision=%" PRIu32, test->precision.value);
     }
-    fprintf(stderr, " sparsity=%zu\n", test->sparsity);
-    fprintf(stderr, "mincover expected ... begin\n");
+    TEST_STDERR_PRINTF(" sparsity=%zu\n", test->sparsity);
+    TEST_STDERR_PRINTF("mincover expected ... begin\n");
     for (const char **p = test->expectMincoverStrings; *p; ++p) {
-        fprintf(stderr, "  %s\n", *p);
+        TEST_STDERR_PRINTF("  %s\n", *p);
     }
-    fprintf(stderr, "mincover expected ... end\n");
-    fprintf(stderr, "mincover got ... begin\n");
+    TEST_STDERR_PRINTF("mincover expected ... end\n");
+    TEST_STDERR_PRINTF("mincover got ... begin\n");
     for (size_t i = 0; i < mc_mincover_len(got); i++) {
-        fprintf(stderr, "  %s\n", mc_mincover_get(got, i));
+        TEST_STDERR_PRINTF("  %s\n", mc_mincover_get(got, i));
     }
-    fprintf(stderr, "mincover got ... end\n");
+    TEST_STDERR_PRINTF("mincover got ... end\n");
 }
 #endif // MONGOCRYPT_HAVE_DECIMAL128_SUPPORT
 

--- a/test/test-mc-rangeopts.c
+++ b/test/test-mc-rangeopts.c
@@ -87,7 +87,7 @@ static void test_mc_RangeOpts_parse(_mongocrypt_tester_t *tester) {
         testcase *test = tests + i;
         mongocrypt_status_t *status = mongocrypt_status_new();
         mc_RangeOpts_t ro;
-        printf("running test_mc_RangeOpts_parse subtest: %s\n", test->desc);
+        TEST_PRINTF("running test_mc_RangeOpts_parse subtest: %s\n", test->desc);
         bool ret = mc_RangeOpts_parse(&ro, TMP_BSON(test->in), test->useRangeV2, status);
         if (!test->expectError) {
             ASSERT_OK_STATUS(ret, status);
@@ -316,7 +316,7 @@ static void test_mc_RangeOpts_to_FLE2RangeInsertSpec(_mongocrypt_tester_t *teste
         testcase *test = tests + i;
         mongocrypt_status_t *status = mongocrypt_status_new();
         mc_RangeOpts_t ro;
-        printf("running test_mc_RangeOpts_to_FLE2RangeInsertSpec subtest: %s\n", test->desc);
+        TEST_PRINTF("running test_mc_RangeOpts_to_FLE2RangeInsertSpec subtest: %s\n", test->desc);
         ASSERT_OK_STATUS(mc_RangeOpts_parse(&ro, TMP_BSON(test->in), !test->disableRangeV2, status), status);
         bson_t out = BSON_INITIALIZER;
         bool ret = mc_RangeOpts_to_FLE2RangeInsertSpec(&ro, TMP_BSON(test->v), &out, !test->disableRangeV2, status);

--- a/test/test-mc-tokens.c
+++ b/test/test-mc-tokens.c
@@ -81,7 +81,7 @@ static void _mc_token_test_cleanup(_mc_token_test *test) {
 }
 
 static void _mc_token_test_run(_mongocrypt_tester_t *tester, const char *path) {
-    printf("Loading test from %s...\n", path);
+    TEST_PRINTF("Loading test from %s...\n", path);
 
     mongocrypt_binary_t *test_bin = TEST_FILE(path);
     if (!test_bin) {
@@ -318,7 +318,7 @@ static void _mc_token_test_run(_mongocrypt_tester_t *tester, const char *path) {
     mongocrypt_destroy(crypt);
     mongocrypt_status_destroy(status);
 
-    printf("Finished tests in %s\n", path);
+    TEST_PRINTF("Finished tests in %s\n", path);
 }
 
 static void _test_mc_tokens(_mongocrypt_tester_t *tester) {

--- a/test/test-mongocrypt-assert-match-bson.c
+++ b/test/test-mongocrypt-assert-match-bson.c
@@ -167,7 +167,7 @@ bool match_json(const bson_t *doc,
     pattern = bson_new_from_json((const uint8_t *)double_quoted, -1, &error);
 
     if (!pattern) {
-        fprintf(stderr, "couldn't parse JSON: %s\n", error.message);
+        TEST_STDERR_PRINTF("couldn't parse JSON: %s\n", error.message);
         abort();
     }
 
@@ -176,18 +176,17 @@ bool match_json(const bson_t *doc,
 
     if (!matches) {
         char *as_string = doc ? bson_as_canonical_extended_json(doc, NULL) : NULL;
-        fprintf(stderr,
-                "ASSERT_MATCH failed with document:\n\n"
-                "%s\n"
-                "pattern:\n%s\n"
-                "%s\n"
-                "%s:%d %s()\n",
-                as_string ? as_string : "{}",
-                double_quoted,
-                ctx.errmsg,
-                filename,
-                lineno,
-                funcname);
+        TEST_STDERR_PRINTF("ASSERT_MATCH failed with document:\n\n"
+                           "%s\n"
+                           "pattern:\n%s\n"
+                           "%s\n"
+                           "%s:%d %s()\n",
+                           as_string ? as_string : "{}",
+                           double_quoted,
+                           ctx.errmsg,
+                           filename,
+                           lineno,
+                           funcname);
         bson_free(as_string);
     }
 
@@ -580,7 +579,7 @@ static bool get_type_operator(const bson_value_t *value, bson_type_t *out) {
         } else if (0 == strcasecmp("maxKey", value_string)) {
             *out = BSON_TYPE_MAXKEY;
         } else {
-            fprintf(stderr, "unrecognized $$type value: %s\n", value_string);
+            TEST_STDERR_PRINTF("unrecognized $$type value: %s\n", value_string);
             abort();
         }
         return true;

--- a/test/test-mongocrypt-assert.h
+++ b/test/test-mongocrypt-assert.h
@@ -25,6 +25,24 @@
 
 #include <stdio.h>
 
+// TEST_PRINTF ensures stdout and stderr are flushed.
+#define TEST_PRINTF(...)                                                                                               \
+    if (1) {                                                                                                           \
+        fflush(stderr);                                                                                                \
+        fprintf(stdout, __VA_ARGS__);                                                                                  \
+        fflush(stdout);                                                                                                \
+    } else                                                                                                             \
+        ((void)0)
+
+// TEST_STDERR_PRINTF ensures stdout and stderr are flushed.
+#define TEST_STDERR_PRINTF(...)                                                                                        \
+    if (1) {                                                                                                           \
+        fflush(stdout);                                                                                                \
+        fprintf(stderr, __VA_ARGS__);                                                                                  \
+        fflush(stderr);                                                                                                \
+    } else                                                                                                             \
+        ((void)0)
+
 #define TEST_ERROR(...)                                                                                                \
     do {                                                                                                               \
         fprintf(stderr, "test error %s:%d %s(): ", __FILE__, __LINE__, __FUNCTION__);                                  \

--- a/test/test-mongocrypt-assert.h
+++ b/test/test-mongocrypt-assert.h
@@ -45,10 +45,9 @@
 
 #define TEST_ERROR(...)                                                                                                \
     do {                                                                                                               \
-        fprintf(stderr, "test error %s:%d %s(): ", __FILE__, __LINE__, __FUNCTION__);                                  \
-        fprintf(stderr, __VA_ARGS__);                                                                                  \
-        fprintf(stderr, "\n");                                                                                         \
-        fflush(stderr);                                                                                                \
+        TEST_STDERR_PRINTF("test error %s:%d %s(): ", __FILE__, __LINE__, __FUNCTION__);                               \
+        TEST_STDERR_PRINTF(__VA_ARGS__);                                                                               \
+        TEST_STDERR_PRINTF("\n");                                                                                      \
         abort();                                                                                                       \
     } while (0)
 

--- a/test/test-mongocrypt-cache.c
+++ b/test/test-mongocrypt-cache.c
@@ -86,8 +86,9 @@ static void _test_cache_expiration(_mongocrypt_tester_t *tester) {
     BSON_ASSERT(bson_equal(entry, tmp));
     bson_destroy(tmp);
 
-    /* Sleep for 100 milliseconds */
-    _usleep(1000 * 100);
+    // Sleep to trigger cache expiration.
+    // Cache entries expire after 1ms, but use 20ms to avoid timing errors observed on Windows distros: CDRIVER-4526
+    _usleep(20 * 1000);
 
     BSON_ASSERT(_mongocrypt_cache_get(&cache, "1", (void **)&tmp));
     BSON_ASSERT(!tmp);

--- a/test/test-mongocrypt-crypto-hooks.c
+++ b/test/test-mongocrypt-crypto-hooks.c
@@ -813,7 +813,7 @@ static void test_setting_only_ctr_hook(_mongocrypt_tester_t *tester) {
     // macOS <= 10.14 does not support native CTR encryption.
 
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 

--- a/test/test-mongocrypt-crypto.c
+++ b/test/test-mongocrypt-crypto.c
@@ -49,11 +49,11 @@ static bool _test_uses_ctr(const _test_mc_crypto_roundtrip_t *test) {
 
 static void _test_roundtrip_single(const _test_mc_crypto_roundtrip_t *test) {
     if (!_aes_ctr_is_supported_by_os && _test_uses_ctr(test)) {
-        printf("Common Crypto with no CTR support detected. Skipping %s", test->name);
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping %s", test->name);
         return;
     }
 
-    printf("Begin %s...\n", test->name);
+    TEST_PRINTF("Begin %s...\n", test->name);
 
     mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
     mongocrypt_status_t *const status = mongocrypt_status_new();
@@ -125,7 +125,7 @@ done:
     mongocrypt_status_destroy(status);
     mongocrypt_destroy(crypt);
 
-    printf("End %s...\n", test->name);
+    TEST_PRINTF("End %s...\n", test->name);
 }
 
 static const _mongocrypt_value_encryption_algorithm_t *get_algo_by_name(const char *name) {
@@ -233,7 +233,7 @@ static void _test_mc_crypto_roundtrip_destroy(_test_mc_crypto_roundtrip_t *test)
 }
 
 static void _test_roundtrip_set(_mongocrypt_tester_t *tester, const char *path) {
-    printf("Loading tests from %s...\n", path);
+    TEST_PRINTF("Loading tests from %s...\n", path);
 
     mongocrypt_binary_t *test_bin = TEST_FILE(path);
     if (!test_bin) {
@@ -259,7 +259,7 @@ static void _test_roundtrip_set(_mongocrypt_tester_t *tester, const char *path) 
         _test_mc_crypto_roundtrip_destroy(&test);
     }
 
-    printf("Finished tests in %s\n", path);
+    TEST_PRINTF("Finished tests in %s\n", path);
 }
 
 static void _test_roundtrip(_mongocrypt_tester_t *tester) {
@@ -324,7 +324,7 @@ void _test_native_crypto_hmac_sha_256(_mongocrypt_tester_t *tester) {
         _mongocrypt_buffer_t got;
         mongocrypt_status_t *status;
 
-        printf("Begin test '%s'.\n", test->testname);
+        TEST_PRINTF("Begin test '%s'.\n", test->testname);
 
         _mongocrypt_buffer_copy_from_hex(&key, test->key);
         _mongocrypt_buffer_copy_from_hex(&input, test->input);
@@ -347,7 +347,7 @@ void _test_native_crypto_hmac_sha_256(_mongocrypt_tester_t *tester) {
         _mongocrypt_buffer_cleanup(&input);
         _mongocrypt_buffer_cleanup(&key);
 
-        printf("End test '%s'.\n", test->testname);
+        TEST_PRINTF("End test '%s'.\n", test->testname);
     }
 
     mongocrypt_destroy(crypt);

--- a/test/test-mongocrypt-ctx-decrypt.c
+++ b/test/test-mongocrypt-ctx-decrypt.c
@@ -275,7 +275,7 @@ static void _test_decrypt_fle2(_mongocrypt_tester_t *tester) {
     _mongocrypt_buffer_t K_KeyId;
 
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 
@@ -602,7 +602,7 @@ static void _test_explicit_decrypt_fle2_ieev(_mongocrypt_tester_t *tester) {
     _mongocrypt_buffer_t K_KeyId;
 
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 
@@ -675,7 +675,7 @@ static void _test_explicit_decrypt_fle2_ieev(_mongocrypt_tester_t *tester) {
 
 static void _test_decrypt_fle2_iup(_mongocrypt_tester_t *tester) {
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 
@@ -788,7 +788,7 @@ static void _test_decrypt_wrong_binary_subtype(_mongocrypt_tester_t *tester) {
 /* Test decrypting FLE2IndexedRangeEncryptedValue */
 static void _test_decrypt_fle2_irev(_mongocrypt_tester_t *tester) {
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 
@@ -848,7 +848,7 @@ static void _test_decrypt_fle2_irev(_mongocrypt_tester_t *tester) {
 // Test explicitly decrypting an FLE2IndexedRangeEncryptedValue.
 static void _test_explicit_decrypt_fle2_irev(_mongocrypt_tester_t *tester) {
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 
@@ -907,7 +907,7 @@ static void _test_explicit_decrypt_fle2_irev(_mongocrypt_tester_t *tester) {
 // Test explicitly decrypting an FLE2InsertUpdatePayload with edges.
 static void _test_explicit_decrypt_fle2_iup_with_edges(_mongocrypt_tester_t *tester) {
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -763,7 +763,9 @@ static void _test_encrypt_cache_expiration(_mongocrypt_tester_t *tester) {
     _mongocrypt_tester_run_ctx_to(tester, ctx, MONGOCRYPT_CTX_DONE);
     mongocrypt_ctx_destroy(ctx);
 
-    _usleep(2000);
+    // Sleep to trigger cache expiration.
+    // Cache entries expire after 1ms, but use 20ms to avoid timing errors observed on Windows distros: CDRIVER-4526
+    _usleep(20 * 1000);
     /* The next context requests keys again
      */
     ctx = mongocrypt_ctx_new(crypt);

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1964,7 +1964,7 @@ static void _test_encrypt_fle2_encryption_placeholder(_mongocrypt_tester_t *test
         ((void)0)
 
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 
@@ -2248,7 +2248,7 @@ typedef struct {
 } ee_testcase;
 
 static void ee_testcase_run(ee_testcase *tc) {
-    printf("  explicit_encryption_finalize test case: %s ... begin\n", tc->desc);
+    TEST_PRINTF("  explicit_encryption_finalize test case: %s ... begin\n", tc->desc);
     extern void mc_reset_payloadId_for_testing(void);
     mc_reset_payloadId_for_testing();
     mongocrypt_t *crypt;
@@ -2330,7 +2330,7 @@ static void ee_testcase_run(ee_testcase *tc) {
     }
 
 cleanup:
-    printf("  explicit_encryption_finalize test case: %s ... end\n", tc->desc);
+    TEST_PRINTF("  explicit_encryption_finalize test case: %s ... end\n", tc->desc);
     mongocrypt_ctx_destroy(ctx);
     mongocrypt_destroy(crypt);
 }
@@ -2341,7 +2341,7 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
     _mongocrypt_buffer_t key123_id;
 
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 
@@ -4601,7 +4601,7 @@ static void _test_encrypt_macos_no_ctr(_mongocrypt_tester_t *tester) {
     _mongocrypt_buffer_t key_id;
 
     if (_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with CTR support detected. Skipping.");
         return;
     }
 
@@ -4682,7 +4682,7 @@ static void _test_fle1_collmod_without_jsonSchema(_mongocrypt_tester_t *tester) 
 
 static void _test_bulkWrite(_mongocrypt_tester_t *tester) {
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Required by QEv2 encryption. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Required by QEv2 encryption. Skipping.");
         return;
     }
 
@@ -5154,11 +5154,11 @@ typedef struct {
 
 static void autoencryption_test_run(autoencryption_test *aet) {
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 
-    printf("  auto_encryption test: '%s' ... begin\n", aet->desc);
+    TEST_PRINTF("  auto_encryption test: '%s' ... begin\n", aet->desc);
 
     // Reset global counter for the `payloadId` to produce deterministic payloads.
     extern void mc_reset_payloadId_for_testing(void);
@@ -5225,14 +5225,14 @@ static void autoencryption_test_run(autoencryption_test *aet) {
         mongocrypt_binary_destroy(got);
     }
 
-    printf("  auto_encryption test: '%s' ... end\n", aet->desc);
+    TEST_PRINTF("  auto_encryption test: '%s' ... end\n", aet->desc);
     mongocrypt_ctx_destroy(ctx);
     mongocrypt_destroy(crypt);
 }
 
 static void _test_no_trimFactor(_mongocrypt_tester_t *tester) {
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 
@@ -5300,7 +5300,7 @@ static void lookup_payload_bson(mongocrypt_binary_t *result, char *path, bson_t 
 // Test that the crypto params added in SERVER-91889 are sent for "range" payloads.
 static void _test_range_sends_cryptoParams(_mongocrypt_tester_t *tester) {
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -508,9 +508,7 @@ static void _test_encrypt_need_markings(_mongocrypt_tester_t *tester) {
 
 static void _test_encrypt_csfle_no_needs_markings(_mongocrypt_tester_t *tester) {
     if (!TEST_MONGOCRYPT_HAVE_REAL_CRYPT_SHARED_LIB) {
-        fputs("No 'real' csfle library is available. The "
-              "_test_encrypt_csfle_no_needs_markings test is a no-op.",
-              stderr);
+        fprintf(stderr, "No 'real' csfle library is available. The %s test is a no-op.\n", BSON_FUNC);
         return;
     }
 
@@ -3941,9 +3939,7 @@ static void _test_encrypt_fle2_explain_with_mongocryptd(_mongocrypt_tester_t *te
 
 static void _test_encrypt_fle2_explain_with_csfle(_mongocrypt_tester_t *tester) {
     if (!TEST_MONGOCRYPT_HAVE_REAL_CRYPT_SHARED_LIB) {
-        fputs("No 'real' csfle library is available. The "
-              "_test_encrypt_fle2_explain_with_csfle test is a no-op.",
-              stderr);
+        fprintf(stderr, "No 'real' csfle library is available. The %s test is a no-op.\n", BSON_FUNC);
         return;
     }
 
@@ -4039,9 +4035,7 @@ static void _test_encrypt_fle1_explain_with_mongocryptd(_mongocrypt_tester_t *te
 
 static void _test_encrypt_fle1_explain_with_csfle(_mongocrypt_tester_t *tester) {
     if (!TEST_MONGOCRYPT_HAVE_REAL_CRYPT_SHARED_LIB) {
-        fputs("No 'real' csfle library is available. The "
-              "_test_encrypt_fle1_explain_with_csfle test is a no-op.",
-              stderr);
+        fprintf(stderr, "No 'real' csfle library is available. The %s test is a no-op.\n", BSON_FUNC);
         return;
     }
 
@@ -4496,9 +4490,7 @@ static void _test_fle1_create_old_mongocryptd(_mongocrypt_tester_t *tester) {
 
 static void _test_fle1_create_with_csfle(_mongocrypt_tester_t *tester) {
     if (!TEST_MONGOCRYPT_HAVE_REAL_CRYPT_SHARED_LIB) {
-        fputs("No 'real' csfle library is available. The "
-              "_test_fle1_create_with_csfle test is a no-op.",
-              stderr);
+        fprintf(stderr, "No 'real' csfle library is available. The %s test is a no-op.\n", BSON_FUNC);
         return;
     }
 

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -508,7 +508,7 @@ static void _test_encrypt_need_markings(_mongocrypt_tester_t *tester) {
 
 static void _test_encrypt_csfle_no_needs_markings(_mongocrypt_tester_t *tester) {
     if (!TEST_MONGOCRYPT_HAVE_REAL_CRYPT_SHARED_LIB) {
-        fprintf(stderr, "No 'real' csfle library is available. The %s test is a no-op.\n", BSON_FUNC);
+        TEST_STDERR_PRINTF("No 'real' csfle library is available. The %s test is a no-op.\n", BSON_FUNC);
         return;
     }
 
@@ -3939,7 +3939,7 @@ static void _test_encrypt_fle2_explain_with_mongocryptd(_mongocrypt_tester_t *te
 
 static void _test_encrypt_fle2_explain_with_csfle(_mongocrypt_tester_t *tester) {
     if (!TEST_MONGOCRYPT_HAVE_REAL_CRYPT_SHARED_LIB) {
-        fprintf(stderr, "No 'real' csfle library is available. The %s test is a no-op.\n", BSON_FUNC);
+        TEST_STDERR_PRINTF("No 'real' csfle library is available. The %s test is a no-op.\n", BSON_FUNC);
         return;
     }
 
@@ -4035,7 +4035,7 @@ static void _test_encrypt_fle1_explain_with_mongocryptd(_mongocrypt_tester_t *te
 
 static void _test_encrypt_fle1_explain_with_csfle(_mongocrypt_tester_t *tester) {
     if (!TEST_MONGOCRYPT_HAVE_REAL_CRYPT_SHARED_LIB) {
-        fprintf(stderr, "No 'real' csfle library is available. The %s test is a no-op.\n", BSON_FUNC);
+        TEST_STDERR_PRINTF("No 'real' csfle library is available. The %s test is a no-op.\n", BSON_FUNC);
         return;
     }
 
@@ -4490,7 +4490,7 @@ static void _test_fle1_create_old_mongocryptd(_mongocrypt_tester_t *tester) {
 
 static void _test_fle1_create_with_csfle(_mongocrypt_tester_t *tester) {
     if (!TEST_MONGOCRYPT_HAVE_REAL_CRYPT_SHARED_LIB) {
-        fprintf(stderr, "No 'real' csfle library is available. The %s test is a no-op.\n", BSON_FUNC);
+        TEST_STDERR_PRINTF("No 'real' csfle library is available. The %s test is a no-op.\n", BSON_FUNC);
         return;
     }
 

--- a/test/test-mongocrypt-kek.c
+++ b/test/test-mongocrypt-kek.c
@@ -46,7 +46,7 @@ static void _run_one_test(_mongocrypt_tester_t *tester, bson_t *test) {
     }
 
     input_str = bson_as_relaxed_extended_json(&input, NULL);
-    printf("- testcase: %s\n", input_str);
+    TEST_PRINTF("- testcase: %s\n", input_str);
     bson_free(input_str);
 
     ret = _mongocrypt_kek_parse_owned(&input, &kek, status);

--- a/test/test-mongocrypt-key-cache.c
+++ b/test/test-mongocrypt-key-cache.c
@@ -236,7 +236,7 @@ static bool _match_one_cache_entry(_mongocrypt_cache_pair_t *pair, bson_t *expec
     }
 
     if (!_mongocrypt_key_alt_name_unique_list_equal(key_alt_names, attr->alt_names)) {
-        printf("failed to match key alt names\n");
+        TEST_PRINTF("failed to match key alt names\n");
         goto done;
     }
 
@@ -268,7 +268,7 @@ static void _match_cache_entry(_mongocrypt_tester_t *tester, mongocrypt_ctx_t *c
     while (pair) {
         if (_match_one_cache_entry(pair, expected_entry)) {
             if (matched) {
-                printf("double matched entry: %s\n", bson_as_relaxed_extended_json(expected_entry, NULL));
+                TEST_PRINTF("double matched entry: %s\n", bson_as_relaxed_extended_json(expected_entry, NULL));
                 BSON_ASSERT(false);
             }
             matched = true;
@@ -278,7 +278,7 @@ static void _match_cache_entry(_mongocrypt_tester_t *tester, mongocrypt_ctx_t *c
     }
 
     if (!matched) {
-        printf("could not match entry: %s\n", bson_as_relaxed_extended_json(expected_entry, NULL));
+        TEST_PRINTF("could not match entry: %s\n", bson_as_relaxed_extended_json(expected_entry, NULL));
         BSON_ASSERT(false);
     }
 }
@@ -291,11 +291,11 @@ static void _run_one_test(_mongocrypt_tester_t *tester, mongocrypt_ctx_t *ctx, b
     mongocrypt_status_t *status;
 
     if (bson_iter_init_find(&iter, test, "description")) {
-        printf("- %s\n", bson_iter_utf8(&iter, NULL));
+        TEST_PRINTF("- %s\n", bson_iter_utf8(&iter, NULL));
     }
 
     if (bson_iter_init_find(&iter, test, "skipReason")) {
-        printf("  - skipping: %s\n", bson_iter_utf8(&iter, NULL));
+        TEST_PRINTF("  - skipping: %s\n", bson_iter_utf8(&iter, NULL));
         return;
     }
 

--- a/test/test-mongocrypt-kms-responses.c
+++ b/test/test-mongocrypt-kms-responses.c
@@ -51,7 +51,7 @@ static void _test_one_kms_response(_mongocrypt_tester_t *tester, bson_t *test) {
     bson_iter_t ctx_iter;
 
     BSON_ASSERT(bson_iter_init_find(&iter, test, "description"));
-    printf("- %s\n", bson_iter_utf8(&iter, NULL));
+    TEST_PRINTF("- %s\n", bson_iter_utf8(&iter, NULL));
     BSON_ASSERT(bson_iter_init_find(&ctx_iter, test, "ctx"));
     BSON_ASSERT(bson_iter_recurse(&ctx_iter, &ctx_iter));
     while (bson_iter_next(&ctx_iter)) {

--- a/test/test-mongocrypt-kms-responses.c
+++ b/test/test-mongocrypt-kms-responses.c
@@ -94,7 +94,7 @@ static void _test_one_kms_response(_mongocrypt_tester_t *tester, bson_t *test) {
             tester->paths.key_file = "./test/data/key-document-gcp.json";
             ASSERT_OK(mongocrypt_ctx_decrypt_init(ctx, bin), ctx);
         } else {
-            fprintf(stderr, "unsupported ctx type: %s\n", ctx_type);
+            TEST_STDERR_PRINTF("unsupported ctx type: %s\n", ctx_type);
             abort();
         }
 

--- a/test/test-mongocrypt-marking.c
+++ b/test/test-mongocrypt-marking.c
@@ -849,9 +849,9 @@ static void test_mc_get_mincover_from_FLE2RangeFindSpec(_mongocrypt_tester_t *te
         mongocrypt_status_t *status = mongocrypt_status_new();
 
         if (test->description) {
-            printf("  %zu: %s\n", i, test->description);
+            TEST_PRINTF("  %zu: %s\n", i, test->description);
         } else {
-            printf("  %zu\n", i);
+            TEST_PRINTF("  %zu\n", i);
         }
 
         bson_t *findSpecVal = bson_new_from_json((const uint8_t *)test->findSpecJSON, -1, &error);
@@ -1068,7 +1068,7 @@ static mc_ECOCToken_t *getECOCToken(mongocrypt_t *crypt) {
 
 static void test_mc_marking_to_ciphertext(_mongocrypt_tester_t *tester) {
     if (!_aes_ctr_is_supported_by_os) {
-        printf("Common Crypto with no CTR support detected. Skipping.");
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
         return;
     }
 

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -158,12 +158,12 @@ void _mongocrypt_tester_install(_mongocrypt_tester_t *tester,
 #endif
 
     if (crypto_spec == CRYPTO_REQUIRED && !crypto_enabled) {
-        printf("Skipping test: %s – requires crypto to be enabled\n", name);
+        TEST_PRINTF("Skipping test: %s – requires crypto to be enabled\n", name);
         return;
     }
 
     if (crypto_spec == CRYPTO_PROHIBITED && crypto_enabled) {
-        printf("Skipping test: %s – requires crypto to be disabled\n", name);
+        TEST_PRINTF("Skipping test: %s – requires crypto to be disabled\n", name);
         return;
     }
 
@@ -862,8 +862,8 @@ int main(int argc, char **argv) {
     _mongocrypt_tester_t tester = {0};
     int i;
 
-    printf("Pass a list of test names to run only specific tests. E.g.:\n");
-    printf("test-mongocrypt _mongocrypt_test_mcgrew\n\n");
+    TEST_PRINTF("Pass a list of test names to run only specific tests. E.g.:\n");
+    TEST_PRINTF("test-mongocrypt _mongocrypt_test_mcgrew\n\n");
 
     /* Install all tests. */
     _mongocrypt_tester_install_crypto(&tester);
@@ -954,7 +954,7 @@ int main(int argc, char **argv) {
 get_os_version_failed:
 #endif
 
-    printf("Running tests...\n");
+    TEST_PRINTF("Running tests...\n");
     for (i = 0; tester.test_names[i]; i++) {
         int j;
         bool found = false;
@@ -970,16 +970,16 @@ get_os_version_failed:
                 continue;
             }
         }
-        printf("  begin %s\n", tester.test_names[i]);
+        TEST_PRINTF("  begin %s\n", tester.test_names[i]);
         tester.test_fns[i](&tester);
         /* Clear state. */
         memset(&tester.paths, 0, sizeof(tester.paths));
-        printf("  end %s\n", tester.test_names[i]);
+        TEST_PRINTF("  end %s\n", tester.test_names[i]);
     }
-    printf("... done running tests\n");
+    TEST_PRINTF("... done running tests\n");
 
     if (i == 0) {
-        printf("WARNING - no tests run.\n");
+        TEST_PRINTF("WARNING - no tests run.\n");
     }
 
     /* Clean up tester. */

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -52,7 +52,7 @@ void _load_json_as_bson(const char *path, bson_t *out) {
 
     reader = bson_json_reader_new_from_file(path, &error);
     if (!reader) {
-        fprintf(stderr, "error reading: %s\n", path);
+        TEST_STDERR_PRINTF("error reading: %s\n", path);
     }
     ASSERT_OR_PRINT_BSON(reader, error);
     bson_init(out);
@@ -118,7 +118,7 @@ static void _load_http(_mongocrypt_tester_t *tester, const char *path) {
     }
 
     if (n_read < 0) {
-        fprintf(stderr, "failed to read %s\n", path);
+        TEST_STDERR_PRINTF("failed to read %s\n", path);
         abort();
     }
 
@@ -218,7 +218,7 @@ bson_t *_mongocrypt_tester_bson_from_json(_mongocrypt_tester_t *tester, const ch
     bson = &tester->test_bson[tester->bson_count];
     TEST_DATA_COUNT_INC(tester->bson_count);
     if (!bson_init_from_json(bson, full_json, strlen(full_json), &error)) {
-        fprintf(stderr, "%s", error.message);
+        TEST_STDERR_PRINTF("%s", error.message);
         abort();
     }
     bson_free(full_json);
@@ -246,7 +246,7 @@ mongocrypt_binary_t *_mongocrypt_tester_bin_from_json(_mongocrypt_tester_t *test
     bson = &tester->test_bson[tester->bson_count];
     TEST_DATA_COUNT_INC(tester->bson_count);
     if (!bson_init_from_json(bson, full_json, strlen(full_json), &error)) {
-        fprintf(stderr, "failed to parse JSON %s: %s", error.message, json);
+        TEST_STDERR_PRINTF("failed to parse JSON %s: %s", error.message, json);
         abort();
     }
     bin = mongocrypt_binary_new();
@@ -363,7 +363,7 @@ void _mongocrypt_tester_run_ctx_to(_mongocrypt_tester_t *tester,
             break;
         case MONGOCRYPT_CTX_ERROR:
             mongocrypt_ctx_status(ctx, status);
-            fprintf(stderr, "Got error: %s\n", mongocrypt_status_message(status, NULL));
+            TEST_STDERR_PRINTF("Got error: %s\n", mongocrypt_status_message(status, NULL));
             ASSERT_STATE_EQUAL(state, stop_state);
             mongocrypt_status_destroy(status);
             return;


### PR DESCRIPTION
# Summary

- Increase sleep time in `_test_encrypt_cache_expiration`.
- Flush stdout and stderr in tests to fix test log output.

Verified by this [patch build](https://spruce.mongodb.com/version/677e86c33b8c4a0007633e5e). The `debian-package-build*` task failures appear unrelated.

# Background & Motivation

The sleep time in `_test_encrypt_cache_expiration` is increased from 2ms to 10ms to address observed test failures on [Windows tasks](https://spruce.mongodb.com/task/libmongocrypt_windows_test_build_and_test_shared_bson_patch_0727c321e4982446ea235cb613976b68c694b4a8_6777edfd528c89000717db3b_25_01_03_14_02_38/logs?execution=0). I expect this is due to the coarse resolution of `bson_get_monotonic_time` on Windows: CDRIVER-4526. `bson_get_montonic_time` is used to [check the current time](https://github.com/mongodb/libmongocrypt/blob/9262d91c40d28c4ebc8cc50c475b4435afc94529/src/mongocrypt-cache.c#L28). Pending CDRIVER-4526, the test is updated to increase the sleep time to 20ms.

`TEST_PRINTF` and `TEST_STDERR_PRINTF` macros are added to flush stdout and stderr. This is intended to fix mixed log output from stdout and stderr. [Before](https://spruce.mongodb.com/task/libmongocrypt_windows_test_build_and_test_shared_bson_patch_0727c321e4982446ea235cb613976b68c694b4a8_6777edfd528c89000717db3b_25_01_03_14_02_38/logs?execution=0):

```
[2025/01/03 09:20:41.815] End test 'NIST CAVP No 'real' csfle library is available. The _test_encrypt_csfle_no_needs_markings test is a no-op.C:\data\mci\17866ad9f3891046e65d08db63c551ae\libmongocrypt\test\test-mongocrypt-ctx-encrypt.c:774 _test_encrypt_cache_expiration(): precondition failed: mongocrypt_ctx_state(ctx) == MONGOCRYPT_CTX_NEED_MONGO_KEYS
```

[After](https://spruce.mongodb.com/task/libmongocrypt_windows_test_build_and_test_shared_bson_patch_0727c321e4982446ea235cb613976b68c694b4a8_677d9c383669330007690f84_25_01_07_21_27_20/logs?execution=0):
```
[2025/01/07 16:29:44.388]   begin _test_encrypt_cache_expiration
[2025/01/07 16:29:44.388] C:\data\mci\01ac186cc57bfcd8230260d4e398ff47\libmongocrypt\test\test-mongocrypt-ctx-encrypt.c:774 _test_encrypt_cache_expiration(): precondition failed: mongocrypt_ctx_state(ctx) == MONGOCRYPT_CTX_NEED_MONGO_KEYS
```

Source files in `kms-message` are not currently formatted to the current `.clang-format`. This PR does not attempt to reformat. I used the `.clang-format` file from https://github.com/mongodb/libmongocrypt/commit/8c9ed66d45ac0b2a33d3b5d3fa533e52bde9509e and ignored format-only diffs.
