### PR TITLE
add CODEOWNERS for all source

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,7 @@
 # Code Owners will automatically be added as reviewers on PRs
 
+# Listing code owners is required by DRIVERS-3098
+* @mongodb/dbx-c-cxx
+
 # Python Bindings
 bindings/python @mongodb/dbx-python


### PR DESCRIPTION
To meet requirement of DRIVERS-3098.

This PR is intends to keep `dbx-python` ownership over `bindings/python`, and use `dbx-c-cxx` for the rest. Quoting https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file:

> the last matching pattern takes the most precedence.

