### PR TITLE
MONGOCRYPT-794 fix possible double free on parse error

### DIFF
--- a/src/mc-fle2-encryption-placeholder.c
+++ b/src/mc-fle2-encryption-placeholder.c
@@ -184,7 +184,6 @@ bool mc_FLE2EncryptionPlaceholder_parse(mc_FLE2EncryptionPlaceholder_t *out,
     return true;
 
 fail:
-    mc_FLE2EncryptionPlaceholder_cleanup(out);
     return false;
 }
 

--- a/src/mc-fle2-find-equality-payload-v2.c
+++ b/src/mc-fle2-find-equality-payload-v2.c
@@ -114,7 +114,6 @@ bool mc_FLE2FindEqualityPayloadV2_parse(mc_FLE2FindEqualityPayloadV2_t *out,
 
     return true;
 fail:
-    mc_FLE2FindEqualityPayloadV2_cleanup(out);
     return false;
 }
 

--- a/src/mc-fle2-find-equality-payload.c
+++ b/src/mc-fle2-find-equality-payload.c
@@ -117,7 +117,6 @@ bool mc_FLE2FindEqualityPayload_parse(mc_FLE2FindEqualityPayload_t *out,
 
     return true;
 fail:
-    mc_FLE2FindEqualityPayload_cleanup(out);
     return false;
 }
 

--- a/src/mc-fle2-insert-update-payload-v2.c
+++ b/src/mc-fle2-insert-update-payload-v2.c
@@ -301,7 +301,6 @@ bool mc_FLE2InsertUpdatePayloadV2_parse(mc_FLE2InsertUpdatePayloadV2_t *out,
 
     return true;
 fail:
-    mc_FLE2InsertUpdatePayloadV2_cleanup(out);
     return false;
 }
 

--- a/src/mc-fle2-insert-update-payload.c
+++ b/src/mc-fle2-insert-update-payload.c
@@ -168,7 +168,6 @@ bool mc_FLE2InsertUpdatePayload_parse(mc_FLE2InsertUpdatePayload_t *out,
 
     return true;
 fail:
-    mc_FLE2InsertUpdatePayload_cleanup(out);
     return false;
 }
 

--- a/test/test-mc-fle2-encryption-placeholder.c
+++ b/test/test-mc-fle2-encryption-placeholder.c
@@ -440,8 +440,29 @@ static void _test_FLE2EncryptionPlaceholder_textSearch_parse(_mongocrypt_tester_
     }
 }
 
+static void _test_FLE2EncryptionPlaceholder_parse_errors(_mongocrypt_tester_t *tester) {
+    bson_t *input_bson = TMP_BSON_STR(BSON_STR({
+        "t" : {"$numberInt" : "1"},
+        "a" : {"$numberInt" : "1"},
+        "ki" : {"$binary" : {"base64" : "EjRWeBI0mHYSNBI0VniQEg==", "subType" : "04"}},
+        "ku" : {"$binary" : {"base64" : "q83vqxI0mHYSNBI0VniQEg==", "subType" : "04"}},
+        "v" : "foobar",
+        "cm" : "wrong type!"
+    }));
+
+    mc_FLE2EncryptionPlaceholder_t payload;
+    mc_FLE2EncryptionPlaceholder_init(&payload);
+    mongocrypt_status_t *status = mongocrypt_status_new();
+    ASSERT_FAILS_STATUS(mc_FLE2EncryptionPlaceholder_parse(&payload, input_bson, status),
+                        status,
+                        "'cm' must be an int64");
+    mc_FLE2EncryptionPlaceholder_cleanup(&payload);
+    mongocrypt_status_destroy(status);
+}
+
 void _mongocrypt_tester_install_fle2_encryption_placeholder(_mongocrypt_tester_t *tester) {
     INSTALL_TEST(_test_FLE2EncryptionPlaceholder_parse);
     INSTALL_TEST(_test_FLE2EncryptionPlaceholder_range_parse);
     INSTALL_TEST(_test_FLE2EncryptionPlaceholder_textSearch_parse);
+    INSTALL_TEST(_test_FLE2EncryptionPlaceholder_parse_errors);
 }

