### PR TITLE
Apply post-1.15.0 release steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # ChangeLog
-## 1.15.0 (Unreleased)
+## 1.15.0
+
+### Features
+- Support Queryable Encryption text indexes with `cleanupStructuredEncryptionData` and `compactStructuredEncryptionData`.
+- Support explicit encryption for algorithm type: `textPreview` and query types: `prefixPreview`, `suffixPreview` and `substringPreview`
+    - Add `mongocrypt_setopt_algorithm_text` to apply options for explicit encryption.
+
+### Fixed
+- Bypass command `buildinfo` (previously only `buildInfo` was bypassed).
+- Bypass command `serverStatus`.
+
 ### Removed
 - Support for building with Visual Studio 2015. Use Visual Studio 2017 or newer.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 ### Improvements
 - Improve performance of OpenSSL crypto operations.
 - Improve error for incorrect path to crypt_shared library.
+### New features
+- Support experimental Queryable Encryption text indexes for automatic encryption.
 
 ## 1.13.2
 ### Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # ChangeLog
 ## 1.15.0
 
-### Features
-- Support Queryable Encryption text indexes with `cleanupStructuredEncryptionData` and `compactStructuredEncryptionData`.
-- Support explicit encryption for algorithm type: `textPreview` and query types: `prefixPreview`, `suffixPreview` and `substringPreview`
+### New features
+- Support experimental Queryable Encryption text indexes with `cleanupStructuredEncryptionData` and `compactStructuredEncryptionData`.
+- Support experimental explicit encryption for algorithm type: `textPreview` and query types: `prefixPreview`, `suffixPreview` and `substringPreview`
     - Add `mongocrypt_setopt_algorithm_text` to apply options for explicit encryption.
 
 ### Fixed

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -130,7 +130,7 @@ Do the following when releasing:
 - Add a link to the Evergreen waterfall for the tagged commit to [libmongocrypt Security Testing Summary](https://docs.google.com/document/d/1dc7uvBzu3okAIsA8LSW5sVQGkYIvwpBVdg5v4wb4c4s/edit#heading=h.5t79jwe4p0ss).
 
 ## Homebrew steps ##
-Submit a PR to update the Homebrew package https://github.com/mongodb/homebrew-brew/blob/master/Formula/libmongocrypt.rb. ([Example](https://github.com/mongodb/homebrew-brew/pull/234)). If not on macOS, request a team member to do this step.
+Submit a PR to update the Homebrew package https://github.com/mongodb/homebrew-brew/blob/master/Formula/libmongocrypt.rb. ([Example](https://github.com/mongodb/homebrew-brew/pull/249)). If not on macOS, request a team member to do this step.
 Request review by posting in #ask-devprod-build.
 
 ## Debian steps ##

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -90,7 +90,7 @@ Do the following when releasing:
    ```
    Commit resulting `etc/cyclonedx.sbom.json` and push to `rx.y`.
 - If this is a new non-patch release (e.g. `x.y.0`):
-   - File a DOCSP ticket to update the installation instructions on [Install libmongocrypt](https://www.mongodb.com/docs/manual/core/csfle/reference/libmongocrypt/). ([Example](https://jira.mongodb.org/browse/DOCSP-47954))
+   - File a DOCSP ticket to update the installation instructions on [Install libmongocrypt](https://www.mongodb.com/docs/manual/core/csfle/reference/libmongocrypt/). ([Example](https://jira.mongodb.org/browse/DOCSP-52575))
    - Create a new Snyk reference target. The following instructions use the example branch `rx.y`:
 
      Run `cmake` to ensure generated source files are present:

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -57,7 +57,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2025-05-01T15:38:41.666776+00:00",
+    "timestamp": "2025-08-01T13:26:30.945797+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -100,7 +100,7 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:d8fdcd9d-84d2-4b60-9b8a-fcdd9041be0b",
+  "serialNumber": "urn:uuid:de1683b2-bcff-4e7b-a995-f464e1c3ba6a",
   "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",


### PR DESCRIPTION
- Update CHANGELOG.md for 1.15.0.
- Update SBOM with new serial number.
- Refer to newer DOCSP ticket as an example in release steps.