### PR TITLE
MONGOCRYPT-768 remove possible double-free

### DIFF
--- a/src/mc-schema-broker.c
+++ b/src/mc-schema-broker.c
@@ -475,7 +475,6 @@ bool mc_schema_broker_satisfy_from_cache(mc_schema_broker_t *sb,
 
         if (!mc_schema_entry_satisfy_from_collinfo(it, collinfo, sb->db, it->coll, sb->use_range_v2, status)) {
             bson_destroy(collinfo);
-            bson_free(ns);
             goto loop_fail;
         }
 

--- a/src/mc-schema-broker.c
+++ b/src/mc-schema-broker.c
@@ -474,7 +474,6 @@ bool mc_schema_broker_satisfy_from_cache(mc_schema_broker_t *sb,
         }
 
         if (!mc_schema_entry_satisfy_from_collinfo(it, collinfo, sb->db, it->coll, sb->use_range_v2, status)) {
-            bson_destroy(collinfo);
             goto loop_fail;
         }
 


### PR DESCRIPTION
Fix an (unreleased) bug discovered by Coverity with ID [171701](https://coverity.corp.mongodb.com/#/project-view/20156/10050?selectedIssue=171701).

Intended to unblock the upcoming 1.13.0 release.