### PR TITLE
Fix `check-format` task

### DIFF
--- a/.evergreen/earthly.sh
+++ b/.evergreen/earthly.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-: "${EARTHLY_VERSION:=0.7.8}"
+: "${EARTHLY_VERSION:=0.8.16}"
 
 # Calc the arch of the executable we want
 arch="$(uname -m)"

--- a/Earthfile
+++ b/Earthfile
@@ -363,7 +363,7 @@ packaging-full-test:
     BUILD +rpm-runtime-test
 
 check-format:
-    FROM +init --base=python:3.11.2-slim-buster
+    FROM +init --base=python:3.13.5-slim-bookworm
     RUN __install build-essential # To install `make` to install clang-format.
     RUN pip install pipx
     COPY etc/format* /X/etc/


### PR DESCRIPTION
Update the docker image used in the `check-format` Earthly target from `python:3.11.2-slim-buster` to `python:3.13.5-slim-bookworm` to fix errors on the [check-format](https://spruce.mongodb.com/task/libmongocrypt_misc_check_format_5a33cd5fc5f960e1ee603323ef96614f6e8f1329_25_07_23_19_44_06/logs?execution=0) task:
```
+check-format | Err:4 http://deb.debian.org/debian buster Release
+check-format |   404  Not Found [IP: 146.75.34.132 80]
```

As a drive-by fix, the version of Earthly used is upgraded from 0.7.8 to 0.8.16 to fix observed error logs running the `earthly` CLI:
```
retrying http request due to unexpected error Get "https://api.earthly.dev/api/v0/account/auth-challenge": dial tcp: lookup api.earthly.dev: no such host {reqID: e8efcd25-9dd9-4a06-abea-b65ea192f264}
```

This appears related to the Earthly cloud shutdown. https://github.com/earthly/earthly/releases/tag/v0.8.16 notes:

> v0.8.16 does not emit log messages after the cloud shutdown
