### PR TITLE
[r1.14] MONGOCRYPT-813 add repo config for Ubuntu 24.04

### DIFF
--- a/etc/repo_config.yaml
+++ b/etc/repo_config.yaml
@@ -311,3 +311,17 @@ repos:
       - arm64
     repos:
       - apt/ubuntu/dists/jammy/libmongocrypt
+
+  - name: ubuntu2404
+    type: deb
+    code_name: "noble"
+    edition: org
+    bucket: libmongocrypt
+    region: us-east-1
+    component: universe
+    architectures:
+      - amd64
+      - i386
+      - arm64
+    repos:
+      - apt/ubuntu/dists/noble/libmongocrypt


### PR DESCRIPTION
Cherry-picks changes from https://github.com/mongodb/libmongocrypt/pull/1018 onto r1.14.