### PR TITLE
MONGOCRYPT-807 Add missing error state transition

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -1259,6 +1259,7 @@ static bool FLE2RangeFindDriverSpec_to_ciphertexts(mongocrypt_ctx_t *ctx, mongoc
                                                   &iter,
                                                   &with_ciphertexts,
                                                   ctx->status)) {
+            _mongocrypt_ctx_fail(ctx);
             goto fail;
         }
     }


### PR DESCRIPTION
# Summary

Add missing transition to `MONGOCRYPT_CTX_ERROR` on failure in `mongocrypt_ctx_finalize`.

# Background

Observed reviewing libmongocrypt code during Skunkworks for possible missing state transitions.

On an error for the `mongocrypt_ctx_t` functions, libmongocrypt is expected to both return an error status and set the context state to `MONGOCRYPT_CTX_ERROR`.
