### PR TITLE
MONGOCRYPT-786 Fix incompatible type error

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -40,7 +40,6 @@ static bool _mongo_op_collinfo(mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out) 
         _mongocrypt_ctx_fail(ctx);
         return false;
     }
-    CRYPT_TRACEF(&ectx->parent.crypt->log, "constructed: %s\n", tmp_json(&filter));
     _mongocrypt_buffer_steal_from_bson(&ectx->list_collections_filter, &filter);
     out->data = ectx->list_collections_filter.data;
     out->len = ectx->list_collections_filter.len;

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -40,7 +40,7 @@ static bool _mongo_op_collinfo(mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out) 
         _mongocrypt_ctx_fail(ctx);
         return false;
     }
-    CRYPT_TRACEF(&ectx->parent.crypt->log, "constructed: %s\n", tmp_json(filter));
+    CRYPT_TRACEF(&ectx->parent.crypt->log, "constructed: %s\n", tmp_json(&filter));
     _mongocrypt_buffer_steal_from_bson(&ectx->list_collections_filter, &filter);
     out->data = ectx->list_collections_filter.data;
     out->len = ectx->list_collections_filter.len;


### PR DESCRIPTION
Building libmongocrypt on Linux from the current master commit 8270531 was unsuccessful. The following error was produced.

````{verbatim, lang = "markdown"}
[ 22%] Building C object CMakeFiles/mongocrypt.dir/src/mongocrypt-ctx-encrypt.c.o
In file included from libmongocrypt/src/mongocrypt-opts-private.h:27,
                 from libmongocrypt/src/mongocrypt-key-private.h:22,
                 from libmongocrypt/src/mongocrypt-cache-key-private.h:22,
                 from libmongocrypt/src/mongocrypt-key-broker-private.h:24,
                 from libmongocrypt/src/mongocrypt-ctx-private.h:26,
                 from libmongocrypt/src/mongocrypt-ctx-encrypt.c:22:
libmongocrypt/src/mongocrypt-ctx-encrypt.c: In function ‘_mongo_op_collinfo’:
libmongocrypt/src/mongocrypt-ctx-encrypt.c:43:74: error: incompatible type for argument 1 of ‘tmp_json’
   43 | RACEF(&ectx->parent.crypt->log, "constructed: %s\n", tmp_json(filter));
      |                                                               ^~~~~~
      |                                                               |
      |                                                               bson_t {aka struct _bson_t}
libmongocrypt/src/mongocrypt-log-private.h:44:91: note: in definition of macro ‘CRYPT_TRACEF’
   44 | CRYPT_LOG_LEVEL_TRACE, "(%s:%d) " fmt, BSON_FUNC, __LINE__, __VA_ARGS__)
      |                                                             ^~~~~~~~~~~
In file included from libmongocrypt/src/mongocrypt-ctx-private.h:28:
libmongocrypt/src/mongocrypt-private.h:57:36: note: expected ‘const bson_t *’ {aka ‘const struct _bson_t *’} but argument is of type ‘bson_t’ {aka ‘struct _bson_t’}
   57 | const char *tmp_json(const bson_t *bson);
      |                      ~~~~~~~~~~~~~~^~~~
make[2]: *** [CMakeFiles/mongocrypt.dir/build.make:639: CMakeFiles/mongocrypt.dir/src/mongocrypt-ctx-encrypt.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1296: CMakeFiles/mongocrypt.dir/all] Error 2
make: *** [Makefile:166: all] Error 2
````

This problem can be fixed by a minor change in this pull request. The caller ``tmp_json`` in ``src/mongocrypt-ctx-encrypt.c`` must take the address ``&filter``, not the object ``filter`` because a pointer argument is passed to the function pointer ``tmp_json`` defined in ``src/mongocrypt-private.h``. Now it is successful to build libmongocrypt.