### PR TITLE
MONGOCRYPT-723 support `$lookup`

### DIFF
--- a/integrating.md
+++ b/integrating.md
@@ -144,7 +144,9 @@ All contexts.
 > [!IMPORTANT]
 > **Multi-collection commands**: prior to 1.13.0, drivers were expected to pass _at most one result_ from `listCollections`. In 1.13.0, drivers are expected to pass _all results_ from `listCollections` to support multi-collection commands (e.g. aggregate with `$lookup`).
 >
-> Drivers must call `mongocrypt_setopt_enable_multiple_collinfo` to indicate the new behavior is implemented and enable support for multi-collection commands.
+> Drivers must call `mongocrypt_setopt_enable_multiple_collinfo` to indicate the new behavior is implemented and opt-in to support for multi-collection commands.
+>
+> The opt-in is avoids the following example scenario: Driver upgrades to 1.13.0 and does not update the behavior. A multi-collection command requests schemas for both `db.c1` and `db.c2`. Driver only passes the result for `db.c1` (even though `db.c2` has a result). libmongocrypt mistakenly assumes `db.c2` has no schema.
 
 **libmongocrypt needs**...
 

--- a/integrating.md
+++ b/integrating.md
@@ -140,6 +140,14 @@ All contexts.
 
 #### State: `MONGOCRYPT_CTX_NEED_MONGO_COLLINFO` ####
 
+##### Multi-collection commands
+Prior to 1.13.0, drivers were expected to return at most one result from `listCollections`. In 1.13.0, drivers are
+expected to return all results to support multi-collection commands (e.g. aggregate with `$lookup`).
+
+libmongocrypt cannot distinguish between "did not pass all results" and "server did not have results". Drivers must call
+`mongocrypt_setopt_enable_multiple_collinfo` to indicate the new behavior is implemented and enable support for
+multi-collection commands.
+
 **libmongocrypt needs**...
 
 A result from a listCollections cursor.
@@ -148,7 +156,7 @@ A result from a listCollections cursor.
 
 1.  Run listCollections on the encrypted MongoClient with the filter
     provided by `mongocrypt_ctx_mongo_op`
-2.  Return the first result (if any) with `mongocrypt_ctx_mongo_feed` or proceed to the next step if nothing was returned.
+2.  Return all results (if any) with calls to `mongocrypt_ctx_mongo_feed` or proceed to the next step if nothing was returned.
 3.  Call `mongocrypt_ctx_mongo_done`
 
 **Applies to...**
@@ -156,6 +164,8 @@ A result from a listCollections cursor.
 auto encrypt
 
 #### State: `MONGOCRYPT_CTX_NEED_MONGO_COLLINFO_WITH_DB` ####
