### PR TITLE
MONGOCRYPT-820 bypass `serverStatus` from auto-encryption

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -559,7 +559,7 @@ tasks:
 - name: "release-python-linux"
   tags: ["release_python_tag"]
   run_on: ubuntu2004-large
-  exec_timeout_secs: 216000  # 60 minutes (manylinux task is slow).
+  exec_timeout_secs: 3600  # 60 minutes (manylinux task is slow).
   commands:
     - func: "fetch source"
     - func: "build python release"

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -2186,6 +2186,8 @@ _check_cmd_for_auto_encrypt(mongocrypt_binary_t *cmd, bool *bypass, char **targe
         *bypass = true;
     } else if (0 == strcmp(cmd_name, "updateSearchIndex")) {
         *bypass = true;
+    } else if (0 == strcmp(cmd_name, "serverStatus")) {
+        *bypass = true;
     }
 
     /* database/client commands are ineligible. */

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -990,6 +990,7 @@ static void _test_encrypt_init_each_cmd(_mongocrypt_tester_t *tester) {
     _init_bypass(tester, "{'createSearchIndexes': 'coll' }");
     _init_bypass(tester, "{'dropSearchIndex': 'coll' }");
     _init_bypass(tester, "{'updateSearchIndex': 'coll' }");
+    _init_bypass(tester, "{'serverStatus': 1 }");
 }
 
 static void _test_encrypt_invalid_siblings(_mongocrypt_tester_t *tester) {


### PR DESCRIPTION
Bypasses `serverStatus` from query analysis instead of erroring.

As a drive-by fix, reduces the `exec_timeout_secs` in `release-python-linux` to fix an error observed by `evergreen validate`:

```
ERROR: task 'release-python-linux' exec timeout (216000) is too high and will be set to maximum limit (180000)
```

## Background
libmongocrypt errors if trying to auto-encrypt a command [not explicitly listed](https://github.com/mongodb/libmongocrypt/blob/0840a84aa78578b50ef586ebbb12e5318108db9b/src/mongocrypt-ctx-encrypt.c#L2207). This is intended to err towards safety: if libmongocrypt is unsure if the command might have values to encrypt reject it rather than risk sending plaintext that should be encrypted. [serverStatus](https://www.mongodb.com/docs/manual/reference/command/serverStatus/) is not expected to have values needing encryption.
