### PR TITLE
MONGOCRYPT-828 improve checks for text required options

### DIFF
--- a/test/test-mongocrypt-ctx-setopt.c
+++ b/test/test-mongocrypt-ctx-setopt.c
@@ -1028,6 +1028,26 @@ static void _test_setopt_for_explicit_encrypt(_mongocrypt_tester_t *tester) {
         ASSERT_EX_ENCRYPT_INIT_FAILS(bson, "suffixPreview query type requires textPreview index type");
     }
 
+    /* It is an error to set a text algorithm without setting text options */
+    {
+        REFRESH;
+        /* Set key ID to get past the 'either key id or key alt name required' error */
+        ASSERT_KEY_ID_OK(uuid);
+        ASSERT_OK(mongocrypt_ctx_setopt_algorithm(ctx, MONGOCRYPT_ALGORITHM_TEXTPREVIEW_STR, -1), ctx);
+        ASSERT_OK(mongocrypt_ctx_setopt_contention_factor(ctx, 0), ctx);
+        ASSERT_EX_ENCRYPT_INIT_FAILS(bson, "text opts are required for textPreview algorithm");
+    }
+
+    /* It is an error to set a text algorithm without setting contention */
+    {
+        REFRESH;
+        /* Set key ID to get past the 'either key id or key alt name required' error */
+        ASSERT_KEY_ID_OK(uuid);
+        ASSERT_OK(mongocrypt_ctx_setopt_algorithm(ctx, MONGOCRYPT_ALGORITHM_TEXTPREVIEW_STR, -1), ctx);
+        ASSERT_OK(mongocrypt_ctx_setopt_algorithm_text(ctx, textopts), ctx);
+        ASSERT_EX_ENCRYPT_INIT_FAILS(bson, "contention factor is required for textPreview algorithm");
+    }
+
     mongocrypt_ctx_destroy(ctx);
     mongocrypt_destroy(crypt);
 }


### PR DESCRIPTION
# Summary

Follow-up to https://github.com/mongodb/libmongocrypt/pull/1037:

- Improve error if text algorithm is set and text options are unset.
- Error (do not default) if text algorithm is set and contention factor is unset.

Verified with this patch build: https://spruce.mongodb.com/version/689201dabf203b0007a3782b

# Background & Motivation

Improves the following error when setting the `textPreview` algorithm but not setting text options (via  `mongocrypt_ctx_setopt_algorithm_text`). Before:

> Error parsing FLE2TextSearchInsertSpec: must be an iterator to a document

After:

> text opts are required for textPreview algorithm

Checks the `contention` option is set. libmongocrypt currently [applies a default of 0](https://github.com/mongodb/libmongocrypt/blob/bfc1ebdd08e2a7f17bc0bd91c298d8b3cac97a58/src/mongocrypt-ctx-encrypt.c#L1407). I consider this a bug, and [does not match server defaults](https://github.com/10gen/mongo/blob/6caa16d9c98bc528d40a1457fbc76624ac45d66e/src/mongo/crypto/encryption_fields.idl#L74). This is a backwards breaking change from 1.15.0, but I expect is acceptable since `textPreview` is unstable. Until MONGOCRYPT-713 is resolved, I expect libmongocrypt to error if `contention` is not set.