+
+See [note](#multi-collection-commands) about multi-collection commands.
 
 **libmongocrypt needs**...
 
@@ -165,7 +175,7 @@ Results from a listCollections cursor from a specified database.
 
 1.  Run listCollections on the encrypted MongoClient with the filter
     provided by `mongocrypt_ctx_mongo_op` on the database provided by `mongocrypt_ctx_mongo_db`.
-2.  Return the first result (if any) with `mongocrypt_ctx_mongo_feed` or proceed to the next step if nothing was returned.
+2.  Return all results (if any) with calls to `mongocrypt_ctx_mongo_feed` or proceed to the next step if nothing was returned.
 3.  Call `mongocrypt_ctx_mongo_done`
 
 **Applies to...**

--- a/integrating.md
+++ b/integrating.md
@@ -143,9 +143,11 @@ All contexts.
 > [!IMPORTANT]
 > <a name="multi-collection-commands"></a> **Multi-collection commands**: prior to 1.13.0, drivers were expected to pass _at most one result_ from `listCollections`. In 1.13.0, drivers are expected to pass _all results_ from `listCollections` to support multi-collection commands (e.g. aggregate with `$lookup`).
 >
-> Drivers must call `mongocrypt_setopt_enable_multiple_collinfo` to indicate the new behavior is implemented and opt-in to support for multi-collection commands.
->
-> The opt-in is avoids the following example scenario: Driver upgrades to 1.13.0 and does not update the behavior. A multi-collection command requests schemas for both `db.c1` and `db.c2`. Driver only passes the result for `db.c1` (even though `db.c2` has a result). libmongocrypt mistakenly assumes `db.c2` has no schema.
+> Drivers must call `mongocrypt_setopt_enable_multiple_collinfo` to indicate the new behavior is implemented and opt-in to support for multi-collection commands. This opt-in is to prevent the following bug scenario:
+> > A driver upgrades to 1.13.0, but does not update prior behavior which passes at most one result of a multi-collection command.
+> > A multi-collection command requests schemas for both `db.c1` and `db.c2`.
+> > The driver only passes the result for `db.c1` even though `db.c2` also has a result.
+> > Therefore, libmongocrypt incorrectly believes `db.c2` has no schema.
 
 **libmongocrypt needs**...
 

--- a/integrating.md
+++ b/integrating.md
@@ -140,9 +140,8 @@ All contexts.
 
 #### State: `MONGOCRYPT_CTX_NEED_MONGO_COLLINFO` ####
 
-<a name="multi-collection-commands"></a>
 > [!IMPORTANT]
-> **Multi-collection commands**: prior to 1.13.0, drivers were expected to pass _at most one result_ from `listCollections`. In 1.13.0, drivers are expected to pass _all results_ from `listCollections` to support multi-collection commands (e.g. aggregate with `$lookup`).
+> <a name="multi-collection-commands"></a> **Multi-collection commands**: prior to 1.13.0, drivers were expected to pass _at most one result_ from `listCollections`. In 1.13.0, drivers are expected to pass _all results_ from `listCollections` to support multi-collection commands (e.g. aggregate with `$lookup`).
 >
 > Drivers must call `mongocrypt_setopt_enable_multiple_collinfo` to indicate the new behavior is implemented and opt-in to support for multi-collection commands.
 >

--- a/integrating.md
+++ b/integrating.md
@@ -156,7 +156,7 @@ A result from a listCollections cursor.
 
 1.  Run listCollections on the encrypted MongoClient with the filter
     provided by `mongocrypt_ctx_mongo_op`
-2.  Pass all results (if any) with calls to `mongocrypt_ctx_mongo_feed` or proceed to the next step if nothing was passed. Results may be passed in any order.
+2.  Pass all results (if any) with calls to `mongocrypt_ctx_mongo_feed` or proceed to the next step if nothing was returned. Results may be passed in any order.
 3.  Call `mongocrypt_ctx_mongo_done`
 
 **Applies to...**
@@ -175,7 +175,7 @@ Results from a listCollections cursor from a specified database.
 
 1.  Run listCollections on the encrypted MongoClient with the filter
     provided by `mongocrypt_ctx_mongo_op` on the database provided by `mongocrypt_ctx_mongo_db`.
-2.  Pass all results (if any) with calls to `mongocrypt_ctx_mongo_feed` or proceed to the next step if nothing was passed. Results may be passed in any order.
+2.  Pass all results (if any) with calls to `mongocrypt_ctx_mongo_feed` or proceed to the next step if nothing was returned. Results may be passed in any order.
 3.  Call `mongocrypt_ctx_mongo_done`
 
 **Applies to...**

--- a/integrating.md
+++ b/integrating.md
@@ -156,7 +156,7 @@ A result from a listCollections cursor.
 
 1.  Run listCollections on the encrypted MongoClient with the filter
     provided by `mongocrypt_ctx_mongo_op`
-2.  Return all results (if any) with calls to `mongocrypt_ctx_mongo_feed` or proceed to the next step if nothing was returned.
+2.  Pass all results (if any) with calls to `mongocrypt_ctx_mongo_feed` or proceed to the next step if nothing was passed. Results may be passed in any order.
 3.  Call `mongocrypt_ctx_mongo_done`
 
 **Applies to...**
@@ -175,7 +175,7 @@ Results from a listCollections cursor from a specified database.
 
 1.  Run listCollections on the encrypted MongoClient with the filter
     provided by `mongocrypt_ctx_mongo_op` on the database provided by `mongocrypt_ctx_mongo_db`.
-2.  Return all results (if any) with calls to `mongocrypt_ctx_mongo_feed` or proceed to the next step if nothing was returned.
+2.  Pass all results (if any) with calls to `mongocrypt_ctx_mongo_feed` or proceed to the next step if nothing was passed. Results may be passed in any order.
 3.  Call `mongocrypt_ctx_mongo_done`
 
 **Applies to...**

--- a/integrating.md
+++ b/integrating.md
@@ -140,13 +140,11 @@ All contexts.
 
 #### State: `MONGOCRYPT_CTX_NEED_MONGO_COLLINFO` ####
 
-##### Multi-collection commands
-Prior to 1.13.0, drivers were expected to return at most one result from `listCollections`. In 1.13.0, drivers are
-expected to return all results to support multi-collection commands (e.g. aggregate with `$lookup`).
-
-libmongocrypt cannot distinguish between "did not pass all results" and "server did not have results". Drivers must call
-`mongocrypt_setopt_enable_multiple_collinfo` to indicate the new behavior is implemented and enable support for
-multi-collection commands.
+<a name="multi-collection-commands"></a>
+> [!IMPORTANT]
+> **Multi-collection commands**: prior to 1.13.0, drivers were expected to pass _at most one result_ from `listCollections`. In 1.13.0, drivers are expected to pass _all results_ from `listCollections` to support multi-collection commands (e.g. aggregate with `$lookup`).
+>
+> Drivers must call `mongocrypt_setopt_enable_multiple_collinfo` to indicate the new behavior is implemented and enable support for multi-collection commands.
 
 **libmongocrypt needs**...
 

--- a/src/mc-schema-broker-private.h
+++ b/src/mc-schema-broker-private.h
@@ -41,6 +41,9 @@ void mc_schema_broker_use_rangev2(mc_schema_broker_t *sb);
 // Returns error if two requests have different databases (not-yet supported).
 bool mc_schema_broker_request(mc_schema_broker_t *sb, const char *db, const char *coll, mongocrypt_status_t *status);
 
+// mc_schema_broker_has_multiple_requests returns true if there are requests for multiple unique collections
+bool mc_schema_broker_has_multiple_requests(const mc_schema_broker_t *sb);
+
 // mc_schema_broker_append_listCollections_filter appends a filter to use with the listCollections command.
 // Example: { "name": { "$in": [ "coll1", "coll2" ] } }
 // The filter matches all not-yet-satisfied collections.

--- a/src/mc-schema-broker.c
+++ b/src/mc-schema-broker.c
@@ -93,6 +93,11 @@ bool mc_schema_broker_request(mc_schema_broker_t *sb, const char *db, const char
     return true;
 }
 
+bool mc_schema_broker_has_multiple_requests(const mc_schema_broker_t *sb) {
+    BSON_ASSERT_PARAM(sb);
+    return sb->ll_len > 1;
+}
+
 void mc_schema_broker_destroy(mc_schema_broker_t *sb) {
     if (!sb) {
         return;

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -2509,7 +2509,7 @@ bool mongocrypt_ctx_encrypt_init(mongocrypt_ctx_t *ctx, const char *db, int32_t 
         bson_free(cmd_val);
     }
 
-    // Check if an isMaster request to mongocryptd is needed check for feature support:
+    // Check if an isMaster request to mongocryptd is needed to detect feature support:
     if (needs_ismaster_check(ctx)) {
         ectx->ismaster.needed = true;
         ctx->state = MONGOCRYPT_CTX_NEED_MONGO_MARKINGS;

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -2374,11 +2374,7 @@ find_collections_in_agg(mongocrypt_binary_t *cmd, mc_schema_broker_t *sb, const 
         return true;
     }
 
-    if (!find_collections_in_pipeline(sb, iter, db, mstrv_lit("aggregate.pipeline"), status)) {
-        return false;
-    }
-
-    return true;
+    return find_collections_in_pipeline(sb, iter, db, mstrv_lit("aggregate.pipeline"), status);
 }
 
 bool mongocrypt_ctx_encrypt_init(mongocrypt_ctx_t *ctx, const char *db, int32_t db_len, mongocrypt_binary_t *cmd) {

--- a/src/mongocrypt-private.h
+++ b/src/mongocrypt-private.h
@@ -130,6 +130,7 @@ struct _mongocrypt_t {
     /// Pointer to the global csfle_lib object. Should not be freed directly.
     mongo_crypt_v1_lib *csfle_lib;
     bool retry_enabled;
+    bool multiple_collinfo_enabled;
 };
 
 typedef enum {

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -166,6 +166,12 @@ bool mongocrypt_setopt_retry_kms(mongocrypt_t *crypt, bool enable) {
     return true;
 }
 
+bool mongocrypt_setopt_enable_multiple_collinfo(mongocrypt_t *crypt) {
+    ASSERT_MONGOCRYPT_PARAM_UNINIT(crypt);
+    crypt->multiple_collinfo_enabled = true;
+    return true;
+}
+
 bool mongocrypt_setopt_kms_provider_aws(mongocrypt_t *crypt,
                                         const char *aws_access_key_id,
                                         int32_t aws_access_key_id_len,

--- a/src/mongocrypt.h
+++ b/src/mongocrypt.h
@@ -323,6 +323,17 @@ MONGOCRYPT_EXPORT
 bool mongocrypt_setopt_retry_kms(mongocrypt_t *crypt, bool enable);
 
 /**
+ * Enable support for multiple collection schemas. Required to support $lookup.
+ *
+ * @param[in] crypt The @ref mongocrypt_t object.
+ * @pre @ref mongocrypt_init has not been called on @p crypt.
+ * @returns A boolean indicating success. If false, an error status is set.
+ * Retrieve it with @ref mongocrypt_ctx_status
+ */
+MONGOCRYPT_EXPORT
+bool mongocrypt_setopt_enable_multiple_collinfo(mongocrypt_t *crypt);
+
+/**
  * Configure an AWS KMS provider on the @ref mongocrypt_t object.
  *
  * This has been superseded by the more flexible:

--- a/test/data/lookup/csfle-facet/cmd.json
+++ b/test/data/lookup/csfle-facet/cmd.json
@@ -1,0 +1,20 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$facet": {
+            "output": [
+               {
+                  "$lookup": {
+                     "from": "c2",
+                     "localField": "joinme",
+                     "foreignField": "joinme",
+                     "as": "matched"
+                  }
+               }
+            ]
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/csfle-mismatch/cmd.json
+++ b/test/data/lookup/csfle-mismatch/cmd.json
@@ -1,0 +1,14 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/csfle-mismatch/collInfo-c1.json
+++ b/test/data/lookup/csfle-mismatch/collInfo-c1.json
@@ -1,0 +1,39 @@
+{
+    "type": "collection",
+    "name": "c1",
+    "idIndex": {
+        "ns": "db.c1",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {
+        "validator": {
+            "$jsonSchema": {
+                "properties": {
+                    "e1": {
+                        "encrypt": {
+                            "keyId": [
+                                {
+                                    "$binary": {
+                                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                        "subType": "04"
+                                    }
+                                }
+                            ],
+                            "bsonType": "string",
+                            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                        }
+                    }
+                },
+                "bsonType": "object"
+            }
+        }
+    }
+}

--- a/test/data/lookup/csfle-mismatch/collInfo-c3.json
+++ b/test/data/lookup/csfle-mismatch/collInfo-c3.json
@@ -1,0 +1,39 @@
+{
+    "type": "collection",
+    "name": "c3",
+    "idIndex": {
+        "ns": "db.c3",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {
+        "validator": {
+            "$jsonSchema": {
+                "properties": {
+                    "e2": {
+                        "encrypt": {
+                            "keyId": [
+                                {
+                                    "$binary": {
+                                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                        "subType": "04"
+                                    }
+                                }
+                            ],
+                            "bsonType": "string",
+                            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                        }
+                    }
+                },
+                "bsonType": "object"
+            }
+        }
+    }
+}

--- a/test/data/lookup/csfle-nested/cmd.json
+++ b/test/data/lookup/csfle-nested/cmd.json
@@ -1,0 +1,24 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched",
+            "pipeline": [
+               {
+                  "$lookup": {
+                     "from": "c3",
+                     "localField": "joinme",
+                     "foreignField": "joinme",
+                     "as": "matched"
+                  }
+               }
+            ]
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/csfle-only-schemaMap/cmd-to-mongocryptd.json
+++ b/test/data/lookup/csfle-only-schemaMap/cmd-to-mongocryptd.json
@@ -1,0 +1,60 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      }
+   ],
+   "cursor": {},
+   "csfleEncryptionSchemas": {
+      "db.c1": {
+         "jsonSchema": {
+            "properties": {
+               "e1": {
+                  "encrypt": {
+                     "keyId": [
+                        {
+                           "$binary": {
+                              "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                              "subType": "04"
+                           }
+                        }
+                     ],
+                     "bsonType": "string",
+                     "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+               }
+            },
+            "bsonType": "object"
+         },
+         "isRemoteSchema": false
+      },
+      "db.c2": {
+         "jsonSchema": {
+            "properties": {
+               "e2": {
+                  "encrypt": {
+                     "keyId": [
+                        {
+                           "$binary": {
+                              "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                              "subType": "04"
+                           }
+                        }
+                     ],
+                     "bsonType": "string",
+                     "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+               }
+            },
+            "bsonType": "object"
+         },
+         "isRemoteSchema": false
+      }
+   }
+}

--- a/test/data/lookup/csfle-only-schemaMap/cmd.json
+++ b/test/data/lookup/csfle-only-schemaMap/cmd.json
@@ -1,0 +1,14 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/csfle-only-schemaMap/schemaMap.json
+++ b/test/data/lookup/csfle-only-schemaMap/schemaMap.json
@@ -1,0 +1,40 @@
+{
+   "db.c1": {
+      "properties": {
+         "e1": {
+            "encrypt": {
+               "keyId": [
+                  {
+                     "$binary": {
+                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                        "subType": "04"
+                     }
+                  }
+               ],
+               "bsonType": "string",
+               "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+            }
+         }
+      },
+      "bsonType": "object"
+   },
+   "db.c2": {
+      "properties": {
+         "e2": {
+            "encrypt": {
+               "keyId": [
+                  {
+                     "$binary": {
+                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                        "subType": "04"
+                     }
+                  }
+               ],
+               "bsonType": "string",
+               "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+            }
+         }
+      },
+      "bsonType": "object"
+   }
+}

--- a/test/data/lookup/csfle-schemaMap/cmd-to-mongocryptd.json
+++ b/test/data/lookup/csfle-schemaMap/cmd-to-mongocryptd.json
@@ -1,0 +1,60 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      }
+   ],
+   "cursor": {},
+   "csfleEncryptionSchemas": {
+      "db.c1": {
+         "jsonSchema": {
+            "properties": {
+               "e1": {
+                  "encrypt": {
+                     "keyId": [
+                        {
+                           "$binary": {
+                              "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                              "subType": "04"
+                           }
+                        }
+                     ],
+                     "bsonType": "string",
+                     "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+               }
+            },
+            "bsonType": "object"
+         },
+         "isRemoteSchema": true
+      },
+      "db.c2": {
+         "jsonSchema": {
+            "properties": {
+               "e2": {
+                  "encrypt": {
+                     "keyId": [
+                        {
+                           "$binary": {
+                              "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                              "subType": "04"
+                           }
+                        }
+                     ],
+                     "bsonType": "string",
+                     "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+               }
+            },
+            "bsonType": "object"
+         },
+         "isRemoteSchema": false
+      }
+   }
+}

--- a/test/data/lookup/csfle-schemaMap/cmd.json
+++ b/test/data/lookup/csfle-schemaMap/cmd.json
@@ -1,0 +1,14 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/csfle-schemaMap/collInfo-c1.json
+++ b/test/data/lookup/csfle-schemaMap/collInfo-c1.json
@@ -1,0 +1,39 @@
+{
+    "type": "collection",
+    "name": "c1",
+    "idIndex": {
+        "ns": "db.c1",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {
+        "validator": {
+            "$jsonSchema": {
+                "properties": {
+                    "e1": {
+                        "encrypt": {
+                            "keyId": [
+                                {
+                                    "$binary": {
+                                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                        "subType": "04"
+                                    }
+                                }
+                            ],
+                            "bsonType": "string",
+                            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                        }
+                    }
+                },
+                "bsonType": "object"
+            }
+        }
+    }
+}

--- a/test/data/lookup/csfle-schemaMap/schemaMap.json
+++ b/test/data/lookup/csfle-schemaMap/schemaMap.json
@@ -1,0 +1,21 @@
+{
+   "db.c2": {
+      "properties": {
+         "e2": {
+            "encrypt": {
+               "keyId": [
+                  {
+                     "$binary": {
+                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                        "subType": "04"
+                     }
+                  }
+               ],
+               "bsonType": "string",
+               "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+            }
+         }
+      },
+      "bsonType": "object"
+   }
+}

--- a/test/data/lookup/csfle-self/cmd-to-mongocryptd.json
+++ b/test/data/lookup/csfle-self/cmd-to-mongocryptd.json
@@ -1,0 +1,34 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c1",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      }
+   ],
+   "cursor": {},
+   "jsonSchema": {
+      "properties": {
+         "e1": {
+            "encrypt": {
+               "keyId": [
+                  {
+                     "$binary": {
+                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                        "subType": "04"
+                     }
+                  }
+               ],
+               "bsonType": "string",
+               "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+            }
+         }
+      },
+      "bsonType": "object"
+   },
+   "isRemoteSchema": true
+}

--- a/test/data/lookup/csfle-self/cmd.json
+++ b/test/data/lookup/csfle-self/cmd.json
@@ -1,0 +1,14 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c1",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/csfle-self/collInfo-c1.json
+++ b/test/data/lookup/csfle-self/collInfo-c1.json
@@ -1,0 +1,39 @@
+{
+    "type": "collection",
+    "name": "c1",
+    "idIndex": {
+        "ns": "db.c1",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {
+        "validator": {
+            "$jsonSchema": {
+                "properties": {
+                    "e1": {
+                        "encrypt": {
+                            "keyId": [
+                                {
+                                    "$binary": {
+                                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                        "subType": "04"
+                                    }
+                                }
+                            ],
+                            "bsonType": "string",
+                            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                        }
+                    }
+                },
+                "bsonType": "object"
+            }
+        }
+    }
+}

--- a/test/data/lookup/csfle-sibling/cmd-to-mongocryptd.json
+++ b/test/data/lookup/csfle-sibling/cmd-to-mongocryptd.json
@@ -1,0 +1,49 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      }
+   ],
+   "cursor": {},
+   "csfleEncryptionSchemas": {
+      "db.c1": {
+         "jsonSchema": {
+            "properties": {
+               "e1": {
+                  "encrypt": {
+                     "keyId": [
+                        {
+                           "$binary": {
+                              "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                              "subType": "04"
+                           }
+                        }
+                     ],
+                     "bsonType": "string",
+                     "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+               }
+            },
+            "bsonType": "object"
+         },
+         "isRemoteSchema": true
+      },
+      "db.c2": {
+         "jsonSchema": {
+            "properties": {
+               "unencrypted": {
+                  "bsonType": "string"
+               }
+            },
+            "bsonType": "object"
+         },
+         "isRemoteSchema": true
+      }
+   }
+}

--- a/test/data/lookup/csfle-sibling/cmd.json
+++ b/test/data/lookup/csfle-sibling/cmd.json
@@ -1,0 +1,14 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/csfle-sibling/collInfo-c1.json
+++ b/test/data/lookup/csfle-sibling/collInfo-c1.json
@@ -1,0 +1,39 @@
+{
+    "type": "collection",
+    "name": "c1",
+    "idIndex": {
+        "ns": "db.c1",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {
+        "validator": {
+            "$jsonSchema": {
+                "properties": {
+                    "e1": {
+                        "encrypt": {
+                            "keyId": [
+                                {
+                                    "$binary": {
+                                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                        "subType": "04"
+                                    }
+                                }
+                            ],
+                            "bsonType": "string",
+                            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                        }
+                    }
+                },
+                "bsonType": "object"
+            }
+        }
+    }
+}

--- a/test/data/lookup/csfle-sibling/collInfo-c2.json
+++ b/test/data/lookup/csfle-sibling/collInfo-c2.json
@@ -1,0 +1,29 @@
+{
+    "type": "collection",
+    "name": "c2",
+    "idIndex": {
+        "ns": "db.c2",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {
+        "validator": {
+            "$jsonSchema": {
+                "properties": {
+                    "unencrypted": {
+                        "bsonType": "string"
+                    }
+                },
+                "bsonType": "object"
+            },
+            "foo": "bar"
+        }
+    }
+}

--- a/test/data/lookup/csfle-sibling/reply-from-mongocryptd.json
+++ b/test/data/lookup/csfle-sibling/reply-from-mongocryptd.json
@@ -1,0 +1,18 @@
+{
+   "result": {
+      "aggregate": "c1",
+      "pipeline": [
+         {
+            "$lookup": {
+               "from": "c2",
+               "localField": "joinme",
+               "foreignField": "joinme",
+               "as": "matched"
+            }
+         }
+      ],
+      "cursor": {}
+   },
+   "hasEncryptionPlaceholders": false,
+   "schemaRequiresEncryption": true
+}

--- a/test/data/lookup/csfle-unionWith/cmd.json
+++ b/test/data/lookup/csfle-unionWith/cmd.json
@@ -1,0 +1,21 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$unionWith": {
+            "coll": "c2",
+            "pipeline": [
+               {
+                  "$lookup": {
+                     "from": "c3",
+                     "localField": "joinme",
+                     "foreignField": "joinme",
+                     "as": "matched"
+                  }
+               }
+            ]
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/csfle-view/cmd.json
+++ b/test/data/lookup/csfle-view/cmd.json
@@ -1,0 +1,14 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "v1",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/csfle-view/collInfo-c1.json
+++ b/test/data/lookup/csfle-view/collInfo-c1.json
@@ -1,0 +1,39 @@
+{
+    "type": "collection",
+    "name": "c1",
+    "idIndex": {
+        "ns": "db.c1",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {
+        "validator": {
+            "$jsonSchema": {
+                "properties": {
+                    "e1": {
+                        "encrypt": {
+                            "keyId": [
+                                {
+                                    "$binary": {
+                                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                        "subType": "04"
+                                    }
+                                }
+                            ],
+                            "bsonType": "string",
+                            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                        }
+                    }
+                },
+                "bsonType": "object"
+            }
+        }
+    }
+}

--- a/test/data/lookup/csfle-view/collInfo-v1.json
+++ b/test/data/lookup/csfle-view/collInfo-v1.json
@@ -1,0 +1,11 @@
+{
+    "name": "v1",
+    "type": "view",
+    "options": {
+        "viewOn": "c1",
+        "pipeline": []
+    },
+    "info": {
+        "readOnly": true
+    }
+}

--- a/test/data/lookup/csfle/cmd-to-mongocryptd.json
+++ b/test/data/lookup/csfle/cmd-to-mongocryptd.json
@@ -1,0 +1,60 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      }
+   ],
+   "cursor": {},
+   "csfleEncryptionSchemas": {
+      "db.c1": {
+         "jsonSchema": {
+            "properties": {
+               "e1": {
+                  "encrypt": {
+                     "keyId": [
+                        {
+                           "$binary": {
+                              "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                              "subType": "04"
+                           }
+                        }
+                     ],
+                     "bsonType": "string",
+                     "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+               }
+            },
+            "bsonType": "object"
+         },
+         "isRemoteSchema": true
+      },
+      "db.c2": {
+         "jsonSchema": {
+            "properties": {
+               "e2": {
+                  "encrypt": {
+                     "keyId": [
+                        {
+                           "$binary": {
+                              "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                              "subType": "04"
+                           }
+                        }
+                     ],
+                     "bsonType": "string",
+                     "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+               }
+            },
+            "bsonType": "object"
+         },
+         "isRemoteSchema": true
+      }
+   }
+}

--- a/test/data/lookup/csfle/cmd.json
+++ b/test/data/lookup/csfle/cmd.json
@@ -1,0 +1,14 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/csfle/collInfo-c1.json
+++ b/test/data/lookup/csfle/collInfo-c1.json
@@ -1,0 +1,39 @@
+{
+    "type": "collection",
+    "name": "c1",
+    "idIndex": {
+        "ns": "db.c1",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {
+        "validator": {
+            "$jsonSchema": {
+                "properties": {
+                    "e1": {
+                        "encrypt": {
+                            "keyId": [
+                                {
+                                    "$binary": {
+                                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                        "subType": "04"
+                                    }
+                                }
+                            ],
+                            "bsonType": "string",
+                            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                        }
+                    }
+                },
+                "bsonType": "object"
+            }
+        }
+    }
+}

--- a/test/data/lookup/csfle/collInfo-c2.json
+++ b/test/data/lookup/csfle/collInfo-c2.json
@@ -1,0 +1,39 @@
+{
+    "type": "collection",
+    "name": "c2",
+    "idIndex": {
+        "ns": "db.c2",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {
+        "validator": {
+            "$jsonSchema": {
+                "properties": {
+                    "e2": {
+                        "encrypt": {
+                            "keyId": [
+                                {
+                                    "$binary": {
+                                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                        "subType": "04"
+                                    }
+                                }
+                            ],
+                            "bsonType": "string",
+                            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                        }
+                    }
+                },
+                "bsonType": "object"
+            }
+        }
+    }
+}

--- a/test/data/lookup/mixed/csfle/csfle/cmd-to-mongocryptd.json
+++ b/test/data/lookup/mixed/csfle/csfle/cmd-to-mongocryptd.json
@@ -1,0 +1,65 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {},
+   "csfleEncryptionSchemas": {
+      "db.c1": {
+         "jsonSchema": {
+            "properties": {
+               "e1": {
+                  "encrypt": {
+                     "keyId": [
+                        {
+                           "$binary": {
+                              "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                              "subType": "04"
+                           }
+                        }
+                     ],
+                     "bsonType": "string",
+                     "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+               }
+            },
+            "bsonType": "object"
+         },
+         "isRemoteSchema": true
+      },
+      "db.c2": {
+         "jsonSchema": {
+            "properties": {
+               "e2": {
+                  "encrypt": {
+                     "keyId": [
+                        {
+                           "$binary": {
+                              "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                              "subType": "04"
+                           }
+                        }
+                     ],
+                     "bsonType": "string",
+                     "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+               }
+            },
+            "bsonType": "object"
+         },
+         "isRemoteSchema": true
+      }
+   }
+}

--- a/test/data/lookup/mixed/csfle/csfle/cmd-to-mongod.json
+++ b/test/data/lookup/mixed/csfle/csfle/cmd-to-mongod.json
@@ -1,0 +1,26 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": {
+               "$eq": {
+                  "$binary": {
+                     "base64": "AbidjY8vGEA7mCm87trxCkIC8kZKVHsnE5QVf4xhKcl5AesA5UowxrXhd2IOU6/bQ5EjCTRjLABgU4qpPkwCtbkZX4COgHCmiyzOenkRVBV7NQ==",
+                     "subType": "06"
+                  }
+               }
+            }
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/mixed/csfle/csfle/cmd.json
+++ b/test/data/lookup/mixed/csfle/csfle/cmd.json
@@ -1,0 +1,19 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/mixed/csfle/csfle/collInfo-c1.json
+++ b/test/data/lookup/mixed/csfle/csfle/collInfo-c1.json
@@ -1,0 +1,39 @@
+{
+    "type": "collection",
+    "name": "c1",
+    "idIndex": {
+        "ns": "db.c1",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {
+        "validator": {
+            "$jsonSchema": {
+                "properties": {
+                    "e1": {
+                        "encrypt": {
+                            "keyId": [
+                                {
+                                    "$binary": {
+                                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                        "subType": "04"
+                                    }
+                                }
+                            ],
+                            "bsonType": "string",
+                            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                        }
+                    }
+                },
+                "bsonType": "object"
+            }
+        }
+    }
+}

--- a/test/data/lookup/mixed/csfle/csfle/collInfo-c2.json
+++ b/test/data/lookup/mixed/csfle/csfle/collInfo-c2.json
@@ -1,0 +1,39 @@
+{
+    "type": "collection",
+    "name": "c2",
+    "idIndex": {
+        "ns": "db.c2",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {
+        "validator": {
+            "$jsonSchema": {
+                "properties": {
+                    "e2": {
+                        "encrypt": {
+                            "keyId": [
+                                {
+                                    "$binary": {
+                                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                        "subType": "04"
+                                    }
+                                }
+                            ],
+                            "bsonType": "string",
+                            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                        }
+                    }
+                },
+                "bsonType": "object"
+            }
+        }
+    }
+}

--- a/test/data/lookup/mixed/csfle/csfle/key-doc.json
+++ b/test/data/lookup/mixed/csfle/csfle/key-doc.json
@@ -1,0 +1,30 @@
+{
+    "_id": {
+        "$binary": {
+            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+            "subType": "04"
+        }
+    },
+    "keyMaterial": {
+        "$binary": {
+            "base64": "NTpfCae5j0TnbRGsSvHOw7LcIPDhlg8//4N+TQllLZfH0nlj/G3+huCZmWcra+DPH2VbDnmcEmUTCmyPA+Qijjo0v+oL7qNNWUttL4dS8w5GOagQ3/kUtH+ZppgrjbYb1EcPP2G783iYLrTN+9J+fsLV3G36u2hLatGhDmRqDeV9erJOB0bEC69ouki054RWCNJ3AUockMNxxUDe/aQBKw==",
+            "subType": "00"
+        }
+    },
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1733927626824"
+        }
+    },
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1733927626824"
+        }
+    },
+    "status": {
+        "$numberInt": "0"
+    },
+    "masterKey": {
+        "provider": "local"
+    }
+}

--- a/test/data/lookup/mixed/csfle/csfle/reply-from-mongocryptd.json
+++ b/test/data/lookup/mixed/csfle/csfle/reply-from-mongocryptd.json
@@ -1,0 +1,33 @@
+{
+   "hasEncryptionPlaceholders": false,
+   "schemaRequiresEncryption": true,
+   "result": {
+      "aggregate": "c1",
+      "pipeline": [
+         {
+            "$lookup": {
+               "from": "c2",
+               "localField": "joinme",
+               "foreignField": "joinme",
+               "as": "matched"
+            }
+         },
+         {
+            "$match": {
+               "e1": {
+                  "$eq": {
+                     "$binary": {
+                        "base64": "ADAAAAAQYQABAAAABWtpABAAAAAEuJ2Njy8YQDuYKbzu2vEKQgJ2AAQAAABmb28AAA==",
+                        "subType": "06"
+                     }
+                  }
+               }
+            }
+         }
+      ],
+      "cursor": {}
+   },
+   "ok": {
+      "$numberDouble": "1.0"
+   }
+}

--- a/test/data/lookup/mixed/csfle/no-schema/cmd-to-mongocryptd.json
+++ b/test/data/lookup/mixed/csfle/no-schema/cmd-to-mongocryptd.json
@@ -1,0 +1,47 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {},
+   "csfleEncryptionSchemas": {
+      "db.c1": {
+         "jsonSchema": {
+            "properties": {
+               "e1": {
+                  "encrypt": {
+                     "keyId": [
+                        {
+                           "$binary": {
+                              "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                              "subType": "04"
+                           }
+                        }
+                     ],
+                     "bsonType": "string",
+                     "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+               }
+            },
+            "bsonType": "object"
+         },
+         "isRemoteSchema": true
+      },
+      "db.c2": {
+         "jsonSchema": {},
+         "isRemoteSchema": false
+      }
+   }
+}

--- a/test/data/lookup/mixed/csfle/no-schema/cmd-to-mongod.json
+++ b/test/data/lookup/mixed/csfle/no-schema/cmd-to-mongod.json
@@ -1,0 +1,26 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": {
+               "$eq": {
+                  "$binary": {
+                     "base64": "AbidjY8vGEA7mCm87trxCkIC8kZKVHsnE5QVf4xhKcl5AesA5UowxrXhd2IOU6/bQ5EjCTRjLABgU4qpPkwCtbkZX4COgHCmiyzOenkRVBV7NQ==",
+                     "subType": "06"
+                  }
+               }
+            }
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/mixed/csfle/no-schema/cmd.json
+++ b/test/data/lookup/mixed/csfle/no-schema/cmd.json
@@ -1,0 +1,19 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/mixed/csfle/no-schema/collInfo-c1.json
+++ b/test/data/lookup/mixed/csfle/no-schema/collInfo-c1.json
@@ -1,0 +1,39 @@
+{
+    "type": "collection",
+    "name": "c1",
+    "idIndex": {
+        "ns": "db.c1",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {
+        "validator": {
+            "$jsonSchema": {
+                "properties": {
+                    "e1": {
+                        "encrypt": {
+                            "keyId": [
+                                {
+                                    "$binary": {
+                                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                        "subType": "04"
+                                    }
+                                }
+                            ],
+                            "bsonType": "string",
+                            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                        }
+                    }
+                },
+                "bsonType": "object"
+            }
+        }
+    }
+}

--- a/test/data/lookup/mixed/csfle/no-schema/collInfo-c2.json
+++ b/test/data/lookup/mixed/csfle/no-schema/collInfo-c2.json
@@ -1,0 +1,17 @@
+{
+    "type": "collection",
+    "name": "c2",
+    "idIndex": {
+        "ns": "db.c2",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {}
+}

--- a/test/data/lookup/mixed/csfle/no-schema/key-doc.json
+++ b/test/data/lookup/mixed/csfle/no-schema/key-doc.json
@@ -1,0 +1,30 @@
+{
+    "_id": {
+        "$binary": {
+            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+            "subType": "04"
+        }
+    },
+    "keyMaterial": {
+        "$binary": {
+            "base64": "NTpfCae5j0TnbRGsSvHOw7LcIPDhlg8//4N+TQllLZfH0nlj/G3+huCZmWcra+DPH2VbDnmcEmUTCmyPA+Qijjo0v+oL7qNNWUttL4dS8w5GOagQ3/kUtH+ZppgrjbYb1EcPP2G783iYLrTN+9J+fsLV3G36u2hLatGhDmRqDeV9erJOB0bEC69ouki054RWCNJ3AUockMNxxUDe/aQBKw==",
+            "subType": "00"
+        }
+    },
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1733927626824"
+        }
+    },
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1733927626824"
+        }
+    },
+    "status": {
+        "$numberInt": "0"
+    },
+    "masterKey": {
+        "provider": "local"
+    }
+}

--- a/test/data/lookup/mixed/csfle/no-schema/reply-from-mongocryptd.json
+++ b/test/data/lookup/mixed/csfle/no-schema/reply-from-mongocryptd.json
@@ -1,0 +1,33 @@
+{
+   "hasEncryptionPlaceholders": false,
+   "schemaRequiresEncryption": true,
+   "result": {
+      "aggregate": "c1",
+      "pipeline": [
+         {
+            "$lookup": {
+               "from": "c2",
+               "localField": "joinme",
+               "foreignField": "joinme",
+               "as": "matched"
+            }
+         },
+         {
+            "$match": {
+               "e1": {
+                  "$eq": {
+                     "$binary": {
+                        "base64": "ADAAAAAQYQABAAAABWtpABAAAAAEuJ2Njy8YQDuYKbzu2vEKQgJ2AAQAAABmb28AAA==",
+                        "subType": "06"
+                     }
+                  }
+               }
+            }
+         }
+      ],
+      "cursor": {}
+   },
+   "ok": {
+      "$numberDouble": "1.0"
+   }
+}

--- a/test/data/lookup/mixed/csfle/qe/cmd-to-mongocryptd.json
+++ b/test/data/lookup/mixed/csfle/qe/cmd-to-mongocryptd.json
@@ -1,0 +1,70 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {},
+   "encryptionInformation": {
+      "type": {
+         "$numberInt": "1"
+      },
+      "schema": {
+         "db.c2": {
+            "escCollection": "enxcol_.c2.esc",
+            "ecocCollection": "enxcol_.c2.ecoc",
+            "fields": [
+               {
+                  "keyId": {
+                     "$binary": {
+                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                        "subType": "04"
+                     }
+                  },
+                  "path": "e2",
+                  "bsonType": "string",
+                  "queries": {
+                     "queryType": "equality",
+                     "contention": 0
+                  }
+               }
+            ]
+         }
+      }
+   },
+   "csfleEncryptionSchemas": {
+      "db.c1": {
+         "jsonSchema": {
+            "properties": {
+               "e1": {
+                  "encrypt": {
+                     "keyId": [
+                        {
+                           "$binary": {
+                              "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                              "subType": "04"
+                           }
+                        }
+                     ],
+                     "bsonType": "string",
+                     "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+               }
+            },
+            "bsonType": "object"
+         },
+         "isRemoteSchema": true
+      }
+   }
+}

--- a/test/data/lookup/mixed/csfle/qe/cmd.json
+++ b/test/data/lookup/mixed/csfle/qe/cmd.json
@@ -1,0 +1,19 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/mixed/csfle/qe/collInfo-c1.json
+++ b/test/data/lookup/mixed/csfle/qe/collInfo-c1.json
@@ -1,0 +1,39 @@
+{
+    "type": "collection",
+    "name": "c1",
+    "idIndex": {
+        "ns": "db.c1",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {
+        "validator": {
+            "$jsonSchema": {
+                "properties": {
+                    "e1": {
+                        "encrypt": {
+                            "keyId": [
+                                {
+                                    "$binary": {
+                                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                        "subType": "04"
+                                    }
+                                }
+                            ],
+                            "bsonType": "string",
+                            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                        }
+                    }
+                },
+                "bsonType": "object"
+            }
+        }
+    }
+}

--- a/test/data/lookup/mixed/csfle/qe/collInfo-c2.json
+++ b/test/data/lookup/mixed/csfle/qe/collInfo-c2.json
@@ -1,0 +1,42 @@
+{
+    "name": "c2",
+    "type": "collection",
+    "options": {
+        "encryptedFields": {
+            "escCollection": "enxcol_.c2.esc",
+            "ecocCollection": "enxcol_.c2.ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "e2",
+                    "bsonType": "string",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": 0
+                    }
+                }
+            ]
+        }
+    },
+    "info": {
+        "readOnly": false,
+        "uuid": {
+            "$binary": {
+                "base64": "1dVWZUeyRZGZ3/NwfKTdLQ==",
+                "subType": "04"
+            }
+        }
+    },
+    "idIndex": {
+        "v": 2,
+        "key": {
+            "_id": 1
+        },
+        "name": "_id_"
+    }
+}

--- a/test/data/lookup/mixed/no-schema/csfle/cmd-to-mongocryptd.json
+++ b/test/data/lookup/mixed/no-schema/csfle/cmd-to-mongocryptd.json
@@ -1,0 +1,47 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "matched.e2": "foo"
+         }
+      }
+   ],
+   "cursor": {},
+   "csfleEncryptionSchemas": {
+      "db.c1": {
+         "jsonSchema": {},
+         "isRemoteSchema": false
+      },
+      "db.c2": {
+         "jsonSchema": {
+            "properties": {
+               "e2": {
+                  "encrypt": {
+                     "keyId": [
+                        {
+                           "$binary": {
+                              "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                              "subType": "04"
+                           }
+                        }
+                     ],
+                     "bsonType": "string",
+                     "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+               }
+            },
+            "bsonType": "object"
+         },
+         "isRemoteSchema": true
+      }
+   }
+}

--- a/test/data/lookup/mixed/no-schema/csfle/cmd-to-mongod.json
+++ b/test/data/lookup/mixed/no-schema/csfle/cmd-to-mongod.json
@@ -1,0 +1,26 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "matched.e2": {
+               "$eq": {
+                  "$binary": {
+                     "base64": "AbidjY8vGEA7mCm87trxCkIC8kZKVHsnE5QVf4xhKcl5AesA5UowxrXhd2IOU6/bQ5EjCTRjLABgU4qpPkwCtbkZX4COgHCmiyzOenkRVBV7NQ==",
+                     "subType": "06"
+                  }
+               }
+            }
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/mixed/no-schema/csfle/cmd.json
+++ b/test/data/lookup/mixed/no-schema/csfle/cmd.json
@@ -1,0 +1,19 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "matched.e2": "foo"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/mixed/no-schema/csfle/collInfo-c1.json
+++ b/test/data/lookup/mixed/no-schema/csfle/collInfo-c1.json
@@ -1,0 +1,17 @@
+{
+    "type": "collection",
+    "name": "c1",
+    "idIndex": {
+        "ns": "db.c1",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {}
+}

--- a/test/data/lookup/mixed/no-schema/csfle/collInfo-c2.json
+++ b/test/data/lookup/mixed/no-schema/csfle/collInfo-c2.json
@@ -1,0 +1,39 @@
+{
+    "type": "collection",
+    "name": "c2",
+    "idIndex": {
+        "ns": "db.c2",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {
+        "validator": {
+            "$jsonSchema": {
+                "properties": {
+                    "e2": {
+                        "encrypt": {
+                            "keyId": [
+                                {
+                                    "$binary": {
+                                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                        "subType": "04"
+                                    }
+                                }
+                            ],
+                            "bsonType": "string",
+                            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                        }
+                    }
+                },
+                "bsonType": "object"
+            }
+        }
+    }
+}

--- a/test/data/lookup/mixed/no-schema/csfle/key-doc.json
+++ b/test/data/lookup/mixed/no-schema/csfle/key-doc.json
@@ -1,0 +1,30 @@
+{
+    "_id": {
+        "$binary": {
+            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+            "subType": "04"
+        }
+    },
+    "keyMaterial": {
+        "$binary": {
+            "base64": "NTpfCae5j0TnbRGsSvHOw7LcIPDhlg8//4N+TQllLZfH0nlj/G3+huCZmWcra+DPH2VbDnmcEmUTCmyPA+Qijjo0v+oL7qNNWUttL4dS8w5GOagQ3/kUtH+ZppgrjbYb1EcPP2G783iYLrTN+9J+fsLV3G36u2hLatGhDmRqDeV9erJOB0bEC69ouki054RWCNJ3AUockMNxxUDe/aQBKw==",
+            "subType": "00"
+        }
+    },
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1733927626824"
+        }
+    },
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1733927626824"
+        }
+    },
+    "status": {
+        "$numberInt": "0"
+    },
+    "masterKey": {
+        "provider": "local"
+    }
+}

--- a/test/data/lookup/mixed/no-schema/csfle/reply-from-mongocryptd.json
+++ b/test/data/lookup/mixed/no-schema/csfle/reply-from-mongocryptd.json
@@ -1,0 +1,33 @@
+{
+   "hasEncryptionPlaceholders": false,
+   "schemaRequiresEncryption": true,
+   "result": {
+      "aggregate": "c1",
+      "pipeline": [
+         {
+            "$lookup": {
+               "from": "c2",
+               "localField": "joinme",
+               "foreignField": "joinme",
+               "as": "matched"
+            }
+         },
+         {
+            "$match": {
+               "matched.e2": {
+                  "$eq": {
+                     "$binary": {
+                        "base64": "ADAAAAAQYQABAAAABWtpABAAAAAEuJ2Njy8YQDuYKbzu2vEKQgJ2AAQAAABmb28AAA==",
+                        "subType": "06"
+                     }
+                  }
+               }
+            }
+         }
+      ],
+      "cursor": {}
+   },
+   "ok": {
+      "$numberDouble": "1.0"
+   }
+}

--- a/test/data/lookup/mixed/no-schema/no-schema/cmd-to-mongocryptd.json
+++ b/test/data/lookup/mixed/no-schema/no-schema/cmd-to-mongocryptd.json
@@ -1,0 +1,29 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {},
+   "csfleEncryptionSchemas": {
+      "db.c1": {
+         "jsonSchema": {},
+         "isRemoteSchema": false
+      },
+      "db.c2": {
+         "jsonSchema": {},
+         "isRemoteSchema": false
+      }
+   }
+}

--- a/test/data/lookup/mixed/no-schema/no-schema/cmd-to-mongod.json
+++ b/test/data/lookup/mixed/no-schema/no-schema/cmd-to-mongod.json
@@ -1,0 +1,19 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/mixed/no-schema/no-schema/cmd.json
+++ b/test/data/lookup/mixed/no-schema/no-schema/cmd.json
@@ -1,0 +1,19 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/mixed/no-schema/no-schema/collInfo-c1.json
+++ b/test/data/lookup/mixed/no-schema/no-schema/collInfo-c1.json
@@ -1,0 +1,17 @@
+{
+    "type": "collection",
+    "name": "c1",
+    "idIndex": {
+        "ns": "db.c1",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {}
+}

--- a/test/data/lookup/mixed/no-schema/no-schema/collInfo-c2.json
+++ b/test/data/lookup/mixed/no-schema/no-schema/collInfo-c2.json
@@ -1,0 +1,17 @@
+{
+    "type": "collection",
+    "name": "c2",
+    "idIndex": {
+        "ns": "db.c2",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {}
+}

--- a/test/data/lookup/mixed/no-schema/no-schema/reply-from-mongocryptd.json
+++ b/test/data/lookup/mixed/no-schema/no-schema/reply-from-mongocryptd.json
@@ -1,0 +1,26 @@
+{
+   "hasEncryptionPlaceholders": false,
+   "schemaRequiresEncryption": true,
+   "result": {
+      "aggregate": "c1",
+      "pipeline": [
+         {
+            "$lookup": {
+               "from": "c2",
+               "localField": "joinme",
+               "foreignField": "joinme",
+               "as": "matched"
+            }
+         },
+         {
+            "$match": {
+               "e1": "foo"
+            }
+         }
+      ],
+      "cursor": {}
+   },
+   "ok": {
+      "$numberDouble": "1.0"
+   }
+}

--- a/test/data/lookup/mixed/no-schema/qe/cmd-to-mongocryptd.json
+++ b/test/data/lookup/mixed/no-schema/qe/cmd-to-mongocryptd.json
@@ -1,0 +1,53 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "matched.e2": "foo"
+         }
+      }
+   ],
+   "cursor": {},
+   "encryptionInformation": {
+      "type": {
+         "$numberInt": "1"
+      },
+      "schema": {
+         "db.c1": {
+            "escCollection": "enxcol_.c1.esc",
+            "ecocCollection": "enxcol_.c1.ecoc",
+            "fields": []
+         },
+         "db.c2": {
+            "escCollection": "enxcol_.c2.esc",
+            "ecocCollection": "enxcol_.c2.ecoc",
+            "fields": [
+               {
+                  "keyId": {
+                     "$binary": {
+                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                        "subType": "04"
+                     }
+                  },
+                  "path": "e2",
+                  "bsonType": "string",
+                  "queries": {
+                     "queryType": "equality",
+                     "contention": {
+                        "$numberInt": "0"
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   }
+}

--- a/test/data/lookup/mixed/no-schema/qe/cmd-to-mongod.json
+++ b/test/data/lookup/mixed/no-schema/qe/cmd-to-mongod.json
@@ -1,0 +1,58 @@
+{
+    "aggregate": "c1",
+    "pipeline": [
+        {
+            "$lookup": {
+                "from": "c2",
+                "as": "matched",
+                "localField": "joinme",
+                "foreignField": "joinme"
+            }
+        },
+        {
+            "$match": {
+                "matched.e2": {
+                    "$binary": {
+                        "base64": "DIkAAAAFZAAgAAAAAJg7KMGBFzQvSG5ipqeBSZ9oz6bVVQ7VWhOlAEb/g286BXMAIAAAAAAyC0j6Jl0oR17xumRgOxHlZSHkHtaQDkaV+ooVn7dVXgVsACAAAAAAxCCKn0pGHRJv9x2o1rDoFdTQfqbGN0anbP9RVNoYbrESY20AAAAAAAAAAAAA",
+                        "subType": "06"
+                    }
+                }
+            }
+        }
+    ],
+    "cursor": {},
+    "encryptionInformation": {
+        "type": {
+            "$numberInt": "1"
+        },
+        "schema": {
+            "db.c1": {
+                "escCollection": "enxcol_.c1.esc",
+                "ecocCollection": "enxcol_.c1.ecoc",
+                "fields": []
+            },
+            "db.c2": {
+                "escCollection": "enxcol_.c2.esc",
+                "ecocCollection": "enxcol_.c2.ecoc",
+                "fields": [
+                    {
+                        "keyId": {
+                            "$binary": {
+                                "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                "subType": "04"
+                            }
+                        },
+                        "path": "e2",
+                        "bsonType": "string",
+                        "queries": {
+                            "queryType": "equality",
+                            "contention": {
+                                "$numberInt": "0"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/test/data/lookup/mixed/no-schema/qe/cmd.json
+++ b/test/data/lookup/mixed/no-schema/qe/cmd.json
@@ -1,0 +1,19 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "matched.e2": "foo"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/mixed/no-schema/qe/collInfo-c1.json
+++ b/test/data/lookup/mixed/no-schema/qe/collInfo-c1.json
@@ -1,0 +1,17 @@
+{
+    "type": "collection",
+    "name": "c1",
+    "idIndex": {
+        "ns": "db.c1",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {}
+}

--- a/test/data/lookup/mixed/no-schema/qe/collInfo-c2.json
+++ b/test/data/lookup/mixed/no-schema/qe/collInfo-c2.json
@@ -1,0 +1,42 @@
+{
+    "name": "c2",
+    "type": "collection",
+    "options": {
+        "encryptedFields": {
+            "escCollection": "enxcol_.c2.esc",
+            "ecocCollection": "enxcol_.c2.ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "e2",
+                    "bsonType": "string",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": 0
+                    }
+                }
+            ]
+        }
+    },
+    "info": {
+        "readOnly": false,
+        "uuid": {
+            "$binary": {
+                "base64": "1dVWZUeyRZGZ3/NwfKTdLQ==",
+                "subType": "04"
+            }
+        }
+    },
+    "idIndex": {
+        "v": 2,
+        "key": {
+            "_id": 1
+        },
+        "name": "_id_"
+    }
+}

--- a/test/data/lookup/mixed/no-schema/qe/key-doc.json
+++ b/test/data/lookup/mixed/no-schema/qe/key-doc.json
@@ -1,0 +1,30 @@
+{
+    "_id": {
+        "$binary": {
+            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+            "subType": "04"
+        }
+    },
+    "keyMaterial": {
+        "$binary": {
+            "base64": "NTpfCae5j0TnbRGsSvHOw7LcIPDhlg8//4N+TQllLZfH0nlj/G3+huCZmWcra+DPH2VbDnmcEmUTCmyPA+Qijjo0v+oL7qNNWUttL4dS8w5GOagQ3/kUtH+ZppgrjbYb1EcPP2G783iYLrTN+9J+fsLV3G36u2hLatGhDmRqDeV9erJOB0bEC69ouki054RWCNJ3AUockMNxxUDe/aQBKw==",
+            "subType": "00"
+        }
+    },
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1733927626824"
+        }
+    },
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1733927626824"
+        }
+    },
+    "status": {
+        "$numberInt": "0"
+    },
+    "masterKey": {
+        "provider": "local"
+    }
+}

--- a/test/data/lookup/mixed/no-schema/qe/reply-from-mongocryptd.json
+++ b/test/data/lookup/mixed/no-schema/qe/reply-from-mongocryptd.json
@@ -1,0 +1,65 @@
+{
+    "hasEncryptionPlaceholders": false,
+    "schemaRequiresEncryption": true,
+    "result": {
+        "aggregate": "c1",
+        "pipeline": [
+            {
+                "$lookup": {
+                    "from": "c2",
+                    "as": "matched",
+                    "localField": "joinme",
+                    "foreignField": "joinme"
+                }
+            },
+            {
+                "$match": {
+                    "matched.e2": {
+                        "$binary": {
+                            "base64": "A1wAAAAQdAACAAAAEGEAAgAAAAVraQAQAAAABLidjY8vGEA7mCm87trxCkIFa3UAEAAAAAS4nY2PLxhAO5gpvO7a8QpCAnYABAAAAGZvbwASY20AAAAAAAAAAAAA",
+                            "subType": "06"
+                        }
+                    }
+                }
+            }
+        ],
+        "cursor": {},
+        "encryptionInformation": {
+            "type": {
+                "$numberInt": "1"
+            },
+            "schema": {
+                "db.c1": {
+                    "escCollection": "enxcol_.c1.esc",
+                    "ecocCollection": "enxcol_.c1.ecoc",
+                    "fields": []
+                },
+                "db.c2": {
+                    "escCollection": "enxcol_.c2.esc",
+                    "ecocCollection": "enxcol_.c2.ecoc",
+                    "fields": [
+                        {
+                            "keyId": {
+                                "$binary": {
+                                    "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                    "subType": "04"
+                                }
+                            },
+                            "path": "e2",
+                            "bsonType": "string",
+                            "queries": {
+                                "queryType": "equality",
+                                "contention": {
+                                    "$numberInt": "0"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "ok": {
+        "$numberDouble": "1.0"
+    }
+}

--- a/test/data/lookup/mixed/qe/csfle/cmd-to-mongocryptd.json
+++ b/test/data/lookup/mixed/qe/csfle/cmd-to-mongocryptd.json
@@ -1,0 +1,70 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {},
+   "encryptionInformation": {
+      "type": {
+         "$numberInt": "1"
+      },
+      "schema": {
+         "db.c1": {
+            "escCollection": "enxcol_.c1.esc",
+            "ecocCollection": "enxcol_.c1.ecoc",
+            "fields": [
+               {
+                  "keyId": {
+                     "$binary": {
+                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                        "subType": "04"
+                     }
+                  },
+                  "path": "e1",
+                  "bsonType": "string",
+                  "queries": {
+                     "queryType": "equality",
+                     "contention": 0
+                  }
+               }
+            ]
+         }
+      }
+   },
+   "csfleEncryptionSchemas": {
+      "db.c2": {
+         "jsonSchema": {
+            "properties": {
+               "e2": {
+                  "encrypt": {
+                     "keyId": [
+                        {
+                           "$binary": {
+                              "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                              "subType": "04"
+                           }
+                        }
+                     ],
+                     "bsonType": "string",
+                     "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+               }
+            },
+            "bsonType": "object"
+         },
+         "isRemoteSchema": true
+      }
+   }
+}

--- a/test/data/lookup/mixed/qe/csfle/cmd.json
+++ b/test/data/lookup/mixed/qe/csfle/cmd.json
@@ -1,0 +1,19 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/mixed/qe/csfle/collInfo-c1.json
+++ b/test/data/lookup/mixed/qe/csfle/collInfo-c1.json
@@ -1,0 +1,42 @@
+{
+    "name": "c1",
+    "type": "collection",
+    "options": {
+        "encryptedFields": {
+            "escCollection": "enxcol_.c1.esc",
+            "ecocCollection": "enxcol_.c1.ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "e1",
+                    "bsonType": "string",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": 0
+                    }
+                }
+            ]
+        }
+    },
+    "info": {
+        "readOnly": false,
+        "uuid": {
+            "$binary": {
+                "base64": "1dVWZUeyRZGZ3/NwfKTdLQ==",
+                "subType": "04"
+            }
+        }
+    },
+    "idIndex": {
+        "v": 2,
+        "key": {
+            "_id": 1
+        },
+        "name": "_id_"
+    }
+}

--- a/test/data/lookup/mixed/qe/csfle/collInfo-c2.json
+++ b/test/data/lookup/mixed/qe/csfle/collInfo-c2.json
@@ -1,0 +1,39 @@
+{
+    "type": "collection",
+    "name": "c2",
+    "idIndex": {
+        "ns": "db.c2",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {
+        "validator": {
+            "$jsonSchema": {
+                "properties": {
+                    "e2": {
+                        "encrypt": {
+                            "keyId": [
+                                {
+                                    "$binary": {
+                                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                        "subType": "04"
+                                    }
+                                }
+                            ],
+                            "bsonType": "string",
+                            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                        }
+                    }
+                },
+                "bsonType": "object"
+            }
+        }
+    }
+}

--- a/test/data/lookup/mixed/qe/no-schema/cmd-to-mongocryptd.json
+++ b/test/data/lookup/mixed/qe/no-schema/cmd-to-mongocryptd.json
@@ -1,0 +1,53 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {},
+   "encryptionInformation": {
+      "type": {
+         "$numberInt": "1"
+      },
+      "schema": {
+         "db.c1": {
+            "escCollection": "enxcol_.c1.esc",
+            "ecocCollection": "enxcol_.c1.ecoc",
+            "fields": [
+               {
+                  "keyId": {
+                     "$binary": {
+                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                        "subType": "04"
+                     }
+                  },
+                  "path": "e1",
+                  "bsonType": "string",
+                  "queries": {
+                     "queryType": "equality",
+                     "contention": {
+                        "$numberInt": "0"
+                     }
+                  }
+               }
+            ]
+         },
+         "db.c2": {
+            "escCollection": "enxcol_.c2.esc",
+            "ecocCollection": "enxcol_.c2.ecoc",
+            "fields": []
+         }
+      }
+   }
+}

--- a/test/data/lookup/mixed/qe/no-schema/cmd-to-mongod.json
+++ b/test/data/lookup/mixed/qe/no-schema/cmd-to-mongod.json
@@ -1,0 +1,56 @@
+{
+    "aggregate": "c1",
+    "pipeline": [
+        {
+            "$lookup": {
+                "from": "c2",
+                "as": "matched",
+                "localField": "joinme",
+                "foreignField": "joinme"
+            }
+        },
+        {
+            "$match": {
+                "e1": {
+                    "$binary": {
+                        "base64": "DIkAAAAFZAAgAAAAAJg7KMGBFzQvSG5ipqeBSZ9oz6bVVQ7VWhOlAEb/g286BXMAIAAAAAAyC0j6Jl0oR17xumRgOxHlZSHkHtaQDkaV+ooVn7dVXgVsACAAAAAAxCCKn0pGHRJv9x2o1rDoFdTQfqbGN0anbP9RVNoYbrESY20AAAAAAAAAAAAA",
+                        "subType": "06"
+                    }
+                }
+            }
+        }
+    ],
+    "cursor": {},
+    "encryptionInformation": {
+        "type": {
+            "$numberInt": "1"
+        },
+        "schema": {
+            "db.c1": {
+                "escCollection": "enxcol_.c1.esc",
+                "ecocCollection": "enxcol_.c1.ecoc",
+                "fields": [
+                    {
+                        "keyId": {
+                            "$binary": {
+                                "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                "subType": "04"
+                            }
+                        },
+                        "path": "e1",
+                        "bsonType": "string",
+                        "queries": {
+                            "queryType": "equality",
+                            "contention": 0
+                        }
+                    }
+                ]
+            },
+            "db.c2": {
+                "escCollection": "enxcol_.c2.esc",
+                "ecocCollection": "enxcol_.c2.ecoc",
+                "fields": []
+            }
+        }
+    }
+}

--- a/test/data/lookup/mixed/qe/no-schema/cmd.json
+++ b/test/data/lookup/mixed/qe/no-schema/cmd.json
@@ -1,0 +1,19 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/mixed/qe/no-schema/collInfo-c1.json
+++ b/test/data/lookup/mixed/qe/no-schema/collInfo-c1.json
@@ -1,0 +1,42 @@
+{
+    "name": "c1",
+    "type": "collection",
+    "options": {
+        "encryptedFields": {
+            "escCollection": "enxcol_.c1.esc",
+            "ecocCollection": "enxcol_.c1.ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "e1",
+                    "bsonType": "string",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": 0
+                    }
+                }
+            ]
+        }
+    },
+    "info": {
+        "readOnly": false,
+        "uuid": {
+            "$binary": {
+                "base64": "1dVWZUeyRZGZ3/NwfKTdLQ==",
+                "subType": "04"
+            }
+        }
+    },
+    "idIndex": {
+        "v": 2,
+        "key": {
+            "_id": 1
+        },
+        "name": "_id_"
+    }
+}

--- a/test/data/lookup/mixed/qe/no-schema/collInfo-c2.json
+++ b/test/data/lookup/mixed/qe/no-schema/collInfo-c2.json
@@ -1,0 +1,17 @@
+{
+    "type": "collection",
+    "name": "c2",
+    "idIndex": {
+        "ns": "db.c2",
+        "name": "_id_",
+        "key": {
+            "_id": {
+                "$numberInt": "1"
+            }
+        },
+        "v": {
+            "$numberInt": "2"
+        }
+    },
+    "options": {}
+}

--- a/test/data/lookup/mixed/qe/no-schema/key-doc.json
+++ b/test/data/lookup/mixed/qe/no-schema/key-doc.json
@@ -1,0 +1,30 @@
+{
+    "_id": {
+        "$binary": {
+            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+            "subType": "04"
+        }
+    },
+    "keyMaterial": {
+        "$binary": {
+            "base64": "NTpfCae5j0TnbRGsSvHOw7LcIPDhlg8//4N+TQllLZfH0nlj/G3+huCZmWcra+DPH2VbDnmcEmUTCmyPA+Qijjo0v+oL7qNNWUttL4dS8w5GOagQ3/kUtH+ZppgrjbYb1EcPP2G783iYLrTN+9J+fsLV3G36u2hLatGhDmRqDeV9erJOB0bEC69ouki054RWCNJ3AUockMNxxUDe/aQBKw==",
+            "subType": "00"
+        }
+    },
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1733927626824"
+        }
+    },
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1733927626824"
+        }
+    },
+    "status": {
+        "$numberInt": "0"
+    },
+    "masterKey": {
+        "provider": "local"
+    }
+}

--- a/test/data/lookup/mixed/qe/no-schema/reply-from-mongocryptd.json
+++ b/test/data/lookup/mixed/qe/no-schema/reply-from-mongocryptd.json
@@ -1,0 +1,63 @@
+{
+    "hasEncryptionPlaceholders": false,
+    "schemaRequiresEncryption": true,
+    "result": {
+        "aggregate": "c1",
+        "pipeline": [
+            {
+                "$lookup": {
+                    "from": "c2",
+                    "as": "matched",
+                    "localField": "joinme",
+                    "foreignField": "joinme"
+                }
+            },
+            {
+                "$match": {
+                    "e1": {
+                        "$binary": {
+                            "base64": "A1wAAAAQdAACAAAAEGEAAgAAAAVraQAQAAAABLidjY8vGEA7mCm87trxCkIFa3UAEAAAAAS4nY2PLxhAO5gpvO7a8QpCAnYABAAAAGZvbwASY20AAAAAAAAAAAAA",
+                            "subType": "06"
+                        }
+                    }
+                }
+            }
+        ],
+        "cursor": {},
+        "encryptionInformation": {
+            "type": {
+                "$numberInt": "1"
+            },
+            "schema": {
+                "db.c1": {
+                    "escCollection": "enxcol_.c1.esc",
+                    "ecocCollection": "enxcol_.c1.ecoc",
+                    "fields": [
+                        {
+                            "keyId": {
+                                "$binary": {
+                                    "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                    "subType": "04"
+                                }
+                            },
+                            "path": "e1",
+                            "bsonType": "string",
+                            "queries": {
+                                "queryType": "equality",
+                                "contention": 0
+                            }
+                        }
+                    ]
+                },
+                "db.c2": {
+                    "escCollection": "enxcol_.c2.esc",
+                    "ecocCollection": "enxcol_.c2.ecoc",
+                    "fields": []
+                }
+            }
+        }
+    },
+    "ok": {
+        "$numberDouble": "1.0"
+    }
+}

--- a/test/data/lookup/mixed/qe/qe/cmd-to-mongocryptd.json
+++ b/test/data/lookup/mixed/qe/qe/cmd-to-mongocryptd.json
@@ -1,0 +1,66 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {},
+   "encryptionInformation": {
+      "type": {
+         "$numberInt": "1"
+      },
+      "schema": {
+         "db.c1": {
+            "escCollection": "enxcol_.c1.esc",
+            "ecocCollection": "enxcol_.c1.ecoc",
+            "fields": [
+               {
+                  "keyId": {
+                     "$binary": {
+                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                        "subType": "04"
+                     }
+                  },
+                  "path": "e1",
+                  "bsonType": "string",
+                  "queries": {
+                     "queryType": "equality",
+                     "contention": 0
+                  }
+               }
+            ]
+         },
+         "db.c2": {
+            "escCollection": "enxcol_.c2.esc",
+            "ecocCollection": "enxcol_.c2.ecoc",
+            "fields": [
+               {
+                  "keyId": {
+                     "$binary": {
+                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                        "subType": "04"
+                     }
+                  },
+                  "path": "e2",
+                  "bsonType": "string",
+                  "queries": {
+                     "queryType": "equality",
+                     "contention": 0
+                  }
+               }
+            ]
+         }
+      }
+   }
+}

--- a/test/data/lookup/mixed/qe/qe/cmd-to-mongod.json
+++ b/test/data/lookup/mixed/qe/qe/cmd-to-mongod.json
@@ -1,0 +1,71 @@
+{
+    "aggregate": "c1",
+    "pipeline": [
+        {
+            "$lookup": {
+                "from": "c2",
+                "as": "matched",
+                "localField": "joinme",
+                "foreignField": "joinme"
+            }
+        },
+        {
+            "$match": {
+                "e1": {
+                    "$binary": {
+                        "base64": "DIkAAAAFZAAgAAAAAJg7KMGBFzQvSG5ipqeBSZ9oz6bVVQ7VWhOlAEb/g286BXMAIAAAAAAyC0j6Jl0oR17xumRgOxHlZSHkHtaQDkaV+ooVn7dVXgVsACAAAAAAxCCKn0pGHRJv9x2o1rDoFdTQfqbGN0anbP9RVNoYbrESY20AAAAAAAAAAAAA",
+                        "subType": "06"
+                    }
+                }
+            }
+        }
+    ],
+    "cursor": {},
+    "encryptionInformation": {
+        "type": {
+            "$numberInt": "1"
+        },
+        "schema": {
+            "db.c1": {
+                "escCollection": "enxcol_.c1.esc",
+                "ecocCollection": "enxcol_.c1.ecoc",
+                "fields": [
+                    {
+                        "keyId": {
+                            "$binary": {
+                                "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                "subType": "04"
+                            }
+                        },
+                        "path": "e1",
+                        "bsonType": "string",
+                        "queries": {
+                            "queryType": "equality",
+                            "contention": 0
+                        }
+                    }
+                ]
+            },
+            "db.c2": {
+                "escCollection": "enxcol_.c2.esc",
+                "ecocCollection": "enxcol_.c2.ecoc",
+                "fields": [
+                    {
+                        "keyId": {
+                            "$binary": {
+                                "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                "subType": "04"
+                            }
+                        },
+                        "path": "e2",
+                        "bsonType": "string",
+                        "queries": {
+                            "queryType": "equality",
+                            "contention": 0
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/test/data/lookup/mixed/qe/qe/cmd.json
+++ b/test/data/lookup/mixed/qe/qe/cmd.json
@@ -1,0 +1,19 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/mixed/qe/qe/collInfo-c1.json
+++ b/test/data/lookup/mixed/qe/qe/collInfo-c1.json
@@ -1,0 +1,42 @@
+{
+    "name": "c1",
+    "type": "collection",
+    "options": {
+        "encryptedFields": {
+            "escCollection": "enxcol_.c1.esc",
+            "ecocCollection": "enxcol_.c1.ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "e1",
+                    "bsonType": "string",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": 0
+                    }
+                }
+            ]
+        }
+    },
+    "info": {
+        "readOnly": false,
+        "uuid": {
+            "$binary": {
+                "base64": "1dVWZUeyRZGZ3/NwfKTdLQ==",
+                "subType": "04"
+            }
+        }
+    },
+    "idIndex": {
+        "v": 2,
+        "key": {
+            "_id": 1
+        },
+        "name": "_id_"
+    }
+}

--- a/test/data/lookup/mixed/qe/qe/collInfo-c2.json
+++ b/test/data/lookup/mixed/qe/qe/collInfo-c2.json
@@ -1,0 +1,42 @@
+{
+    "name": "c2",
+    "type": "collection",
+    "options": {
+        "encryptedFields": {
+            "escCollection": "enxcol_.c2.esc",
+            "ecocCollection": "enxcol_.c2.ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "e2",
+                    "bsonType": "string",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": 0
+                    }
+                }
+            ]
+        }
+    },
+    "info": {
+        "readOnly": false,
+        "uuid": {
+            "$binary": {
+                "base64": "1dVWZUeyRZGZ3/NwfKTdLQ==",
+                "subType": "04"
+            }
+        }
+    },
+    "idIndex": {
+        "v": 2,
+        "key": {
+            "_id": 1
+        },
+        "name": "_id_"
+    }
+}

--- a/test/data/lookup/mixed/qe/qe/key-doc.json
+++ b/test/data/lookup/mixed/qe/qe/key-doc.json
@@ -1,0 +1,30 @@
+{
+    "_id": {
+        "$binary": {
+            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+            "subType": "04"
+        }
+    },
+    "keyMaterial": {
+        "$binary": {
+            "base64": "NTpfCae5j0TnbRGsSvHOw7LcIPDhlg8//4N+TQllLZfH0nlj/G3+huCZmWcra+DPH2VbDnmcEmUTCmyPA+Qijjo0v+oL7qNNWUttL4dS8w5GOagQ3/kUtH+ZppgrjbYb1EcPP2G783iYLrTN+9J+fsLV3G36u2hLatGhDmRqDeV9erJOB0bEC69ouki054RWCNJ3AUockMNxxUDe/aQBKw==",
+            "subType": "00"
+        }
+    },
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1733927626824"
+        }
+    },
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1733927626824"
+        }
+    },
+    "status": {
+        "$numberInt": "0"
+    },
+    "masterKey": {
+        "provider": "local"
+    }
+}

--- a/test/data/lookup/mixed/qe/qe/reply-from-mongocryptd.json
+++ b/test/data/lookup/mixed/qe/qe/reply-from-mongocryptd.json
@@ -1,0 +1,78 @@
+{
+    "hasEncryptionPlaceholders": false,
+    "schemaRequiresEncryption": true,
+    "result": {
+        "aggregate": "c1",
+        "pipeline": [
+            {
+                "$lookup": {
+                    "from": "c2",
+                    "as": "matched",
+                    "localField": "joinme",
+                    "foreignField": "joinme"
+                }
+            },
+            {
+                "$match": {
+                    "e1": {
+                        "$binary": {
+                            "base64": "A1wAAAAQdAACAAAAEGEAAgAAAAVraQAQAAAABLidjY8vGEA7mCm87trxCkIFa3UAEAAAAAS4nY2PLxhAO5gpvO7a8QpCAnYABAAAAGZvbwASY20AAAAAAAAAAAAA",
+                            "subType": "06"
+                        }
+                    }
+                }
+            }
+        ],
+        "cursor": {},
+        "encryptionInformation": {
+            "type": {
+                "$numberInt": "1"
+            },
+            "schema": {
+                "db.c1": {
+                    "escCollection": "enxcol_.c1.esc",
+                    "ecocCollection": "enxcol_.c1.ecoc",
+                    "fields": [
+                        {
+                            "keyId": {
+                                "$binary": {
+                                    "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                    "subType": "04"
+                                }
+                            },
+                            "path": "e1",
+                            "bsonType": "string",
+                            "queries": {
+                                "queryType": "equality",
+                                "contention": 0
+                            }
+                        }
+                    ]
+                },
+                "db.c2": {
+                    "escCollection": "enxcol_.c2.esc",
+                    "ecocCollection": "enxcol_.c2.ecoc",
+                    "fields": [
+                        {
+                            "keyId": {
+                                "$binary": {
+                                    "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                    "subType": "04"
+                                }
+                            },
+                            "path": "e2",
+                            "bsonType": "string",
+                            "queries": {
+                                "queryType": "equality",
+                                "contention": 0
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "ok": {
+        "$numberDouble": "1.0"
+    }
+}

--- a/test/data/lookup/qe-encryptedFieldsMap/cmd-to-mongocryptd.json
+++ b/test/data/lookup/qe-encryptedFieldsMap/cmd-to-mongocryptd.json
@@ -1,0 +1,66 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {},
+   "encryptionInformation": {
+      "type": {
+         "$numberInt": "1"
+      },
+      "schema": {
+         "db.c1": {
+            "escCollection": "enxcol_.c1.esc",
+            "ecocCollection": "enxcol_.c1.ecoc",
+            "fields": [
+               {
+                  "keyId": {
+                     "$binary": {
+                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                        "subType": "04"
+                     }
+                  },
+                  "path": "e1",
+                  "bsonType": "string",
+                  "queries": {
+                     "queryType": "equality",
+                     "contention": 0
+                  }
+               }
+            ]
+         },
+         "db.c2": {
+            "escCollection": "enxcol_.c2.esc",
+            "ecocCollection": "enxcol_.c2.ecoc",
+            "fields": [
+               {
+                  "keyId": {
+                     "$binary": {
+                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                        "subType": "04"
+                     }
+                  },
+                  "path": "e2",
+                  "bsonType": "string",
+                  "queries": {
+                     "queryType": "equality",
+                     "contention": 0
+                  }
+               }
+            ]
+         }
+      }
+   }
+}

--- a/test/data/lookup/qe-encryptedFieldsMap/cmd-to-mongod.json
+++ b/test/data/lookup/qe-encryptedFieldsMap/cmd-to-mongod.json
@@ -1,0 +1,71 @@
+{
+    "aggregate": "c1",
+    "pipeline": [
+        {
+            "$lookup": {
+                "from": "c2",
+                "as": "matched",
+                "localField": "joinme",
+                "foreignField": "joinme"
+            }
+        },
+        {
+            "$match": {
+                "e1": {
+                    "$binary": {
+                        "base64": "DIkAAAAFZAAgAAAAAJg7KMGBFzQvSG5ipqeBSZ9oz6bVVQ7VWhOlAEb/g286BXMAIAAAAAAyC0j6Jl0oR17xumRgOxHlZSHkHtaQDkaV+ooVn7dVXgVsACAAAAAAxCCKn0pGHRJv9x2o1rDoFdTQfqbGN0anbP9RVNoYbrESY20AAAAAAAAAAAAA",
+                        "subType": "06"
+                    }
+                }
+            }
+        }
+    ],
+    "cursor": {},
+    "encryptionInformation": {
+        "type": {
+            "$numberInt": "1"
+        },
+        "schema": {
+            "db.c1": {
+                "escCollection": "enxcol_.c1.esc",
+                "ecocCollection": "enxcol_.c1.ecoc",
+                "fields": [
+                    {
+                        "keyId": {
+                            "$binary": {
+                                "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                "subType": "04"
+                            }
+                        },
+                        "path": "e1",
+                        "bsonType": "string",
+                        "queries": {
+                            "queryType": "equality",
+                            "contention": 0
+                        }
+                    }
+                ]
+            },
+            "db.c2": {
+                "escCollection": "enxcol_.c2.esc",
+                "ecocCollection": "enxcol_.c2.ecoc",
+                "fields": [
+                    {
+                        "keyId": {
+                            "$binary": {
+                                "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                "subType": "04"
+                            }
+                        },
+                        "path": "e2",
+                        "bsonType": "string",
+                        "queries": {
+                            "queryType": "equality",
+                            "contention": 0
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/test/data/lookup/qe-encryptedFieldsMap/cmd.json
+++ b/test/data/lookup/qe-encryptedFieldsMap/cmd.json
@@ -1,0 +1,19 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/qe-encryptedFieldsMap/collInfo-c1.json
+++ b/test/data/lookup/qe-encryptedFieldsMap/collInfo-c1.json
@@ -1,0 +1,42 @@
+{
+    "name": "c1",
+    "type": "collection",
+    "options": {
+        "encryptedFields": {
+            "escCollection": "enxcol_.c1.esc",
+            "ecocCollection": "enxcol_.c1.ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "e1",
+                    "bsonType": "string",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": 0
+                    }
+                }
+            ]
+        }
+    },
+    "info": {
+        "readOnly": false,
+        "uuid": {
+            "$binary": {
+                "base64": "1dVWZUeyRZGZ3/NwfKTdLQ==",
+                "subType": "04"
+            }
+        }
+    },
+    "idIndex": {
+        "v": 2,
+        "key": {
+            "_id": 1
+        },
+        "name": "_id_"
+    }
+}

--- a/test/data/lookup/qe-encryptedFieldsMap/encryptedFieldsMap.json
+++ b/test/data/lookup/qe-encryptedFieldsMap/encryptedFieldsMap.json
@@ -1,0 +1,22 @@
+{
+    "db.c2": {
+        "escCollection": "enxcol_.c2.esc",
+        "ecocCollection": "enxcol_.c2.ecoc",
+        "fields": [
+            {
+                "keyId": {
+                    "$binary": {
+                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                        "subType": "04"
+                    }
+                },
+                "path": "e2",
+                "bsonType": "string",
+                "queries": {
+                    "queryType": "equality",
+                    "contention": 0
+                }
+            }
+        ]
+    }
+}

--- a/test/data/lookup/qe-encryptedFieldsMap/key-doc.json
+++ b/test/data/lookup/qe-encryptedFieldsMap/key-doc.json
@@ -1,0 +1,30 @@
+{
+    "_id": {
+        "$binary": {
+            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+            "subType": "04"
+        }
+    },
+    "keyMaterial": {
+        "$binary": {
+            "base64": "NTpfCae5j0TnbRGsSvHOw7LcIPDhlg8//4N+TQllLZfH0nlj/G3+huCZmWcra+DPH2VbDnmcEmUTCmyPA+Qijjo0v+oL7qNNWUttL4dS8w5GOagQ3/kUtH+ZppgrjbYb1EcPP2G783iYLrTN+9J+fsLV3G36u2hLatGhDmRqDeV9erJOB0bEC69ouki054RWCNJ3AUockMNxxUDe/aQBKw==",
+            "subType": "00"
+        }
+    },
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1733927626824"
+        }
+    },
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1733927626824"
+        }
+    },
+    "status": {
+        "$numberInt": "0"
+    },
+    "masterKey": {
+        "provider": "local"
+    }
+}

--- a/test/data/lookup/qe-encryptedFieldsMap/reply-from-mongocryptd.json
+++ b/test/data/lookup/qe-encryptedFieldsMap/reply-from-mongocryptd.json
@@ -1,0 +1,78 @@
+{
+    "hasEncryptionPlaceholders": false,
+    "schemaRequiresEncryption": true,
+    "result": {
+        "aggregate": "c1",
+        "pipeline": [
+            {
+                "$lookup": {
+                    "from": "c2",
+                    "as": "matched",
+                    "localField": "joinme",
+                    "foreignField": "joinme"
+                }
+            },
+            {
+                "$match": {
+                    "e1": {
+                        "$binary": {
+                            "base64": "A1wAAAAQdAACAAAAEGEAAgAAAAVraQAQAAAABLidjY8vGEA7mCm87trxCkIFa3UAEAAAAAS4nY2PLxhAO5gpvO7a8QpCAnYABAAAAGZvbwASY20AAAAAAAAAAAAA",
+                            "subType": "06"
+                        }
+                    }
+                }
+            }
+        ],
+        "cursor": {},
+        "encryptionInformation": {
+            "type": {
+                "$numberInt": "1"
+            },
+            "schema": {
+                "db.c1": {
+                    "escCollection": "enxcol_.c1.esc",
+                    "ecocCollection": "enxcol_.c1.ecoc",
+                    "fields": [
+                        {
+                            "keyId": {
+                                "$binary": {
+                                    "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                    "subType": "04"
+                                }
+                            },
+                            "path": "e1",
+                            "bsonType": "string",
+                            "queries": {
+                                "queryType": "equality",
+                                "contention": 0
+                            }
+                        }
+                    ]
+                },
+                "db.c2": {
+                    "escCollection": "enxcol_.c2.esc",
+                    "ecocCollection": "enxcol_.c2.ecoc",
+                    "fields": [
+                        {
+                            "keyId": {
+                                "$binary": {
+                                    "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                    "subType": "04"
+                                }
+                            },
+                            "path": "e2",
+                            "bsonType": "string",
+                            "queries": {
+                                "queryType": "equality",
+                                "contention": 0
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "ok": {
+        "$numberDouble": "1.0"
+    }
+}

--- a/test/data/lookup/qe-self/cmd-to-mongocryptd.json
+++ b/test/data/lookup/qe-self/cmd-to-mongocryptd.json
@@ -1,0 +1,46 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c1",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {},
+   "encryptionInformation": {
+      "type": {
+         "$numberInt": "1"
+      },
+      "schema": {
+         "db.c1": {
+            "escCollection": "enxcol_.c1.esc",
+            "ecocCollection": "enxcol_.c1.ecoc",
+            "fields": [
+               {
+                  "keyId": {
+                     "$binary": {
+                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                        "subType": "04"
+                     }
+                  },
+                  "path": "e1",
+                  "bsonType": "string",
+                  "queries": {
+                     "queryType": "equality",
+                     "contention": 0
+                  }
+               }
+            ]
+         }
+      }
+   }
+}

--- a/test/data/lookup/qe-self/cmd-to-mongod.json
+++ b/test/data/lookup/qe-self/cmd-to-mongod.json
@@ -1,0 +1,53 @@
+{
+    "aggregate": "c1",
+    "pipeline": [
+        {
+            "$lookup": {
+                "from": "c1",
+                "as": "matched",
+                "localField": "joinme",
+                "foreignField": "joinme"
+            }
+        },
+        {
+            "$match": {
+                "e1": {
+                    "$binary": {
+                        "base64": "DIkAAAAFZAAgAAAAAJg7KMGBFzQvSG5ipqeBSZ9oz6bVVQ7VWhOlAEb/g286BXMAIAAAAAAyC0j6Jl0oR17xumRgOxHlZSHkHtaQDkaV+ooVn7dVXgVsACAAAAAAxCCKn0pGHRJv9x2o1rDoFdTQfqbGN0anbP9RVNoYbrESY20AAAAAAAAAAAAA",
+                        "subType": "06"
+                    }
+                }
+            }
+        }
+    ],
+    "cursor": {},
+    "encryptionInformation": {
+        "type": {
+            "$numberInt": "1"
+        },
+        "schema": {
+            "db.c1": {
+                "escCollection": "enxcol_.c1.esc",
+                "ecocCollection": "enxcol_.c1.ecoc",
+                "fields": [
+                    {
+                        "keyId": {
+                            "$binary": {
+                                "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                "subType": "04"
+                            }
+                        },
+                        "path": "e1",
+                        "bsonType": "string",
+                        "queries": {
+                            "queryType": "equality",
+                            "contention": {
+                                "$numberInt": "0"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/test/data/lookup/qe-self/cmd.json
+++ b/test/data/lookup/qe-self/cmd.json
@@ -1,0 +1,19 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c1",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/qe-self/collInfo-c1.json
+++ b/test/data/lookup/qe-self/collInfo-c1.json
@@ -1,0 +1,42 @@
+{
+    "name": "c1",
+    "type": "collection",
+    "options": {
+        "encryptedFields": {
+            "escCollection": "enxcol_.c1.esc",
+            "ecocCollection": "enxcol_.c1.ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "e1",
+                    "bsonType": "string",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": 0
+                    }
+                }
+            ]
+        }
+    },
+    "info": {
+        "readOnly": false,
+        "uuid": {
+            "$binary": {
+                "base64": "1dVWZUeyRZGZ3/NwfKTdLQ==",
+                "subType": "04"
+            }
+        }
+    },
+    "idIndex": {
+        "v": 2,
+        "key": {
+            "_id": 1
+        },
+        "name": "_id_"
+    }
+}

--- a/test/data/lookup/qe-self/key-doc.json
+++ b/test/data/lookup/qe-self/key-doc.json
@@ -1,0 +1,30 @@
+{
+    "_id": {
+        "$binary": {
+            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+            "subType": "04"
+        }
+    },
+    "keyMaterial": {
+        "$binary": {
+            "base64": "NTpfCae5j0TnbRGsSvHOw7LcIPDhlg8//4N+TQllLZfH0nlj/G3+huCZmWcra+DPH2VbDnmcEmUTCmyPA+Qijjo0v+oL7qNNWUttL4dS8w5GOagQ3/kUtH+ZppgrjbYb1EcPP2G783iYLrTN+9J+fsLV3G36u2hLatGhDmRqDeV9erJOB0bEC69ouki054RWCNJ3AUockMNxxUDe/aQBKw==",
+            "subType": "00"
+        }
+    },
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1733927626824"
+        }
+    },
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1733927626824"
+        }
+    },
+    "status": {
+        "$numberInt": "0"
+    },
+    "masterKey": {
+        "provider": "local"
+    }
+}

--- a/test/data/lookup/qe-self/reply-from-mongocryptd.json
+++ b/test/data/lookup/qe-self/reply-from-mongocryptd.json
@@ -1,0 +1,58 @@
+{
+    "hasEncryptionPlaceholders": false,
+    "schemaRequiresEncryption": true,
+    "result": {
+        "aggregate": "c1",
+        "pipeline": [
+            {
+                "$lookup": {
+                    "from": "c1",
+                    "as": "matched",
+                    "localField": "joinme",
+                    "foreignField": "joinme"
+                }
+            },
+            {
+                "$match": {
+                    "e1": {
+                        "$binary": {
+                            "base64": "A1wAAAAQdAACAAAAEGEAAgAAAAVraQAQAAAABLidjY8vGEA7mCm87trxCkIFa3UAEAAAAAS4nY2PLxhAO5gpvO7a8QpCAnYABAAAAGZvbwASY20AAAAAAAAAAAAA",
+                            "subType": "06"
+                        }
+                    }
+                }
+            }
+        ],
+        "cursor": {},
+        "encryptionInformation": {
+            "type": {
+                "$numberInt": "1"
+            },
+            "schema": {
+                "db.c1": {
+                    "escCollection": "enxcol_.c1.esc",
+                    "ecocCollection": "enxcol_.c1.ecoc",
+                    "fields": [
+                        {
+                            "keyId": {
+                                "$binary": {
+                                    "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                    "subType": "04"
+                                }
+                            },
+                            "path": "e1",
+                            "bsonType": "string",
+                            "queries": {
+                                "queryType": "equality",
+                                "contention": 0
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "ok": {
+        "$numberDouble": "1.0"
+    }
+}

--- a/test/data/lookup/qe-with-payload/cmd-to-mongocryptd.json
+++ b/test/data/lookup/qe-with-payload/cmd-to-mongocryptd.json
@@ -1,0 +1,66 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {},
+   "encryptionInformation": {
+      "type": {
+         "$numberInt": "1"
+      },
+      "schema": {
+         "db.c1": {
+            "escCollection": "enxcol_.c1.esc",
+            "ecocCollection": "enxcol_.c1.ecoc",
+            "fields": [
+               {
+                  "keyId": {
+                     "$binary": {
+                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                        "subType": "04"
+                     }
+                  },
+                  "path": "e1",
+                  "bsonType": "string",
+                  "queries": {
+                     "queryType": "equality",
+                     "contention": 0
+                  }
+               }
+            ]
+         },
+         "db.c2": {
+            "escCollection": "enxcol_.c2.esc",
+            "ecocCollection": "enxcol_.c2.ecoc",
+            "fields": [
+               {
+                  "keyId": {
+                     "$binary": {
+                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                        "subType": "04"
+                     }
+                  },
+                  "path": "e2",
+                  "bsonType": "string",
+                  "queries": {
+                     "queryType": "equality",
+                     "contention": 0
+                  }
+               }
+            ]
+         }
+      }
+   }
+}

--- a/test/data/lookup/qe-with-payload/cmd-to-mongod.json
+++ b/test/data/lookup/qe-with-payload/cmd-to-mongod.json
@@ -1,0 +1,75 @@
+{
+    "aggregate": "c1",
+    "pipeline": [
+        {
+            "$lookup": {
+                "from": "c2",
+                "as": "matched",
+                "localField": "joinme",
+                "foreignField": "joinme"
+            }
+        },
+        {
+            "$match": {
+                "e1": {
+                    "$binary": {
+                        "base64": "DIkAAAAFZAAgAAAAAJg7KMGBFzQvSG5ipqeBSZ9oz6bVVQ7VWhOlAEb/g286BXMAIAAAAAAyC0j6Jl0oR17xumRgOxHlZSHkHtaQDkaV+ooVn7dVXgVsACAAAAAAxCCKn0pGHRJv9x2o1rDoFdTQfqbGN0anbP9RVNoYbrESY20AAAAAAAAAAAAA",
+                        "subType": "06"
+                    }
+                }
+            }
+        }
+    ],
+    "cursor": {},
+    "encryptionInformation": {
+        "type": {
+            "$numberInt": "1"
+        },
+        "schema": {
+            "db.c1": {
+                "escCollection": "enxcol_.c1.esc",
+                "ecocCollection": "enxcol_.c1.ecoc",
+                "fields": [
+                    {
+                        "keyId": {
+                            "$binary": {
+                                "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                "subType": "04"
+                            }
+                        },
+                        "path": "e1",
+                        "bsonType": "string",
+                        "queries": {
+                            "queryType": "equality",
+                            "contention": {
+                                "$numberInt": "0"
+                            }
+                        }
+                    }
+                ]
+            },
+            "db.c2": {
+                "escCollection": "enxcol_.c2.esc",
+                "ecocCollection": "enxcol_.c2.ecoc",
+                "fields": [
+                    {
+                        "keyId": {
+                            "$binary": {
+                                "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                "subType": "04"
+                            }
+                        },
+                        "path": "e2",
+                        "bsonType": "string",
+                        "queries": {
+                            "queryType": "equality",
+                            "contention": {
+                                "$numberInt": "0"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/test/data/lookup/qe-with-payload/cmd.json
+++ b/test/data/lookup/qe-with-payload/cmd.json
@@ -1,0 +1,19 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      },
+      {
+         "$match": {
+            "e1": "foo"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/qe-with-payload/collInfo-c1.json
+++ b/test/data/lookup/qe-with-payload/collInfo-c1.json
@@ -1,0 +1,42 @@
+{
+    "name": "c1",
+    "type": "collection",
+    "options": {
+        "encryptedFields": {
+            "escCollection": "enxcol_.c1.esc",
+            "ecocCollection": "enxcol_.c1.ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "e1",
+                    "bsonType": "string",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": 0
+                    }
+                }
+            ]
+        }
+    },
+    "info": {
+        "readOnly": false,
+        "uuid": {
+            "$binary": {
+                "base64": "1dVWZUeyRZGZ3/NwfKTdLQ==",
+                "subType": "04"
+            }
+        }
+    },
+    "idIndex": {
+        "v": 2,
+        "key": {
+            "_id": 1
+        },
+        "name": "_id_"
+    }
+}

--- a/test/data/lookup/qe-with-payload/collInfo-c2.json
+++ b/test/data/lookup/qe-with-payload/collInfo-c2.json
@@ -1,0 +1,42 @@
+{
+    "name": "c2",
+    "type": "collection",
+    "options": {
+        "encryptedFields": {
+            "escCollection": "enxcol_.c2.esc",
+            "ecocCollection": "enxcol_.c2.ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "e2",
+                    "bsonType": "string",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": 0
+                    }
+                }
+            ]
+        }
+    },
+    "info": {
+        "readOnly": false,
+        "uuid": {
+            "$binary": {
+                "base64": "1dVWZUeyRZGZ3/NwfKTdLQ==",
+                "subType": "04"
+            }
+        }
+    },
+    "idIndex": {
+        "v": 2,
+        "key": {
+            "_id": 1
+        },
+        "name": "_id_"
+    }
+}

--- a/test/data/lookup/qe-with-payload/key-doc.json
+++ b/test/data/lookup/qe-with-payload/key-doc.json
@@ -1,0 +1,30 @@
+{
+    "_id": {
+        "$binary": {
+            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+            "subType": "04"
+        }
+    },
+    "keyMaterial": {
+        "$binary": {
+            "base64": "NTpfCae5j0TnbRGsSvHOw7LcIPDhlg8//4N+TQllLZfH0nlj/G3+huCZmWcra+DPH2VbDnmcEmUTCmyPA+Qijjo0v+oL7qNNWUttL4dS8w5GOagQ3/kUtH+ZppgrjbYb1EcPP2G783iYLrTN+9J+fsLV3G36u2hLatGhDmRqDeV9erJOB0bEC69ouki054RWCNJ3AUockMNxxUDe/aQBKw==",
+            "subType": "00"
+        }
+    },
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1733927626824"
+        }
+    },
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1733927626824"
+        }
+    },
+    "status": {
+        "$numberInt": "0"
+    },
+    "masterKey": {
+        "provider": "local"
+    }
+}

--- a/test/data/lookup/qe-with-payload/reply-from-mongocryptd.json
+++ b/test/data/lookup/qe-with-payload/reply-from-mongocryptd.json
@@ -1,0 +1,78 @@
+{
+    "hasEncryptionPlaceholders": false,
+    "schemaRequiresEncryption": true,
+    "result": {
+        "aggregate": "c1",
+        "pipeline": [
+            {
+                "$lookup": {
+                    "from": "c2",
+                    "as": "matched",
+                    "localField": "joinme",
+                    "foreignField": "joinme"
+                }
+            },
+            {
+                "$match": {
+                    "e1": {
+                        "$binary": {
+                            "base64": "A1wAAAAQdAACAAAAEGEAAgAAAAVraQAQAAAABLidjY8vGEA7mCm87trxCkIFa3UAEAAAAAS4nY2PLxhAO5gpvO7a8QpCAnYABAAAAGZvbwASY20AAAAAAAAAAAAA",
+                            "subType": "06"
+                        }
+                    }
+                }
+            }
+        ],
+        "cursor": {},
+        "encryptionInformation": {
+            "type": {
+                "$numberInt": "1"
+            },
+            "schema": {
+                "db.c1": {
+                    "escCollection": "enxcol_.c1.esc",
+                    "ecocCollection": "enxcol_.c1.ecoc",
+                    "fields": [
+                        {
+                            "keyId": {
+                                "$binary": {
+                                    "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                    "subType": "04"
+                                }
+                            },
+                            "path": "e1",
+                            "bsonType": "string",
+                            "queries": {
+                                "queryType": "equality",
+                                "contention": 0
+                            }
+                        }
+                    ]
+                },
+                "db.c2": {
+                    "escCollection": "enxcol_.c2.esc",
+                    "ecocCollection": "enxcol_.c2.ecoc",
+                    "fields": [
+                        {
+                            "keyId": {
+                                "$binary": {
+                                    "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                    "subType": "04"
+                                }
+                            },
+                            "path": "e2",
+                            "bsonType": "string",
+                            "queries": {
+                                "queryType": "equality",
+                                "contention": 0
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "ok": {
+        "$numberDouble": "1.0"
+    }
+}

--- a/test/data/lookup/qe/cmd-to-mongocryptd.json
+++ b/test/data/lookup/qe/cmd-to-mongocryptd.json
@@ -1,0 +1,61 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      }
+   ],
+   "cursor": {},
+   "encryptionInformation": {
+      "type": {
+         "$numberInt": "1"
+      },
+      "schema": {
+         "db.c1": {
+            "escCollection": "enxcol_.c1.esc",
+            "ecocCollection": "enxcol_.c1.ecoc",
+            "fields": [
+               {
+                  "keyId": {
+                     "$binary": {
+                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                        "subType": "04"
+                     }
+                  },
+                  "path": "e1",
+                  "bsonType": "string",
+                  "queries": {
+                     "queryType": "equality",
+                     "contention": 0
+                  }
+               }
+            ]
+         },
+         "db.c2": {
+            "escCollection": "enxcol_.c2.esc",
+            "ecocCollection": "enxcol_.c2.ecoc",
+            "fields": [
+               {
+                  "keyId": {
+                     "$binary": {
+                        "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                        "subType": "04"
+                     }
+                  },
+                  "path": "e2",
+                  "bsonType": "string",
+                  "queries": {
+                     "queryType": "equality",
+                     "contention": 0
+                  }
+               }
+            ]
+         }
+      }
+   }
+}

--- a/test/data/lookup/qe/cmd-to-mongod.json
+++ b/test/data/lookup/qe/cmd-to-mongod.json
@@ -1,0 +1,14 @@
+{
+    "aggregate": "c1",
+    "pipeline": [
+        {
+            "$lookup": {
+                "from": "c2",
+                "as": "matched",
+                "localField": "joinme",
+                "foreignField": "joinme"
+            }
+        }
+    ],
+    "cursor": {}
+}

--- a/test/data/lookup/qe/cmd.json
+++ b/test/data/lookup/qe/cmd.json
@@ -1,0 +1,14 @@
+{
+   "aggregate": "c1",
+   "pipeline": [
+      {
+         "$lookup": {
+            "from": "c2",
+            "localField": "joinme",
+            "foreignField": "joinme",
+            "as": "matched"
+         }
+      }
+   ],
+   "cursor": {}
+}

--- a/test/data/lookup/qe/collInfo-c1.json
+++ b/test/data/lookup/qe/collInfo-c1.json
@@ -1,0 +1,42 @@
+{
+    "name": "c1",
+    "type": "collection",
+    "options": {
+        "encryptedFields": {
+            "escCollection": "enxcol_.c1.esc",
+            "ecocCollection": "enxcol_.c1.ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "e1",
+                    "bsonType": "string",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": 0
+                    }
+                }
+            ]
+        }
+    },
+    "info": {
+        "readOnly": false,
+        "uuid": {
+            "$binary": {
+                "base64": "1dVWZUeyRZGZ3/NwfKTdLQ==",
+                "subType": "04"
+            }
+        }
+    },
+    "idIndex": {
+        "v": 2,
+        "key": {
+            "_id": 1
+        },
+        "name": "_id_"
+    }
+}

--- a/test/data/lookup/qe/collInfo-c2.json
+++ b/test/data/lookup/qe/collInfo-c2.json
@@ -1,0 +1,42 @@
+{
+    "name": "c2",
+    "type": "collection",
+    "options": {
+        "encryptedFields": {
+            "escCollection": "enxcol_.c2.esc",
+            "ecocCollection": "enxcol_.c2.ecoc",
+            "fields": [
+                {
+                    "keyId": {
+                        "$binary": {
+                            "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                            "subType": "04"
+                        }
+                    },
+                    "path": "e2",
+                    "bsonType": "string",
+                    "queries": {
+                        "queryType": "equality",
+                        "contention": 0
+                    }
+                }
+            ]
+        }
+    },
+    "info": {
+        "readOnly": false,
+        "uuid": {
+            "$binary": {
+                "base64": "1dVWZUeyRZGZ3/NwfKTdLQ==",
+                "subType": "04"
+            }
+        }
+    },
+    "idIndex": {
+        "v": 2,
+        "key": {
+            "_id": 1
+        },
+        "name": "_id_"
+    }
+}

--- a/test/data/lookup/qe/reply-from-mongocryptd.json
+++ b/test/data/lookup/qe/reply-from-mongocryptd.json
@@ -1,0 +1,68 @@
+{
+    "hasEncryptionPlaceholders": false,
+    "schemaRequiresEncryption": true,
+    "result": {
+        "aggregate": "c1",
+        "pipeline": [
+            {
+                "$lookup": {
+                    "from": "c2",
+                    "as": "matched",
+                    "localField": "joinme",
+                    "foreignField": "joinme"
+                }
+            }
+        ],
+        "cursor": {},
+        "encryptionInformation": {
+            "type": {
+                "$numberInt": "1"
+            },
+            "schema": {
+                "db.c1": {
+                    "escCollection": "enxcol_.c1.esc",
+                    "ecocCollection": "enxcol_.c1.ecoc",
+                    "fields": [
+                        {
+                            "keyId": {
+                                "$binary": {
+                                    "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                    "subType": "04"
+                                }
+                            },
+                            "path": "e1",
+                            "bsonType": "string",
+                            "queries": {
+                                "queryType": "equality",
+                                "contention": 0
+                            }
+                        }
+                    ]
+                },
+                "db.c2": {
+                    "escCollection": "enxcol_.c2.esc",
+                    "ecocCollection": "enxcol_.c2.ecoc",
+                    "fields": [
+                        {
+                            "keyId": {
+                                "$binary": {
+                                    "base64": "uJ2Njy8YQDuYKbzu2vEKQg==",
+                                    "subType": "04"
+                                }
+                            },
+                            "path": "e2",
+                            "bsonType": "string",
+                            "queries": {
+                                "queryType": "equality",
+                                "contention": 0
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "ok": {
+        "$numberDouble": "1.0"
+    }
+}

--- a/test/data/mongocryptd-ismaster-17.json
+++ b/test/data/mongocryptd-ismaster-17.json
@@ -1,0 +1,12 @@
+{
+    "ismaster": true,
+    "iscryptd": true,
+    "maxBsonObjectSize": 16777216,
+    "maxMessageSizeBytes": 48000000,
+    "localTime": {
+        "$date": 1653058237588
+    },
+    "maxWireVersion": 17,
+    "minWireVersion": 0,
+    "ok": 1.0
+}

--- a/test/data/mongocryptd-ismaster-26.json
+++ b/test/data/mongocryptd-ismaster-26.json
@@ -1,0 +1,12 @@
+{
+    "ismaster": true,
+    "iscryptd": true,
+    "maxBsonObjectSize": 16777216,
+    "maxMessageSizeBytes": 48000000,
+    "localTime": {
+        "$date": 1739534884679
+    },
+    "maxWireVersion": 26,
+    "minWireVersion": 0,
+    "ok": 1.0
+}

--- a/test/test-mc-schema-broker.c
+++ b/test/test-mc-schema-broker.c
@@ -39,6 +39,7 @@ static void test_mc_schema_broker_request(_mongocrypt_tester_t *tester) {
     {
         mongocrypt_status_t *status = mongocrypt_status_new();
         mc_schema_broker_t *sb = mc_schema_broker_new();
+        ASSERT(!mc_schema_broker_has_multiple_requests(sb));
         ASSERT_OK_STATUS(mc_schema_broker_request(sb, "db", "coll1", status), status);
         ASSERT(!mc_schema_broker_has_multiple_requests(sb));
         ASSERT_OK_STATUS(mc_schema_broker_request(sb, "db", "coll2", status), status);
@@ -58,7 +59,9 @@ static void test_mc_schema_broker_request(_mongocrypt_tester_t *tester) {
     {
         mongocrypt_status_t *status = mongocrypt_status_new();
         mc_schema_broker_t *sb = mc_schema_broker_new();
+        ASSERT(!mc_schema_broker_has_multiple_requests(sb));
         ASSERT_OK_STATUS(mc_schema_broker_request(sb, "db", "coll1", status), status);
+        ASSERT(!mc_schema_broker_has_multiple_requests(sb));
         ASSERT_OK_STATUS(mc_schema_broker_request(sb, "db", "coll1", status), status);
         ASSERT(!mc_schema_broker_has_multiple_requests(sb));
 

--- a/test/test-mc-schema-broker.c
+++ b/test/test-mc-schema-broker.c
@@ -40,7 +40,9 @@ static void test_mc_schema_broker_request(_mongocrypt_tester_t *tester) {
         mongocrypt_status_t *status = mongocrypt_status_new();
         mc_schema_broker_t *sb = mc_schema_broker_new();
         ASSERT_OK_STATUS(mc_schema_broker_request(sb, "db", "coll1", status), status);
+        ASSERT(!mc_schema_broker_has_multiple_requests(sb));
         ASSERT_OK_STATUS(mc_schema_broker_request(sb, "db", "coll2", status), status);
+        ASSERT(mc_schema_broker_has_multiple_requests(sb));
 
         // Check listCollections filter:
         bson_t filter = BSON_INITIALIZER;
@@ -58,6 +60,7 @@ static void test_mc_schema_broker_request(_mongocrypt_tester_t *tester) {
         mc_schema_broker_t *sb = mc_schema_broker_new();
         ASSERT_OK_STATUS(mc_schema_broker_request(sb, "db", "coll1", status), status);
         ASSERT_OK_STATUS(mc_schema_broker_request(sb, "db", "coll1", status), status);
+        ASSERT(!mc_schema_broker_has_multiple_requests(sb));
 
         // Check listCollections filter:
         bson_t filter = BSON_INITIALIZER;

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -3288,7 +3288,7 @@ static void _test_dollardb_preserved_fle1(_mongocrypt_tester_t *tester) {
         ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON((expect), got);                                                            \
         mongocrypt_binary_destroy(got);                                                                                \
     } else                                                                                                             \
-        (void)0
+        ((void)0)
 
 #define expect_and_reply_to_ismaster(ctx)                                                                              \
     if (1) {                                                                                                           \
@@ -3296,8 +3296,8 @@ static void _test_dollardb_preserved_fle1(_mongocrypt_tester_t *tester) {
         expect_mongo_op(ctx, TEST_BSON("{'isMaster': 1}"));                                                            \
         ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TEST_FILE("./test/data/mongocryptd-ismaster-26.json")), ctx);         \
         ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);                                                                \
-    }                                                                                                                  \
-    (void)0
+    } else                                                                                                             \
+        ((void)0)
 
 static void _test_fle1_create_without_schema(_mongocrypt_tester_t *tester) {
     mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -3281,24 +3281,23 @@ static void _test_dollardb_preserved_fle1(_mongocrypt_tester_t *tester) {
     mongocrypt_destroy(crypt);
 }
 
+#define expect_mongo_op(ctx, expect)                                                                                   \
+    if (1) {                                                                                                           \
+        mongocrypt_binary_t *got = mongocrypt_binary_new();                                                            \
+        ASSERT_OK(mongocrypt_ctx_mongo_op(ctx, got), ctx);                                                             \
+        ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON((expect), got);                                                            \
+        mongocrypt_binary_destroy(got);                                                                                \
+    } else                                                                                                             \
+        (void)0
+
 #define expect_and_reply_to_ismaster(ctx)                                                                              \
-    do {                                                                                                               \
+    if (1) {                                                                                                           \
         ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);                             \
-        {                                                                                                              \
-            mongocrypt_binary_t *cmd_to_mongocryptd = mongocrypt_binary_new();                                         \
-                                                                                                                       \
-            ASSERT_OK(mongocrypt_ctx_mongo_op(ctx, cmd_to_mongocryptd), ctx);                                          \
-            ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON(TEST_FILE("./test/data/fle1-create/without-schema/"                    \
-                                                          "ismaster-to-mongocryptd.json"),                             \
-                                                cmd_to_mongocryptd);                                                   \
-            mongocrypt_binary_destroy(cmd_to_mongocryptd);                                                             \
-            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx,                                                                   \
-                                                TEST_FILE("./test/data/fle1-create/without-schema/"                    \
-                                                          "mongocryptd-ismaster.json")),                               \
-                      ctx);                                                                                            \
-            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);                                                            \
-        }                                                                                                              \
-    } while (0)
+        expect_mongo_op(ctx, TEST_BSON("{'isMaster': 1}"));                                                            \
+        ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TEST_FILE("./test/data/mongocryptd-ismaster-26.json")), ctx);         \
+        ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);                                                                \
+    }                                                                                                                  \
+    (void)0
 
 static void _test_fle1_create_without_schema(_mongocrypt_tester_t *tester) {
     mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
@@ -4856,6 +4855,944 @@ static void _test_fle2_collinfo_with_bad_str_encode_version(_mongocrypt_tester_t
     mongocrypt_destroy(crypt);
 }
 
+static void _test_lookup(_mongocrypt_tester_t *tester) {
+    // Test $lookup works.
+#define TF(suffix) TEST_FILE("./test/data/lookup/csfle/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+
+        expect_and_reply_to_ismaster(ctx);
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : {"$in" : [ "c1", "c2" ]}})));
+            // Feed both needed schemas.
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c2.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        expect_mongo_op(ctx, TF("cmd-to-mongocryptd.json"));
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+    // Test $lookup errors if multiple-collection support is not opted-in.
+#define TF(suffix) TEST_FILE("./test/data/lookup/csfle/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        crypt->multiple_collinfo_enabled = false;
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+        ASSERT_FAILS(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")),
+                     ctx,
+                     "not configured to support encrypting a command with multiple collections");
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+    // Test $lookup errors if mongocryptd is too old.
+#define TF(suffix) TEST_FILE("./test/data/lookup/csfle/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        {
+            expect_mongo_op(ctx, TEST_BSON("{'isMaster': 1}"));
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TEST_FILE("./test/data/mongocryptd-ismaster-17.json")), ctx);
+            ASSERT_FAILS(mongocrypt_ctx_mongo_done(ctx), ctx, "Upgrade mongocryptd");
+        }
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+    // Test nested $lookup.
+#define TF(suffix) TEST_FILE("./test/data/lookup/csfle-nested/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+
+        expect_and_reply_to_ismaster(ctx);
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : {"$in" : [ "c1", "c2", "c3" ]}})));
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+    // Test $lookup within $unionWith.
+#define TF(suffix) TEST_FILE("./test/data/lookup/csfle-unionWith/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+
+        expect_and_reply_to_ismaster(ctx);
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : {"$in" : [ "c1", "c2", "c3" ]}})));
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+    // Test $lookup within $facet.
+#define TF(suffix) TEST_FILE("./test/data/lookup/csfle-facet/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+
+        expect_and_reply_to_ismaster(ctx);
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : {"$in" : [ "c1", "c2" ]}})));
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+    // Test $lookup when one schema is in the schemaMap.
+#define TF(suffix) TEST_FILE("./test/data/lookup/csfle-schemaMap/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_SKIP_INIT);
+        ASSERT_OK(mongocrypt_setopt_schema_map(crypt, TF("schemaMap.json")), crypt);
+        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+
+        expect_and_reply_to_ismaster(ctx);
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : "c1"})));
+            // Feed remote schema for "c1". "c2" is found in the schemaMap.
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        expect_mongo_op(ctx, TF("cmd-to-mongocryptd.json"));
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+    // Test $lookup with a self-lookup.
+#define TF(suffix) TEST_FILE("./test/data/lookup/csfle-self/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : "c1"})));
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        expect_mongo_op(ctx, TF("cmd-to-mongocryptd.json"));
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+    // Test $lookup when one schema is already cached.
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+
+        // Do a self-lookup to add only "c1" to the cache.
+#define TF(suffix) TEST_FILE("./test/data/lookup/csfle-self/" suffix)
+        {
+            mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+            ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+            ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+            {
+                expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : "c1"})));
+                ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+                ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+            }
+            mongocrypt_ctx_destroy(ctx);
+        }
+#undef TF
+
+#define TF(suffix) TEST_FILE("./test/data/lookup/csfle/" suffix)
+        // Expect "c1" schema is not requested again.
+        {
+            mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+            ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+            expect_and_reply_to_ismaster(ctx);
+            ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+            {
+                expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : "c2"})));
+                // Feed remaining needed schema.
+                ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c2.json")), ctx);
+                ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+            }
+
+            ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+            expect_mongo_op(ctx, TF("cmd-to-mongocryptd.json"));
+
+            mongocrypt_ctx_destroy(ctx);
+        }
+        mongocrypt_destroy(crypt);
+    }
+
+#undef TF
+
+    // Test $lookup caches no collinfo results as empty schemas.
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+
+        // Do a self-lookup to add only "c1" to the cache.
+#define TF(suffix) TEST_FILE("./test/data/lookup/csfle/" suffix)
+        {
+            mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+            ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+            expect_and_reply_to_ismaster(ctx);
+            ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+            // Feed no collinfo results. Expect "c1" and "c2" to be cached as empty schemas.
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+            mongocrypt_ctx_destroy(ctx);
+        }
+#undef TF
+
+#define TF(suffix) TEST_FILE("./test/data/lookup/csfle/" suffix)
+        // Expect "c1" schema is not requested again.
+        {
+            mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+            ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+            expect_and_reply_to_ismaster(ctx);
+            // Expect no more schemas are needed (both empty).
+            ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+            mongocrypt_ctx_destroy(ctx);
+        }
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+// Test $lookup from a view.
+#define TF(suffix) TEST_FILE("./test/data/lookup/csfle-view/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+        expect_and_reply_to_ismaster(ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : {"$in" : [ "c1", "v1" ]}})));
+
+            // Feed both needed schemas.
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_FAILS(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-v1.json")), ctx, "cannot auto encrypt a view");
+        }
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+// Test $lookup with feeding the same schema twice.
+#define TF(suffix) TEST_FILE("./test/data/lookup/csfle/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+        expect_and_reply_to_ismaster(ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            // Feed schema for "c2" twice.
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c2.json")), ctx);
+            ASSERT_FAILS(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c2.json")), ctx, "unexpected duplicate");
+        }
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+// Test $lookup with with feeding a non-matching schema.
+#define TF(suffix) TEST_FILE("./test/data/lookup/csfle-mismatch/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+        expect_and_reply_to_ismaster(ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_FAILS(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c3.json")), ctx, "got unexpected collinfo");
+        }
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+// Test $lookup with only local schemas.
+#define TF(suffix) TEST_FILE("./test/data/lookup/csfle-only-schemaMap/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_SKIP_INIT);
+        ASSERT_OK(mongocrypt_setopt_schema_map(crypt, TF("schemaMap.json")), crypt);
+        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+        expect_and_reply_to_ismaster(ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        expect_mongo_op(ctx, TF("cmd-to-mongocryptd.json"));
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+// Test $lookup from a collection that has no $jsonSchema configured.
+#define TF(suffix) TEST_FILE("./test/data/lookup/csfle-sibling/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+        expect_and_reply_to_ismaster(ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : {"$in" : [ "c1", "c2" ]}})));
+            // Feed both needed schemas.
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c2.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        {
+            expect_mongo_op(ctx, TF("cmd-to-mongocryptd.json"));
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("reply-from-mongocryptd.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+// Test $lookup with QE.
+#define TF(suffix) TEST_FILE("./test/data/lookup/qe/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+        expect_and_reply_to_ismaster(ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : {"$in" : [ "c1", "c2" ]}})));
+            // Feed both needed schemas.
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c2.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        {
+            expect_mongo_op(ctx, TF("cmd-to-mongocryptd.json"));
+            mongocrypt_binary_t *to_feed = TF("reply-from-mongocryptd.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_READY);
+        {
+            // Expect no `encryptionInformation` since no encryption payloads.
+            mongocrypt_binary_t *expect = TF("cmd-to-mongod.json");
+            mongocrypt_binary_t *got = mongocrypt_binary_new();
+            ASSERT_OK(mongocrypt_ctx_finalize(ctx, got), ctx);
+            ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON(expect, got);
+            mongocrypt_binary_destroy(got);
+        }
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+// Test $lookup with QE with an encrypted payload.
+#define TF(suffix) TEST_FILE("./test/data/lookup/qe-with-payload/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+        expect_and_reply_to_ismaster(ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : {"$in" : [ "c1", "c2" ]}})));
+            // Feed both needed schemas.
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c2.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        {
+            expect_mongo_op(ctx, TF("cmd-to-mongocryptd.json"));
+            mongocrypt_binary_t *to_feed = TF("reply-from-mongocryptd.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_KEYS);
+        {
+            mongocrypt_binary_t *to_feed = TF("key-doc.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_READY);
+        {
+            // Expect `encryptionInformation` since command has encryption payloads.
+            mongocrypt_binary_t *expect = TF("cmd-to-mongod.json");
+            mongocrypt_binary_t *got = mongocrypt_binary_new();
+            ASSERT_OK(mongocrypt_ctx_finalize(ctx, got), ctx);
+            ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON(expect, got);
+            mongocrypt_binary_destroy(got);
+        }
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+// Test $lookup with QE from encryptedFieldsMap.
+#define TF(suffix) TEST_FILE("./test/data/lookup/qe-encryptedFieldsMap/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_SKIP_INIT);
+        ASSERT_OK(mongocrypt_setopt_encrypted_field_config_map(crypt, TF("encryptedFieldsMap.json")), crypt);
+        ASSERT_OK(mongocrypt_init(crypt), crypt);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+        expect_and_reply_to_ismaster(ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : "c1"})));
+            // Only feed collinfo for c1. c2 is included in encryptedFieldsMap.
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        {
+            expect_mongo_op(ctx, TF("cmd-to-mongocryptd.json"));
+            mongocrypt_binary_t *to_feed = TF("reply-from-mongocryptd.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_KEYS);
+        {
+            mongocrypt_binary_t *to_feed = TF("key-doc.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_READY);
+        {
+            mongocrypt_binary_t *expect = TF("cmd-to-mongod.json");
+            mongocrypt_binary_t *got = mongocrypt_binary_new();
+            ASSERT_OK(mongocrypt_ctx_finalize(ctx, got), ctx);
+            ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON(expect, got);
+            mongocrypt_binary_destroy(got);
+        }
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+// Test $lookup with QE with self-lookup.
+#define TF(suffix) TEST_FILE("./test/data/lookup/qe-self/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : "c1"})));
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        {
+            expect_mongo_op(ctx, TF("cmd-to-mongocryptd.json"));
+            mongocrypt_binary_t *to_feed = TF("reply-from-mongocryptd.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_KEYS);
+        {
+            mongocrypt_binary_t *to_feed = TF("key-doc.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_READY);
+        {
+            mongocrypt_binary_t *expect = TF("cmd-to-mongod.json");
+            mongocrypt_binary_t *got = mongocrypt_binary_new();
+            ASSERT_OK(mongocrypt_ctx_finalize(ctx, got), ctx);
+            ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON(expect, got);
+            mongocrypt_binary_destroy(got);
+        }
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+    // Test $lookup with QE from from cache.
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+
+        // Do a self-lookup to add only "c1" to the cache.
+#define TF(suffix) TEST_FILE("./test/data/lookup/qe-self/" suffix)
+        {
+            mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+            ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+            ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+            {
+                expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : "c1"})));
+                ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+                ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+            }
+            mongocrypt_ctx_destroy(ctx);
+        }
+#undef TF
+
+#define TF(suffix) TEST_FILE("./test/data/lookup/qe-with-payload/" suffix)
+        // Expect "c1" schema is not requested again.
+        {
+            mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+            ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+            expect_and_reply_to_ismaster(ctx);
+            ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+            {
+                expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : "c2"})));
+                // Feed remaining needed schema.
+                ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c2.json")), ctx);
+                ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+            }
+
+            ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+            expect_mongo_op(ctx, TF("cmd-to-mongocryptd.json"));
+
+            mongocrypt_ctx_destroy(ctx);
+        }
+        mongocrypt_destroy(crypt);
+    }
+
+#undef TF
+
+// Test $lookup with mixed: QE + CSFLE
+#define TF(suffix) TEST_FILE("./test/data/lookup/mixed/qe/csfle/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+        expect_and_reply_to_ismaster(ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : {"$in" : [ "c1", "c2" ]}})));
+
+            // Feed both needed schemas.
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c2.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        {
+            mongocrypt_binary_t *got = mongocrypt_binary_new();
+            ASSERT_FAILS(mongocrypt_ctx_mongo_op(ctx, got), ctx, "currently not supported");
+            mongocrypt_binary_destroy(got);
+        }
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+// Test $lookup with mixed: QE + no-schema
+#define TF(suffix) TEST_FILE("./test/data/lookup/mixed/qe/no-schema/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+        expect_and_reply_to_ismaster(ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : {"$in" : [ "c1", "c2" ]}})));
+            // Feed both needed schemas.
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c2.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        {
+            expect_mongo_op(ctx, TF("cmd-to-mongocryptd.json"));
+            mongocrypt_binary_t *to_feed = TF("reply-from-mongocryptd.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_KEYS);
+        {
+            mongocrypt_binary_t *to_feed = TF("key-doc.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_READY);
+        {
+            mongocrypt_binary_t *expect = TF("cmd-to-mongod.json");
+            mongocrypt_binary_t *got = mongocrypt_binary_new();
+            ASSERT_OK(mongocrypt_ctx_finalize(ctx, got), ctx);
+            ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON(expect, got);
+            mongocrypt_binary_destroy(got);
+        }
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+// Test $lookup with mixed: QE + QE
+#define TF(suffix) TEST_FILE("./test/data/lookup/mixed/qe/qe/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+        expect_and_reply_to_ismaster(ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : {"$in" : [ "c1", "c2" ]}})));
+            // Feed both needed schemas.
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c2.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        {
+            expect_mongo_op(ctx, TF("cmd-to-mongocryptd.json"));
+            mongocrypt_binary_t *to_feed = TF("reply-from-mongocryptd.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_KEYS);
+        {
+            mongocrypt_binary_t *to_feed = TF("key-doc.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_READY);
+        {
+            mongocrypt_binary_t *expect = TF("cmd-to-mongod.json");
+            mongocrypt_binary_t *got = mongocrypt_binary_new();
+            ASSERT_OK(mongocrypt_ctx_finalize(ctx, got), ctx);
+            ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON(expect, got);
+            mongocrypt_binary_destroy(got);
+        }
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+// Test $lookup with mixed: CSFLE + CSFLE.
+#define TF(suffix) TEST_FILE("./test/data/lookup/mixed/csfle/csfle/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+        expect_and_reply_to_ismaster(ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : {"$in" : [ "c1", "c2" ]}})));
+            // Feed both needed schemas.
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c2.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        {
+            expect_mongo_op(ctx, TF("cmd-to-mongocryptd.json"));
+            mongocrypt_binary_t *to_feed = TF("reply-from-mongocryptd.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_KEYS);
+        {
+            mongocrypt_binary_t *to_feed = TF("key-doc.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_READY);
+        {
+            mongocrypt_binary_t *expect = TF("cmd-to-mongod.json");
+            mongocrypt_binary_t *got = mongocrypt_binary_new();
+            ASSERT_OK(mongocrypt_ctx_finalize(ctx, got), ctx);
+            ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON(expect, got);
+            mongocrypt_binary_destroy(got);
+        }
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+#define TF(suffix) TEST_FILE("./test/data/lookup/mixed/csfle/qe/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+        expect_and_reply_to_ismaster(ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : {"$in" : [ "c1", "c2" ]}})));
+            // Feed both needed schemas.
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c2.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        {
+            mongocrypt_binary_t *got = mongocrypt_binary_new();
+            ASSERT_FAILS(mongocrypt_ctx_mongo_op(ctx, got), ctx, "This is currently not supported");
+            mongocrypt_binary_destroy(got);
+        }
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+#define TF(suffix) TEST_FILE("./test/data/lookup/mixed/csfle/no-schema/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+        expect_and_reply_to_ismaster(ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : {"$in" : [ "c1", "c2" ]}})));
+            // Feed both needed schemas.
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c2.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        {
+            expect_mongo_op(ctx, TF("cmd-to-mongocryptd.json"));
+            mongocrypt_binary_t *to_feed = TF("reply-from-mongocryptd.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_KEYS);
+        {
+            mongocrypt_binary_t *to_feed = TF("key-doc.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_READY);
+        {
+            mongocrypt_binary_t *expect = TF("cmd-to-mongod.json");
+            mongocrypt_binary_t *got = mongocrypt_binary_new();
+            ASSERT_OK(mongocrypt_ctx_finalize(ctx, got), ctx);
+            ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON(expect, got);
+            mongocrypt_binary_destroy(got);
+        }
+
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+#define TF(suffix) TEST_FILE("./test/data/lookup/mixed/no-schema/csfle/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+        expect_and_reply_to_ismaster(ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : {"$in" : [ "c1", "c2" ]}})));
+            // Feed both needed schemas.
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c2.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        {
+            expect_mongo_op(ctx, TF("cmd-to-mongocryptd.json"));
+            mongocrypt_binary_t *to_feed = TF("reply-from-mongocryptd.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_KEYS);
+        {
+            mongocrypt_binary_t *to_feed = TF("key-doc.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_READY);
+        {
+            mongocrypt_binary_t *expect = TF("cmd-to-mongod.json");
+            mongocrypt_binary_t *got = mongocrypt_binary_new();
+            ASSERT_OK(mongocrypt_ctx_finalize(ctx, got), ctx);
+            ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON(expect, got);
+            mongocrypt_binary_destroy(got);
+        }
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+#define TF(suffix) TEST_FILE("./test/data/lookup/mixed/no-schema/no-schema/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+        expect_and_reply_to_ismaster(ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : {"$in" : [ "c1", "c2" ]}})));
+            // Feed both needed schemas.
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c2.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        {
+            expect_mongo_op(ctx, TF("cmd-to-mongocryptd.json"));
+            mongocrypt_binary_t *to_feed = TF("reply-from-mongocryptd.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_READY);
+        {
+            mongocrypt_binary_t *expect = TF("cmd-to-mongod.json");
+            mongocrypt_binary_t *got = mongocrypt_binary_new();
+            ASSERT_OK(mongocrypt_ctx_finalize(ctx, got), ctx);
+            ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON(expect, got);
+            mongocrypt_binary_destroy(got);
+        }
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+
+#define TF(suffix) TEST_FILE("./test/data/lookup/mixed/no-schema/qe/" suffix)
+    {
+        mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+        mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
+
+        ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "db", -1, TF("cmd.json")), ctx);
+        expect_and_reply_to_ismaster(ctx);
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_COLLINFO);
+        {
+            expect_mongo_op(ctx, TEST_BSON(BSON_STR({"name" : {"$in" : [ "c1", "c2" ]}})));
+            // Feed both needed schemas.
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c1.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, TF("collInfo-c2.json")), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_MARKINGS);
+        {
+            expect_mongo_op(ctx, TF("cmd-to-mongocryptd.json"));
+            mongocrypt_binary_t *to_feed = TF("reply-from-mongocryptd.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_MONGO_KEYS);
+        {
+            mongocrypt_binary_t *to_feed = TF("key-doc.json");
+            ASSERT_OK(mongocrypt_ctx_mongo_feed(ctx, to_feed), ctx);
+            ASSERT_OK(mongocrypt_ctx_mongo_done(ctx), ctx);
+        }
+
+        ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_READY);
+        {
+            mongocrypt_binary_t *expect = TF("cmd-to-mongod.json");
+            mongocrypt_binary_t *got = mongocrypt_binary_new();
+            ASSERT_OK(mongocrypt_ctx_finalize(ctx, got), ctx);
+            ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON(expect, got);
+            mongocrypt_binary_destroy(got);
+        }
+        mongocrypt_ctx_destroy(ctx);
+        mongocrypt_destroy(crypt);
+    }
+#undef TF
+}
+
 void _mongocrypt_tester_install_ctx_encrypt(_mongocrypt_tester_t *tester) {
     INSTALL_TEST(_test_explicit_encrypt_init);
     INSTALL_TEST(_test_encrypt_init);
@@ -4953,4 +5890,5 @@ void _mongocrypt_tester_install_ctx_encrypt(_mongocrypt_tester_t *tester) {
     INSTALL_TEST(_test_fle2_encrypted_field_config_with_bad_str_encode_version);
     INSTALL_TEST(_test_fle2_encrypted_fields_with_unmatching_str_encode_version);
     INSTALL_TEST(_test_fle2_collinfo_with_bad_str_encode_version);
+    INSTALL_TEST(_test_lookup);
 }

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -586,12 +586,12 @@ mongocrypt_t *_mongocrypt_tester_mongocrypt(tester_mongocrypt_flags flags) {
     ASSERT_OK(mongocrypt_setopt_enable_multiple_collinfo(crypt), crypt);
     if (!(flags & TESTER_MONGOCRYPT_SKIP_INIT)) {
         ASSERT_OK(mongocrypt_init(crypt), crypt);
-    }
-    if (flags & TESTER_MONGOCRYPT_WITH_CRYPT_SHARED_LIB) {
-        if (mongocrypt_crypt_shared_lib_version(crypt) == 0) {
-            BSON_ASSERT(false
-                        && "tester mongocrypt requested WITH_CRYPT_SHARED_LIB, but "
-                           "no crypt_shared library was loaded by mongocrypt_init");
+        if (flags & TESTER_MONGOCRYPT_WITH_CRYPT_SHARED_LIB) {
+            if (mongocrypt_crypt_shared_lib_version(crypt) == 0) {
+                BSON_ASSERT(false
+                            && "tester mongocrypt requested WITH_CRYPT_SHARED_LIB, but "
+                               "no crypt_shared library was loaded by mongocrypt_init");
+            }
         }
     }
     return crypt;

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -583,8 +583,10 @@ mongocrypt_t *_mongocrypt_tester_mongocrypt(tester_mongocrypt_flags flags) {
     if (flags & TESTER_MONGOCRYPT_WITH_SHORT_CACHE) {
         ASSERT(mongocrypt_setopt_key_expiration(crypt, 1));
     }
-    ASSERT_OK(mongocrypt_init(crypt), crypt);
     ASSERT_OK(mongocrypt_setopt_enable_multiple_collinfo(crypt), crypt);
+    if (!(flags & TESTER_MONGOCRYPT_SKIP_INIT)) {
+        ASSERT_OK(mongocrypt_init(crypt), crypt);
+    }
     if (flags & TESTER_MONGOCRYPT_WITH_CRYPT_SHARED_LIB) {
         if (mongocrypt_crypt_shared_lib_version(crypt) == 0) {
             BSON_ASSERT(false

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -584,6 +584,7 @@ mongocrypt_t *_mongocrypt_tester_mongocrypt(tester_mongocrypt_flags flags) {
         ASSERT(mongocrypt_setopt_key_expiration(crypt, 1));
     }
     ASSERT_OK(mongocrypt_init(crypt), crypt);
+    ASSERT_OK(mongocrypt_setopt_enable_multiple_collinfo(crypt), crypt);
     if (flags & TESTER_MONGOCRYPT_WITH_CRYPT_SHARED_LIB) {
         if (mongocrypt_crypt_shared_lib_version(crypt) == 0) {
             BSON_ASSERT(false

--- a/test/test-mongocrypt.h
+++ b/test/test-mongocrypt.h
@@ -44,6 +44,8 @@ typedef enum tester_mongocrypt_flags {
     TESTER_MONGOCRYPT_WITH_RANGE_V2 = 1 << 2,
     /// Short cache expiration
     TESTER_MONGOCRYPT_WITH_SHORT_CACHE = 1 << 3,
+    /// Do not call `mongocrypt_init`. Enables test to further configure `mongocrypt_t`.
+    TESTER_MONGOCRYPT_SKIP_INIT = 1 << 4,
 } tester_mongocrypt_flags;
 
 /* Arbitrary max of 2048 instances of temporary test data. Increase as needed.

--- a/test/test-mongocrypt.h
+++ b/test/test-mongocrypt.h
@@ -48,9 +48,10 @@ typedef enum tester_mongocrypt_flags {
     TESTER_MONGOCRYPT_SKIP_INIT = 1 << 4,
 } tester_mongocrypt_flags;
 
-/* Arbitrary max of 2048 instances of temporary test data. Increase as needed.
+/* Arbitrary max of 2148 instances of temporary test data. Increase as needed.
+ * TODO(MONGOCRYPT-775) increasing further (e.g. 3000+) causes a segfault on Windows test runs. Revise.
  */
-#define TEST_DATA_COUNT 2048
+#define TEST_DATA_COUNT 2148
 
 typedef struct __mongocrypt_tester_t {
     int test_count;

--- a/test/test-mongocrypt.h
+++ b/test/test-mongocrypt.h
@@ -44,7 +44,7 @@ typedef enum tester_mongocrypt_flags {
     TESTER_MONGOCRYPT_WITH_RANGE_V2 = 1 << 2,
     /// Short cache expiration
     TESTER_MONGOCRYPT_WITH_SHORT_CACHE = 1 << 3,
-    /// Do not call `mongocrypt_init`. Enables test to further configure `mongocrypt_t`.
+    /// Do not call `mongocrypt_init` yet to allow for further configuration of the resulting `mongocrypt_t`.
     TESTER_MONGOCRYPT_SKIP_INIT = 1 << 4,
 } tester_mongocrypt_flags;
 


### PR DESCRIPTION
# Summary

Support encrypting "aggregate" commands with `$lookup`

Tested with libmongocrypt patch: https://spruce.mongodb.com/version/67af62d2eff4dc0007490c8f
Tested with C driver patch pointing to this branch: https://spruce.mongodb.com/version/67af5960bad7a30007a37b90

# Background & Motivation

## Parsing

Enough of the aggregate pipeline is parsed to find occurrences of `$lookup`. `$lookup` can be nested within `$lookup`, `$facet`, and `$unionWith`.

mongocryptd/crypt_shared return [an error for `$unionWith` and `$facet`](https://github.com/kevinAlbs/iue-bootstrap/blob/219aa33638498ff835b67514ef25b9c43f3bd9ee/tools/generate-markings/tests/lookup-csfle-unionWith.yml#L4-L5): `Aggregation stage $unionWith is not allowed or supported with automatic encryption.`. Regardless, this PR parses within `$unionWith` and `$facet` for completeness.

Parsing in libmongocrypt may require future changes. If a future server version extends the aggregate pipeline, libmongocrypt may not find all `$lookup` stages. However, if libmongocrypt does not pass a schema for a needed collection, mongocryptd/crypt_shared errors (e.g. `Missing encryption schema for namespace: db.c2`) rather than assumes the collection has no schema. This was decided acceptable in [Technical Design: Support $lookup in CSFLE and QE](https://docs.google.com/document/d/1HQKM6s8naGFcArVpBgZSnKCWANJ7qhKm_QFM_iFY1TI/edit?tab=t.0#heading=h.6568vliqavvt):

## mongocryptd/crypt_shared version check

A version check is added to ensure mongocryptd/crypt_shared supports multiple schemas. This is intended to improve the error that would otherwise be returned from a too-old mongocryptd/crypt_shared. Testing mongocryptd 8.0 gets the following errors:
- `jsonSchema or encryptionInformation is required` when passing multiple CSFLE schemas.
- `Exactly one namespace is supported with encryptionInformation` when passing multiple QE schemas.

Instead, libmongocrypt returns an error like the following:
- `Encrypting 'aggregate' requires multiple schemas. Detected mongocryptd with wire version 17, but need 26. Upgrade mongocryptd to 8.1 or newer.` when using mongocryptd
- `Encrypting 'aggregate' requires multiple schemas. Detected crypt_shared with version 8.0.4, but need 8.1. Upgrade crypt_shared to 8.1 or newer.` when using crypt_shared

## Opt-in to support multi-collection commands

The state `MONGOCRYPT_CTX_NEED_MONGO_COLLINFO` requests the driver send `listCollections` to check for server-side schemas. Before this PR, this state only expected at most one result from `listCollections`. Quoting [integrating.md](https://github.com/mongodb/libmongocrypt/blob/c3dff011c9c0dc326c31414471a4b613e0d91365/integrating.md#state-mongocrypt_ctx_need_mongo_collinfo):

> Return the first result (if any) with `mongocrypt_ctx_mongo_feed`

To support `$lookup`, drivers are now expected to return all results from `listCollections`.

libmongocrypt cannot distinguish between "did not pass all results" (following old protocol) and "server did not have results". libmongocrypt applies empty schemas to collections that have no known schema. If a driver upgrades libmongocrypt and does not implement the new protocol, an empty schema might be applied to a collection that really has a server-side schema.

To ensure drivers upgrading libmongocrypt follow the new protocol, drivers must call `mongocrypt_setopt_enable_multiple_collinfo` to enable support for multi-collection commands. Without opting-in, libmongocrypt returns an error if a command requires multiple collections. This is to avoid the risk that a driver upgrades libmongocrypt without implementing the new protocol.

## Increasing `TEST_DATA_COUNT`

Increasing `TEST_DATA_COUNT` was done to support the new tests. Increasing too high resulted in a segfault on Windows (too large stack frame?). Filed MONGOCRYPT-775 to investigate separately (not strictly needed for this PR).

