### PR TITLE
MONGOCRYPT-797 bump libbson to 1.30.3

### DIFF
--- a/.evergreen/linker-tests.sh
+++ b/.evergreen/linker-tests.sh
@@ -59,8 +59,9 @@ if is_true USE_NINJA; then
 fi
 
 run_chdir "$MONGOC_DIR" git apply --ignore-whitespace "$linker_tests_deps_root/bson_patches/libbson1.patch"
-# Apply patch to fix compile on RHEL 6.2. TODO: try to remove once RHEL 6.2 is dropped (MONGOCRYPT-688).
+# Apply patches to fix compile on RHEL 6.2. TODO: try to remove once RHEL 6.2 is dropped (MONGOCRYPT-688).
 run_chdir "$MONGOC_DIR" git apply "$LIBMONGOCRYPT_DIR/etc/libbson-remove-GCC-diagnostic-pragma.patch"
+run_chdir "$MONGOC_DIR" git apply "$LIBMONGOCRYPT_DIR/etc/libbson-remove-GCC-diagnostic-in-functions.patch"
 
 BUILD_PATH="$MONGOC_DIR/cmake-build"
 BSON1_INSTALL_PATH="$linker_tests_root/install/bson1"
@@ -79,6 +80,7 @@ run_chdir "$MONGOC_DIR" git reset --hard
 run_chdir "$MONGOC_DIR" git apply --ignore-whitespace "$linker_tests_deps_root/bson_patches/libbson2.patch"
 # Apply patch to fix compile on RHEL 6.2. TODO: try to remove once RHEL 6.2 is dropped (MONGOCRYPT-688).
 run_chdir "$MONGOC_DIR" git apply "$LIBMONGOCRYPT_DIR/etc/libbson-remove-GCC-diagnostic-pragma.patch"
+run_chdir "$MONGOC_DIR" git apply "$LIBMONGOCRYPT_DIR/etc/libbson-remove-GCC-diagnostic-in-functions.patch"
 LIBBSON2_SRC_DIR="$MONGOC_DIR"
 echo "Prepare libbson2 ... done"
 

--- a/.evergreen/prep_c_driver_source.sh
+++ b/.evergreen/prep_c_driver_source.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 # Clone mongo-c-driver and check out to a tagged version.
-MONGO_C_DRIVER_VERSION=1.30.2
+MONGO_C_DRIVER_VERSION=1.30.3
 
 # Force checkout with lf endings since .sh must have lf, not crlf on Windows
 git clone https://github.com/mongodb/mongo-c-driver.git --config core.eol=lf --config core.autocrlf=false --depth=1 --branch $MONGO_C_DRIVER_VERSION

--- a/.evergreen/prep_c_driver_source.sh
+++ b/.evergreen/prep_c_driver_source.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 # Clone mongo-c-driver and check out to a tagged version.
-MONGO_C_DRIVER_VERSION=1.28.1
+MONGO_C_DRIVER_VERSION=1.30.2
 
 # Force checkout with lf endings since .sh must have lf, not crlf on Windows
 git clone https://github.com/mongodb/mongo-c-driver.git --config core.eol=lf --config core.autocrlf=false --depth=1 --branch $MONGO_C_DRIVER_VERSION

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # ChangeLog
+## 1.13.2
+### Notes
+- Bump downloaded libbson version from 1.28.1 to 1.30.3. Fixes a CMake configure error on macOS with CMake 4.
 ## 1.13.1
 ### Fixed
 - Fix possible double free on parse error of malformed payload.

--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -1,7 +1,7 @@
 include (FetchContent)
 
 # Set the tag that we will fetch.
-# When updating the version of libbson, also update the version in etc/purls.txt
+# When updating the version of libbson, also update the version in etc/purls.txt and .evergreen/prep_c_driver_source.sh
 set (MONGOC_FETCH_TAG_FOR_LIBBSON "1.30.2" CACHE STRING "The Git tag of mongo-c-driver that will be fetched to obtain libbson")
 
 # Add an option to disable patching if a patch command is unavailable.

--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -2,7 +2,7 @@ include (FetchContent)
 
 # Set the tag that we will fetch.
 # When updating the version of libbson, also update the version in etc/purls.txt
-set (MONGOC_FETCH_TAG_FOR_LIBBSON "1.28.1" CACHE STRING "The Git tag of mongo-c-driver that will be fetched to obtain libbson")
+set (MONGOC_FETCH_TAG_FOR_LIBBSON "1.30.2" CACHE STRING "The Git tag of mongo-c-driver that will be fetched to obtain libbson")
 
 # Add an option to disable patching if a patch command is unavailable.
 option (LIBBSON_PATCH_ENABLED "Whether to apply patches to the libbson library" ON)

