### PR TITLE
make `windows-upload-release` non-patchable

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -884,6 +884,7 @@ tasks:
     - func: "setup packaging credentials"
     - func: "publish packages"
 - name: windows-upload-release
+  patchable: false # Garasign credentials are marked as "Admin only" in Evergreen and are not included in patch builds.
   depends_on:
   - variant: windows-test
     name: build-and-test-and-upload


### PR DESCRIPTION
To fix observed task failures on Evergreen patch builds: [example](https://spruce.mongodb.com/task/libmongocrypt_ubuntu2204_64_windows_upload_release_patch_c3ec2b7d2f54ece42649ffe74947841b83ba1226_68c844bf9afd870007042fbe_25_09_15_16_54_25/logs?execution=0):

> User is not valid. The apikey, username, password, certhash and devicecerthash are all empty

Garasign credentials are marked as `Admin Only` and I expect are only reliably visible in mainline commits. Quoting [Evergreen docs](https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Project-and-Distro-Settings#variables):

> Checking admin only ensures that the variable can only be used by admins and mainline commits.