### PR TITLE
MONGOCRYPT-833 fix bounds check

### DIFF
--- a/kms-message/src/kms_kmip_reader_writer.c
+++ b/kms-message/src/kms_kmip_reader_writer.c
@@ -205,7 +205,7 @@ kmip_writer_begin_struct (kmip_writer_t *writer, kmip_tag_type_t tag)
    size_t pos = writer->buffer->len;
 
    kmip_writer_write_u32 (writer, 0);
-   KMS_ASSERT(writer->cur_pos < MAX_KMIP_WRITER_POSITIONS);
+   KMS_ASSERT(writer->cur_pos < MAX_KMIP_WRITER_POSITIONS - 1);
    writer->cur_pos++;
    writer->positions[writer->cur_pos] = pos;
 }


### PR DESCRIPTION
Fixes an incorrect bounds check in `kmip_writer_begin_struct` identified by Coverity (issue 175729). I expect this has no impact since the structure of the KMIP messages libmongocrypt produces are fixed.