--- a/test/test-mc-fle2-find-equality-payload-v2.c
+++ b/test/test-mc-fle2-find-equality-payload-v2.c
@@ -73,6 +73,25 @@ static void _test_FLE2FindEqualityPayloadV2_roundtrip(_mongocrypt_tester_t *test
 
 #undef TEST_FIND_EQ_PAYLOAD_HEX_V2
 
+static void _test_FLE2FindEqualityPayloadV2_errors(_mongocrypt_tester_t *tester) {
+    bson_t *input_bson = TMP_BSON_STR(BSON_STR({
+        "d" : {"$binary" : {"base64" : "AAAA", "subType" : "00"}},
+        "s" : {"$binary" : {"base64" : "AAAA", "subType" : "00"}},
+        "l" : {"$binary" : {"base64" : "AAAA", "subType" : "00"}},
+        "cm" : "wrong type!"
+    }));
+
+    mc_FLE2FindEqualityPayloadV2_t payload;
+    mc_FLE2FindEqualityPayloadV2_init(&payload);
+    mongocrypt_status_t *status = mongocrypt_status_new();
+    ASSERT_FAILS_STATUS(mc_FLE2FindEqualityPayloadV2_parse(&payload, input_bson, status),
+                        status,
+                        "Field 'cm' expected to hold an int64");
+    mc_FLE2FindEqualityPayloadV2_cleanup(&payload);
+    mongocrypt_status_destroy(status);
+}
+
 void _mongocrypt_tester_install_fle2_payload_find_equality_v2(_mongocrypt_tester_t *tester) {
     INSTALL_TEST(_test_FLE2FindEqualityPayloadV2_roundtrip);
+    INSTALL_TEST(_test_FLE2FindEqualityPayloadV2_errors);
 }

--- a/test/test-mc-fle2-payload-iup-v2.c
+++ b/test/test-mc-fle2-payload-iup-v2.c
@@ -227,9 +227,31 @@ static void _test_mc_FLE2InsertUpdatePayloadV2_parses_crypto_params(_mongocrypt_
     mc_FLE2InsertUpdatePayloadV2_cleanup(&got);
 }
 
+static void _test_mc_FLE2InsertUpdatePayloadV2_parse_errors(_mongocrypt_tester_t *tester) {
+    bson_t *input_bson = TMP_BSON_STR(BSON_STR({
+        "d" : {"$binary" : {"base64" : "AAAA", "subType" : "00"}}, //
+        "t" : "wrong type!"
+    }));
+    _mongocrypt_buffer_t input_buf;
+    _mongocrypt_buffer_init_size(&input_buf, 1 + input_bson->len);
+    input_buf.data[0] = (uint8_t)MC_SUBTYPE_FLE2InsertUpdatePayloadV2;
+    memcpy(input_buf.data + 1, bson_get_data(input_bson), input_bson->len);
+
+    mc_FLE2InsertUpdatePayloadV2_t payload;
+    mc_FLE2InsertUpdatePayloadV2_init(&payload);
+    mongocrypt_status_t *status = mongocrypt_status_new();
+    ASSERT_FAILS_STATUS(mc_FLE2InsertUpdatePayloadV2_parse(&payload, &input_buf, status),
+                        status,
+                        "Field 't' expected to hold an int32");
+    mc_FLE2InsertUpdatePayloadV2_cleanup(&payload);
+    mongocrypt_status_destroy(status);
+    _mongocrypt_buffer_cleanup(&input_buf);
+}
+
 void _mongocrypt_tester_install_fle2_payload_iup_v2(_mongocrypt_tester_t *tester) {
     INSTALL_TEST(_test_FLE2InsertUpdatePayloadV2_parse);
     INSTALL_TEST(_test_mc_FLE2InsertUpdatePayloadV2_decrypt);
     INSTALL_TEST(_test_mc_FLE2InsertUpdatePayloadV2_includes_crypto_params);
     INSTALL_TEST(_test_mc_FLE2InsertUpdatePayloadV2_parses_crypto_params);
+    INSTALL_TEST(_test_mc_FLE2InsertUpdatePayloadV2_parse_errors);
 }


### PR DESCRIPTION
# Summary

Fixes a possible double-free on failure to parse in:
- `mc_FLE2EncryptionPlaceholder_parse`
- `mc_FLE2FindEqualityPayload_parse`
- `mc_FLE2FindEqualityPayloadV2_parse`
- `mc_FLE2InsertUpdatePayload_parse`
- `mc_FLE2InsertUpdatePayloadV2_parse`

Verified by this patch build: https://spruce.mongodb.com/version/67d42734867d07000729edd7

# Background & Motivation

Bug identified in https://github.com/mongodb/libmongocrypt/pull/985#discussion_r1985700576. This PR proposes removing the repeated calls to `*_cleanup`.

Callers are expected to always call `*_cleanup`. This is intended to simplify cleanup, e.g. with the `goto fail` pattern:

```c
mc_FLE2EncryptionPlaceholder_t out;
mc_FLE2EncryptionPlaceholder_init (&out);
if (!mc_FLE2EncryptionPlaceholder_parse(&out, in, status)) {
    goto fail;
}
// ... use `out` ...
fail:
    mc_FLE2EncryptionPlaceholder_cleanup (&out); // Called regardless of whether _parse succeeded.
```

Prior to this PR, a failed parse could result in a double-free.


## Rejected Alternatives

https://github.com/mongodb/libmongocrypt/pull/985 proposed making `_mongocrypt_buffer_cleanup` safe to call repeatedly. This PR proposes does not change the behavior of `_mongocrypt_buffer_cleanup` for consistency with other interfaces (e.g. `bson_destroy`, `mc_EncryptedFieldConfig_cleanup`, `mc_RangeOpts_cleanup` are not safe to call repeatedly).


