### PR TITLE
DEVPROD-17574 - Replace perf.send with new data submission end point

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1065,9 +1065,38 @@ tasks:
         working_dir: "./libmongocrypt"
         args:
           - "./.evergreen/benchmark-python.sh"
-    - command: "perf.send"
+    - command: shell.exec
       params:
-        file: libmongocrypt/bindings/python/results.json
+        script: |
+          # We use the requester expansion to determine whether the data is from a mainline evergreen run or not
+          if [ "${requester}" == "commit" ]; then
+            is_mainline=true
+          else
+            is_mainline=false
+          fi
+
+          # We parse the username out of the order_id as patches append that in and SPS does not need that information
+          parsed_order_id=$(echo "${revision_order_id}" | awk -F'_' '{print $NF}')
+
+          # Submit the performance data to the SPS endpoint
+          response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X 'POST' \
+            "https://performance-monitoring-api.corp.mongodb.com/raw_perf_results/cedar_report?project=${project_id}&version=${version_id}&variant=${build_variant}&order=$parsed_order_id&task_name=${task_name}&task_id=${task_id}&execution=${execution}&mainline=$is_mainline" \
+            -H 'accept: application/json' \
+            -H 'Content-Type: application/json' \
+            -d @libmongocrypt/bindings/python/results.json)
+
+          http_status=$(echo "$response" | grep "HTTP_STATUS" | awk -F':' '{print $2}')
+          response_body=$(echo "$response" | sed '/HTTP_STATUS/d')
+
+          # We want to throw an error if the data was not successfully submitted
+          if [ "$http_status" -ne 200 ]; then
+            echo "Error: Received HTTP status $http_status"
+            echo "Response Body: $response_body"
+            exit 1
+          fi
+
+          echo "Response Body: $response_body"
+          echo "HTTP Status: $http_status"
 
 - name: sbom
   commands:


### PR DESCRIPTION
The perf.send functionality in evergreen is no longer maintained and is not the preferred method of sending performance data to the signal processing service. This PR updates the evergreen yaml file to instead send the data down stream using the preferred performance-monitoring-api.corp.mongodb.com/raw_perf_results/cedar_report end point.

Changes were tested in [this patch](https://spruce.mongodb.com/version/681b802216c6160007eea0c0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)