--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -18,6 +18,8 @@ make_patch_command (patch_command
     DISABLED "${patch_disabled}"
     PATCHES
         ${PROJECT_SOURCE_DIR}/etc/libbson-remove-GCC-diagnostic-pragma.patch
+        # Fix old GCC error: "#pragma GCC diagnostic not allowed inside functions". Remove patch after libbson 2.0.0:
+        ${PROJECT_SOURCE_DIR}/etc/libbson-remove-GCC-diagnostic-in-functions.patch
     )
 
 # Fetch the source archive for the requested tag from GitHub

--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -2,7 +2,7 @@ include (FetchContent)
 
 # Set the tag that we will fetch.
 # When updating the version of libbson, also update the version in etc/purls.txt and .evergreen/prep_c_driver_source.sh
-set (MONGOC_FETCH_TAG_FOR_LIBBSON "1.30.2" CACHE STRING "The Git tag of mongo-c-driver that will be fetched to obtain libbson")
+set (MONGOC_FETCH_TAG_FOR_LIBBSON "1.30.3" CACHE STRING "The Git tag of mongo-c-driver that will be fetched to obtain libbson")
 
 # Add an option to disable patching if a patch command is unavailable.
 option (LIBBSON_PATCH_ENABLED "Whether to apply patches to the libbson library" ON)

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -1,16 +1,16 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.30.2#src/libbson",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.30.3#src/libbson",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/v1.30.2.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/v1.30.3.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/v1.30.2"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/v1.30.3"
         }
       ],
       "group": "mongodb",
@@ -22,9 +22,9 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@v1.30.2#src/libbson",
+      "purl": "pkg:github/mongodb/mongo-c-driver@v1.30.3#src/libbson",
       "type": "library",
-      "version": "v1.30.2"
+      "version": "v1.30.3"
     },
     {
       "bom-ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz",
@@ -53,11 +53,11 @@
       "ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz"
     },
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@v1.30.2#src/libbson"
+      "ref": "pkg:github/mongodb/mongo-c-driver@v1.30.3#src/libbson"
     }
   ],
   "metadata": {
-    "timestamp": "2025-04-07T13:22:52.187027+00:00",
+    "timestamp": "2025-04-08T13:06:37.750496+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -1,16 +1,16 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.28.1#src/libbson",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v1.30.2#src/libbson",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/v1.28.1.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/v1.30.2.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/v1.28.1"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/v1.30.2"
         }
       ],
       "group": "mongodb",
@@ -22,9 +22,9 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@v1.28.1#src/libbson",
+      "purl": "pkg:github/mongodb/mongo-c-driver@v1.30.2#src/libbson",
       "type": "library",
