### PR TITLE
MONGOCRYPT-839 set CMake minimum required version to 3.15...4.0

### DIFF
--- a/.evergreen/linker_tests_deps/app/CMakeLists.txt
+++ b/.evergreen/linker_tests_deps/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.15...4.0)
 project (app C)
 add_executable (app app.c)
 find_package (bson-1.0 1.11 REQUIRED)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # ChangeLog
+
+## 1.16.0 (Unreleased)
+
+### Changed
+
+- Set CMake minimum required version to `3.15...4.0` (with maximum policy version set to `4.0`).
+
 ## 1.15.0
 
 ### New features

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,4 @@
-cmake_minimum_required (VERSION 3.12)
-
-# Preempt the MSVC_RUNTIME_LIBRARY properties
-if (POLICY CMP0091)
-   cmake_policy (SET CMP0091 NEW)
-elseif (DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
-   message (WARNING "The CMAKE_MSVC_RUNTIME_LIBRARY variable is set, but CMake is too old to understand it")
-endif ()
-
-if (POLICY CMP0135)
-   cmake_policy (SET CMP0135 NEW)
-endif ()
+cmake_minimum_required (VERSION 3.15...4.0)
 
 project (mongocrypt C)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,20 +16,7 @@ option (ENABLE_BUILD_FOR_PPA "Maintainer-only option for preparing PPA build" OF
 option (ENABLE_ONLINE_TESTS "Enable online tests and the csfle utility. Requires libmongoc." ON)
 
 if (ENABLE_WINDOWS_STATIC_RUNTIME)
-   if (POLICY CMP0091)
-      # CMake 3.15 makes this trivial:
-      set (CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-   else ()
-      # Fix it up the old-fashioned way
-      string (REPLACE "/MDd" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-      string (REPLACE "/MD" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
-      string (REPLACE "/MDd" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-      string (REPLACE "/MD" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
-      string (APPEND CMAKE_C_FLAGS_DEBUG " /MTd")
-      string (APPEND CMAKE_CXX_FLAGS_DEBUG " /MTd")
-      string (APPEND CMAKE_C_FLAGS_RELEASE " /MT")
-      string (APPEND CMAKE_CXX_FLAGS_RELEASE " /MT")
-   endif ()
+   set (CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif ()
 
 list (APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)

--- a/cmake/MongoC-Warnings.cmake
+++ b/cmake/MongoC-Warnings.cmake
@@ -42,14 +42,7 @@ function (mongoc_add_platform_compile_options)
    endforeach ()
 endfunction ()
 
-if (CMAKE_VERSION VERSION_LESS 3.3)
-   # On older CMake versions, we'll just always pass the warning options, even
-   # if the generate warnings for the C++ check file
-   set (is_c_lang "1")
-else ()
-   # $<COMPILE_LANGUAGE> is only valid in CMake 3.3+
-   set (is_c_lang "$<COMPILE_LANGUAGE:C>")
-endif ()
+set (is_c_lang "$<COMPILE_LANGUAGE:C>")
 
 # These below warnings should always be unconditional hard errors, as the code is
 # almost definitely broken

--- a/kms-message/CMakeLists.txt
+++ b/kms-message/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.15...4.0)
 project (kms_message
    VERSION 0.0.1
    LANGUAGES C
@@ -7,8 +7,7 @@ project (kms_message
 set (CMAKE_C_STANDARD 99)
 
 include (CheckCCompilerFlag)
-# All targets obey visibility, not just library targets.
-cmake_policy (SET CMP0063 NEW)
+
 set (CMAKE_C_VISIBILITY_PRESET hidden)
 set (KMS_MESSAGE_SOURCES
    src/kms_b64.c


### PR DESCRIPTION
Resolves MONGOCRYPT-839. Prompted by the following CMake configuration error (among various other CMake compatibility warnings) on MacOS 14 arm64 (with [CMake 4.1.0](https://github.com/mongodb/mongo-cxx-driver/blob/939c33683944e0a8b3b78d1f4db13cb148392e59/.evergreen/scripts/install-c-driver.sh#L58) -> [libmongocrypt 1.13.0](https://github.com/mongodb/libmongocrypt/blob/1cf03f1fdd8fa439d43b8548b546c00ce71d1bc1/cmake/FetchMongoC.cmake#L5) -> [mongo-c-driver 1.28.1](https://github.com/mongodb/mongo-c-driver/blob/97f166d8d784d6096d48ba288f98b48028cdfe8b/src/libbson/CMakeLists.txt#L37)):

```
CMake Error at cmake-build/_deps/embedded_mcd-src/src/libbson/CMakeLists.txt:37 (cmake_policy):
  Policy CMP0042 may not be set to OLD behavior because this version of CMake
  no longer supports it.  The policy was introduced in CMake version 3.0.0,
  and use of NEW behavior is now required.
  Please either update your CMakeLists.txt files to conform to the new
  behavior or use an older version of CMake that still supports the old
  behavior.  Run cmake --help-policy CMP0042 for more information.
```

https://github.com/mongodb/mongo-c-driver/pull/1973 and https://github.com/mongodb/mongo-c-driver/pull/2066 already addressed this issue on the C Driver's side ([backported](https://github.com/mongodb/mongo-c-driver/commit/23440389b76dad06ac11640f06e6e5682e5e4b35) into the 1.30.3 release), which was inherited by libmongocrypt in https://github.com/mongodb/libmongocrypt/pull/996 (in the 1.14.0 release). However, libmongocrypt can/should also be updated with similar CMake compatibility improvements, as CMake dropped support for versions older than 3.5 (in the 4.0 release) and deprecated supported for versions older than 3.10 (in the 3.31 release).

The minimum required CMake version was last updated from 3.5 to 3.12 in https://github.com/mongodb/libmongocrypt/pull/522 to obtain `FetchContent`. However, this was not extended to the kms-message project, which is [still set](https://github.com/mongodb/libmongocrypt/blob/68dabfa1a9112303ce8c96e670408a30238d22fc/kms-message/CMakeLists.txt#L1) to `3.5`. Given libmongocrypt uses `FetchContent` (thus `add_subdirectory()`) to obtain mongo-c-driver, and mongo-c-driver already raised its CMake minimum required version to 3.15 in https://github.com/mongodb/mongo-c-driver/pull/1289 (1.24.0), and libmongocrypt currently depends on the [1.30.3 release](https://github.com/mongodb/libmongocrypt/blob/f5b809c6b9dca4023aba4ec3adf7c50e119a9ce2/cmake/FetchMongoC.cmake#L5), raising the minimum required CMake version for libmongocrypt to 3.15 should be safe (already in effect via mongo-c-driver's CMake configuration).

This PR proposes also setting the CMake maximum policy version to `4.0` for consistency with mongo-c-driver (see https://github.com/mongodb/mongo-c-driver/pull/2066), forward-compatibility with CMake 4.0, and reduction of explicit calls to `cmake_policy()`. This addresses numerous CMake compatibility warnings and removes the need for explicit `cmake_policy()` calls. Some obsolete `CMAKE_VERSION` branches are also removed.