### PR TITLE
MONGOCRYPT-764 add latest downloads

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -834,7 +834,7 @@ tasks:
         remote_file: 'libmongocrypt/all/${tag_upload_location}/libmongocrypt-all.tar.gz'
         bucket: mciuploads
         permissions: public-read
-        optional: true
+        optional: true # Do not fail task if `local_file` does not exist. `local_file` only exists for tagged release.
         display_name: 'libmongocrypt-all-${tag_upload_location}.tar.gz'
         local_file: 'libmongocrypt-all-${tag_upload_location}.tar.gz'
         content_type: '${content_type|application/x-gzip}'

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -808,6 +808,15 @@ tasks:
             # the "fetch source" step detected a release tag on HEAD, so we
             # prepare a local file for upload to a location based on the tag
             cp -a libmongocrypt-all.tar.gz libmongocrypt-all-${tag_upload_location}.tar.gz
+
+            if [[ "$tag_upload_location" = *-* ]]; then
+              # Unstable release, like 1.1.0-beta1 or 1.0.1-rc0.
+              mkdir unstable
+              cp -a libmongocrypt-all.tar.gz unstable/libmongocrypt-all-${tag_upload_location}.tar.gz
+            else
+              mkdir stable
+              cp -a libmongocrypt-all.tar.gz stable/libmongocrypt-all-${tag_upload_location}.tar.gz
+            fi
           fi
     - command: s3.put
       params:
@@ -837,6 +846,28 @@ tasks:
         optional: true # Do not fail task if `local_file` does not exist. `local_file` only exists for tagged release.
         display_name: 'libmongocrypt-all-${tag_upload_location}.tar.gz'
         local_file: 'libmongocrypt-all-${tag_upload_location}.tar.gz'
+        content_type: '${content_type|application/x-gzip}'
+    - command: s3.put
+      params:
+        aws_key: '${aws_key}'
+        aws_secret: '${aws_secret}'
+        remote_file: 'libmongocrypt/all/latest/stable/libmongocrypt-all.tar.gz'
+        bucket: mciuploads
+        permissions: public-read
+        optional: true # Do not fail task if `local_file` does not exist. `local_file` only exists for stable release.
+        display_name: 'stable/libmongocrypt-all-${tag_upload_location}.tar.gz'
+        local_file: 'stable/libmongocrypt-all-${tag_upload_location}.tar.gz'
+        content_type: '${content_type|application/x-gzip}'
+    - command: s3.put
+      params:
+        aws_key: '${aws_key}'
+        aws_secret: '${aws_secret}'
+        remote_file: 'libmongocrypt/all/latest/unstable/libmongocrypt-all.tar.gz'
+        bucket: mciuploads
+        permissions: public-read
+        optional: true # Do not fail task if `local_file` does not exist. `local_file` only exists for unstable release.
+        display_name: 'unstable/libmongocrypt-all-${tag_upload_location}.tar.gz'
+        local_file: 'unstable/libmongocrypt-all-${tag_upload_location}.tar.gz'
         content_type: '${content_type|application/x-gzip}'
 
 - name: publish-packages


### PR DESCRIPTION
# Summary
Add downloads for the libmongocrypt-all.tar.gz for the latest stable and unstable tagged releases.

The 1.13.0 release was manually uploaded and is accessible by:
https://mciuploads.s3.amazonaws.com/libmongocrypt/all/latest/stable/libmongocrypt-all.tar.gz

Once available, latest unstable releases are expected to accessible by:
https://mciuploads.s3.amazonaws.com/libmongocrypt/all/latest/unstable/libmongocrypt-all.tar.gz

# Background & Motivation
Requested in MONGOCRYPT-764.