### PR TITLE
use lower debhelper compat level on obsolete Debian/Ubuntu releases

### DIFF
--- a/.evergreen/create-packages-and-repos.sh
+++ b/.evergreen/create-packages-and-repos.sh
@@ -52,6 +52,39 @@ pushd "$LIBMONGOCRYPT_DIR/"
   (git remote | grep -q upstream) || git remote add upstream https://github.com/mongodb/libmongocrypt
   git fetch upstream
   git checkout $(git rev-parse upstream/debian/unstable) -- debian
+  # The 1.16.0-1 Debian package bumped the debhelper compatibility level to 13, but this level
+  # isn't supported on some of the older (now unsupported) versions we still build for; so,
+  # patch back to a lower level for the versions that don't support the current level
+  if [[ ! -x /usr/bin/dh_assistant ]]; then
+
+    patch -p1 <<EOF
+diff --git b/debian/compat a/debian/compat
+new file mode 100644
+index 00000000..f599e28b
+--- /dev/null
++++ a/debian/compat
+@@ -0,0 +1 @@
++10
+diff --git b/debian/control a/debian/control
+index 12eb7557..602fadbb 100644
+--- b/debian/control
++++ a/debian/control
+@@ -3,7 +3,7 @@ Priority: optional
+ Maintainer: Mongo C Driver Team <mongo-c-driver-debian@googlegroups.com>
+ Uploaders: Kevin Albertson <kevin.albertson@mongodb.com>,
+            Roberto C. Sanchez <roberto@connexer.com>
+-Build-Depends: debhelper-compat (= 13),
++Build-Depends: debhelper (>= 10),
+                cmake,
+                libssl-dev,
+                pkgconf,
+EOF
+
+  else
+     # even on the newer versions, we need to specify via debian/compat, owing to the
+     # barebones debian/control file we use for PPA packaging
+     echo 13 > debian/compat
+  fi
 popd
 pushd "$LIBMONGOCRYPT_DIR/etc/"
   # The files from libmongocrypt/debian/ are the official maintainer scripts,

--- a/etc/debian/control
+++ b/etc/debian/control
@@ -2,8 +2,6 @@ Source: libmongocrypt
 Priority: optional
 Maintainer: Mongo C Driver Team <mongo-c-driver-debian@googlegroups.com>
 Uploaders: Kevin Albertson <kevin.albertson@mongodb.com>,
-           Clyde Bazile <clyde.bazile@mongodb.com>,
-           Samantha Ritter <samantha.ritter@mongodb.com>,
            Roberto C. Sanchez <roberto@connexer.com>
 Standards-Version: 4.5.0
 Section: libs


### PR DESCRIPTION
This change fixes tasks running on older Debian and Ubuntu versions. The tasks were broken by the 1.16.0-1 Debian package, which made some packaging-specific changes that resulted in the breakage.