### PR TITLE
MONGOCRYPT-824 Allow setting deterministic contention factor during FLE2 field encryption

### DIFF
--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -729,15 +729,17 @@ fail:
 }
 
 static bool _fle2_choose_contention_factor(mongocrypt_t *crypt,
-                                           int64_t exclusive_upper_bound,
+                                           int64_t maxContentionFactor,
                                            int64_t *out,
                                            mongocrypt_status_t *status) {
+    BSON_ASSERT_PARAM(crypt);
+    BSON_ASSERT_PARAM(out);
     if (crypt->opts.contention_factor_fn) {
-        if (!crypt->opts.contention_factor_fn(exclusive_upper_bound, out)) {
+        if (!crypt->opts.contention_factor_fn(maxContentionFactor + 1, out)) {
             CLIENT_ERR("contention_factor_fn failed");
             return false;
         }
-        if (*out < 0 || *out > exclusive_upper_bound) {
+        if (*out < 0 || *out > maxContentionFactor) {
             CLIENT_ERR("chosen contentionFactor out of range");
             return false;
         }
@@ -771,7 +773,7 @@ static bool _mongocrypt_fle2_placeholder_to_insert_update_common(_mongocrypt_key
         /* Choose a contentionFactor in the inclusive range [0,
          * placeholder->maxContentionFactor] */
         if (!_fle2_choose_contention_factor(kb->crypt,
-                                            placeholder->maxContentionFactor + 1,
+                                            placeholder->maxContentionFactor,
                                             &out->contentionFactor,
                                             status)) {
             goto fail;
@@ -1570,7 +1572,7 @@ static bool _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForTextSearc
         /* Choose a contentionFactor in the inclusive range [0,
          * placeholder->maxContentionFactor] */
         if (!_fle2_choose_contention_factor(kb->crypt,
-                                            placeholder->maxContentionFactor + 1,
+                                            placeholder->maxContentionFactor,
                                             &payload.contentionFactor,
                                             status)) {
             goto fail;

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -747,17 +747,16 @@ static bool _mongocrypt_fle2_placeholder_to_insert_update_common(_mongocrypt_key
     _mongocrypt_buffer_t value = {0};
     bool res = false;
 
+    /* Choose a contentionFactor in the inclusive range [0,
+     * placeholder->maxContentionFactor] */
     out->contentionFactor = 0; // k
     if (placeholder->maxContentionFactor > 0) {
         if (kb->crypt->opts.contention_factor_fn) {
             if (!kb->crypt->opts.contention_factor_fn(placeholder->maxContentionFactor + 1, &out->contentionFactor)) {
-                CLIENT_ERR("contention_factor_fn failed");
                 goto fail;
             }
         }
 
-        /* Choose a random contentionFactor in the inclusive range [0,
-         * placeholder->maxContentionFactor] */
         else if (!_mongocrypt_random_int64(crypto, placeholder->maxContentionFactor + 1, &out->contentionFactor, status)) {
             goto fail;
         }
@@ -1552,20 +1551,18 @@ static bool _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForTextSearc
     // k
     payload.contentionFactor = 0;
     if (placeholder->maxContentionFactor > 0) {
-        /* Choose a random contentionFactor in the inclusive range [0,
+        /* Choose a contentionFactor in the inclusive range [0,
          * placeholder->maxContentionFactor] */
         if (kb->crypt->opts.contention_factor_fn) {
-            if (!kb->crypt->opts.contention_factor_fn(placeholder->maxContentionFactor + 1, &out->contentionFactor)) {
-                CLIENT_ERR("contention_factor_fn failed");
+            if (!kb->crypt->opts.contention_factor_fn(placeholder->maxContentionFactor + 1,
+                                                      &payload.contentionFactor)) {
                 goto fail;
             }
         }
 
-        /* Choose a random contentionFactor in the inclusive range [0,
-         * placeholder->maxContentionFactor] */
-        else if (!_mongocrypt_random_int64(crypto,
+        else if (!_mongocrypt_random_int64(kb->crypt->crypto,
                                            placeholder->maxContentionFactor + 1,
-                                           &out->contentionFactor,
+                                           &payload.contentionFactor,
                                            status)) {
             goto fail;
         }

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -728,13 +728,33 @@ fail:
     return false;
 }
 
+static bool _fle2_choose_contention_factor(mongocrypt_t *crypt,
+                                           int64_t exclusive_upper_bound,
+                                           int64_t *out,
+                                           mongocrypt_status_t *status) {
+    if (crypt->opts.contention_factor_fn) {
+        if (!crypt->opts.contention_factor_fn(exclusive_upper_bound, out)) {
+            CLIENT_ERR("contention_factor_fn failed");
+            return false;
+        }
+        if (*out < 0 || *out > exclusive_upper_bound) {
+            CLIENT_ERR("chosen contentionFactor out of range");
+            return false;
+        }
+        return true;
+    }
+    
+    return _mongocrypt_random_int64(crypt->crypto, exclusive_upper_bound, out, status);
+}
+
 // Shared implementation for insert/update and insert/update ForRange (v2)
-static bool _mongocrypt_fle2_placeholder_to_insert_update_common(_mongocrypt_key_broker_t *kb,
-                                                                 mc_FLE2InsertUpdatePayloadV2_t *out,
-                                                                 _FLE2EncryptedPayloadCommon_t *common,
-                                                                 const mc_FLE2EncryptionPlaceholder_t *placeholder,
-                                                                 bson_iter_t *value_iter,
-                                                                 mongocrypt_status_t *status) {
+static bool
+    _mongocrypt_fle2_placeholder_to_insert_update_common(_mongocrypt_key_broker_t *kb,
+                                                         mc_FLE2InsertUpdatePayloadV2_t *out,
+                                                         _FLE2EncryptedPayloadCommon_t *common,
+                                                         const mc_FLE2EncryptionPlaceholder_t *placeholder,
+                                                         bson_iter_t *value_iter,
+                                                         mongocrypt_status_t *status) {
     BSON_ASSERT_PARAM(kb);
     BSON_ASSERT_PARAM(out);
     BSON_ASSERT_PARAM(common);
@@ -747,25 +767,12 @@ static bool _mongocrypt_fle2_placeholder_to_insert_update_common(_mongocrypt_key
     _mongocrypt_buffer_t value = {0};
     bool res = false;
 
-    /* Choose a contentionFactor in the inclusive range [0,
-     * placeholder->maxContentionFactor] */
+
     out->contentionFactor = 0; // k
     if (placeholder->maxContentionFactor > 0) {
-        if (kb->crypt->opts.contention_factor_fn) {
-            if (!kb->crypt->opts.contention_factor_fn(placeholder->maxContentionFactor + 1, &out->contentionFactor)) {
-                CLIENT_ERR("contention_factor_fn failed");
-                goto fail;
-            }
-            if (out->contentionFactor < 0 || out->contentionFactor > placeholder->maxContentionFactor) {
-                CLIENT_ERR("chosen contentionFactor out of range");
-                goto fail;
-            }
-        }
-
-        else if (!_mongocrypt_random_int64(crypto,
-                                           placeholder->maxContentionFactor + 1,
-                                           &out->contentionFactor,
-                                           status)) {
+        /* Choose a contentionFactor in the inclusive range [0,
+         * placeholder->maxContentionFactor] */
+        if (!_fle2_choose_contention_factor(kb->crypt, placeholder->maxContentionFactor + 1, &out->contentionFactor, status)) {
             goto fail;
         }
     }
@@ -1561,22 +1568,10 @@ static bool _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForTextSearc
     if (placeholder->maxContentionFactor > 0) {
         /* Choose a contentionFactor in the inclusive range [0,
          * placeholder->maxContentionFactor] */
-        if (kb->crypt->opts.contention_factor_fn) {
-            if (!kb->crypt->opts.contention_factor_fn(placeholder->maxContentionFactor + 1,
-                                                      &payload.contentionFactor)) {
-                CLIENT_ERR("contention_factor_fn failed");
-                goto fail;
-            }
-            if (payload.contentionFactor < 0 || payload.contentionFactor > placeholder->maxContentionFactor) {
-                CLIENT_ERR("chosen contentionFactor out of range");
-                goto fail;
-            }
-        }
-
-        else if (!_mongocrypt_random_int64(kb->crypt->crypto,
-                                           placeholder->maxContentionFactor + 1,
-                                           &payload.contentionFactor,
-                                           status)) {
+        if (!_fle2_choose_contention_factor(kb->crypt,
+                                            placeholder->maxContentionFactor + 1,
+                                            &payload.contentionFactor,
+                                            status)) {
             goto fail;
         }
     }

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -749,9 +749,16 @@ static bool _mongocrypt_fle2_placeholder_to_insert_update_common(_mongocrypt_key
 
     out->contentionFactor = 0; // k
     if (placeholder->maxContentionFactor > 0) {
+        if (kb->crypt->opts.contention_factor_fn) {
+            if (!kb->crypt->opts.contention_factor_fn(placeholder->maxContentionFactor + 1, &out->contentionFactor)) {
+                CLIENT_ERR("contention_factor_fn failed");
+                goto fail;
+            }
+        }
+
         /* Choose a random contentionFactor in the inclusive range [0,
          * placeholder->maxContentionFactor] */
-        if (!_mongocrypt_random_int64(crypto, placeholder->maxContentionFactor + 1, &out->contentionFactor, status)) {
+        else if (!_mongocrypt_random_int64(crypto, placeholder->maxContentionFactor + 1, &out->contentionFactor, status)) {
             goto fail;
         }
     }
@@ -1547,10 +1554,19 @@ static bool _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForTextSearc
     if (placeholder->maxContentionFactor > 0) {
         /* Choose a random contentionFactor in the inclusive range [0,
          * placeholder->maxContentionFactor] */
-        if (!_mongocrypt_random_int64(kb->crypt->crypto,
-                                      placeholder->maxContentionFactor + 1,
-                                      &payload.contentionFactor,
-                                      status)) {
+        if (kb->crypt->opts.contention_factor_fn) {
+            if (!kb->crypt->opts.contention_factor_fn(placeholder->maxContentionFactor + 1, &out->contentionFactor)) {
+                CLIENT_ERR("contention_factor_fn failed");
+                goto fail;
+            }
+        }
+
+        /* Choose a random contentionFactor in the inclusive range [0,
+         * placeholder->maxContentionFactor] */
+        else if (!_mongocrypt_random_int64(crypto,
+                                           placeholder->maxContentionFactor + 1,
+                                           &out->contentionFactor,
+                                           status)) {
             goto fail;
         }
     }

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -746,7 +746,7 @@ static bool _fle2_choose_contention_factor(mongocrypt_t *crypt,
         return true;
     }
 
-    return _mongocrypt_random_int64(crypt->crypto, exclusive_upper_bound, out, status);
+    return _mongocrypt_random_int64(crypt->crypto, maxContentionFactor + 1, out, status);
 }
 
 // Shared implementation for insert/update and insert/update ForRange (v2)

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -753,6 +753,11 @@ static bool _mongocrypt_fle2_placeholder_to_insert_update_common(_mongocrypt_key
     if (placeholder->maxContentionFactor > 0) {
         if (kb->crypt->opts.contention_factor_fn) {
             if (!kb->crypt->opts.contention_factor_fn(placeholder->maxContentionFactor + 1, &out->contentionFactor)) {
+                CLIENT_ERR("contention_factor_fn failed");
+                goto fail;
+            }
+            if (out->contentionFactor < 0 || out->contentionFactor > placeholder->maxContentionFactor) {
+                CLIENT_ERR("chosen contentionFactor out of range");
                 goto fail;
             }
         }
@@ -1559,6 +1564,11 @@ static bool _mongocrypt_fle2_placeholder_to_insert_update_ciphertextForTextSearc
         if (kb->crypt->opts.contention_factor_fn) {
             if (!kb->crypt->opts.contention_factor_fn(placeholder->maxContentionFactor + 1,
                                                       &payload.contentionFactor)) {
+                CLIENT_ERR("contention_factor_fn failed");
+                goto fail;
+            }
+            if (payload.contentionFactor < 0 || payload.contentionFactor > placeholder->maxContentionFactor) {
+                CLIENT_ERR("chosen contentionFactor out of range");
                 goto fail;
             }
         }

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -743,18 +743,17 @@ static bool _fle2_choose_contention_factor(mongocrypt_t *crypt,
         }
         return true;
     }
-    
+
     return _mongocrypt_random_int64(crypt->crypto, exclusive_upper_bound, out, status);
 }
 
 // Shared implementation for insert/update and insert/update ForRange (v2)
-static bool
-    _mongocrypt_fle2_placeholder_to_insert_update_common(_mongocrypt_key_broker_t *kb,
-                                                         mc_FLE2InsertUpdatePayloadV2_t *out,
-                                                         _FLE2EncryptedPayloadCommon_t *common,
-                                                         const mc_FLE2EncryptionPlaceholder_t *placeholder,
-                                                         bson_iter_t *value_iter,
-                                                         mongocrypt_status_t *status) {
+static bool _mongocrypt_fle2_placeholder_to_insert_update_common(_mongocrypt_key_broker_t *kb,
+                                                                 mc_FLE2InsertUpdatePayloadV2_t *out,
+                                                                 _FLE2EncryptedPayloadCommon_t *common,
+                                                                 const mc_FLE2EncryptionPlaceholder_t *placeholder,
+                                                                 bson_iter_t *value_iter,
+                                                                 mongocrypt_status_t *status) {
     BSON_ASSERT_PARAM(kb);
     BSON_ASSERT_PARAM(out);
     BSON_ASSERT_PARAM(common);
@@ -767,12 +766,14 @@ static bool
     _mongocrypt_buffer_t value = {0};
     bool res = false;
 
-
     out->contentionFactor = 0; // k
     if (placeholder->maxContentionFactor > 0) {
         /* Choose a contentionFactor in the inclusive range [0,
          * placeholder->maxContentionFactor] */
-        if (!_fle2_choose_contention_factor(kb->crypt, placeholder->maxContentionFactor + 1, &out->contentionFactor, status)) {
+        if (!_fle2_choose_contention_factor(kb->crypt,
+                                            placeholder->maxContentionFactor + 1,
+                                            &out->contentionFactor,
+                                            status)) {
             goto fail;
         }
     }

--- a/src/mongocrypt-marking.c
+++ b/src/mongocrypt-marking.c
@@ -757,7 +757,10 @@ static bool _mongocrypt_fle2_placeholder_to_insert_update_common(_mongocrypt_key
             }
         }
 
-        else if (!_mongocrypt_random_int64(crypto, placeholder->maxContentionFactor + 1, &out->contentionFactor, status)) {
+        else if (!_mongocrypt_random_int64(crypto,
+                                           placeholder->maxContentionFactor + 1,
+                                           &out->contentionFactor,
+                                           status)) {
             goto fail;
         }
     }

--- a/src/mongocrypt-opts-private.h
+++ b/src/mongocrypt-opts-private.h
@@ -144,6 +144,7 @@ bool _mongocrypt_opts_kms_providers_validate(_mongocrypt_opts_t *opts,
                                              _mongocrypt_opts_kms_providers_t *kms_providers,
                                              mongocrypt_status_t *status) MONGOCRYPT_WARN_UNUSED_RESULT;
 
+// For testing only: register a custom contention factor function with crypt.
 void _mongocrypt_opts_set_contention_factor_fn(mongocrypt_t *crypt,
                                                _mongocrypt_contention_factor_fn contention_factor_fn);
 

--- a/src/mongocrypt-opts-private.h
+++ b/src/mongocrypt-opts-private.h
@@ -107,7 +107,7 @@ typedef struct {
     mongocrypt_hmac_fn sign_rsaes_pkcs1_v1_5;
     void *sign_ctx;
 
-    // For testing only.
+    // Support overriding random contentionFactor (when null, default) with a custom setter.
     _mongocrypt_contention_factor_fn contention_factor_fn;
 
     /// Keep an array of search paths for finding the crypt_shared library

--- a/src/mongocrypt-opts-private.h
+++ b/src/mongocrypt-opts-private.h
@@ -84,6 +84,9 @@ typedef struct {
     mc_array_t named_mut;
 } _mongocrypt_opts_kms_providers_t;
 
+typedef bool (*_mongocrypt_contention_factor_fn)(int64_t exclusive_upper_bound,
+                                                 int64_t *out);
+
 void _mongocrypt_opts_kms_providers_init(_mongocrypt_opts_kms_providers_t *kms_providers);
 
 bool _mongocrypt_parse_kms_providers(mongocrypt_binary_t *kms_providers_definition,
@@ -104,6 +107,9 @@ typedef struct {
     _mongocrypt_opts_kms_providers_t kms_providers;
     mongocrypt_hmac_fn sign_rsaes_pkcs1_v1_5;
     void *sign_ctx;
+
+    // For testing only.
+    _mongocrypt_contention_factor_fn contention_factor_fn;
 
     /// Keep an array of search paths for finding the crypt_shared library
     /// during mongocrypt_init()
@@ -137,6 +143,9 @@ bool _mongocrypt_opts_validate(_mongocrypt_opts_t *opts, mongocrypt_status_t *st
 bool _mongocrypt_opts_kms_providers_validate(_mongocrypt_opts_t *opts,
                                              _mongocrypt_opts_kms_providers_t *kms_providers,
                                              mongocrypt_status_t *status) MONGOCRYPT_WARN_UNUSED_RESULT;
+
+void _mongocrypt_opts_set_contention_factor_fn(mongocrypt_t *crypt,
+                                               _mongocrypt_contention_factor_fn contention_factor_fn);
 
 /*
  * Parse an optional UTF-8 value from BSON.

--- a/src/mongocrypt-opts-private.h
+++ b/src/mongocrypt-opts-private.h
@@ -84,8 +84,7 @@ typedef struct {
     mc_array_t named_mut;
 } _mongocrypt_opts_kms_providers_t;
 
-typedef bool (*_mongocrypt_contention_factor_fn)(int64_t exclusive_upper_bound,
-                                                 int64_t *out);
+typedef bool (*_mongocrypt_contention_factor_fn)(int64_t exclusive_upper_bound, int64_t *out);
 
 void _mongocrypt_opts_kms_providers_init(_mongocrypt_opts_kms_providers_t *kms_providers);
 

--- a/src/mongocrypt-opts.c
+++ b/src/mongocrypt-opts.c
@@ -329,8 +329,7 @@ void _mongocrypt_opts_set_contention_factor_fn(mongocrypt_t *crypt,
     opts->contention_factor_fn = contention_factor_fn;
 }
 
-    bool
-    _mongocrypt_parse_optional_utf8(const bson_t *bson, const char *dotkey, char **out, mongocrypt_status_t *status) {
+bool _mongocrypt_parse_optional_utf8(const bson_t *bson, const char *dotkey, char **out, mongocrypt_status_t *status) {
     bson_iter_t iter;
     bson_iter_t child;
 

--- a/src/mongocrypt-opts.c
+++ b/src/mongocrypt-opts.c
@@ -320,7 +320,17 @@ bool _mongocrypt_opts_kms_providers_lookup(const _mongocrypt_opts_kms_providers_
     return false;
 }
 
-bool _mongocrypt_parse_optional_utf8(const bson_t *bson, const char *dotkey, char **out, mongocrypt_status_t *status) {
+void _mongocrypt_opts_set_contention_factor_fn(mongocrypt_t *crypt,
+                                               _mongocrypt_contention_factor_fn contention_factor_fn) {
+    BSON_ASSERT_PARAM(crypt);
+    BSON_ASSERT_PARAM(contention_factor_fn);
+
+    _mongocrypt_opts_t *opts = &crypt->opts;
+    opts->contention_factor_fn = contention_factor_fn;
+}
+
+    bool
+    _mongocrypt_parse_optional_utf8(const bson_t *bson, const char *dotkey, char **out, mongocrypt_status_t *status) {
     bson_iter_t iter;
     bson_iter_t child;
 

--- a/src/mongocrypt-opts.c
+++ b/src/mongocrypt-opts.c
@@ -323,10 +323,7 @@ bool _mongocrypt_opts_kms_providers_lookup(const _mongocrypt_opts_kms_providers_
 void _mongocrypt_opts_set_contention_factor_fn(mongocrypt_t *crypt,
                                                _mongocrypt_contention_factor_fn contention_factor_fn) {
     BSON_ASSERT_PARAM(crypt);
-    BSON_ASSERT_PARAM(contention_factor_fn);
-
-    _mongocrypt_opts_t *opts = &crypt->opts;
-    opts->contention_factor_fn = contention_factor_fn;
+    crypt->opts.contention_factor_fn = contention_factor_fn;
 }
 
 bool _mongocrypt_parse_optional_utf8(const bson_t *bson, const char *dotkey, char **out, mongocrypt_status_t *status) {


### PR DESCRIPTION
### Summary

Currently, libmongocrypt chooses a random value if a FLE2 field has a contention factor max greater than zero. This PR introduces a callback `contention_factor_fn` in `crypt->opts` which can be set by the internal `_mongocrypt_opts_set_contention_factor_fn`.

An additional test in `test-monongocrypt-ctx-encrypt` shows how this functionality can be used to deterministically select a contention factor. 