-      "version": "v1.28.1"
+      "version": "v1.30.2"
     },
     {
       "bom-ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz",
@@ -53,11 +53,11 @@
       "ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz"
     },
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@v1.28.1#src/libbson"
+      "ref": "pkg:github/mongodb/mongo-c-driver@v1.30.2#src/libbson"
     }
   ],
   "metadata": {
-    "timestamp": "2025-04-01T17:28:16.597112+00:00",
+    "timestamp": "2025-04-07T13:22:52.187027+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/libbson-remove-GCC-diagnostic-in-functions.patch
+++ b/etc/libbson-remove-GCC-diagnostic-in-functions.patch
@@ -1,0 +1,158 @@
+diff --git a/src/libmongoc/src/mongoc/mongoc-collection.c b/src/libmongoc/src/mongoc/mongoc-collection.c
+index d21a043788..ac0194e477 100644
+--- a/src/libmongoc/src/mongoc/mongoc-collection.c
++++ b/src/libmongoc/src/mongoc/mongoc-collection.c
+@@ -681,6 +681,7 @@ mongoc_collection_command_simple (mongoc_collection_t *collection,
+  *--------------------------------------------------------------------------
+  */
+ 
++BEGIN_IGNORE_DEPRECATIONS
+ int64_t
+ mongoc_collection_count (mongoc_collection_t *collection,       /* IN */
+                          mongoc_query_flags_t flags,            /* IN */
+@@ -705,13 +706,12 @@ mongoc_collection_count (mongoc_collection_t *collection,       /* IN */
+    /* Server Selection Spec: "may-use-secondary" commands SHOULD take a read
+     * preference argument and otherwise MUST use the default read preference
+     * from client, database or collection configuration. */
+-   BEGIN_IGNORE_DEPRECATIONS
+    ret = mongoc_collection_count_with_opts (collection, flags, query, skip, limit, &opts, read_prefs, error);
+-   END_IGNORE_DEPRECATIONS
+ 
+    bson_destroy (&opts);
+    return ret;
+ }
++END_IGNORE_DEPRECATIONS
+ 
+ 
+ int64_t
+@@ -1231,6 +1231,7 @@ mongoc_collection_keys_to_index_string (const bson_t *keys)
+ }
+ 
+ 
++BEGIN_IGNORE_DEPRECATIONS
+ bool
+ mongoc_collection_create_index (mongoc_collection_t *collection,
+                                 const bson_t *keys,
+@@ -1240,15 +1241,14 @@ mongoc_collection_create_index (mongoc_collection_t *collection,
+    bson_t reply;
+    bool ret;
+ 
+-   BEGIN_IGNORE_DEPRECATIONS
+ 
+    ret = mongoc_collection_create_index_with_opts (collection, keys, opt, NULL, &reply, error);
+ 
+-   END_IGNORE_DEPRECATIONS
+ 
+    bson_destroy (&reply);
+    return ret;
+ }
++END_IGNORE_DEPRECATIONS
+ 
+ static bool
+ _mongoc_collection_index_keys_equal (const bson_t *expected, const bson_t *actual)
+@@ -1578,16 +1578,16 @@ done:
+ }
+ 
+ 
++BEGIN_IGNORE_DEPRECATIONS
+ bool
+ mongoc_collection_ensure_index (mongoc_collection_t *collection,
+                                 const bson_t *keys,
+                                 const mongoc_index_opt_t *opt,
+                                 bson_error_t *error)
+ {
+-   BEGIN_IGNORE_DEPRECATIONS
+    return mongoc_collection_create_index (collection, keys, opt, error);
+-   END_IGNORE_DEPRECATIONS
+ }
++END_IGNORE_DEPRECATIONS
+ 
+ 
+ mongoc_cursor_t *
+@@ -2317,6 +2317,7 @@ mongoc_collection_replace_one (mongoc_collection_t *collection,
+  *--------------------------------------------------------------------------
+  */
+ 
++BEGIN_IGNORE_DEPRECATIONS
+ bool
+ mongoc_collection_save (mongoc_collection_t *collection,
+                         const bson_t *document,
+@@ -2330,7 +2331,6 @@ mongoc_collection_save (mongoc_collection_t *collection,
+    BSON_ASSERT_PARAM (collection);
+    BSON_ASSERT_PARAM (document);
+ 
+-   BEGIN_IGNORE_DEPRECATIONS
+    if (!bson_iter_init_find (&iter, document, "_id")) {
+       return mongoc_collection_insert (collection, MONGOC_INSERT_NONE, document, write_concern, error);
+    }
+@@ -2350,12 +2350,12 @@ mongoc_collection_save (mongoc_collection_t *collection,
+ 
+    ret = mongoc_collection_update (
+       collection, MONGOC_UPDATE_UPSERT | MONGOC_UPDATE_NO_VALIDATE, &selector, document, write_concern, error);
+-   END_IGNORE_DEPRECATIONS
+ 
+    bson_destroy (&selector);
+ 
+    return ret;
+ }
++END_IGNORE_DEPRECATIONS
+ 
+ 
+ bool
+diff --git a/src/libmongoc/src/mongoc/mongoc-stream-tls.c b/src/libmongoc/src/mongoc/mongoc-stream-tls.c
+index 744fdc4089..252d6209f3 100644
+--- a/src/libmongoc/src/mongoc/mongoc-stream-tls.c
++++ b/src/libmongoc/src/mongoc/mongoc-stream-tls.c
+@@ -187,6 +187,7 @@ mongoc_stream_tls_check_cert (mongoc_stream_t *stream, const char *host)
+  *--------------------------------------------------------------------------
+  */
+ 
++BEGIN_IGNORE_DEPRECATIONS
+ mongoc_stream_t *
+ mongoc_stream_tls_new_with_hostname (mongoc_stream_t *base_stream, const char *host, mongoc_ssl_opt_t *opt, int client)
+ {
+@@ -208,9 +209,7 @@ mongoc_stream_tls_new_with_hostname (mongoc_stream_t *base_stream, const char *h
+ #if defined(MONGOC_ENABLE_SSL_OPENSSL)
+    return mongoc_stream_tls_openssl_new (base_stream, host, opt, client);
+ #elif defined(MONGOC_ENABLE_SSL_LIBRESSL)
+-   BEGIN_IGNORE_DEPRECATIONS
+    return mongoc_stream_tls_libressl_new (base_stream, host, opt, client);
+-   END_IGNORE_DEPRECATIONS
+ #elif defined(MONGOC_ENABLE_SSL_SECURE_TRANSPORT)
+    return mongoc_stream_tls_secure_transport_new (base_stream, host, opt, client);
+ #elif defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
+@@ -219,6 +218,7 @@ mongoc_stream_tls_new_with_hostname (mongoc_stream_t *base_stream, const char *h
+ #error "Don't know how to create TLS stream"
+ #endif
+ }
++END_IGNORE_DEPRECATIONS
+ 
+ #if defined(MONGOC_ENABLE_SSL_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x10100000L
+ /*
+diff --git a/src/libmongoc/src/mongoc/mongoc-write-concern.c b/src/libmongoc/src/mongoc/mongoc-write-concern.c
+index 82ac8d3c32..10b8585c1c 100644
+--- a/src/libmongoc/src/mongoc/mongoc-write-concern.c
++++ b/src/libmongoc/src/mongoc/mongoc-write-concern.c
+@@ -492,6 +492,7 @@ mongoc_write_concern_append (mongoc_write_concern_t *write_concern, bson_t *comm
+  * Returns: A newly allocated mongoc_write_concern_t. This should be freed
+  *    with mongoc_write_concern_destroy().
+  */
++BEGIN_IGNORE_DEPRECATIONS
+ mongoc_write_concern_t *
+ _mongoc_write_concern_new_from_iter (const bson_iter_t *iter, bson_error_t *error)
+ {
+@@ -532,9 +533,7 @@ _mongoc_write_concern_new_from_iter (const bson_iter_t *iter, bson_error_t *erro
+          if (!BSON_ITER_HOLDS_BOOL (&inner)) {
+             goto fail;
+          }
+-         BEGIN_IGNORE_DEPRECATIONS
+          mongoc_write_concern_set_fsync (write_concern, bson_iter_bool (&inner));
+-         END_IGNORE_DEPRECATIONS
+       } else if (BSON_ITER_IS_KEY (&inner, "j")) {
+          if (!BSON_ITER_HOLDS_BOOL (&inner)) {
+             goto fail;
+@@ -560,3 +559,4 @@ fail:
+    mongoc_write_concern_destroy (write_concern);
+    return NULL;
+ }
++END_IGNORE_DEPRECATIONS

--- a/etc/libbson-remove-GCC-diagnostic-pragma.patch
+++ b/etc/libbson-remove-GCC-diagnostic-pragma.patch
@@ -1,7 +1,7 @@
-diff --git a/src/common/bson-dsl.h b/src/common/bson-dsl.h
+diff --git a/src/common/src/common-bson-dsl-private.h b/src/common/src/common-bson-dsl-private.h
 index 58a14e28e..3341e603f 100644
---- a/src/common/bson-dsl.h
-+++ b/src/common/bson-dsl.h
+--- a/src/common/src/common-bson-dsl-private.h
++++ b/src/common/src/common-bson-dsl-private.h
 @@ -29,6 +29,13 @@ enum {
     BSON_IF_WINDOWS (__declspec (selectany)) \
     BSON_IF_POSIX (__attribute__ ((weak)))

--- a/etc/purls.txt
+++ b/etc/purls.txt
@@ -8,7 +8,7 @@
 # `copyright` property. This information can be manually added.
 
 # libbson is obtained via `cmake/FetchMongoC.cmake`.
-pkg:github/mongodb/mongo-c-driver@v1.28.1?#src/libbson
+pkg:github/mongodb/mongo-c-driver@v1.30.2?#src/libbson
 
 # IntelDFP is obtained via `cmake/IntelDFP.cmake`
 pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz

--- a/etc/purls.txt
+++ b/etc/purls.txt
@@ -8,7 +8,7 @@
 # `copyright` property. This information can be manually added.
 
 # libbson is obtained via `cmake/FetchMongoC.cmake`.
-pkg:github/mongodb/mongo-c-driver@v1.30.2?#src/libbson
+pkg:github/mongodb/mongo-c-driver@v1.30.3?#src/libbson
 
 # IntelDFP is obtained via `cmake/IntelDFP.cmake`
 pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz


### PR DESCRIPTION
# Summary

Update downloaded libbson version from 1.28.1 to 1.30.3.

Verified with this patch build: https://spruce.mongodb.com/version/67f51fcc5e1706000725b5ab

# Background & Motivation

See MONGOCRYPT-797. Intended to include CDRIVER-5967 fix Homebrew install of libmongocrypt.

libbson is updated to 1.30 instead of 2.0 to avoid disrupting package releases. The Fedora package [builds with a system install of libbson](https://src.fedoraproject.org/rpms/libmongocrypt/blob/rawhide/f/libmongocrypt.spec#_75) and does not-yet appear to have a libbson package for 2.0 to depend on.

