### PR TITLE
MONGOCRYPT-813 publish packages for Ubuntu 24.04 (#1016)

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -713,6 +713,10 @@ tasks:
       name: build-and-test-and-upload
     - variant: ubuntu2204-arm64
       name: build-and-test-and-upload
+    - variant: ubuntu2404-64
+      name: build-and-test-and-upload
+    - variant: ubuntu2404-arm64
+      name: build-and-test-and-upload
     - variant: macos
       name: build-and-test-and-upload
     - variant: alpine-amd64-earthly
@@ -1517,6 +1521,30 @@ buildvariants:
   - build-and-test-and-upload
   - build-and-test-shared-bson
   - build-and-test-asan
+  - name: publish-packages
+    distros:
+    - ubuntu2004-small
+- name: ubuntu2404-64
+  display_name: "Ubuntu 24.04 64-bit"
+  run_on: ubuntu2404-small
+  expansions:
+    has_packages: true
+    packager_distro: ubuntu2404
+    packager_arch: x86_64
+  tasks:
+  - build-and-test-and-upload
+  - name: publish-packages
+    distros:
+    - ubuntu2004-small
+- name: ubuntu2404-arm64
+  display_name: "Ubuntu 24.04 arm64"
+  run_on: ubuntu2404-arm64-small
+  expansions:
+    has_packages: true
+    packager_distro: ubuntu2404
+    packager_arch: arm64
+  tasks:
+  - build-and-test-and-upload
   - name: publish-packages
     distros:
     - ubuntu2004-small

--- a/etc/packager.py
+++ b/etc/packager.py
@@ -327,6 +327,8 @@ class Distro(object):
                 return "focal"
             elif build_os == 'ubuntu2204':
                 return "jammy"
+            elif build_os == 'ubuntu2404':
+                return "noble"
             else:
                 raise Exception("unsupported build_os: %s" % build_os)
         elif self.dname == 'debian':
@@ -390,6 +392,7 @@ class Distro(object):
                 "ubuntu1804",
                 "ubuntu2004",
                 "ubuntu2204",
+                "ubuntu2404",
             ]
         elif self.dname == 'debian':
             return ["debian81", "debian92", "debian10", "debian11", "debian12"]


### PR DESCRIPTION
This is a cherry-pick of https://github.com/mongodb/libmongocrypt/pull/1016 onto r1.14 branch. No additional changes were needed.