### PR TITLE
MONGOCRYPT-751 document installation of packages on arm64/aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ sudo apt-get install -y libmongocrypt-dev
 
 ### .rpm Packages (RedHat, Suse, and Amazon) ###
 
+RPMs are available for supported systems running on both x86_64 and AArch64 (also called ARM64) processors. The sections below use `x86_64` in the example repository URLs. Substituting `aarch64` in the place of `x86_64` will permit installation of libmongocrypt packages on systems running on AArch64 processors.
 
 #### RedHat Enterprise Linux ####
 


### PR DESCRIPTION
I tested that aarch64/arm64 RPM packages would install by spawning an Amazon 2023 Evergreen host and following the steps, substituting `aarch64` in place of `x86_64` in the repository URL. No additional note/documentation is required for installation of Debian packages, since the repo URLs do not require the user to specify the hardware architecture (the system detects the hardware architecture and constructs the appropriate URL automatically). No updates are required to the Windows or macOS sections.