### PR TITLE
MONGOCRYPT-738 Improve error on failure to load crypt_shared

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,6 +533,8 @@ target_compile_definitions (test-mongocrypt PRIVATE
    "TEST_MONGOCRYPT_OUTPUT_PATH=\"$<TARGET_FILE:test-mongocrypt>\""
    # Tell test-mongocrypt whether we have a real csfle library for testing
    TEST_MONGOCRYPT_HAVE_REAL_CRYPT_SHARED_LIB=$<BOOL:${MONGOCRYPT_TESTING_CRYPT_SHARED_FILE}>
+   # Tell test-mongocrypt the path of the libmongocrypt shared library for testing.
+   "TEST_MONGOCRYPT_MONGOCRYPT_SHARED_PATH=\"$<TARGET_FILE:mongocrypt>\""
    )
 
 add_test (

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -436,6 +436,13 @@ static _loaded_csfle _try_load_csfle(const char *filepath, mongocrypt_status_t *
 #undef X_FUNC
 
     if (!vtable.okay) {
+        // A common mistake is to pass the path to libmongocrypt instead of than crypt_shared.
+        // Check if the library has a libmongocrypt symbol.
+        if (mcr_dll_sym(lib, "mongocrypt_version")) {
+            CLIENT_ERR("Tried to load crypt_shared dynamic library at path [%s] but detected libmongocrypt", filepath);
+            mcr_dll_close(lib);
+            return (_loaded_csfle){.okay = false};
+        }
         mcr_dll_close(lib);
         _mongocrypt_log(log,
                         MONGOCRYPT_LOG_LEVEL_ERROR,

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -396,10 +396,10 @@ static _loaded_csfle _try_load_csfle(const char *filepath, mongocrypt_status_t *
         // Error opening candidate
         _mongocrypt_log(log,
                         MONGOCRYPT_LOG_LEVEL_WARNING,
-                        "Error while opening candidate for CSFLE dynamic library [%s]: %s",
+                        "Error while opening candidate for crypt_shared dynamic library [%s]: %s",
                         filepath,
                         lib.error_string.raw.data);
-        CLIENT_ERR("Error while opening candidate for CSFLE dynamic library [%s]: %s",
+        CLIENT_ERR("Error while opening candidate for crypt_shared dynamic library [%s]: %s",
                    filepath,
                    lib.error_string.raw.data);
         // Free resources, which will include the error string
@@ -409,7 +409,7 @@ static _loaded_csfle _try_load_csfle(const char *filepath, mongocrypt_status_t *
     }
 
     // Successfully opened DLL
-    _mongocrypt_log(log, MONGOCRYPT_LOG_LEVEL_TRACE, "Loading CSFLE dynamic library [%s]", filepath);
+    _mongocrypt_log(log, MONGOCRYPT_LOG_LEVEL_TRACE, "Loading crypt_shared dynamic library [%s]", filepath);
 
     // Construct the library vtable
     _mongo_crypt_v1_vtable vtable = {.okay = true};
@@ -424,7 +424,7 @@ static _loaded_csfle _try_load_csfle(const char *filepath, mongocrypt_status_t *
             /* The requested symbol is not present */                                                                  \
             _mongocrypt_log(log,                                                                                       \
                             MONGOCRYPT_LOG_LEVEL_ERROR,                                                                \
-                            "Missing required symbol '%s' from CSFLE dynamic library [%s]",                            \
+                            "Missing required symbol '%s' from crypt_shared dynamic library [%s]",                     \
                             symname,                                                                                   \
                             filepath);                                                                                 \
             /* Mark the vtable as broken, but keep trying to load more symbols to                                      \
@@ -439,14 +439,14 @@ static _loaded_csfle _try_load_csfle(const char *filepath, mongocrypt_status_t *
         mcr_dll_close(lib);
         _mongocrypt_log(log,
                         MONGOCRYPT_LOG_LEVEL_ERROR,
-                        "One or more required symbols are missing from CSFLE dynamic library "
+                        "One or more required symbols are missing from crypt_shared dynamic library "
                         "[%s], so this dynamic library will not be used.",
                         filepath);
         return (_loaded_csfle){.okay = false};
     }
 
     // Success!
-    _mongocrypt_log(log, MONGOCRYPT_LOG_LEVEL_INFO, "Opened CSFLE dynamic library [%s]", filepath);
+    _mongocrypt_log(log, MONGOCRYPT_LOG_LEVEL_INFO, "Opened crypt_shared dynamic library [%s]", filepath);
     return (_loaded_csfle){.okay = true, .lib = lib, .vtable = vtable};
 }
 
@@ -480,7 +480,7 @@ static bool _try_replace_dollar_origin(mstr *filepath, _mongocrypt_log_t *log) {
         _mongocrypt_log(log,
                         MONGOCRYPT_LOG_LEVEL_WARNING,
                         "Error while loading the executable module path for "
-                        "substitution of $ORIGIN in CSFLE search path [%s]: %s",
+                        "substitution of $ORIGIN in crypt_shared search path [%s]: %s",
                         filepath->raw.data,
                         error.raw.data);
         mstr_free(error);
@@ -596,7 +596,7 @@ static bool _validate_csfle_singleton(mongocrypt_t *crypt, _loaded_csfle found) 
     bool okay = true;
     if (!found.okay) {
         // There is one loaded, but we failed to find that same library. Error:
-        CLIENT_ERR("An existing CSFLE library is loaded by the application at "
+        CLIENT_ERR("An existing crypt_shared library is loaded by the application at "
                    "[%s], but the current call to mongocrypt_init() failed to "
                    "find that same library.",
                    existing_path.data);
@@ -610,9 +610,9 @@ static bool _validate_csfle_singleton(mongocrypt_t *crypt, _loaded_csfle found) 
         if (!mstr_eq(found_path.path.view, existing_path)) {
             // Our find-result should only ever find the existing same library.
             // Error:
-            CLIENT_ERR("An existing CSFLE library is loaded by the application at [%s], "
+            CLIENT_ERR("An existing crypt_shared library is loaded by the application at [%s], "
                        "but the current call to mongocrypt_init() attempted to load a "
-                       "second CSFLE library from [%s]. This is not allowed.",
+                       "second crypt_shared library from [%s]. This is not allowed.",
                        existing_path.data,
                        found_path.path.raw.data);
             okay = false;

--- a/src/mongocrypt.c
+++ b/src/mongocrypt.c
@@ -442,6 +442,9 @@ static _loaded_csfle _try_load_csfle(const char *filepath, mongocrypt_status_t *
                         "One or more required symbols are missing from crypt_shared dynamic library "
                         "[%s], so this dynamic library will not be used.",
                         filepath);
+        CLIENT_ERR("One or more required symbols are missing from crypt_shared dynamic library "
+                   "[%s], so this dynamic library will not be used.",
+                   filepath);
         return (_loaded_csfle){.okay = false};
     }
 

--- a/test/test-mongocrypt-csfle-lib.c
+++ b/test/test-mongocrypt-csfle-lib.c
@@ -190,6 +190,15 @@ static void _test_lookup_version_check(_mongocrypt_tester_t *tester) {
     mongocrypt_destroy(crypt);
 }
 
+static void _test_loading_libmongocrypt_fails(_mongocrypt_tester_t *tester) {
+    mongocrypt_t *const crypt = get_test_mongocrypt(tester);
+    const char *path_to_libmongocrypt = TEST_MONGOCRYPT_MONGOCRYPT_SHARED_PATH;
+    mongocrypt_setopt_set_crypt_shared_lib_path_override(crypt, path_to_libmongocrypt);
+    bool ok = mongocrypt_init(crypt);
+    ASSERT_FAILS(ok, crypt, "detected libmongocrypt");
+    mongocrypt_destroy(crypt);
+}
+
 void _mongocrypt_tester_install_csfle_lib(_mongocrypt_tester_t *tester) {
     INSTALL_TEST(_test_csfle_no_paths);
     INSTALL_TEST(_test_csfle_not_found);
@@ -202,4 +211,5 @@ void _mongocrypt_tester_install_csfle_lib(_mongocrypt_tester_t *tester) {
     INSTALL_TEST(_test_csfle_not_loaded_with_bypassqueryanalysis);
     INSTALL_TEST(_test_override_error_includes_reason);
     INSTALL_TEST(_test_lookup_version_check);
+    INSTALL_TEST(_test_loading_libmongocrypt_fails);
 }

--- a/test/test-mongocrypt-csfle-lib.c
+++ b/test/test-mongocrypt-csfle-lib.c
@@ -96,7 +96,7 @@ static void _test_csfle_load_twice_fail(_mongocrypt_tester_t *tester) {
     mongocrypt_t *const crypt2 = get_test_mongocrypt(tester);
     mongocrypt_setopt_set_crypt_shared_lib_path_override(crypt2, "$ORIGIN/stubbed-crypt_shared-2.dll");
     // Loading a second different library is an error:
-    ASSERT_FAILS(_mongocrypt_init_for_test(crypt2), crypt2, "attempted to load a second CSFLE library");
+    ASSERT_FAILS(_mongocrypt_init_for_test(crypt2), crypt2, "attempted to load a second crypt_shared library");
 
     mstr_view version = mstrv_view_cstr(mongocrypt_crypt_shared_lib_version_string(crypt1, NULL));
     if (TEST_MONGOCRYPT_HAVE_REAL_CRYPT_SHARED_LIB) {


### PR DESCRIPTION
# Summary

- Improve error message when loading incorrect library for crypt_shared.
- Change "CSFLE" to "crypt_shared" in log and error messages to match the library rename in MONGOCRYPT-434.

Verified with this [Evergreen patch](https://spruce.mongodb.com/version/67c85a9a61fd92000765f040).

# Background & Motivation

https://jira.mongodb.org/browse/MONGOCRYPT-738 references several reports of users accidentally passing the path to libmongocrypt instead of the crypt_shared library. This produces an error message like:

```
A CSFLE override path was specified [./cmake-build/libmongocrypt.dylib], but we failed to open a dynamic library at that location. Load error: [(null)]
```

With this PR, accidentally passing a path to libmongocrypt results in an error like:
```
Tried to load crypt_shared dynamic library at path [./cmake-build/libmongocrypt.dylib] but detected libmongocrypt
```


Attempting to load a different library (not libmongocrypt or crypt_shared) results in an error like:
```
A crypt_shared override path was specified [./cmake-build/libmongocrypt.dylib], but we failed to open a dynamic library at that location. Load error: [One or more required symbols are missing from crypt_shared dynamic library [/Users/kevin.albertson/code/tasks/libmongocrypt-M738/./cmake-build/libmongocrypt.dylib], so this dynamic library will not be used.]
```
