### PR TITLE
MONGOCRYPT-783 set CMAKE_C_STANDARD=99 for kms-message

### DIFF
--- a/kms-message/CMakeLists.txt
+++ b/kms-message/CMakeLists.txt
@@ -4,7 +4,7 @@ project (kms_message
    LANGUAGES C
 )
 
-set (CMAKE_C_STANDARD 90)
+set (CMAKE_C_STANDARD 99)
 
 include (CheckCCompilerFlag)
 # All targets obey visibility, not just library targets.


### PR DESCRIPTION
Related to MONGOCRYPT-783.

kms-message [sets](https://github.com/mongodb/libmongocrypt/blob/9378602db9d57ab82e47f8eee7bdd212c7234026/kms-message/CMakeLists.txt#L7) `CMAKE_C_STANDARD` to `90` despite extensively using C99 features.

This is also despite both [libmongocrypt](https://github.com/mongodb/libmongocrypt/blob/95f8281e98e65a08c9e529090e174e2249037202/CMakeLists.txt#L19) and the (bundled) [C Driver](https://github.com/mongodb/mongo-c-driver/blob/9b19be93f114a96ece47b7530e5e60e7a0512cae/CMakeLists.txt#L403) already requiring C99.

Raising the C standard to C99 addresses the following warnings:

- Clang:
    - `-Wc99-extensions` for `_Bool`: 145 unique, 3532 total.
    - `-Wlong-long`: 11 unique, 67 total.
    - `-Wvariadic-macros`: 6 unique, 117 total.
    - `-Woverlength-strings`: 1 unique, 1 total.
- GCC:
    - `-Wdeclaration-after-statement`: 39 unique, 127 total.
    - `-Wpedantic` for runtime initializers: 12 unique, 12 total.
    - `-Wlong-long`: 11 unique, 67 total.
    - `-Wvariadic-macros`: 6 unique, 117 total.
    - `-Wpedantic` for `__func__`: 1 unique, 4 total.
    - `-Woverlength-strings`: 1 unique, 1 total
