### PR TITLE
MONGOCRYPT-813 add repo config for Ubuntu 24.04

### DIFF
--- a/etc/repo_config.yaml
+++ b/etc/repo_config.yaml
@@ -311,3 +311,17 @@ repos:
       - arm64
     repos:
       - apt/ubuntu/dists/jammy/libmongocrypt
+
+  - name: ubuntu2404
+    type: deb
+    code_name: "noble"
+    edition: org
+    bucket: libmongocrypt
+    region: us-east-1
+    component: universe
+    architectures:
+      - amd64
+      - i386
+      - arm64
+    repos:
+      - apt/ubuntu/dists/noble/libmongocrypt


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/libmongocrypt/pull/1016.

Add missing Ubuntu 24.04 repo config. Intended to address this failure in `publish-packages` task added for MONGOCRYPT-813:

```
[curator] 2025/05/27 15:48:30 [p=error]: repo not defined for distro=ubuntu2404, edition=org
```

The failure was not noticed since package publishing [is skipped](https://github.com/mongodb/libmongocrypt/blob/467c6bf1538aafe43c1af4db1d085e5b25b93624/.evergreen/config.yml#L279-L282) on patch builds. [This patch build](https://spruce.mongodb.com/version/68374893e5c4bc00075f59e5) includes a change to temporarily unskip publishing packages for patch builds. The patch build is only expected to upload the development packages for Ubuntu 24.04.
