### PR TITLE
use script from drivers evergreen tools to find python

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -14,6 +14,40 @@ functions:
           rm -rf ~/.aws ~/.notary_env.sh
           exit 0
 
+  "fetch drivers-evergreen-tools":
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
+        args:
+          - -c
+          - |
+            if [[ ! -d drivers-evergreen-tools ]]; then
+                git clone --depth=1 https://github.com/mongodb-labs/drivers-evergreen-tools.git
+            fi
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
+        working_dir: drivers-evergreen-tools
+        args:
+          - -c
+          - find .evergreen -type f -name "*.sh" -exec chmod +rx "{}" \;
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
+        args:
+          - -c
+          - |
+            set -o errexit
+            . drivers-evergreen-tools/.evergreen/find-python3.sh
+            echo "PYTHON3_BINARY: $(find_python3)" >|python3_binary.yml
+    - command: expansions.update
+      type: setup
+      params:
+        file: python3_binary.yml
+
   "fetch source":
     - command: git.get_project
       params: {directory: libmongocrypt}
@@ -89,7 +123,7 @@ functions:
         shell: bash
         script: |
           env "WORKDIR=${workdir}" \
-              "PYTHON=${python|}" \
+              "PYTHON=${PYTHON3_BINARY|}" \
               "HAS_PACKAGES=${has_packages|false}" \
               "PACKAGER_DISTRO=${packager_distro}" \
               "PACKAGER_ARCH=${packager_arch}" \
@@ -360,6 +394,7 @@ tasks:
   - func: "fetch source"
   - func: "build and test"
   - func: "tar and upload libmongocrypt libraries"
+  - func: "fetch drivers-evergreen-tools" # Set PYTHON3_BINARY.
   - func: "create packages and repos"
   - func: "upload packages and repos"
 
@@ -1155,7 +1190,6 @@ buildvariants:
     has_packages: true
     packager_distro: debian12
     packager_arch: x86_64
-    python: python3
   tasks:
   - build-and-test-and-upload
   - name: publish-packages

--- a/.evergreen/create-packages-and-repos.sh
+++ b/.evergreen/create-packages-and-repos.sh
@@ -22,7 +22,9 @@ if test -d "$WORKDIR/venv"; then
   fi
   python=python
 else
-  python="${PYTHON:-/opt/mongodbtoolchain/v3/bin/python3}"
+  # Require PYTHON be set:
+  : "${PYTHON:?}"
+  python="${PYTHON}"
 fi
 
 export PYTHONPATH


### PR DESCRIPTION
To fix an observed error on [RHEL 7.1 ppc64el](https://spruce.mongodb.com/task/libmongocrypt_rhel_71_ppc64el_build_and_test_and_upload_5b381e9968cdc8d39fbad7ef9bd60c38bd838c41_25_01_09_21_28_37/logs?execution=0):

```
/opt/mongodbtoolchain/v3/bin/python3: /lib64/libc.so.6: version `GLIBC_2.25' not found (required by /opt/mongodbtoolchain/revisions/69f4f0673ffcb290ce2307560a4883ecf2ad138c/stow/openssl.Dd4/lib/libcrypto.so.1.1)
```

Verified by this [patch build](https://spruce.mongodb.com/version/678664ae6eb3120007b4e83f).

Uses the find-python3 script from drivers-evergreen-tools to find a working version of Python on the host.


