### PR TITLE
PYTHON-5466 Test with Python 3.14 on MacOS

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1628,7 +1628,8 @@ buildvariants:
     use_ninja: OFF
   tasks:
   - build-and-test-and-upload
-  - test-python
+  - name: test-python
+    distros: macos-14-arm64
 - name: windows-vs2017-32bit
   # Test Windows 32 bit builds for PHPC. PHPC builds libmongocrypt from source. See MONGOCRYPT-391.
   display_name: "Windows VS 2017 32-bit compile"

--- a/bindings/python/.evergreen/test.sh
+++ b/bindings/python/.evergreen/test.sh
@@ -36,8 +36,7 @@ elif [ "Darwin" = "$(uname -s)" ]; then
           "/Library/Frameworks/Python.framework/Versions/3.11/bin/python3"
           "/Library/Frameworks/Python.framework/Versions/3.12/bin/python3"
           "/Library/Frameworks/Python.framework/Versions/3.13/bin/python3"
-          # TODO: PYTHON-5466
-          #"/Library/Frameworks/Python.framework/Versions/3.14/bin/python3"
+          "/Library/Frameworks/Python.framework/Versions/3.14/bin/python3"
           )
 
     export CRYPT_SHARED_PATH="../crypt_shared/lib/mongo_crypt_v1.dylib"


### PR DESCRIPTION
Use macos11 to build and macos14 to run the python tests.