### PR TITLE
MONGOCRYPT-783 address -Wformat warnings

### DIFF
--- a/kms-message/src/kms_kmip_request.c
+++ b/kms-message/src/kms_kmip_request.c
@@ -83,7 +83,7 @@ kms_kmip_request_register_secretdata_new (void *reserved,
 
    if (len != KMS_KMIP_REQUEST_SECRETDATA_LENGTH) {
       KMS_ERROR (req,
-                 "expected SecretData length of %d, got %" PRIu32,
+                 "expected SecretData length of %d, got %zu",
                  KMS_KMIP_REQUEST_SECRETDATA_LENGTH,
                  len);
       return req;
@@ -463,4 +463,3 @@ kms_kmip_request_decrypt_new (void *reserved, const char* unique_identifer, cons
    */
    return kmip_encrypt_decrypt(unique_identifer, ciphertext, len, iv_data, iv_len, false);
 }
-

--- a/kms-message/src/kms_message_private.h
+++ b/kms-message/src/kms_message_private.h
@@ -124,6 +124,9 @@ struct _kms_response_parser_t {
       }                      \
    } while (0)
 
+#ifdef __GNUC__
+__attribute__((format(__printf__, 3, 4)))
+#endif
 void
 kms_set_error (char *error, size_t size, const char *fmt, ...);
 

--- a/kms-message/src/kms_request_str.h
+++ b/kms-message/src/kms_request_str.h
@@ -64,10 +64,19 @@ kms_request_str_append_newline (kms_request_str_t *str);
 KMS_MSG_EXPORT (void)
 kms_request_str_append_lowercase (kms_request_str_t *str,
                                   kms_request_str_t *appended);
+
+#ifdef __GNUC__
+__attribute__((format(__printf__, 2, 3)))
+#endif
 KMS_MSG_EXPORT (void)
 kms_request_str_appendf (kms_request_str_t *str, const char *format, ...);
+
+#ifdef __GNUC__
+__attribute__((format(__printf__, 2, 3)))
+#endif
 KMS_MSG_EXPORT (void)
 kms_request_strdupf (kms_request_str_t *str, const char *format, ...);
+
 KMS_MSG_EXPORT (void)
 kms_request_str_append_escaped (kms_request_str_t *str,
                                 kms_request_str_t *appended,

--- a/kms-message/test/test_kms_request.c
+++ b/kms-message/test/test_kms_request.c
@@ -1240,7 +1240,7 @@ main (int argc, char *argv[])
 
    int ret = kms_message_init ();
    if (ret != 0) {
-      TEST_PRINTF ("kms_message_init failed: 0x%x\n", ret);
+      TEST_PRINTF ("kms_message_init failed: 0x%d\n", ret);
       abort ();
    }
 

--- a/src/mc-efc.c
+++ b/src/mc-efc.c
@@ -51,7 +51,7 @@ _parse_supported_query_types(bson_iter_t *iter, supported_query_type_flags *out,
     BSON_ASSERT_PARAM(iter);
     BSON_ASSERT_PARAM(out);
     if (!BSON_ITER_HOLDS_DOCUMENT(iter)) {
-        CLIENT_ERR("When parsing supported query types: Expected type document, got: %d", bson_iter_type(iter));
+        CLIENT_ERR("When parsing supported query types: Expected type document, got: %d", (int)bson_iter_type(iter));
         return false;
     }
 
@@ -66,7 +66,7 @@ _parse_supported_query_types(bson_iter_t *iter, supported_query_type_flags *out,
     }
     if (!BSON_ITER_HOLDS_UTF8(&query_type_iter)) {
         CLIENT_ERR("When parsing supported query types: Expected 'queryType' to be type UTF-8, got: %d",
-                   bson_iter_type(&query_type_iter));
+                   (int)bson_iter_type(&query_type_iter));
         return false;
     }
     const char *queryType = bson_iter_utf8(&query_type_iter, NULL /* length */);
@@ -91,7 +91,7 @@ _parse_field(mc_EncryptedFieldConfig_t *efc, bson_t *field, mongocrypt_status_t 
         return false;
     }
     if (!BSON_ITER_HOLDS_BINARY(&field_iter)) {
-        CLIENT_ERR("expected 'fields.keyId' to be type binary, got: %d", bson_iter_type(&field_iter));
+        CLIENT_ERR("expected 'fields.keyId' to be type binary, got: %d", (int)bson_iter_type(&field_iter));
         return false;
     }
     _mongocrypt_buffer_t field_keyid;
@@ -106,7 +106,7 @@ _parse_field(mc_EncryptedFieldConfig_t *efc, bson_t *field, mongocrypt_status_t 
         return false;
     }
     if (!BSON_ITER_HOLDS_UTF8(&field_iter)) {
-        CLIENT_ERR("expected 'fields.path' to be type UTF-8, got: %d", bson_iter_type(&field_iter));
+        CLIENT_ERR("expected 'fields.path' to be type UTF-8, got: %d", (int)bson_iter_type(&field_iter));
         return false;
     }
     field_path = bson_iter_utf8(&field_iter, NULL /* length */);

--- a/src/mc-fle2-find-equality-payload-v2.c
+++ b/src/mc-fle2-find-equality-payload-v2.c
@@ -50,12 +50,14 @@ void mc_FLE2FindEqualityPayloadV2_cleanup(mc_FLE2FindEqualityPayloadV2_t *payloa
         uint32_t len;                                                                                                  \
         const uint8_t *data;                                                                                           \
         if (bson_iter_type(&iter) != BSON_TYPE_BINARY) {                                                               \
-            CLIENT_ERR("Field '" #Name "' expected to be bindata, got: %d", bson_iter_type(&iter));                    \
+            CLIENT_ERR("Field '" #Name "' expected to be bindata, got: %d", (int)bson_iter_type(&iter));               \
             goto fail;                                                                                                 \
         }                                                                                                              \
         bson_iter_binary(&iter, &subtype, &len, &data);                                                                \
         if (subtype != BSON_SUBTYPE_BINARY) {                                                                          \
-            CLIENT_ERR("Field '" #Name "' expected to be bindata subtype %d, got: %d", BSON_SUBTYPE_BINARY, subtype);  \
+            CLIENT_ERR("Field '" #Name "' expected to be bindata subtype %d, got: %d",                                 \
+                       BSON_SUBTYPE_BINARY,                                                                            \
+                       (int)subtype);                                                                                  \
             goto fail;                                                                                                 \
         }                                                                                                              \
         if (!_mongocrypt_buffer_copy_from_binary_iter(&out->Dest, &iter)) {                                            \

--- a/src/mc-fle2-find-equality-payload.c
+++ b/src/mc-fle2-find-equality-payload.c
@@ -51,12 +51,14 @@ void mc_FLE2FindEqualityPayload_cleanup(mc_FLE2FindEqualityPayload_t *payload) {
         uint32_t len;                                                                                                  \
         const uint8_t *data;                                                                                           \
         if (bson_iter_type(&iter) != BSON_TYPE_BINARY) {                                                               \
-            CLIENT_ERR("Field '" #Name "' expected to be bindata, got: %d", bson_iter_type(&iter));                    \
+            CLIENT_ERR("Field '" #Name "' expected to be bindata, got: %d", (int)bson_iter_type(&iter));               \
             goto fail;                                                                                                 \
         }                                                                                                              \
         bson_iter_binary(&iter, &subtype, &len, &data);                                                                \
         if (subtype != BSON_SUBTYPE_BINARY) {                                                                          \
-            CLIENT_ERR("Field '" #Name "' expected to be bindata subtype %d, got: %d", BSON_SUBTYPE_BINARY, subtype);  \
+            CLIENT_ERR("Field '" #Name "' expected to be bindata subtype %d, got: %d",                                 \
+                       BSON_SUBTYPE_BINARY,                                                                            \
+                       (int)subtype);                                                                                  \
             goto fail;                                                                                                 \
         }                                                                                                              \
         if (!_mongocrypt_buffer_copy_from_binary_iter(&out->Dest, &iter)) {                                            \

--- a/src/mc-fle2-insert-update-payload-v2.c
+++ b/src/mc-fle2-insert-update-payload-v2.c
@@ -137,12 +137,12 @@ void mc_FLE2InsertUpdatePayloadV2_cleanup(mc_FLE2InsertUpdatePayloadV2_t *payloa
         uint32_t len;                                                                                                  \
         const uint8_t *data;                                                                                           \
         if (bson_iter_type(&iter) != BSON_TYPE_BINARY) {                                                               \
-            CLIENT_ERR("Field '" #Name "' expected to be bindata, got: %d", bson_iter_type(&iter));                    \
+            CLIENT_ERR("Field '" #Name "' expected to be bindata, got: %d", (int)bson_iter_type(&iter));               \
             goto fail;                                                                                                 \
         }                                                                                                              \
         bson_iter_binary(&iter, &subtype, &len, &data);                                                                \
         if (subtype != Type) {                                                                                         \
-            CLIENT_ERR("Field '" #Name "' expected to be bindata subtype %d, got: %d", Type, subtype);                 \
+            CLIENT_ERR("Field '" #Name "' expected to be bindata subtype %d, got: %d", Type, (int)subtype);            \
             goto fail;                                                                                                 \
         }                                                                                                              \
         if (!_mongocrypt_buffer_copy_from_binary_iter(&out->Dest, &iter)) {                                            \

--- a/src/mc-fle2-insert-update-payload.c
+++ b/src/mc-fle2-insert-update-payload.c
@@ -73,12 +73,12 @@ void mc_FLE2InsertUpdatePayload_cleanup(mc_FLE2InsertUpdatePayload_t *payload) {
         uint32_t len;                                                                                                  \
         const uint8_t *data;                                                                                           \
         if (bson_iter_type(&iter) != BSON_TYPE_BINARY) {                                                               \
-            CLIENT_ERR("Field '" #Name "' expected to be bindata, got: %d", bson_iter_type(&iter));                    \
+            CLIENT_ERR("Field '" #Name "' expected to be bindata, got: %d", (int)bson_iter_type(&iter));               \
             goto fail;                                                                                                 \
         }                                                                                                              \
         bson_iter_binary(&iter, &subtype, &len, &data);                                                                \
         if (subtype != Type) {                                                                                         \
-            CLIENT_ERR("Field '" #Name "' expected to be bindata subtype %d, got: %d", Type, subtype);                 \
+            CLIENT_ERR("Field '" #Name "' expected to be bindata subtype %d, got: %d", Type, (int)subtype);            \
             goto fail;                                                                                                 \
         }                                                                                                              \
         if (!_mongocrypt_buffer_copy_from_binary_iter(&out->Dest, &iter)) {                                            \

--- a/src/mc-fle2-payload-iev.c
+++ b/src/mc-fle2-payload-iev.c
@@ -135,7 +135,7 @@ bool mc_FLE2IndexedEncryptedValue_write(_mongocrypt_crypto_t *crypto,
     const uint8_t subtype = (uint8_t)MC_SUBTYPE_FLE2IndexedEqualityEncryptedValue;
 
     if (((int)original_bson_type < 0) || ((int)original_bson_type > 0xFF)) {
-        CLIENT_ERR("Field 't' must be a valid BSON type, got: %d", original_bson_type);
+        CLIENT_ERR("Field 't' must be a valid BSON type, got: %d", (int)original_bson_type);
         CHECK_AND_GOTO(false);
     }
 

--- a/src/mc-range-edge-generation.c
+++ b/src/mc-range-edge-generation.c
@@ -51,7 +51,7 @@ static mc_edges_t *mc_edges_new(const char *leaf,
     if (trimFactor != 0 && mc_cmp_greater_equal_su(trimFactor, leaf_len)) {
         // We append a total of leaf_len + 1 (for the root) - trimFactor edges. When this number is equal to 1, we
         // degenerate into equality, which is not desired, so trimFactor must be less than leaf_len.
-        CLIENT_ERR("trimFactor must be less than the number of bits (%ld) used to represent an element of the domain, "
+        CLIENT_ERR("trimFactor must be less than the number of bits (%zu) used to represent an element of the domain, "
                    "but got %" PRId32,
                    leaf_len,
                    trimFactor);

--- a/src/mc-range-mincover-generator.template.h
+++ b/src/mc-range-mincover-generator.template.h
@@ -125,7 +125,7 @@ static inline DECORATE_NAME(MinCoverGenerator)
     size_t maxlen = (size_t)BITS - DECORATE_NAME(mc_count_leading_zeros)(max);
     int32_t trimFactor = trimFactorDefault(maxlen, opt_trimFactor, use_range_v2);
     if (trimFactor != 0 && mc_cmp_greater_equal_su(trimFactor, maxlen)) {
-        CLIENT_ERR("Trim factor must be less than the number of bits (%ld) used to represent an element of the domain, "
+        CLIENT_ERR("Trim factor must be less than the number of bits (%zu) used to represent an element of the domain, "
                    "but got %" PRId32,
                    maxlen,
                    trimFactor);

--- a/src/mc-rangeopts.c
+++ b/src/mc-rangeopts.c
@@ -506,8 +506,8 @@ bool mc_RangeOpts_appendTrimFactor(const mc_RangeOpts_t *ro,
     // if nbits = 0, we want to allow trim factor = 0.
     uint32_t test = nbits ? nbits : 1;
     if (mc_cmp_greater_equal_su(ro->trimFactor.value, test)) {
-        CLIENT_ERR_PREFIXED("Trim factor (%d) must be less than the total number of bits (%d) used to represent "
-                            "any element in the domain.",
+        CLIENT_ERR_PREFIXED("Trim factor (%" PRId32 ") must be less than the total number of bits (%" PRIu32
+                            ") used to represent any element in the domain.",
                             ro->trimFactor.value,
                             nbits);
         return false;

--- a/src/mc-text-search-str-encode.c
+++ b/src/mc-text-search-str-encode.c
@@ -181,7 +181,7 @@ mc_str_encode_sets_t *mc_text_search_str_encode(const mc_FLE2TextSearchInsertSpe
                                                 mongocrypt_status_t *status) {
     BSON_ASSERT_PARAM(spec);
     if (spec->len > MAX_ENCODE_BYTE_LEN) {
-        CLIENT_ERR("StrEncode: String passed in was too long: String was %u bytes, but max is %u bytes",
+        CLIENT_ERR("StrEncode: String passed in was too long: String was %" PRIu32 " bytes, but max is %d bytes",
                    spec->len,
                    MAX_ENCODE_BYTE_LEN);
         return NULL;

--- a/src/mongocrypt-crypto.c
+++ b/src/mongocrypt-crypto.c
@@ -305,9 +305,7 @@ bool _mongocrypt_hmac_sha_256(_mongocrypt_crypto_t *crypto,
     BSON_ASSERT_PARAM(out);
 
     if (key->len != MONGOCRYPT_MAC_KEY_LEN) {
-        CLIENT_ERR("invalid hmac_sha_256 key length. Got %" PRIu32 ", expected: %" PRIu32,
-                   key->len,
-                   MONGOCRYPT_MAC_KEY_LEN);
+        CLIENT_ERR("invalid hmac_sha_256 key length. Got %" PRIu32 ", expected: %d", key->len, MONGOCRYPT_MAC_KEY_LEN);
         return false;
     }
 
@@ -501,12 +499,14 @@ static bool _encrypt_step(_mongocrypt_crypto_t *crypto,
     *bytes_written = 0;
 
     if (MONGOCRYPT_IV_LEN != iv->len) {
-        CLIENT_ERR("IV should have length %d, but has length %d", MONGOCRYPT_IV_LEN, iv->len);
+        CLIENT_ERR("IV should have length %d, but has length %" PRIu32, MONGOCRYPT_IV_LEN, iv->len);
         return false;
     }
 
     if (MONGOCRYPT_ENC_KEY_LEN != enc_key->len) {
-        CLIENT_ERR("Encryption key should have length %d, but has length %d", MONGOCRYPT_ENC_KEY_LEN, enc_key->len);
+        CLIENT_ERR("Encryption key should have length %d, but has length %" PRIu32,
+                   MONGOCRYPT_ENC_KEY_LEN,
+                   enc_key->len);
         return false;
     }
 
@@ -575,7 +575,9 @@ static bool _encrypt_step(_mongocrypt_crypto_t *crypto,
     }
 
     if (*bytes_written % MONGOCRYPT_BLOCK_SIZE != 0) {
-        CLIENT_ERR("encryption failure, wrote %d bytes, not a multiple of %d", *bytes_written, MONGOCRYPT_BLOCK_SIZE);
+        CLIENT_ERR("encryption failure, wrote %" PRIu32 " bytes, not a multiple of %d",
+                   *bytes_written,
+                   MONGOCRYPT_BLOCK_SIZE);
         return false;
     }
 
@@ -628,12 +630,12 @@ static bool _hmac_step(_mongocrypt_crypto_t *crypto,
     _mongocrypt_buffer_init(&to_hmac);
 
     if (MONGOCRYPT_MAC_KEY_LEN != Km->len) {
-        CLIENT_ERR("HMAC key wrong length: %d", Km->len);
+        CLIENT_ERR("HMAC key wrong length: %" PRIu32, Km->len);
         goto done;
     }
 
     if (out->len != MONGOCRYPT_HMAC_LEN) {
-        CLIENT_ERR("out wrong length: %d", out->len);
+        CLIENT_ERR("out wrong length: %" PRIu32, out->len);
         goto done;
     }
 
@@ -761,18 +763,18 @@ static bool _mongocrypt_do_encryption(_mongocrypt_crypto_t *crypto,
         return false;
     }
     if (expect_ciphertext_len != ciphertext->len) {
-        CLIENT_ERR("output ciphertext should have been allocated with %d bytes", expect_ciphertext_len);
+        CLIENT_ERR("output ciphertext should have been allocated with %" PRIu32 " bytes", expect_ciphertext_len);
         return false;
     }
 
     if (MONGOCRYPT_IV_LEN != iv->len) {
-        CLIENT_ERR("IV should have length %d, but has length %d", MONGOCRYPT_IV_LEN, iv->len);
+        CLIENT_ERR("IV should have length %d, but has length %" PRIu32, MONGOCRYPT_IV_LEN, iv->len);
         return false;
     }
 
     const uint32_t expected_key_len = (key_format == KEY_FORMAT_FLE2) ? MONGOCRYPT_ENC_KEY_LEN : MONGOCRYPT_KEY_LEN;
     if (key->len != expected_key_len) {
-        CLIENT_ERR("key should have length %d, but has length %d", expected_key_len, key->len);
+        CLIENT_ERR("key should have length %" PRIu32 ", but has length %" PRIu32, expected_key_len, key->len);
         return false;
     }
 
@@ -886,11 +888,13 @@ static bool _decrypt_step(_mongocrypt_crypto_t *crypto,
     *bytes_written = 0;
 
     if (MONGOCRYPT_IV_LEN != iv->len) {
-        CLIENT_ERR("IV should have length %d, but has length %d", MONGOCRYPT_IV_LEN, iv->len);
+        CLIENT_ERR("IV should have length %d, but has length %" PRIu32, MONGOCRYPT_IV_LEN, iv->len);
         return false;
     }
     if (MONGOCRYPT_ENC_KEY_LEN != enc_key->len) {
-        CLIENT_ERR("encryption key should have length %d, but has length %d", MONGOCRYPT_ENC_KEY_LEN, enc_key->len);
+        CLIENT_ERR("encryption key should have length %d, but has length %" PRIu32,
+                   MONGOCRYPT_ENC_KEY_LEN,
+                   enc_key->len);
         return false;
     }
 
@@ -986,8 +990,8 @@ static bool _mongocrypt_do_decryption(_mongocrypt_crypto_t *crypto,
         return false;
     }
     if (plaintext->len != expect_plaintext_len) {
-        CLIENT_ERR("output plaintext should have been allocated with %d bytes, "
-                   "but has: %d",
+        CLIENT_ERR("output plaintext should have been allocated with %" PRIu32 " bytes, "
+                   "but has: %" PRIu32,
                    expect_plaintext_len,
                    plaintext->len);
         return false;
@@ -1004,13 +1008,13 @@ static bool _mongocrypt_do_decryption(_mongocrypt_crypto_t *crypto,
 
     const uint32_t expected_key_len = (key_format == KEY_FORMAT_FLE2) ? MONGOCRYPT_ENC_KEY_LEN : MONGOCRYPT_KEY_LEN;
     if (expected_key_len != key->len) {
-        CLIENT_ERR("key should have length %d, but has length %d", expected_key_len, key->len);
+        CLIENT_ERR("key should have length %" PRIu32 ", but has length %" PRIu32, expected_key_len, key->len);
         return false;
     }
 
     const uint32_t min_cipherlen = _mongocrypt_calculate_ciphertext_len(0, mode, hmac, NULL);
     if (ciphertext->len < min_cipherlen) {
-        CLIENT_ERR("corrupt ciphertext - must be >= %d bytes", min_cipherlen);
+        CLIENT_ERR("corrupt ciphertext - must be >= %" PRIu32 " bytes", min_cipherlen);
         return false;
     }
 
@@ -1181,7 +1185,7 @@ bool _mongocrypt_random(_mongocrypt_crypto_t *crypto,
     BSON_ASSERT_PARAM(out);
 
     if (count != out->len) {
-        CLIENT_ERR("out should have length %d, but has length %d", count, out->len);
+        CLIENT_ERR("out should have length %" PRIu32 ", but has length %" PRIu32, count, out->len);
         return false;
     }
 
@@ -1233,11 +1237,11 @@ bool _mongocrypt_calculate_deterministic_iv(_mongocrypt_crypto_t *crypto,
     BSON_ASSERT_PARAM(out);
 
     if (MONGOCRYPT_KEY_LEN != key->len) {
-        CLIENT_ERR("key should have length %d, but has length %d\n", MONGOCRYPT_KEY_LEN, key->len);
+        CLIENT_ERR("key should have length %d, but has length %" PRIu32 "\n", MONGOCRYPT_KEY_LEN, key->len);
         goto done;
     }
     if (MONGOCRYPT_IV_LEN != out->len) {
-        CLIENT_ERR("out should have length %d, but has length %d\n", MONGOCRYPT_IV_LEN, out->len);
+        CLIENT_ERR("out should have length %d, but has length %" PRIu32 "\n", MONGOCRYPT_IV_LEN, out->len);
         goto done;
     }
 
@@ -1300,7 +1304,7 @@ bool _mongocrypt_wrap_key(_mongocrypt_crypto_t *crypto,
     _mongocrypt_buffer_init(encrypted_dek);
 
     if (dek->len != MONGOCRYPT_KEY_LEN) {
-        CLIENT_ERR("data encryption key is incorrect length, expected: %" PRIu32 ", got: %" PRIu32,
+        CLIENT_ERR("data encryption key is incorrect length, expected: %d, got: %" PRIu32,
                    MONGOCRYPT_KEY_LEN,
                    dek->len);
         goto done;
@@ -1348,9 +1352,7 @@ bool _mongocrypt_unwrap_key(_mongocrypt_crypto_t *crypto,
     dek->len = bytes_written;
 
     if (dek->len != MONGOCRYPT_KEY_LEN) {
-        CLIENT_ERR("decrypted key is incorrect length, expected: %" PRIu32 ", got: %" PRIu32,
-                   MONGOCRYPT_KEY_LEN,
-                   dek->len);
+        CLIENT_ERR("decrypted key is incorrect length, expected: %d, got: %" PRIu32, MONGOCRYPT_KEY_LEN, dek->len);
         return false;
     }
     return true;

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -1062,7 +1062,7 @@ static bool _fle2_fixup_encryptedFields_strEncodeVersion(const char *cmd_name,
         } else {
             // Check strEncodeVersion for match against EFC
             if (!BSON_ITER_HOLDS_INT32(&sev_iter)) {
-                CLIENT_ERR("expected 'strEncodeVersion' to be type int32, got: %d", bson_iter_type(&sev_iter));
+                CLIENT_ERR("expected 'strEncodeVersion' to be type int32, got: %d", (int)bson_iter_type(&sev_iter));
                 return false;
             }
             int32_t version = bson_iter_int32(&sev_iter);
@@ -1902,7 +1902,7 @@ static bool explicit_encrypt_init(mongocrypt_ctx_t *ctx, mongocrypt_binary_t *ms
             matches = (ctx->opts.index_type.value == MONGOCRYPT_INDEX_TYPE_EQUALITY);
             break;
         default:
-            CLIENT_ERR("unsupported value for query_type: %d", ctx->opts.query_type.value);
+            CLIENT_ERR("unsupported value for query_type: %d", (int)ctx->opts.query_type.value);
             return _mongocrypt_ctx_fail(ctx);
         }
 

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -597,7 +597,7 @@ static bool _get_tokenKey(_mongocrypt_key_broker_t *kb,
     }
 
     if (indexKey.len != MONGOCRYPT_KEY_LEN) {
-        CLIENT_ERR("invalid indexKey, expected len=%" PRIu32 ", got len=%" PRIu32, MONGOCRYPT_KEY_LEN, indexKey.len);
+        CLIENT_ERR("invalid indexKey, expected len=%d, got len=%" PRIu32, MONGOCRYPT_KEY_LEN, indexKey.len);
         _mongocrypt_buffer_cleanup(&indexKey);
         return false;
     }

--- a/test/test-gcp-auth.c
+++ b/test/test-gcp-auth.c
@@ -32,7 +32,7 @@ static void _test_createdatakey_with_credentials(_mongocrypt_tester_t *tester) {
 
     crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
     ctx = mongocrypt_ctx_new(crypt);
-    ASSERT_OK(mongocrypt_ctx_setopt_key_encryption_key(ctx, TEST_BSON(kek)), ctx);
+    ASSERT_OK(mongocrypt_ctx_setopt_key_encryption_key(ctx, TEST_BSON_STR(kek)), ctx);
     ASSERT_OK(mongocrypt_ctx_datakey_init(ctx), ctx);
 
     ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_KMS);
@@ -159,7 +159,7 @@ static void _test_createdatakey_with_accesstoken(_mongocrypt_tester_t *tester) {
     mongocrypt_setopt_use_need_kms_credentials_state(crypt);
     ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     ctx = mongocrypt_ctx_new(crypt);
-    ASSERT_OK(mongocrypt_ctx_setopt_key_encryption_key(ctx, TEST_BSON(kek)), ctx);
+    ASSERT_OK(mongocrypt_ctx_setopt_key_encryption_key(ctx, TEST_BSON_STR(kek)), ctx);
     ASSERT_OK(mongocrypt_ctx_datakey_init(ctx), ctx);
 
     ASSERT_STATE_EQUAL(mongocrypt_ctx_state(ctx), MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS);

--- a/test/test-mc-fle2-encryption-placeholder.c
+++ b/test/test-mc-fle2-encryption-placeholder.c
@@ -321,15 +321,20 @@ static bool _parse_text_search_spec_from_placeholder(_mongocrypt_tester_t *teste
                                                      const char *spec_json_in,
                                                      mc_FLE2TextSearchInsertSpec_t *spec_out,
                                                      mongocrypt_status_t *status_out) {
-    const char *template = RAW_STRING({
-        "t" : {"$numberInt" : "1"},
-        "a" : {"$numberInt" : "4"},
-        "ki" : {"$binary" : {"base64" : "EjRWeBI0mHYSNBI0VniQEg==", "subType" : "04"}},
-        "ku" : {"$binary" : {"base64" : "q83vqxI0mHYSNBI0VniQEg==", "subType" : "04"}},
-        "v" : % s,
-        "cm" : {"$numberLong" : "7"}
-    });
-    bson_t *const as_bson = TMP_BSON(template, spec_json_in);
+    // Preserve `%s` which gets incorrectly formatted to `% s`.
+    // clang-format off
+#define PLACEHOLDER_TEMPLATE                                                            \
+    RAW_STRING({                                                                        \
+        "t" : {"$numberInt" : "1"},                                                     \
+        "a" : {"$numberInt" : "4"},                                                     \
+        "ki" : {"$binary" : {"base64" : "EjRWeBI0mHYSNBI0VniQEg==", "subType" : "04"}}, \
+        "ku" : {"$binary" : {"base64" : "q83vqxI0mHYSNBI0VniQEg==", "subType" : "04"}}, \
+        "v" : %s,                                                                       \
+        "cm" : {"$numberLong" : "7"}                                                    \
+    })
+    // clang-format on
+
+    bson_t *const as_bson = TMP_BSON(PLACEHOLDER_TEMPLATE, spec_json_in);
 
     mc_FLE2EncryptionPlaceholder_t placeholder;
     mc_FLE2EncryptionPlaceholder_init(&placeholder);
@@ -355,6 +360,8 @@ static bool _parse_text_search_spec_from_placeholder(_mongocrypt_tester_t *teste
 
     mc_FLE2EncryptionPlaceholder_cleanup(&placeholder);
     return res;
+
+#undef PLACEHOLDER_TEMPLATE
 }
 
 static void _test_FLE2EncryptionPlaceholder_textSearch_parse(_mongocrypt_tester_t *tester) {

--- a/test/test-mc-fle2-encryption-placeholder.c
+++ b/test/test-mc-fle2-encryption-placeholder.c
@@ -321,20 +321,17 @@ static bool _parse_text_search_spec_from_placeholder(_mongocrypt_tester_t *teste
                                                      const char *spec_json_in,
                                                      mc_FLE2TextSearchInsertSpec_t *spec_out,
                                                      mongocrypt_status_t *status_out) {
-    // Preserve `%s` which gets incorrectly formatted to `% s`.
-    // clang-format off
-#define PLACEHOLDER_TEMPLATE                                                            \
-    RAW_STRING({                                                                        \
-        "t" : {"$numberInt" : "1"},                                                     \
-        "a" : {"$numberInt" : "4"},                                                     \
-        "ki" : {"$binary" : {"base64" : "EjRWeBI0mHYSNBI0VniQEg==", "subType" : "04"}}, \
-        "ku" : {"$binary" : {"base64" : "q83vqxI0mHYSNBI0VniQEg==", "subType" : "04"}}, \
-        "v" : %s,                                                                       \
-        "cm" : {"$numberLong" : "7"}                                                    \
+#define PLACEHOLDER_TEMPLATE                                                                                           \
+    RAW_STRING({                                                                                                       \
+        "t" : {"$numberInt" : "1"},                                                                                    \
+        "a" : {"$numberInt" : "4"},                                                                                    \
+        "ki" : {"$binary" : {"base64" : "EjRWeBI0mHYSNBI0VniQEg==", "subType" : "04"}},                                \
+        "ku" : {"$binary" : {"base64" : "q83vqxI0mHYSNBI0VniQEg==", "subType" : "04"}},                                \
+        "v" : MC_BSON,                                                                                                 \
+        "cm" : {"$numberLong" : "7"}                                                                                   \
     })
-    // clang-format on
 
-    bson_t *const as_bson = TMP_BSON(PLACEHOLDER_TEMPLATE, spec_json_in);
+    bson_t *const as_bson = TMP_BSONF(PLACEHOLDER_TEMPLATE, TMP_BSON_STR(spec_json_in));
 
     mc_FLE2EncryptionPlaceholder_t placeholder;
     mc_FLE2EncryptionPlaceholder_init(&placeholder);

--- a/test/test-mc-fle2-rfds.c
+++ b/test/test-mc-fle2-rfds.c
@@ -93,7 +93,7 @@ static void test_mc_FLE2RangeFindDriverSpec_parse(_mongocrypt_tester_t *tester) 
         mongocrypt_status_t *status = mongocrypt_status_new();
         mc_FLE2RangeFindDriverSpec_t rfds;
         TEST_PRINTF("running subtest: %s\n", test->desc);
-        bool ret = mc_FLE2RangeFindDriverSpec_parse(&rfds, TMP_BSON(test->in), status);
+        bool ret = mc_FLE2RangeFindDriverSpec_parse(&rfds, TMP_BSON_STR(test->in), status);
         if (!test->expectError) {
             ASSERT_OK_STATUS(ret, status);
             ASSERT_STREQUAL(test->expect.field, rfds.field);
@@ -330,12 +330,12 @@ static void test_mc_FLE2RangeFindDriverSpec_to_placeholders(_mongocrypt_tester_t
     for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
         testcase_t *test = tests + i;
         TEST_PRINTF("running subtest: %s : %s\n", test->desc, test->in);
-        ASSERT_OK_STATUS(mc_FLE2RangeFindDriverSpec_parse(&spec, TMP_BSON(test->in), status), status);
+        ASSERT_OK_STATUS(mc_FLE2RangeFindDriverSpec_parse(&spec, TMP_BSON_STR(test->in), status), status);
 
         // Create the expected document.
         bson_t *expected;
         {
-            expected = TMP_BSON(test->expected);
+            expected = TMP_BSON_STR(test->expected);
 
             _mongocrypt_buffer_t p1 = {0}, p2 = {0};
 

--- a/test/test-mc-fle2-rfds.c
+++ b/test/test-mc-fle2-rfds.c
@@ -323,7 +323,10 @@ static void test_mc_FLE2RangeFindDriverSpec_to_placeholders(_mongocrypt_tester_t
     };
 
     bson_t *range_opts_bson =
-        TMP_BSON("{'min': %d, 'max': %d, 'sparsity': {'$numberLong': '%d'}}", indexMin, indexMax, sparsity);
+        TMP_BSON("{'min': %" PRId32 ", 'max': %" PRId32 ", 'sparsity': {'$numberLong': '%" PRId64 "'}}",
+                 indexMin,
+                 indexMax,
+                 sparsity);
 
     ASSERT_OK_STATUS(mc_RangeOpts_parse(&range_opts, range_opts_bson, true /* use_range_v2 */, status), status);
 

--- a/test/test-mc-range-encoding.c
+++ b/test/test-mc-range-encoding.c
@@ -201,7 +201,7 @@ static void _test_canUsePrecisionModeDouble(_mongocrypt_tester_t *tester) {
     {                                                                                                                  \
         uint32_t bits_out = 0;                                                                                         \
         mongocrypt_status_t *const status = mongocrypt_status_new();                                                   \
-        TEST_PRINTF("_test_canUsePrecisionModeDecimal, min: %f, max: %f, prc: %" PRIu32, lb, ub, prc);                 \
+        TEST_PRINTF("_test_canUsePrecisionModeDecimal, min: %f, max: %f, prc: %" PRId32, lb, ub, prc);                 \
         bool result = mc_canUsePrecisionModeDouble(lb, ub, prc, &bits_out, status);                                    \
         ASSERT_OK_STATUS(mongocrypt_status_ok(status), status);                                                        \
         ASSERT(result == expected);                                                                                    \
@@ -212,7 +212,7 @@ static void _test_canUsePrecisionModeDouble(_mongocrypt_tester_t *tester) {
 #define CAN_USE_PRECISION_MODE_ERRORS(lb, ub, prc, error)                                                              \
     {                                                                                                                  \
         mongocrypt_status_t *const status = mongocrypt_status_new();                                                   \
-        TEST_PRINTF("_test_canUsePrecisionModeDecimal errors, min: %f, max: %f, prc: %" PRIu32, lb, ub, prc);          \
+        TEST_PRINTF("_test_canUsePrecisionModeDecimal errors, min: %f, max: %f, prc: %" PRId32, lb, ub, prc);          \
         uint32_t bits_out = 0;                                                                                         \
         bool result = mc_canUsePrecisionModeDouble(lb, ub, prc, &bits_out, status);                                    \
         ASSERT_OR_PRINT_MSG(!result, "expected error, but got none");                                                  \
@@ -220,37 +220,43 @@ static void _test_canUsePrecisionModeDouble(_mongocrypt_tester_t *tester) {
         mongocrypt_status_destroy(status);                                                                             \
     }
 
-    CAN_USE_PRECISION_MODE(1.0, 16.0, 0, true, 4);
-    CAN_USE_PRECISION_MODE(0.0, 16.0, 0, true, 5);
+    CAN_USE_PRECISION_MODE(1.0, 16.0, INT32_C(0), true, 4);
+    CAN_USE_PRECISION_MODE(0.0, 16.0, INT32_C(0), true, 5);
     // 2^53 + 1 is where double starts to lose precision, so we need to ensure that we get the
     // correct value for max_bits out.
-    CAN_USE_PRECISION_MODE_ERRORS(1.0, 9007199254740992.0, 0, "Invalid upper bound for double precision. Absolute");
-    CAN_USE_PRECISION_MODE_ERRORS(0.0, 9007199254740992.0, 0, "Invalid upper bound for double precision. Absolute");
+    CAN_USE_PRECISION_MODE_ERRORS(1.0,
+                                  9007199254740992.0,
+                                  INT32_C(0),
+                                  "Invalid upper bound for double precision. Absolute");
+    CAN_USE_PRECISION_MODE_ERRORS(0.0,
+                                  9007199254740992.0,
+                                  INT32_C(0),
+                                  "Invalid upper bound for double precision. Absolute");
 
     CAN_USE_PRECISION_MODE(2.718281, 314.159265, 6, true, 29);
 
     CAN_USE_PRECISION_MODE_ERRORS(-1000000000.0,
                                   9223372036844775424.0,
-                                  0,
+                                  INT32_C(0),
                                   "Invalid upper bound for double precision. Absolute");
 
     CAN_USE_PRECISION_MODE_ERRORS(2.710000,
                                   314.150000,
-                                  2,
+                                  INT32_C(2),
                                   "Invalid upper bound for double precision. Fractional digits");
     CAN_USE_PRECISION_MODE_ERRORS(314.150000, 350.0, 2, "Invalid lower bound for double precision. Fractional digits");
 
     CAN_USE_PRECISION_MODE_ERRORS((double)9007199254740992,
                                   INT_64_MAX_DOUBLE,
-                                  0,
+                                  INT32_C(0),
                                   "Invalid upper bound for double precision. Absolute scaled value");
     CAN_USE_PRECISION_MODE_ERRORS(-1 * INT_64_MAX_DOUBLE,
                                   1.0,
-                                  0,
+                                  INT32_C(0),
                                   "Invalid lower bound for double precision. Absolute scaled value");
     CAN_USE_PRECISION_MODE_ERRORS(-92233720368547.0,
                                   92233720368547.0,
-                                  5,
+                                  INT32_C(5),
                                   "Invalid upper bound for double precision. Absolute");
 
 #undef CAN_USE_PRECISION_MODE

--- a/test/test-mc-range-encoding.c
+++ b/test/test-mc-range-encoding.c
@@ -558,7 +558,7 @@ static void _test_RangeTest_Encode_Double(_mongocrypt_tester_t *tester) {
 
         if (test->min.set && test->max.set && test->precision.set) {
             TEST_PRINTF("_test_RangeTest_Encode_Double: value=%f, min=%f, max=%f, "
-                        "precision=%" PRIu32 "\n",
+                        "precision=%" PRId32 "\n",
                         test->value,
                         test->min.value,
                         test->max.value,

--- a/test/test-mc-range-mincover.c
+++ b/test/test-mc-range-mincover.c
@@ -314,7 +314,7 @@ static void _test_dump_Double(void *tests, size_t idx, mc_mincover_t *got) {
         TEST_STDERR_PRINTF(" max=%f", test->max.value);
     }
     if (test->precision.set) {
-        TEST_STDERR_PRINTF(" precision=%" PRIu32, test->precision.value);
+        TEST_STDERR_PRINTF(" precision=%" PRId32, test->precision.value);
     }
     TEST_STDERR_PRINTF(" sparsity=%zu\n", test->sparsity);
     TEST_STDERR_PRINTF("mincover expected ... begin\n");

--- a/test/test-mc-rangeopts.c
+++ b/test/test-mc-rangeopts.c
@@ -88,7 +88,7 @@ static void test_mc_RangeOpts_parse(_mongocrypt_tester_t *tester) {
         mongocrypt_status_t *status = mongocrypt_status_new();
         mc_RangeOpts_t ro;
         TEST_PRINTF("running test_mc_RangeOpts_parse subtest: %s\n", test->desc);
-        bool ret = mc_RangeOpts_parse(&ro, TMP_BSON(test->in), test->useRangeV2, status);
+        bool ret = mc_RangeOpts_parse(&ro, TMP_BSON_STR(test->in), test->useRangeV2, status);
         if (!test->expectError) {
             ASSERT_OK_STATUS(ret, status);
             ASSERT_CMPINT(test->expectMin.set, ==, ro.min.set);
@@ -317,12 +317,12 @@ static void test_mc_RangeOpts_to_FLE2RangeInsertSpec(_mongocrypt_tester_t *teste
         mongocrypt_status_t *status = mongocrypt_status_new();
         mc_RangeOpts_t ro;
         TEST_PRINTF("running test_mc_RangeOpts_to_FLE2RangeInsertSpec subtest: %s\n", test->desc);
-        ASSERT_OK_STATUS(mc_RangeOpts_parse(&ro, TMP_BSON(test->in), !test->disableRangeV2, status), status);
+        ASSERT_OK_STATUS(mc_RangeOpts_parse(&ro, TMP_BSON_STR(test->in), !test->disableRangeV2, status), status);
         bson_t out = BSON_INITIALIZER;
-        bool ret = mc_RangeOpts_to_FLE2RangeInsertSpec(&ro, TMP_BSON(test->v), &out, !test->disableRangeV2, status);
+        bool ret = mc_RangeOpts_to_FLE2RangeInsertSpec(&ro, TMP_BSON_STR(test->v), &out, !test->disableRangeV2, status);
         if (!test->expectError) {
             ASSERT_OK_STATUS(ret, status);
-            ASSERT_EQUAL_BSON(TMP_BSON(test->expect), &out);
+            ASSERT_EQUAL_BSON(TMP_BSON_STR(test->expect), &out);
         } else {
             ASSERT_FAILS_STATUS(ret, status, test->expectError);
         }

--- a/test/test-mongocrypt-assert-match-bson.c
+++ b/test/test-mongocrypt-assert-match-bson.c
@@ -849,7 +849,8 @@ bool match_bson_value(const bson_value_t *doc, const bson_value_t *pattern, matc
                       "numeric values may be equal)");
         }
         break;
-    default: match_err(ctx, "unexpected value type %d: %s", doc->value_type, _mongoc_bson_type_to_str(doc->value_type));
+    default:
+        match_err(ctx, "unexpected value type %d: %s", (int)doc->value_type, _mongoc_bson_type_to_str(doc->value_type));
     }
 
     if (!ret) {

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -883,7 +883,7 @@ static void _init_fails(_mongocrypt_tester_t *tester, const char *json, const ch
 
     crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
     ctx = mongocrypt_ctx_new(crypt);
-    ASSERT_FAILS(mongocrypt_ctx_encrypt_init(ctx, "test", -1, TEST_BSON(json)), ctx, msg);
+    ASSERT_FAILS(mongocrypt_ctx_encrypt_init(ctx, "test", -1, TEST_BSON_STR(json)), ctx, msg);
     mongocrypt_ctx_destroy(ctx);
     mongocrypt_destroy(crypt);
 }
@@ -895,7 +895,7 @@ static void _init_ok(_mongocrypt_tester_t *tester, const char *json) {
     crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
     ctx = mongocrypt_ctx_new(crypt);
 
-    ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "test", -1, TEST_BSON(json)), ctx);
+    ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "test", -1, TEST_BSON_STR(json)), ctx);
 
     if (MONGOCRYPT_CTX_NEED_MONGO_COLLINFO == mongocrypt_ctx_state(ctx)) {
         mongocrypt_binary_t *filter;
@@ -923,10 +923,10 @@ static void _init_bypass(_mongocrypt_tester_t *tester, const char *json) {
     bin = mongocrypt_binary_new();
     crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
     ctx = mongocrypt_ctx_new(crypt);
-    ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "test", -1, TEST_BSON(json)), ctx);
+    ASSERT_OK(mongocrypt_ctx_encrypt_init(ctx, "test", -1, TEST_BSON_STR(json)), ctx);
     BSON_ASSERT(MONGOCRYPT_CTX_READY == mongocrypt_ctx_state(ctx));
     ASSERT_OK(mongocrypt_ctx_finalize(ctx, bin), ctx);
-    ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON(TEST_BSON(json), (bin));
+    ASSERT_MONGOCRYPT_BINARY_EQUAL_BSON(TEST_BSON_STR(json), (bin));
 
     mongocrypt_binary_destroy(bin);
     mongocrypt_ctx_destroy(ctx);

--- a/test/test-mongocrypt-ctx-setopt.c
+++ b/test/test-mongocrypt-ctx-setopt.c
@@ -1174,7 +1174,7 @@ static void _test_createdatakey_with_wrong_kms_provider_helper(_mongocrypt_teste
     mongocrypt_setopt_use_need_kms_credentials_state(crypt);
     ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
     ctx = mongocrypt_ctx_new(crypt);
-    ASSERT_OK(mongocrypt_ctx_setopt_key_encryption_key(ctx, TEST_BSON(kek)), ctx);
+    ASSERT_OK(mongocrypt_ctx_setopt_key_encryption_key(ctx, TEST_BSON_STR(kek)), ctx);
     ASSERT_FAILS(mongocrypt_ctx_datakey_init(ctx), ctx, "kms provider required by datakey is not configured");
 
     mongocrypt_ctx_destroy(ctx);

--- a/test/test-mongocrypt-marking.c
+++ b/test/test-mongocrypt-marking.c
@@ -950,7 +950,7 @@ static void get_ciphertext_from_marking_json(_mongocrypt_tester_t *tester,
                                              const char *markingJSON,
                                              _mongocrypt_ciphertext_t *out) {
     get_ciphertext_from_marking_json_with_bufs(crypt,
-                                               TMP_BSON(markingJSON),
+                                               TMP_BSON_STR(markingJSON),
                                                out,
                                                TEST_FILE("./test/example/cmd.json"),
                                                TEST_BIN(16),
@@ -1720,7 +1720,7 @@ static void test_ciphertext_len_steps_fle2_text_search(_mongocrypt_tester_t *tes
         size_t bufsize = snprintf(NULL, 0, MARKING_JSON_FORMAT, v) + 1;
         char *markingJSON = bson_malloc(bufsize);
         sprintf(markingJSON, MARKING_JSON_FORMAT, v);
-        bson_t *marking_bson = TMP_BSON(markingJSON);
+        bson_t *marking_bson = TMP_BSON_STR(markingJSON);
 
         _mongocrypt_ciphertext_t ciphertext;
         _mongocrypt_ciphertext_init(&ciphertext);

--- a/test/test-mongocrypt-marking.c
+++ b/test/test-mongocrypt-marking.c
@@ -1695,17 +1695,19 @@ static void test_mc_marking_to_ciphertext_fle2_text_search(_mongocrypt_tester_t 
 }
 
 static void test_ciphertext_len_steps_fle2_text_search(_mongocrypt_tester_t *tester) {
-    const char *markingJSONFormat = RAW_STRING({
-        't' : 1,
-        'a' : 4,
-        'v' : {
-            'v' : "%s",
-            'casef' : false,
-            'diacf' : false,
-            'suffix' : {'ub' : {'$numberInt' : '2'}, 'lb' : {'$numberInt' : '1'}}
-        },
-        'cm' : {'$numberLong' : '2'}
-    });
+#define MARKING_JSON_FORMAT                                                                                            \
+    RAW_STRING({                                                                                                       \
+        't' : 1,                                                                                                       \
+        'a' : 4,                                                                                                       \
+        'v' : {                                                                                                        \
+            'v' : "%s",                                                                                                \
+            'casef' : false,                                                                                           \
+            'diacf' : false,                                                                                           \
+            'suffix' : {'ub' : {'$numberInt' : '2'}, 'lb' : {'$numberInt' : '1'}}                                      \
+        },                                                                                                             \
+        'cm' : {'$numberLong' : '2'}                                                                                   \
+    })
+
     size_t last_len = 0;
     mongocrypt_binary_t *cmd = TEST_FILE("./test/example/cmd.json");
     mongocrypt_binary_t *key_file = TEST_BIN(16);
@@ -1715,9 +1717,9 @@ static void test_ciphertext_len_steps_fle2_text_search(_mongocrypt_tester_t *tes
     for (size_t str_len = 0; str_len < 256; str_len++) {
         char *v = bson_malloc0(str_len + 1);
         memset(v, 'a', str_len);
-        size_t bufsize = snprintf(NULL, 0, markingJSONFormat, v) + 1;
+        size_t bufsize = snprintf(NULL, 0, MARKING_JSON_FORMAT, v) + 1;
         char *markingJSON = bson_malloc(bufsize);
-        sprintf(markingJSON, markingJSONFormat, v);
+        sprintf(markingJSON, MARKING_JSON_FORMAT, v);
         bson_t *marking_bson = TMP_BSON(markingJSON);
 
         _mongocrypt_ciphertext_t ciphertext;
@@ -1750,6 +1752,8 @@ static void test_ciphertext_len_steps_fle2_text_search(_mongocrypt_tester_t *tes
         bson_destroy(marking_bson);
         tester->bson_count--;
     }
+
+#undef MARKING_JSON_FORMAT
 }
 
 void _mongocrypt_tester_install_marking(_mongocrypt_tester_t *tester) {

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -207,7 +207,7 @@ bson_t *_mongocrypt_tester_file_as_bson(_mongocrypt_tester_t *tester, const char
 }
 
 bson_t *_mongocrypt_tester_bson_from_str(_mongocrypt_tester_t *tester, const char *json) {
-    char *const full_json = bson_strdup (json);
+    char *const full_json = bson_strdup(json);
 
     /* Replace ' with " */
     for (char *c = full_json; *c; c++) {
@@ -223,7 +223,7 @@ bson_t *_mongocrypt_tester_bson_from_str(_mongocrypt_tester_t *tester, const cha
         TEST_STDERR_PRINTF("%s", error.message);
         abort();
     }
-    bson_free (full_json);
+    bson_free(full_json);
     return bson;
 }
 
@@ -288,7 +288,7 @@ bson_t *tmp_bsonf(_mongocrypt_tester_t *tester, const char *fmt, ...) {
 #undef ENSURE_CAPACITY
 
     dst[dst_len] = '\0';
-    bson_t *tmp = TMP_BSON(dst);
+    bson_t *tmp = TMP_BSON_STR(dst);
     va_end(arg);
     bson_free(dst);
     return tmp;
@@ -870,14 +870,14 @@ static void _test_setopt_kms_providers(_mongocrypt_tester_t *tester) {
             mongocrypt_setopt_use_need_kms_credentials_state(crypt);
         }
         if (!test->errmsg) {
-            ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, TEST_BSON(test->value)), crypt);
+            ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, TEST_BSON_STR(test->value)), crypt);
             if (!test->errmsg_init) {
                 ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);
             } else {
                 ASSERT_FAILS(_mongocrypt_init_for_test(crypt), crypt, test->errmsg_init);
             }
         } else {
-            ASSERT_FAILS(mongocrypt_setopt_kms_providers(crypt, TEST_BSON(test->value)), crypt, test->errmsg);
+            ASSERT_FAILS(mongocrypt_setopt_kms_providers(crypt, TEST_BSON_STR(test->value)), crypt, test->errmsg);
         }
         mongocrypt_destroy(crypt);
     }
@@ -1048,7 +1048,7 @@ get_os_version_failed:
 
             continue; // No match found.
         }
-    found_match: {}
+    found_match : {}
 
         TEST_PRINTF("  begin %s\n", tester.test_names[i]);
         tester.test_fns[i](&tester);

--- a/test/test-mongocrypt.h
+++ b/test/test-mongocrypt.h
@@ -231,6 +231,8 @@ void _mongocrypt_tester_install_mc_schema_broker(_mongocrypt_tester_t *tester);
 bson_t *_mongocrypt_tester_bson_from_str(_mongocrypt_tester_t *tester, const char *json);
 #define TMP_BSON_STR(...) _mongocrypt_tester_bson_from_str(tester, __VA_ARGS__)
 
+/* Get a temporary bson_t from a formattable JSON string. Do not free it. */
+MLIB_ANNOTATE_PRINTF(2, 3)
 bson_t *_mongocrypt_tester_bson_from_json(_mongocrypt_tester_t *tester, const char *json, ...);
 #define TMP_BSON(...) _mongocrypt_tester_bson_from_json(tester, __VA_ARGS__)
 
@@ -252,6 +254,8 @@ bson_t *_mongocrypt_tester_file_as_bson(_mongocrypt_tester_t *tester, const char
 mongocrypt_binary_t *_mongocrypt_tester_bin_from_str(_mongocrypt_tester_t *tester, const char *json);
 #define TEST_BSON_STR(...) _mongocrypt_tester_bin_from_str(tester, __VA_ARGS__)
 
+/* Get a temporary binary from a formattable JSON string. Do not free it. */
+MLIB_ANNOTATE_PRINTF(2, 3)
 mongocrypt_binary_t *_mongocrypt_tester_bin_from_json(_mongocrypt_tester_t *tester, const char *json, ...);
 #define TEST_BSON(...) _mongocrypt_tester_bin_from_json(tester, __VA_ARGS__)
 

--- a/test/test-mongocrypt.h
+++ b/test/test-mongocrypt.h
@@ -228,6 +228,9 @@ void _mongocrypt_tester_install_mc_schema_broker(_mongocrypt_tester_t *tester);
 /* Conveniences for getting test data. */
 
 /* Get a temporary bson_t from a JSON string. Do not free it. */
+bson_t *_mongocrypt_tester_bson_from_str(_mongocrypt_tester_t *tester, const char *json);
+#define TMP_BSON_STR(...) _mongocrypt_tester_bson_from_str(tester, __VA_ARGS__)
+
 bson_t *_mongocrypt_tester_bson_from_json(_mongocrypt_tester_t *tester, const char *json, ...);
 #define TMP_BSON(...) _mongocrypt_tester_bson_from_json(tester, __VA_ARGS__)
 
@@ -246,6 +249,9 @@ bson_t *_mongocrypt_tester_file_as_bson(_mongocrypt_tester_t *tester, const char
 #define TEST_FILE_AS_BSON(path) _mongocrypt_tester_file_as_bson(tester, path)
 
 /* Get a temporary binary from a JSON string. Do not free it. */
+mongocrypt_binary_t *_mongocrypt_tester_bin_from_str(_mongocrypt_tester_t *tester, const char *json);
+#define TEST_BSON_STR(...) _mongocrypt_tester_bin_from_str(tester, __VA_ARGS__)
+
 mongocrypt_binary_t *_mongocrypt_tester_bin_from_json(_mongocrypt_tester_t *tester, const char *json, ...);
 #define TEST_BSON(...) _mongocrypt_tester_bin_from_json(tester, __VA_ARGS__)
 

--- a/test/test-named-kms-providers.c
+++ b/test/test-named-kms-providers.c
@@ -387,7 +387,7 @@ static void test_create_datakey_with_named_kms_provider(_mongocrypt_tester_t *te
     {
         mongocrypt_t *crypt = mongocrypt_new();
         mongocrypt_binary_t *kms_providers =
-            TEST_BSON(BSON_STR({"local" : {}, "local:name1" : {"key" : "%s"}}), LOCAL_KEK1_BASE64, LOCAL_KEK2_BASE64);
+            TEST_BSON(BSON_STR({"local" : {}, "local:name1" : {"key" : "%s"}}), LOCAL_KEK1_BASE64);
         ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
         mongocrypt_setopt_use_need_kms_credentials_state(crypt);
         ASSERT_OK(_mongocrypt_init_for_test(crypt), crypt);

--- a/test/test-named-kms-providers.c
+++ b/test/test-named-kms-providers.c
@@ -425,7 +425,7 @@ static void test_create_datakey_with_named_kms_provider(_mongocrypt_tester_t *te
         bson_t out_bson;
         ASSERT(_mongocrypt_binary_to_bson(out, &out_bson));
         char *pattern = BSON_STR({"masterKey" : {"provider" : "local:name1"}});
-        _assert_match_bson(&out_bson, TMP_BSON(pattern));
+        _assert_match_bson(&out_bson, TMP_BSON_STR(pattern));
         bson_destroy(&out_bson);
         mongocrypt_binary_destroy(out);
         mongocrypt_ctx_destroy(ctx);
@@ -491,7 +491,7 @@ static void test_create_datakey_with_named_kms_provider(_mongocrypt_tester_t *te
         bson_t out_bson;
         ASSERT(_mongocrypt_binary_to_bson(out, &out_bson));
         char *pattern = BSON_STR({"masterKey" : {"provider" : "azure:name1"}});
-        _assert_match_bson(&out_bson, TMP_BSON(pattern));
+        _assert_match_bson(&out_bson, TMP_BSON_STR(pattern));
         bson_destroy(&out_bson);
         mongocrypt_binary_destroy(out);
         mongocrypt_ctx_destroy(ctx);
@@ -536,7 +536,7 @@ static void test_create_datakey_with_named_kms_provider(_mongocrypt_tester_t *te
         bson_t out_bson;
         ASSERT(_mongocrypt_binary_to_bson(out, &out_bson));
         char *pattern = BSON_STR({"masterKey" : {"provider" : "azure:name1"}});
-        _assert_match_bson(&out_bson, TMP_BSON(pattern));
+        _assert_match_bson(&out_bson, TMP_BSON_STR(pattern));
         bson_destroy(&out_bson);
         mongocrypt_binary_destroy(out);
         mongocrypt_ctx_destroy(ctx);
@@ -611,7 +611,7 @@ static void test_create_datakey_with_named_kms_provider(_mongocrypt_tester_t *te
             bson_t out_bson;
             ASSERT(_mongocrypt_binary_to_bson(out, &out_bson));
             char *pattern = BSON_STR({"masterKey" : {"provider" : "azure:name1"}});
-            _assert_match_bson(&out_bson, TMP_BSON(pattern));
+            _assert_match_bson(&out_bson, TMP_BSON_STR(pattern));
             bson_destroy(&out_bson);
             mongocrypt_binary_destroy(out);
             mongocrypt_ctx_destroy(ctx);
@@ -664,7 +664,7 @@ static void test_create_datakey_with_named_kms_provider(_mongocrypt_tester_t *te
             bson_t out_bson;
             ASSERT(_mongocrypt_binary_to_bson(out, &out_bson));
             char *pattern = BSON_STR({"masterKey" : {"provider" : "azure:name2"}});
-            _assert_match_bson(&out_bson, TMP_BSON(pattern));
+            _assert_match_bson(&out_bson, TMP_BSON_STR(pattern));
             bson_destroy(&out_bson);
             mongocrypt_binary_destroy(out);
             mongocrypt_ctx_destroy(ctx);
@@ -717,7 +717,7 @@ static void test_create_datakey_with_named_kms_provider(_mongocrypt_tester_t *te
         bson_t out_bson;
         ASSERT(_mongocrypt_binary_to_bson(out, &out_bson));
         char *pattern = BSON_STR({"masterKey" : {"provider" : "kmip:name1"}});
-        _assert_match_bson(&out_bson, TMP_BSON(pattern));
+        _assert_match_bson(&out_bson, TMP_BSON_STR(pattern));
         bson_destroy(&out_bson);
         mongocrypt_binary_destroy(out);
         mongocrypt_ctx_destroy(ctx);
@@ -810,7 +810,7 @@ static void test_create_datakey_with_named_kms_provider(_mongocrypt_tester_t *te
         bson_t out_bson;
         ASSERT(_mongocrypt_binary_to_bson(out, &out_bson));
         char *pattern = BSON_STR({"masterKey" : {"provider" : "kmip:name1"}});
-        _assert_match_bson(&out_bson, TMP_BSON(pattern));
+        _assert_match_bson(&out_bson, TMP_BSON_STR(pattern));
         bson_destroy(&out_bson);
         mongocrypt_binary_destroy(out);
         mongocrypt_ctx_destroy(ctx);
@@ -2119,7 +2119,7 @@ static void test_rewrap_with_named_kms_provider_local2local(_mongocrypt_tester_t
             bson_t bin_bson;
             ASSERT(_mongocrypt_binary_to_bson(bin, &bin_bson));
             char *pattern = BSON_STR({"v" : [ {"masterKey" : {"provider" : "local:name2"}} ]});
-            _assert_match_bson(&bin_bson, TMP_BSON(pattern));
+            _assert_match_bson(&bin_bson, TMP_BSON_STR(pattern));
         }
         mongocrypt_binary_destroy(bin);
         mongocrypt_ctx_destroy(ctx);
@@ -2242,7 +2242,7 @@ static void test_rewrap_with_named_kms_provider_azure2azure(_mongocrypt_tester_t
             bson_t bin_bson;
             ASSERT(_mongocrypt_binary_to_bson(bin, &bin_bson));
             char *pattern = BSON_STR({"v" : [ {"masterKey" : {"provider" : "azure:name2"}} ]});
-            _assert_match_bson(&bin_bson, TMP_BSON(pattern));
+            _assert_match_bson(&bin_bson, TMP_BSON_STR(pattern));
         }
         mongocrypt_binary_destroy(bin);
         mongocrypt_ctx_destroy(ctx);
@@ -2330,7 +2330,7 @@ static void test_rewrap_with_named_kms_provider_azure2local(_mongocrypt_tester_t
             bson_t bin_bson;
             ASSERT(_mongocrypt_binary_to_bson(bin, &bin_bson));
             char *pattern = BSON_STR({"v" : [ {"masterKey" : {"provider" : "local:name1"}} ]});
-            _assert_match_bson(&bin_bson, TMP_BSON(pattern));
+            _assert_match_bson(&bin_bson, TMP_BSON_STR(pattern));
         }
         mongocrypt_binary_destroy(bin);
         mongocrypt_ctx_destroy(ctx);

--- a/test/util/util.c
+++ b/test/util/util.c
@@ -50,7 +50,7 @@ void _errexit_ctx(mongocrypt_ctx_t *ctx, int line) {
 }
 
 void _errexit_bson(bson_error_t *error, int line) {
-    MONGOC_ERROR("Error at line %d with code %d and msg: %s", line, error->code, error->message);
+    MONGOC_ERROR("Error at line %d with code %" PRIu32 " and msg: %s", line, error->code, error->message);
     exit(1);
 }
 


### PR DESCRIPTION
Related to MONGOCRYPT-783.

The `-Wformat-nonliteral` warning warns when the provided format string cannot be checked at compile-time for correctness or security issues. Currently, there are 2 warnings for GCC and 6 warnings for Clang. Addressing these initial warnings reveal an additional 6 for GCC and 1 for Clang. Addressing _these_ warnings converts all format strings in the codebase into string literals which can be checked at compile-time. These new compile-time checks enabled the following warnings:

- Clang:
    - `-Wformat-security`: 28 unique, 38 total.
    - `-Wformat-extra-args`: 1 unique, 1 total.
    - `-Wformat`: 74 unique, 197 total.
- GCC:
    - `-Wformat-security`: 29 unique, 39 total.
    - `-Wformat-extra-args`: 1 unique, 1 total.
    - `-Wformat=`: 2 unique, 2 total.

To address `-Wformat` warnings for enumerators (e.g. `bson_type_t`), arguments are cast to `int` along with `%d` specifiers, as most enumerators are expected/assumed to be representable by `int`.

Aside from straightforward format specifier fixes, functions that accept a format string are given `format(__printf__)` attributes (addressing most `-Wformat-nonliteral` warnings). This motivated the addition of `*_from_str` equivalents of `*_from_json` test utilities that do _not_ have the formatting requirement (addressing most `-Wformat-security` warnings).

> [!NOTE]
> This PR introduces new `-Wformat=` GCC warnings due to use of `%z` in `kms_request.c`. These new warnings are resolved by https://github.com/mongodb/libmongocrypt/pull/969.