### PR TITLE
Add archive repo to fix Debian 10 task

### DIFF
--- a/.evergreen/earthly.sh
+++ b/.evergreen/earthly.sh
@@ -6,13 +6,6 @@ set -euo pipefail
 
 : "${EARTHLY_VERSION:=0.7.8}"
 
-# Bring in the debian/ directory from the debian/unstable branch
-pushd "$(dirname "${BASH_SOURCE[0]}")/../"
-    (git remote | grep -q upstream) || git remote add upstream https://github.com/mongodb/libmongocrypt
-    git fetch upstream
-    git checkout $(git rev-parse upstream/debian/unstable) -- debian
-popd
-
 # Calc the arch of the executable we want
 arch="$(uname -m)"
 case "$arch" in

--- a/Earthfile
+++ b/Earthfile
@@ -245,7 +245,6 @@ COPY_SOURCE:
         cmake/ \
         kms-message/ \
         test/ \
-        debian/ \
         src/ \
         doc/ \
         etc/ \
@@ -320,13 +319,15 @@ deb-build:
     RUN __install git-buildpackage fakeroot debhelper cmake libbson-dev \
                   libintelrdfpmath-dev
     DO +COPY_SOURCE
+    # Bring in the debian/ directory from the debian/unstable branch
+    GIT CLONE https://github.com/mongodb/libmongocrypt --branch debian/unstable libmongocrypt-debian
     WORKDIR /s/libmongocrypt
     RUN git clean -fdx && git reset --hard
     RUN python3 etc/calc_release_version.py > VERSION_CURRENT
     RUN git add -f VERSION_CURRENT && \
         git -c user.name=anon -c user.email=anon@localhost \
             commit VERSION_CURRENT -m 'Set version' && \
-        env LANG=C bash debian/build_snapshot.sh && \
+        env LANG=C bash libmongocrypt-debian/debian/build_snapshot.sh && \
         debc ../*.changes && \
         dpkg -i ../*.deb
     SAVE ARTIFACT /s/*.deb /debs/


### PR DESCRIPTION
Add Debian 10 archive repo to fix failing [build-deb-packages-with-earthly](https://spruce.mongodb.com/task/libmongocrypt_debian10_arm64_earthly_build_deb_packages_with_earthly_5b4691bfb964155bd1374666f0330446278708df_25_07_21_19_46_15/logs?execution=0) tasks:

```
Err:3 http://security.debian.org/debian-security buster/updates Release
  404  Not Found [IP: 151.101.130.132 80]
```

Tested with this patch build: https://spruce.mongodb.com/version/6881208d3a47b20007c1c90e

As a drive-by improvement, copying the `debian` directory from the `debian/unstable` branch is moved within the Earthly task:

```bash
./.evergreen/earthly.sh +build
# Before : Copies `debian` into working directory.
# After  : Working directory is not changed.
```
