### PR TITLE
use "reviewers" instead of "assignees" for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,12 @@ updates:
       actions:
         patterns:
           - "*"
-    assignees:
+    reviewers:
       - "@mongodb/dbx-python"
   # Python
   - package-ecosystem: "pip"
     directory: "/bindings/python"
     schedule:
       interval: "weekly"
-    assignees:
+    reviewers:
       - "@mongodb/dbx-python"


### PR DESCRIPTION
To address this warning: https://github.com/mongodb/libmongocrypt/pull/1026#issuecomment-2974869739

> The following users could not be added as assignees: `@mongodb/dbx-python`. Either the username does not exist or it does not have the correct permissions to be added as an assignee.

Quoting https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference

> Assignees must have write access to the repository

> Reviewers must have at least read access to the repository

dbx-python does not appear to have repo write access.