### PR TITLE
MONGOCRYPT-775 make `tester` object `static`

### DIFF
--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -924,7 +924,7 @@ static void test_tmp_bsonf(_mongocrypt_tester_t *tester) {
 bool _aes_ctr_is_supported_by_os = true;
 
 int main(int argc, char **argv) {
-    _mongocrypt_tester_t tester = {0};
+    static _mongocrypt_tester_t tester = {0};
     int i;
 
     TEST_PRINTF("Pass a list of patterns to run a subset of tests.\n");

--- a/test/test-mongocrypt.h
+++ b/test/test-mongocrypt.h
@@ -49,7 +49,6 @@ typedef enum tester_mongocrypt_flags {
 } tester_mongocrypt_flags;
 
 /* Arbitrary max of 2148 instances of temporary test data. Increase as needed.
- * TODO(MONGOCRYPT-775) increasing further (e.g. 3000+) causes a segfault on Windows test runs. Revise.
  */
 #define TEST_DATA_COUNT 2148
 


### PR DESCRIPTION
# Summary

Make `tester` object `static` to avoid large stack object.

# Background & Motivation

The test runner uses fixed size arrays for [temporary data](https://github.com/mongodb/libmongocrypt/blob/c3dff011c9c0dc326c31414471a4b613e0d91365/test/test-mongocrypt.h#L49-L51):

```c
/* Arbitrary max of 2048 instances of temporary test data. Increase as needed.
 */
#define TEST_DATA_COUNT 2048
```

Increasing this array was needed for tests added in MONGOCRYPT-723. However, increasing this array to 3000 resulted in an [observed segfault](https://spruce.mongodb.com/task/libmongocrypt_windows_test_build_and_test_and_upload_patch_c3dff011c9c0dc326c31414471a4b613e0d91365_67af5a0f2ac9680007bb2b31_25_02_14_14_58_23/logs?execution=0) on Windows tests.

With this PR, this [patch build](https://spruce.mongodb.com/task/libmongocrypt_windows_test_build_and_test_and_upload_patch_69d9984c76a41ca32d650d44317ee57ab99707df_67c86e149273b100077d77b4_25_03_05_15_30_29/logs?execution=0) tested with `TEST_DATA_COUNT=3000` does not segfault.

More work could be done to clear data between tests. This is not addressed in this PR.