### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # libmongocrypt #
+
 The companion C library for client side encryption in drivers.
+
+This project uses [Semantic Versioning](https://semver.org/).
 
 # Bugs / Feature Requests #
 


### PR DESCRIPTION
Resolves DRIVERS-3105 for libmongocrypt.

Uses the same proposed wording as in https://github.com/mongodb/mongo-cxx-driver/pull/1408 and https://github.com/mongodb/mongo-c-driver/pull/2021.