### PR TITLE
MONGOCRYPT-822 bypass "buildinfo" command

### DIFF
--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -2172,7 +2172,8 @@ _check_cmd_for_auto_encrypt(mongocrypt_binary_t *cmd, bool *bypass, char **targe
         eligible = true;
     } else if (0 == strcmp(cmd_name, "hello")) {
         *bypass = true;
-    } else if (0 == strcmp(cmd_name, "buildInfo")) {
+    } else if (0 == strcmp(cmd_name, "buildInfo") || 0 == strcmp(cmd_name, "buildinfo")) {
+        // Accept either case form to match server behavior.
         *bypass = true;
     } else if (0 == strcmp(cmd_name, "getCmdLineOpts")) {
         *bypass = true;

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -983,6 +983,7 @@ static void _test_encrypt_init_each_cmd(_mongocrypt_tester_t *tester) {
     _init_ok(tester, "{'compactStructuredEncryptionData': 'coll'}");
     _init_bypass(tester, "{'hello': 1}");
     _init_bypass(tester, "{'buildInfo': 1}");
+    _init_bypass(tester, "{'buildinfo': 1}");
     _init_bypass(tester, "{'getCmdLineOpts': 1}");
     _init_bypass(tester, "{'getLog': 1}");
     _init_ok(tester, "{'collMod': 'coll'}");


### PR DESCRIPTION
The server [accepts either](https://github.com/10gen/mongo/blob/aec8c2f2dafa198ea8284885771778f1951d34f5/src/mongo/db/commands/buildinfo_common.idl#L56-L57) "buildInfo" or "buildinfo". libmongocrypt only recognizes "buildInfo". This PR adds "buildinfo".

