### PR TITLE
MONGOCRYPT-577 Assert non-NULL returns from malloc()-family function

### DIFF
--- a/kms-message/src/kms_b64.c
+++ b/kms-message/src/kms_b64.c
@@ -583,6 +583,7 @@ kms_message_raw_to_b64 (const uint8_t *raw, size_t raw_len)
 
    b64_len = (raw_len / 3 + 1) * 4 + 1;
    b64 = malloc (b64_len);
+   KMS_ASSERT (b64);
    memset (b64, 0, b64_len);
    if (-1 == kms_message_b64_ntop (raw, raw_len, b64, b64_len)) {
       free (b64);
@@ -600,6 +601,7 @@ kms_message_b64_to_raw (const char *b64, size_t *out)
 
    b64len = strlen (b64);
    raw = (uint8_t *) malloc (b64len + 1);
+   KMS_ASSERT (raw);
    memset (raw, 0, b64len + 1);
    ret = kms_message_b64_pton (b64, raw, b64len);
    if (ret > 0) {
@@ -642,6 +644,7 @@ kms_message_b64url_to_raw (const char *b64url, size_t *out)
    /* Add four for padding '=' characters. */
    capacity = b64urllen + 4;
    b64 = malloc (capacity);
+   KMS_ASSERT (b64);
    memset (b64, 0, capacity);
    if (-1 ==
        kms_message_b64url_to_b64 (b64url, b64urllen, b64, capacity)) {

--- a/kms-message/src/kms_crypto_libcrypto.c
+++ b/kms-message/src/kms_crypto_libcrypto.c
@@ -58,6 +58,7 @@ kms_sha256 (void *unused_ctx,
             unsigned char *hash_out)
 {
    EVP_MD_CTX *digest_ctxp = EVP_MD_CTX_new ();
+   KMS_ASSERT (digest_ctxp);
    bool rval = false;
 
    if (1 != EVP_DigestInit_ex (digest_ctxp, EVP_sha256 (), NULL)) {
@@ -108,6 +109,7 @@ kms_sign_rsaes_pkcs1_v1_5 (void *unused_ctx,
    size_t signature_out_len = 256;
 
    ctx = EVP_MD_CTX_new ();
+   KMS_ASSERT (ctx);
    KMS_ASSERT (private_key_len <= LONG_MAX);
    pkey = d2i_PrivateKey (EVP_PKEY_RSA,
                           NULL,

--- a/kms-message/src/kms_crypto_windows.c
+++ b/kms-message/src/kms_crypto_windows.c
@@ -179,6 +179,7 @@ kms_sign_rsaes_pkcs1_v1_5 (void *unused_ctx,
    }
 
    blob_private = (LPBYTE) calloc (1, blob_private_len);
+   KMS_ASSERT (blob_private);
 
    success = CryptDecodeObjectEx (X509_ASN_ENCODING,
                                   PKCS_PRIVATE_KEY_INFO,
@@ -208,6 +209,7 @@ kms_sign_rsaes_pkcs1_v1_5 (void *unused_ctx,
    }
 
    raw_private = (LPBYTE) calloc (1, raw_private_len);
+   KMS_ASSERT (raw_private);
 
    success = CryptDecodeObjectEx (X509_ASN_ENCODING,
                                   PKCS_RSA_PRIVATE_KEY,
@@ -234,6 +236,7 @@ kms_sign_rsaes_pkcs1_v1_5 (void *unused_ctx,
    }
 
    hash_value = calloc (1, SHA_256_HASH_LEN);
+   KMS_ASSERT (hash_value);
 
    if(!kms_sha256 (NULL, input, input_len, hash_value)) {
       goto cleanup;

--- a/kms-message/src/kms_gcp_request.c
+++ b/kms-message/src/kms_gcp_request.c
@@ -88,6 +88,7 @@ kms_gcp_request_oauth_new (const char *host,
    }
 
    jwt_signature = calloc (1, SIGNATURE_LEN);
+   KMS_ASSERT (jwt_signature);
    if (!req->crypto.sign_rsaes_pkcs1_v1_5 (
           req->crypto.sign_ctx,
           private_key_data,

--- a/kms-message/src/kms_kmip_reader_writer.c
+++ b/kms-message/src/kms_kmip_reader_writer.c
@@ -43,6 +43,7 @@ kmip_writer_t *
 kmip_writer_new (void)
 {
    kmip_writer_t *writer = calloc (1, sizeof (kmip_writer_t));
+   KMS_ASSERT (writer);
    writer->buffer = kms_request_str_new ();
    return writer;
 }
@@ -241,6 +242,7 @@ kmip_reader_t *
 kmip_reader_new (uint8_t *ptr, size_t len)
 {
    kmip_reader_t *reader = calloc (1, sizeof (kmip_reader_t));
+   KMS_ASSERT (reader);
    reader->ptr = ptr;
    reader->len = len;
    return reader;

--- a/kms-message/src/kms_kmip_request.c
+++ b/kms-message/src/kms_kmip_request.c
@@ -31,6 +31,7 @@ copy_writer_buffer (kms_request_t *req, kmip_writer_t *writer)
 
    buf = kmip_writer_get_buffer (writer, &buflen);
    req->kmip.data = malloc (buflen);
+   KMS_ASSERT (req->kmip.data);
    memcpy (req->kmip.data, buf, buflen);
    req->kmip.len = (uint32_t) buflen;
 }
@@ -79,6 +80,7 @@ kms_kmip_request_register_secretdata_new (void *reserved,
    kms_request_t *req;
 
    req = calloc (1, sizeof (kms_request_t));
+   KMS_ASSERT (req);
    req->provider = KMS_REQUEST_PROVIDER_KMIP;
 
    if (len != KMS_KMIP_REQUEST_SECRETDATA_LENGTH) {
@@ -168,6 +170,7 @@ kms_kmip_request_activate_new (void *reserved, const char *unique_identifer)
    kms_request_t *req;
 
    req = calloc (1, sizeof (kms_request_t));
+   KMS_ASSERT (req);
    req->provider = KMS_REQUEST_PROVIDER_KMIP;
 
    writer = kmip_writer_new ();
@@ -224,6 +227,7 @@ kms_kmip_request_get_new (void *reserved, const char *unique_identifer)
    kms_request_t *req;
 
    req = calloc (1, sizeof (kms_request_t));
+   KMS_ASSERT (req);
    req->provider = KMS_REQUEST_PROVIDER_KMIP;
 
    writer = kmip_writer_new ();
@@ -294,6 +298,7 @@ kms_kmip_request_create_new (void *reserved) {
    kms_request_t *req;
 
    req = calloc (1, sizeof (kms_request_t));
+   KMS_ASSERT (req);
    req->provider = KMS_REQUEST_PROVIDER_KMIP;
 
    writer = kmip_writer_new();
@@ -362,6 +367,7 @@ kmip_encrypt_decrypt (const char* unique_identifer, const uint8_t *data, size_t 
    kms_request_t *req;
 
    req = calloc (1, sizeof (kms_request_t));
+   KMS_ASSERT (req);
    req->provider = KMS_REQUEST_PROVIDER_KMIP;
 
    writer = kmip_writer_new();

--- a/kms-message/src/kms_kmip_response.c
+++ b/kms-message/src/kms_kmip_response.c
@@ -284,6 +284,7 @@ kms_kmip_response_get_iv (kms_response_t *res, size_t *datalen) {
       goto fail;
    }
    data = malloc (len);
+   KMS_ASSERT (data);
    memcpy (data, tmp, len);
    *datalen = len;
 
@@ -364,6 +365,7 @@ kms_kmip_response_get_data (kms_response_t *res, size_t *datalen) {
       goto fail;
    }
    data = malloc (len);
+   KMS_ASSERT (data);
    memcpy (data, tmp, len);
    *datalen = len;
 
@@ -477,6 +479,7 @@ kms_kmip_response_get_secretdata (kms_response_t *res, size_t *secretdatalen)
       goto fail;
    }
    secretdata = malloc (len);
+   KMS_ASSERT (secretdata);
    memcpy (secretdata, tmp, len);
    *secretdatalen = len;
 

--- a/kms-message/src/kms_kmip_response_parser.c
+++ b/kms-message/src/kms_kmip_response_parser.c
@@ -55,6 +55,7 @@ kms_kmip_response_parser_new (void *reserved)
    kms_response_parser_t *parser = kms_response_parser_new ();
 
    parser->kmip = malloc (sizeof (kms_kmip_response_parser_t));
+   KMS_ASSERT (parser->kmip);
    _parser_init (parser->kmip);
 
    return parser;
@@ -119,6 +120,7 @@ kms_kmip_response_parser_get_response (kms_kmip_response_parser_t *parser)
    }
 
    res = calloc (1, sizeof (kms_response_t));
+   KMS_ASSERT (res);
    res->provider = KMS_REQUEST_PROVIDER_KMIP;
    res->kmip.len = (uint32_t) parser->buf->len;
    res->kmip.data = (uint8_t *) kms_request_str_detach (parser->buf);

--- a/kms-message/test/test_kms_azure_online.c
+++ b/kms-message/test/test_kms_azure_online.c
@@ -122,6 +122,7 @@ azure_authenticate (void)
    test_env_init (&test_env);
 
    opt = kms_request_opt_new ();
+   ASSERT (opt);
    kms_request_opt_set_connection_close (opt, true);
    kms_request_opt_set_provider (opt, KMS_REQUEST_PROVIDER_AZURE);
 
@@ -190,6 +191,7 @@ test_azure_wrapkey (void)
    bearer_token = azure_authenticate ();
 
    opt = kms_request_opt_new ();
+   ASSERT (opt);
    kms_request_opt_set_connection_close (opt, true);
    kms_request_opt_set_provider (opt, KMS_REQUEST_PROVIDER_AZURE);
    req = kms_azure_request_wrapkey_new (test_env.key_host,

--- a/kms-message/test/test_kms_gcp_online.c
+++ b/kms-message/test/test_kms_gcp_online.c
@@ -98,6 +98,7 @@ gcp_authenticate (void)
    test_env_init (&test_env);
 
    opt = kms_request_opt_new ();
+   ASSERT (opt);
    kms_request_opt_set_connection_close (opt, true);
    kms_request_opt_set_provider (opt, KMS_REQUEST_PROVIDER_GCP);
 
@@ -171,6 +172,7 @@ test_gcp (void)
    bearer_token = gcp_authenticate ();
 
    opt = kms_request_opt_new ();
+   ASSERT (opt);
    kms_request_opt_set_connection_close (opt, true);
    kms_request_opt_set_provider (opt, KMS_REQUEST_PROVIDER_GCP);
    req = kms_gcp_request_encrypt_new (test_env.kms_host,

--- a/kms-message/test/test_kms_request.c
+++ b/kms-message/test/test_kms_request.c
@@ -604,6 +604,7 @@ connection_close_test (void)
    kms_request_t *request;
 
    opt = kms_request_opt_new ();
+   ASSERT (opt);
    kms_request_opt_set_connection_close (opt, true);
 
    request = kms_request_new ("POST", "/", opt);
@@ -1106,6 +1107,7 @@ kms_request_kmip_prohibited_test (void)
    kms_request_t *req;
 
    opt = kms_request_opt_new ();
+   ASSERT (opt);
    kms_request_opt_set_provider (opt, KMS_REQUEST_PROVIDER_KMIP);
    req = kms_request_new ("method", "path_and_query", opt);
    ASSERT_REQUEST_ERROR (req, "Function not applicable to KMIP");
@@ -1141,6 +1143,7 @@ test_request_newlines (void)
    // Test kms_request_to_string.
    {
       opt = kms_request_opt_new ();
+      ASSERT (opt);
       kms_request_opt_set_connection_close (opt, true);
       ASSERT (kms_request_opt_set_provider (opt, KMS_REQUEST_PROVIDER_AZURE));
       req = kms_azure_request_wrapkey_new ("example-host",
@@ -1167,6 +1170,7 @@ test_request_newlines (void)
    // Test kms_request_get_signed.
    {
       opt = kms_request_opt_new ();
+      ASSERT (opt);
       kms_request_opt_set_connection_close (opt, true);
       req = kms_caller_identity_request_new (opt);
       ASSERT_REQUEST_OK (req);


### PR DESCRIPTION
The `kms_message` library has many unchecked calls to `malloc`/`calloc`. This PR adds missing `KMS_ASSERT` statements on the results of these calls, as well as some `ASSERT`'s in `test_kms`.