### PR TITLE
MONGOCRYPT-779 drop support Visual Studio 2015

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1190,15 +1190,6 @@ buildvariants:
   run_on: rhel83-zseries-small
   tasks:
   - build-and-test-and-upload
-- name: windows-vs2015-compile
-  display_name: "Windows VS 2015 compile"
-  run_on: windows-64-vs2015-test
-  expansions:
-    vs_version: "14"
-    vs_target_arch: amd64
-  tasks:
-  - build-and-test-and-upload
-  - build-and-test-shared-bson
 - name: windows-test
   display_name: "Windows 2016"
   run_on: windows-64-vs2017-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # ChangeLog
+## 1.15.0 (Unreleased)
+### Removed
+- Support for building with Visual Studio 2015. Use Visual Studio 2017 or newer.
+
 ## 1.14.0
 ### Fixed
 - Fix building against libbson with extra alignment enabled (`ENABLE_EXTRA_ALIGNMENT=ON`).


### PR DESCRIPTION
# Summary

Drop test task building libmongocrypt with Visual Studio 2015.

# Background

Dropping support for building libmongocrypt with Visual Studio 2015 is expected to have low impact. (Most drivers provide binaries for libmongocrypt, and PHP [does not use VS 2015](https://jira.mongodb.org/browse/MONGOCRYPT-779?focusedCommentId=7104496&focusedId=7104496&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-7104496)). 