### PR TITLE
MONGOCRYPT-577 add missing include

### DIFF
--- a/kms-message/src/kms_crypto_windows.c
+++ b/kms-message/src/kms_crypto_windows.c
@@ -18,6 +18,8 @@
 
 #ifdef KMS_MESSAGE_ENABLE_CRYPTO_CNG
 
+#include "kms_message_private.h"
+
 // tell windows.h not to include a bunch of headers we don't need:
 #define WIN32_LEAN_AND_MEAN
 


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/libmongocrypt/pull/1061 to fix the [build-and-test-and-upload](https://spruce.mongodb.com/task/libmongocrypt_windows_test_build_and_test_and_upload_patch_1dfa8ac235d6ea16271e2df39e00268e3c860919_68c0943d8657b00007e7c25f_25_09_09_20_55_27/logs?execution=0) Windows task:

```
kms_crypto_windows.c(182): error C4013: 'KMS_ASSERT' undefined; assuming extern returning int
```