### PR TITLE
PYTHON-5047 Fix static scan in release process

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -70,7 +70,7 @@ jobs:
 
   static-scan:
     needs: [pre-publish]
-    uses: ./.github/workflows/codeql.yml
+    uses: ./.github/workflows/codeql-python.yml
     with:
       ref: ${{ needs.pre-publish.outputs.version }}
 


### PR DESCRIPTION
Error seen during overnight build: https://github.com/mongodb/libmongocrypt/actions/runs/13172517847

[Invalid workflow file: .github/workflows/release-python.yml#L73](https://github.com/mongodb/libmongocrypt/actions/runs/13172517847/workflow)
error parsing called workflow ".github/workflows/release-python.yml" -> "./.github/workflows/codeql.yml" : failed to fetch workflow: workflow was not found.