### PR TITLE
MONGOCRYPT-776 Regenerate SBOM Lite for silkbomb:2.0 forward compatibility

### DIFF
--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -2,6 +2,7 @@
   "components": [
     {
       "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.27.1#src/libbson",
+      "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
@@ -13,6 +14,13 @@
         }
       ],
       "group": "mongodb",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
       "name": "mongo-c-driver",
       "purl": "pkg:github/mongodb/mongo-c-driver@v1.27.1#src/libbson",
       "type": "library",
@@ -20,10 +28,18 @@
     },
     {
       "bom-ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz",
+      "copyright": "Copyright (c) 2018, Intel Corp.",
       "externalReferences": [
         {
           "type": "distribution",
           "url": "https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
         }
       ],
       "name": "IntelRDFPMathLib",

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -2,7 +2,6 @@
   "components": [
     {
       "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.27.1#src/libbson",
-      "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
@@ -14,13 +13,6 @@
         }
       ],
       "group": "mongodb",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
       "name": "mongo-c-driver",
       "purl": "pkg:github/mongodb/mongo-c-driver@v1.27.1#src/libbson",
       "type": "library",
@@ -28,18 +20,10 @@
     },
     {
       "bom-ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz",
-      "copyright": "Copyright (c) 2018, Intel Corp.",
       "externalReferences": [
         {
           "type": "distribution",
           "url": "https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz"
-        }
-      ],
-      "licenses": [
-        {
-          "license": {
-            "id": "BSD-3-Clause"
-          }
         }
       ],
       "name": "IntelRDFPMathLib",
@@ -57,7 +41,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2024-05-10T12:07:55.084050+00:00",
+    "timestamp": "2025-02-19T18:41:36.168006+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -100,9 +84,10 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:879e1b41-08d8-4505-8c89-2285bc3e442c",
+  "serialNumber": "urn:uuid:32ddf8dc-857a-4353-b213-7906dc9c07be",
   "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
-  "specVersion": "1.5"
+  "specVersion": "1.5",
+  "vulnerabilities": []
 }

--- a/etc/purls.txt
+++ b/etc/purls.txt
@@ -1,0 +1,14 @@
+# These package URLs (purls) point to the versions (tags) of external dependencies
+# that are committed to the project. Refer: https://github.com/package-url/purl-spec
+
+# This file is fed to silkbomb to generate the cyclonedx.sbom.json file. Edit this file
+# instead of modifying the SBOM JSON directly. After modifying this file, be sure to
+# re-generate the SBOM JSON file with: `./.evergreen/earthly.sh +sbom-generate`. If
+# adding a new dependency, ensure the resulting SBOM JSON includes the `licenses` and
+# `copyright` property. This information can be manually added.
+
+# libbson is obtained via `cmake/FetchMongoC.cmake`.
+pkg:github/mongodb/mongo-c-driver@v1.27.1#src/libbson
+
+# IntelDFP is obtained via `cmake/IntelDFP.cmake`
+pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz


### PR DESCRIPTION
Resolves MONGOCRYPT-776 for the r1.10 release branch. See https://github.com/mongodb/libmongocrypt/pull/960 for more info.