### PR TITLE
MONGOCRYPT-776 Regenerate SBOM Lite for silkbomb:2.0 forward compatibility

### DIFF
--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -2,7 +2,6 @@
   "components": [
     {
       "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.28.1#src/libbson",
-      "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
@@ -14,13 +13,6 @@
         }
       ],
       "group": "mongodb",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
       "name": "mongo-c-driver",
       "purl": "pkg:github/mongodb/mongo-c-driver@v1.28.1#src/libbson",
       "type": "library",
@@ -28,18 +20,10 @@
     },
     {
       "bom-ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz",
-      "copyright": "Copyright (c) 2018, Intel Corp.",
       "externalReferences": [
         {
           "type": "distribution",
           "url": "https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz"
-        }
-      ],
-      "licenses": [
-        {
-          "license": {
-            "id": "BSD-3-Clause"
-          }
         }
       ],
       "name": "IntelRDFPMathLib",
@@ -57,7 +41,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2024-10-10T20:09:56.207649+00:00",
+    "timestamp": "2025-02-19T18:48:39.389784+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -100,8 +84,8 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:879e1b41-08d8-4505-8c89-2285bc3e442c",
-  "version": 2,
+  "serialNumber": "urn:uuid:0325f852-2f52-41eb-9937-ad18000dccab",
+  "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -2,6 +2,7 @@
   "components": [
     {
       "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.28.1#src/libbson",
+      "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
@@ -13,6 +14,13 @@
         }
       ],
       "group": "mongodb",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
       "name": "mongo-c-driver",
       "purl": "pkg:github/mongodb/mongo-c-driver@v1.28.1#src/libbson",
       "type": "library",
@@ -20,10 +28,18 @@
     },
     {
       "bom-ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz",
+      "copyright": "Copyright (c) 2018, Intel Corp.",
       "externalReferences": [
         {
           "type": "distribution",
           "url": "https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
         }
       ],
       "name": "IntelRDFPMathLib",


### PR DESCRIPTION
Resolves MONGOCRYPT-776 for the master branch.

> [!NOTE]
> This PR (and related) only update the purls and SBOM Lite document as needed. Updates to release processes and scripts are deferred to a separate PR.

The CycloneDX specification for the `serialNumber` field [states](https://cyclonedx.org/docs/1.6/json/json/#serialNumber):

> Every BOM generated SHOULD have a unique serial number, even if the contents of the BOM have not changed over time. If specified, the serial number must conform to [RFC 4122](https://www.ietf.org/rfc/rfc4122.html). Use of serial numbers is recommended.

Our release processes up to this point have been updating the SBOM Lite document by bumping the `version` field on each release and reusing the same serial number for all releases (using `serialNumber` only to identify the "libmongocrypt" project as a whole). However, this is not forward-compatible with SilkBomb 2.0, which requires a unique serial number per SBOM. The CycloneDX specification for the `version` field [states](https://cyclonedx.org/docs/1.6/json/#version):

> Whenever an existing BOM is modified, either manually or through automated processes, the version of the BOM SHOULD be incremented by 1. When a system is presented with multiple BOMs with identical serial numbers, the system SHOULD use the most recent version of the BOM. The default version is '1'.

In other words, we should be generating a new serial version [_for each release_](/CISA-SBOM-Community/SBOM-Generation/issues/21#issuecomment-2326865135). We should only bump `version` if we want to make modifications to an existing, uniquely-identifiable SBOM corresponding to a given release (a "patch release" for the SBOM). However, our release and branching strategy does not support the unique identification of the SBOM for a given release using only the `version` field. Therefore, only bumping the `version` field provides no meaningful value for our use cases.

> [!IMPORTANT]
> The `serialNumber` field should identify not only the software (i.e. "libmongocrypt") but also a given distinct _version_ of said software (i.e. "1.11.0" vs. "1.12.0"). The `version` field only defines selection priority when two or more SBOMs have the same `serialNumber`.

Therefore, this PR (and related PRs) updates and regenerates the SBOM Lite document from scratch (generating a new `serialNumber` and resetting `version` to `1`) for all branches which are being tracked by SBOM-aware tooling (r1.10 through r1.12 + master) to ensure the SBOM for each release branch (as well as upcoming releases) contains a unique serial number. Every release going forward should similarly regenerate the SBOM Lite from scratch post-release to ensure a unique serial number corresponding to the SBOM for the next upcoming release.