### PR TITLE
MONGOCRYPT-770 do not warn if local schema does not require encryption

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -792,13 +792,7 @@ static bool _mongo_feed_markings(mongocrypt_ctx_t *ctx, mongocrypt_binary_t *in)
 
     if (bson_iter_init_find(&iter, &as_bson, "schemaRequiresEncryption") && !bson_iter_as_bool(&iter)) {
         /* TODO: update cache: this schema does not require encryption. */
-
-        /* If using a local schema, warn if there are no encrypted fields. */
-        if (ectx->used_local_schema) {
-            _mongocrypt_log(&ctx->crypt->log,
-                            MONGOCRYPT_LOG_LEVEL_WARNING,
-                            "local schema used but does not have encryption specifiers");
-        }
+        // Schema does not require encryption. Skip copying the `result`.
         return true;
     } else {
         /* if the schema requires encryption, but has sibling validators, error.


### PR DESCRIPTION
# Summary

Do not warn if local schema does not require encryption

Verified by this patch build: https://spruce.mongodb.com/version/679f718a7f3b450007729cee

# Background & Motivation

libmongocrypt currently logs a warning if a response from query analysis (mongocryptd/crypt_shared) indicates a local schema does not require encryption. However, this log is generated even for an empty local schema. I do not expect configuring an empty local schema to be discouraged. Quoting [the spec](https://github.com/mongodb/specifications/blob/d9b434db87abec375df46864d4fedb2297bc80ec/source/client-side-encryption/client-side-encryption.md):

> Drivers MUST document that a local schema is more secure

I expect this warning was intended to inform users that non-encryption JSON schema validation does not apply. However, mongocryptd already errors if a local schema is sent with JSON schema keywords that do not apply. [Example](https://github.com/kevinAlbs/iue-bootstrap/blob/9d1646c5756883173325696b2580424818c94141/investigations/error-on-local-with-jsonSchema-keywords.py#L32-L34):

```python
client = MongoClient(auto_encryption_opts=opts)
client.drop_database("db")
client["db"]["coll"].insert_one({}) # Exception: JSON schema keyword 'required' is only allowed with a remote schema
```

Query analysis 8.1 supports a new field `csfleEncryptionSchemas` to accept multiple JSON Schemas. The replied `schemaRequiresEncryption` only indiciates if *any* of the sent schemas require encryption. Multiple schemas further complicates this warning check (E.g. should libmongocrypt warn if `"schemaRequiresEncryption": false` and all schemas are local and non-empty?).

Since the warning seems flawed and redundant with checks done in query analysis, this PR proposes removing.