### PR TITLE
MONGOCRYPT-773 check if `_GNU_SOURCE` is defined before defining

### DIFF
--- a/kms-message/test/test_kms_request.c
+++ b/kms-message/test/test_kms_request.c
@@ -15,7 +15,9 @@
  */
 
 /* Needed for strptime */
+#if !defined(_GNU_SOURCE)
 #define _GNU_SOURCE
+#endif
 
 #include "kms_message/kms_message.h"
 #include "kms_message_private.h"

--- a/src/mongocrypt-util.c
+++ b/src/mongocrypt-util.c
@@ -18,7 +18,9 @@
 #if defined(__has_include) && !(defined(_GNU_SOURCE) || defined(_DARWIN_C_SOURCE))
 #if __has_include(<features.h>)
 // We're using a glibc-compatible library
+#if !defined(_GNU_SOURCE)
 #define _GNU_SOURCE
+#endif
 #elif __has_include(<Availability.h>)
 // We're on Apple/Darwin
 #define _DARWIN_C_SOURCE
@@ -26,7 +28,9 @@
 #else // No __has_include
 #if __GNUC__ < 5
 // Best guess on older GCC is that we are using glibc
+#if !defined(_GNU_SOURCE)
 #define _GNU_SOURCE
+#endif
 #endif
 #endif
 

--- a/src/os_posix/os_dll.c
+++ b/src/os_posix/os_dll.c
@@ -2,7 +2,9 @@
 #if defined(__has_include) && !(defined(_GNU_SOURCE) || defined(_DARWIN_C_SOURCE))
 #if __has_include(<features.h>)
 // We're using a glibc-compatible library
+#if !defined(_GNU_SOURCE)
 #define _GNU_SOURCE
+#endif
 #elif __has_include(<Availability.h>)
 // We're on Apple/Darwin
 #define _DARWIN_C_SOURCE
@@ -10,7 +12,9 @@
 #else // No __has_include
 #if __GNUC__ < 5
 // Best guess on older GCC is that we are using glibc
+#if !defined(_GNU_SOURCE)
 #define _GNU_SOURCE
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Avoid a possible redefinition warning when building with `_GNU_SOURCE` defined by build system.