### PR TITLE
MONGOCRYPT-771 Remove check for `$jsonSchema` siblings

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -426,8 +426,7 @@ static bool _set_schema_from_collinfo(mongocrypt_ctx_t *ctx, bson_t *collinfo) {
                     return _mongocrypt_ctx_fail_w_msg(ctx, "malformed $jsonSchema");
                 }
                 found_jsonschema = true;
-            } else {
-                ectx->collinfo_has_siblings = true;
+                break;
             }
         }
     }
@@ -800,15 +799,6 @@ static bool _mongo_feed_markings(mongocrypt_ctx_t *ctx, mongocrypt_binary_t *in)
                             "local schema used but does not have encryption specifiers");
         }
         return true;
-    } else {
-        /* if the schema requires encryption, but has sibling validators, error.
-         */
-        if (ectx->collinfo_has_siblings) {
-            return _mongocrypt_ctx_fail_w_msg(ctx,
-                                              "schema requires encryption, "
-                                              "but collection JSON schema "
-                                              "validator has siblings");
-        }
     }
 
     if (bson_iter_init_find(&iter, &as_bson, "hasEncryptedPlaceholders") && !bson_iter_as_bool(&iter)) {

--- a/src/mongocrypt-ctx-private.h
+++ b/src/mongocrypt-ctx-private.h
@@ -178,9 +178,6 @@ typedef struct {
     _mongocrypt_buffer_t encrypted_cmd;
     _mongocrypt_buffer_t key_id;
     bool used_local_schema;
-    /* collinfo_has_siblings is true if the schema came from a remote JSON
-     * schema, and there were siblings. */
-    bool collinfo_has_siblings;
     /* encrypted_field_config is set when:
      * 1. `target_ns` is present in an encrypted_field_config_map.
      * 2. (TODO MONGOCRYPT-414) The collection has encryptedFields in the

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1004,9 +1004,8 @@ static void _test_encrypt_invalid_siblings(_mongocrypt_tester_t *tester) {
     ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
 
     BSON_ASSERT(MONGOCRYPT_CTX_NEED_MONGO_MARKINGS == mongocrypt_ctx_state(ctx));
-    ASSERT_FAILS(mongocrypt_ctx_mongo_feed(ctx, TEST_FILE("./test/example/mongocryptd-reply.json")),
-                 ctx,
-                 "JSON schema validator has siblings");
+    // MONGOCRYPT-771 removes checks for sibling validators.
+    ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TEST_FILE("./test/example/mongocryptd-reply.json")), ctx);
 
     mongocrypt_ctx_destroy(ctx);
     mongocrypt_destroy(crypt);

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -1011,25 +1011,6 @@ static void _test_encrypt_invalid_siblings(_mongocrypt_tester_t *tester) {
     mongocrypt_destroy(crypt);
 }
 
-static void _test_encrypt_dupe_jsonschema(_mongocrypt_tester_t *tester) {
-    mongocrypt_t *crypt;
-    mongocrypt_ctx_t *ctx;
-
-    crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
-    ctx = mongocrypt_ctx_new(crypt);
-    ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "test", -1, TEST_FILE("./test/example/cmd.json")), ctx);
-
-    BSON_ASSERT(MONGOCRYPT_CTX_NEED_MONGO_COLLINFO == mongocrypt_ctx_state(ctx));
-    ASSERT_FAILS(mongocrypt_ctx_mongo_feed(ctx,
-                                           TEST_BSON("{'options': {'validator': { '$jsonSchema': {}, "
-                                                     "'$jsonSchema': {} } } }")),
-                 ctx,
-                 "duplicate $jsonSchema");
-
-    mongocrypt_ctx_destroy(ctx);
-    mongocrypt_destroy(crypt);
-}
-
 static void _test_encrypting_with_explicit_encryption(_mongocrypt_tester_t *tester) {
     /* Test that we do not strip existing ciphertexts when automatically
      * encrypting a document. */
@@ -4689,7 +4670,6 @@ void _mongocrypt_tester_install_ctx_encrypt(_mongocrypt_tester_t *tester) {
     INSTALL_TEST(_test_encrypt_is_remote_schema);
     INSTALL_TEST(_test_encrypt_init_each_cmd);
     INSTALL_TEST(_test_encrypt_invalid_siblings);
-    INSTALL_TEST(_test_encrypt_dupe_jsonschema);
     INSTALL_TEST(_test_encrypting_with_explicit_encryption);
     INSTALL_TEST(_test_explicit_encryption);
     INSTALL_TEST(_test_encrypt_empty_aws);


### PR DESCRIPTION
# Summary

Do not error if remote `$jsonSchema` has sibling fields.

# Background & Motivation

When processing a response to `listCollections`, libmongocrypt only checks the response for a top-level `$jsonSchema` within `validator`.

libmongocrypt errors if the `$jsonSchema` has sibling fields and query analysis (mongocryptd/crypt_shared) indicates the JSON Schema has encrypted fields:

```python
db.command({
    "create": "coll",
    "validator": {
        "$jsonSchema": csfle_schema, # Defines 'secret' as encrypted.
        "secret": "foo" # Sibling validator contradicts the JSON schema.
    }
})

encrypted_db["coll"].find_one({}) # Error: schema requires encryption, but collection JSON schema validator has siblings
```

The [spec says this of the motivation](https://github.com/mongodb/specifications/blob/d9b434db87abec375df46864d4fedb2297bc80ec/source/client-side-encryption/client-side-encryption.md#why-limit-to-one-top-level-jsonschema):

> If we allow siblings, we can run into cases where the user specifies a top-level `$and`/`$or` or any arbitrary match-expression that could have nested `$jsonSchema`'s.

However, this check seems incomplete. A validator can have a single top-level JSON schema keyword, and reference encrypted fields:

```python
db.command({
    "create": "coll",
    "validator": {
        "$or": [{"$jsonSchema": csfle_schema}, {"foo": "bar"}]
    }
})

encrypted_db["coll"].insert_one({"secret": "blah", "foo": "bar"}) # libmongocrypt ignores $jsonSchema.
self.assertEqual (db["coll"].find_one()["secret"], "blah") # Unencrypted!
```

And this check can error in valid cases:
```python
db.command({
    "create": "coll",
    "validator": {
        "$jsonSchema": csfle_schema, # Defines 'secret' as encrypted.
        "unrelated": "foo" # Sibling validator does not contradict the JSON schema.
    }
})

with self.assertRaises(EncryptionError) as ctx:
    encrypted_db["coll"].find_one({})
self.assertIn("schema requires encryption, but collection JSON schema validator has siblings", str(ctx.exception))
```

I do not expect this check is useful. If a `$jsonSchema` has sibling fields that contradict the `$jsonSchema`, I expect that is a misconfiguration that would be discovered soon after attempting to insert data. If the siblings do not contradict the JSON Schema, then there is no reason to error.

Related to: https://github.com/mongodb/libmongocrypt/pull/947, query analysis 8.1 supports a new field `csfleEncryptionSchemas` to accept multiple JSON Schemas. The replied `schemaRequiresEncryption` only indicates if __any__ of the sent schemas require encryption. Multiple schemas further complicates this check (I.e. if libmongocrypt gets `"schemaRequiresEncryption": true` it does not know which of the JSON Schemas required encryption).
