### PR TITLE
MONGOCRYPT-766 Fix compilation in C23

### DIFF
--- a/kms-message/src/kms_request.c
+++ b/kms-message/src/kms_request.c
@@ -789,7 +789,7 @@ kms_request_get_signed (kms_request_t *request)
    }
 
    if (!check_and_prohibit_kmip (request)) {
-      return false;
+      return NULL;
    }
 
    if (!finalize (request)) {
@@ -857,11 +857,11 @@ kms_request_to_string (kms_request_t *request)
    size_t i;
 
    if (!finalize (request)) {
-      return false;
+      return NULL;
    }
 
    if (!check_and_prohibit_kmip (request)) {
-      return false;
+      return NULL;
    }
 
    if (request->to_string) {


### PR DESCRIPTION
```
kms/kms_request.c:792:14: warning: initialization of pointer of type
'char *' to null from a constant boolean expression
[-Wbool-conversion]
      return false;
             ^~~~~
kms/kms_request.c:860:14: warning: initialization of pointer of type
'char *' to null from a constant boolean expression
[-Wbool-conversion]
      return false;
             ^~~~~
kms/kms_request.c:864:14: warning: initialization of pointer of type
'char *' to null from a constant boolean expression
[-Wbool-conversion]
      return false;
             ^~~~~
```