### PR TITLE
MONGOCRYPT-807 Add missing error state transition (#1010)

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -1259,6 +1259,7 @@ static bool FLE2RangeFindDriverSpec_to_ciphertexts(mongocrypt_ctx_t *ctx, mongoc
                                                   &iter,
                                                   &with_ciphertexts,
                                                   ctx->status)) {
+            _mongocrypt_ctx_fail(ctx);
             goto fail;
         }
     }


### PR DESCRIPTION
Backport of https://github.com/mongodb/libmongocrypt/pull/1010 to r1.14.