### PR TITLE
Define Version in `calc_release_version.py`

### DIFF
--- a/etc/calc_release_version.py
+++ b/etc/calc_release_version.py
@@ -38,19 +38,45 @@ import datetime
 import re
 import subprocess
 import sys
-try:
-    # Prefer newer `packaging` over deprecated packages.
-    from packaging.version import Version as Version
-    from packaging.version import parse as parse_version
-except ImportError:
-    # Fallback to deprecated pkg_resources.
-    try:
-        from pkg_resources.extern.packaging.version import Version
-        from pkg_resources import parse_version
-    except ImportError:
-        # Fallback to deprecated distutils.
-        from distutils.version import LooseVersion as Version
-        from distutils.version import LooseVersion as parse_version
+
+class Version:
+    def __init__(self, s):
+        pat = r'(\d+)\.(\d+)\.(\d+)(\-\S+)?'
+        match = re.match(pat, s)
+        assert match, "Unrecognized version string %s" % s
+        self.major, self.minor, self.micro = (
+            map(int, (match.group(1), match.group(2), match.group(3))))
+
+        if match.group(4):
+            self.prerelease = match.group(4)[1:]
+        else:
+            self.prerelease = ''
+
+    def __lt__(self, other):
+        if self.major != other.major:
+            return self.major < other.major
+        if self.minor != other.minor:
+            return self.minor < other.minor
+        if self.micro != other.micro:
+            return self.micro < other.micro
+        if self.prerelease != other.prerelease:
+            if self.prerelease != '' and other.prerelease == '':
+                # Consider a prerelease less than non-prerelease.
+                return True
+            # For simplicity, compare prerelease versions lexicographically.
+            return self.prerelease < other.prerelease
+
+        # Versions are equal.
+        return False
+
+    def __eq__(self, other):
+        self_tuple = self.major, self.minor, self.micro, self.prerelease
+        other_tuple = other.major, other.minor, other.micro, other.prerelease
+        return self_tuple == other_tuple
+
+
+def parse_version(ver):
+    return Version(ver)
 
 DEBUG = len(sys.argv) > 1 and '-d' in sys.argv
 if DEBUG:

--- a/etc/calc_release_version_selftest.sh
+++ b/etc/calc_release_version_selftest.sh
@@ -66,7 +66,7 @@ echo "Test next minor version ... begin"
     # failed, then it is probably because a new major/minor release was made.
     # Update the expected output to represent the correct next version.
     # XXX NOTE XXX NOTE XXX
-    assert_eq "$got" "1.9.0-$DATE+git$CURRENT_SHORTREF"
+    assert_eq "$got" "1.14.0-$DATE+git$CURRENT_SHORTREF"
 }
 echo "Test next minor version ... end"
 


### PR DESCRIPTION
Pulls in changes from https://github.com/mongodb/mongo-c-driver/commit/2bf9d591d63dfc079ce7319d570dcbf0b4bdbac4 to address [task failure](https://spruce.mongodb.com/task/libmongocrypt_rhel_80_64_bit_build_and_test_and_upload_681217cd53af330007ca1970_25_04_30_12_30_05/logs?execution=0) on RHEL 8.0:

```
Traceback (most recent call last):
  File "/data/mci/aec0510e232c633d6643661229e23039/libmongocrypt/etc/calc_release_version.py", line 43, in <module>
    from packaging.version import Version as Version
ModuleNotFoundError: No module named 'packaging'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/data/mci/aec0510e232c633d6643661229e23039/libmongocrypt/etc/calc_release_version.py", line 48, in <module>
    from pkg_resources.extern.packaging.version import Version
ModuleNotFoundError: No module named 'pkg_resources'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/data/mci/aec0510e232c633d6643661229e23039/libmongocrypt/etc/calc_release_version.py", line 52, in <module>
    from distutils.version import LooseVersion as Version
ModuleNotFoundError: No module named 'distutils'
```