### PR TITLE
MONGOCRYPT-888 update libbson to 2.3.0

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1588,7 +1588,6 @@ buildvariants:
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
-  - build-and-test-asan
   - build-packages
   - name: publish-packages
     distros:
@@ -1842,7 +1841,6 @@ buildvariants:
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
-  - build-and-test-asan
   - build-packages
   - name: publish-packages
     distros:
@@ -1882,7 +1880,6 @@ buildvariants:
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
-  - build-and-test-asan
   - build-packages
   - name: publish-packages
     distros:
@@ -1910,7 +1907,6 @@ buildvariants:
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
-  - build-and-test-asan
   - build-packages
   - name: publish-packages
     distros:
@@ -1967,7 +1963,6 @@ buildvariants:
   tasks:
   - build-and-test-and-upload
   - build-and-test-shared-bson
-  - build-and-test-asan
   - build-packages
   - name: publish-packages
     distros:

--- a/.evergreen/linker_tests_deps/bson_patches/libbson1.patch
+++ b/.evergreen/linker_tests_deps/bson_patches/libbson1.patch
@@ -2,14 +2,15 @@ Adds a printf to bson_malloc0 to test linking scenarios with two forms of libbso
 See linker-tests.sh. If this patch fails to apply, regenerate from libbson's source.
 
 diff --git a/src/libbson/src/bson/memory.c b/src/libbson/src/bson/memory.c
-index 0e1523331..aa7112305 100644
+index 0d84ea53e5..ad0f8eb0aa 100644
 --- a/src/libbson/src/bson/memory.c
 +++ b/src/libbson/src/bson/memory.c
-@@ -104,6 +104,7 @@ bson_malloc0 (size_t num_bytes) /* IN */
+@@ -140,6 +140,7 @@ bson_malloc0(size_t num_bytes) /* IN */
  {
     void *mem = NULL;
  
-+   printf (".from libbson1.");
-    if (BSON_LIKELY (num_bytes)) {
-       if (BSON_UNLIKELY (!(mem = gMemVtable.calloc (1, num_bytes)))) {
-          fprintf (stderr, "Failure to allocate memory in bson_malloc0(). errno: %d.\n", errno);
++   printf(".from libbson1.");
+    if (BSON_LIKELY(num_bytes)) {
+       if (BSON_UNLIKELY(!(mem = gMemVtable.calloc(1, num_bytes)))) {
+          fprintf(stderr, "Failure to allocate memory in bson_malloc0(). errno: %d.\n", errno);
+

--- a/.evergreen/linker_tests_deps/bson_patches/libbson2.patch
+++ b/.evergreen/linker_tests_deps/bson_patches/libbson2.patch
@@ -2,14 +2,15 @@ Adds a printf to bson_malloc0 to test linking scenarios with two forms of libbso
 See linker-tests.sh. If this patch fails to apply, regenerate from libbson's source.
 
 diff --git a/src/libbson/src/bson/memory.c b/src/libbson/src/bson/memory.c
-index 0e1523331..aa7112305 100644
+index 0d84ea53e5..ad0f8eb0aa 100644
 --- a/src/libbson/src/bson/memory.c
 +++ b/src/libbson/src/bson/memory.c
-@@ -104,6 +104,7 @@ bson_malloc0 (size_t num_bytes) /* IN */
+@@ -140,6 +140,7 @@ bson_malloc0(size_t num_bytes) /* IN */
  {
     void *mem = NULL;
  
-+   printf (".from libbson2.\n");
-    if (BSON_LIKELY (num_bytes)) {
-       if (BSON_UNLIKELY (!(mem = gMemVtable.calloc (1, num_bytes)))) {
-          fprintf (stderr, "Failure to allocate memory in bson_malloc0(). errno: %d.\n", errno);
++   printf(".from libbson2.");
+    if (BSON_LIKELY(num_bytes)) {
+       if (BSON_UNLIKELY(!(mem = gMemVtable.calloc(1, num_bytes)))) {
+          fprintf(stderr, "Failure to allocate memory in bson_malloc0(). errno: %d.\n", errno);
+

--- a/.evergreen/prep_c_driver_source.sh
+++ b/.evergreen/prep_c_driver_source.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 # Clone mongo-c-driver and check out to a tagged version.
-MONGO_C_DRIVER_VERSION=2.1.0
+MONGO_C_DRIVER_VERSION=2.3.0
 
 # Force checkout with lf endings since .sh must have lf, not crlf on Windows
 git clone https://github.com/mongodb/mongo-c-driver.git --config core.eol=lf --config core.autocrlf=false --depth=1 --branch $MONGO_C_DRIVER_VERSION

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changed
 
 - Final release packages in the PPA are now available by specifying `release` in the repository configuration in place of the major/minor version (e.g., `1.17`). Details in `README.md`.
+- Bump downloaded libbson version from 2.1.0 to 2.3.0.
 
 ### Deprecated
 - RHEL 6.2 builds are deprecated and may be removed in the future. The `linux-x86_64-glibc_2_7-nocrypto` release build may be used instead and has equivalent glibc requirements.

--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -2,7 +2,7 @@ include (FetchContent)
 
 # Set the tag that we will fetch.
 # When updating the version of libbson, also update the version in etc/purls.txt and .evergreen/prep_c_driver_source.sh
-set (MONGOC_FETCH_TAG_FOR_LIBBSON "2.1.0" CACHE STRING "The Git tag of mongo-c-driver that will be fetched to obtain libbson")
+set (MONGOC_FETCH_TAG_FOR_LIBBSON "2.3.0" CACHE STRING "The Git tag of mongo-c-driver that will be fetched to obtain libbson")
 
 # Add an option to disable patching if a patch command is unavailable.
 option (LIBBSON_PATCH_ENABLED "Whether to apply patches to the libbson library" ON)

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -1,16 +1,16 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v2.1.0#src/libbson",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v2.3.0#src/libbson",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/v2.1.0.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/v2.3.0.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/v2.1.0"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/v2.3.0"
         }
       ],
       "group": "mongodb",
@@ -22,9 +22,9 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@v2.1.0#src/libbson",
+      "purl": "pkg:github/mongodb/mongo-c-driver@v2.3.0#src/libbson",
       "type": "library",
-      "version": "v2.1.0"
+      "version": "v2.3.0"
     },
     {
       "bom-ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz",
@@ -53,11 +53,11 @@
       "ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz"
     },
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@v2.1.0#src/libbson"
+      "ref": "pkg:github/mongodb/mongo-c-driver@v2.3.0#src/libbson"
     }
   ],
   "metadata": {
-    "timestamp": "2025-11-10T20:52:37.547279+00:00",
+    "timestamp": "2026-04-21T13:26:40.166707+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/libbson-remove-GCC-diagnostic-pragma.patch
+++ b/etc/libbson-remove-GCC-diagnostic-pragma.patch
@@ -1,35 +1,54 @@
 diff --git a/src/common/src/common-bson-dsl-private.h b/src/common/src/common-bson-dsl-private.h
-index b6cb7a2705..c2cb0bcaf2 100644
+index 748ba54046..67a6a4f194 100644
 --- a/src/common/src/common-bson-dsl-private.h
 +++ b/src/common/src/common-bson-dsl-private.h
 @@ -31,6 +31,13 @@ enum {
-    BSON_IF_WINDOWS (__declspec (selectany)) \
-    BSON_IF_POSIX (__attribute__ ((weak)))
+    BSON_IF_WINDOWS(__declspec(selectany)) \
+    BSON_IF_POSIX(__attribute__((weak)))
  
 +#if defined(__GNUC__) && !defined(__clang__) && ((__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ < 6))
 +// Using GCC < 4.6
 +// Do not define `GCC diagnostic` pragma for GCC < 4.6.
-+#define _bsonDSL_disableWarnings() ((void) 0)
-+#define _bsonDSL_restoreWarnings() ((void) 0)
++#define _bsonDSL_disableWarnings() ((void)0)
++#define _bsonDSL_restoreWarnings() ((void)0)
 +#else
 +// Not using GCC < 4.6
  #ifdef __GNUC__
  // GCC has a bug handling pragma statements that disable warnings within complex
  // nested macro expansions. If we're GCC, just disable -Wshadow outright:
-@@ -50,7 +57,7 @@ BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
-       mlib_diagnostic_pop ();      \
+@@ -50,7 +57,7 @@ BSON_IF_GNU_LIKE(_Pragma("GCC diagnostic ignored \"-Wshadow\""))
+       mlib_diagnostic_pop();       \
     } else                          \
-       ((void) 0)
+       ((void)0)
 -
 +#endif
  /**
   * @brief Parse the given BSON document.
   *
+diff --git a/src/common/src/common-macros-private.h b/src/common/src/common-macros-private.h
+index 068b09470f..b5c94c5c9d 100644
+--- a/src/common/src/common-macros-private.h
++++ b/src/common/src/common-macros-private.h
+@@ -97,7 +97,13 @@
+ #endif
+ 
+ // Disable the -Wcast-qual warning
+-#if defined(__GNUC__)
++#if defined(__GNUC__) && !defined(__clang__) && ((__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ < 6))
++// Using GCC < 4.6
++// Do not define `GCC diagnostic` pragma for GCC < 4.6.
++#define MC_DISABLE_CAST_QUAL_WARNING_BEGIN
++#define MC_DISABLE_CAST_QUAL_WARNING_END
++#elif defined(__GNUC__)
++// Not using GCC < 4.6
+ #define MC_DISABLE_CAST_QUAL_WARNING_BEGIN MC_PRAGMA_DIAGNOSTIC_PUSH _Pragma("GCC diagnostic ignored \"-Wcast-qual\"")
+ #define MC_DISABLE_CAST_QUAL_WARNING_END MC_PRAGMA_DIAGNOSTIC_POP
+ #elif defined(__clang__)
 diff --git a/src/common/src/mlib/config.h b/src/common/src/mlib/config.h
-index 6a1e45275b..797f278250 100644
+index a95f917efb..d1494797cd 100644
 --- a/src/common/src/mlib/config.h
 +++ b/src/common/src/mlib/config.h
-@@ -175,7 +175,13 @@
+@@ -204,7 +204,13 @@
   * @brief Expands to `noexcept` when compiled as C++, otherwise expands to
   * nothing
   */
@@ -38,14 +57,14 @@ index 6a1e45275b..797f278250 100644
 +// Don't define this expansion for the older gcc/g++
 +#define mlib_noexcept
 +#else
- #define mlib_noexcept MLIB_IF_CXX (noexcept)
+ #define mlib_noexcept MLIB_IF_CXX(noexcept)
 +#endif
  
  #if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__)
  #define mlib_is_little_endian() (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
-@@ -253,15 +259,29 @@
+@@ -282,15 +288,29 @@
  
- #define MLIB_FUNC MLIB_IF_GNU_LIKE (__func__) MLIB_IF_MSVC (__FUNCTION__)
+ #define MLIB_FUNC MLIB_IF_GNU_LIKE(__func__) MLIB_IF_MSVC(__FUNCTION__)
  
 +#if defined(__GNUC__) && !defined(__clang__) && ((__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ < 6))
 +// Using GCC < 4.6
@@ -53,10 +72,10 @@ index 6a1e45275b..797f278250 100644
 +#define mlib_diagnostic_push()
 +#else
 +// Not using GCC < 4.6
- #define mlib_diagnostic_push()                           \
-    MLIB_IF_GNU_LIKE (mlib_pragma (GCC diagnostic push);) \
-    MLIB_IF_MSVC (mlib_pragma (warning (push));)          \
-    mlib_static_assert (1, "")
+ #define mlib_diagnostic_push()                         \
+    MLIB_IF_GNU_LIKE(mlib_pragma(GCC diagnostic push);) \
+    MLIB_IF_MSVC(mlib_pragma(warning(push));)           \
+    mlib_static_assert(1, "")
 +#endif
  
 +#if defined(__GNUC__) && !defined(__clang__) && ((__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ < 6))
@@ -65,15 +84,15 @@ index 6a1e45275b..797f278250 100644
 +#define mlib_diagnostic_pop()
 +#else
 +// Not using GCC < 4.6
- #define mlib_diagnostic_pop()                           \
-    MLIB_IF_GNU_LIKE (mlib_pragma (GCC diagnostic pop);) \
-    MLIB_IF_MSVC (mlib_pragma (warning (pop));)          \
-    mlib_static_assert (1, "")
+ #define mlib_diagnostic_pop()                         \
+    MLIB_IF_GNU_LIKE(mlib_pragma(GCC diagnostic pop);) \
+    MLIB_IF_MSVC(mlib_pragma(warning(pop));)           \
+    mlib_static_assert(1, "")
 +#endif
  
- #define mlib_gcc_warning_disable(Warning)                      \
-    MLIB_IF_GCC (mlib_pragma (GCC diagnostic ignored Warning);) \
-@@ -315,9 +335,15 @@
+ #define mlib_gcc_warning_disable(Warning)                    \
+    MLIB_IF_GCC(mlib_pragma(GCC diagnostic ignored Warning);) \
+@@ -344,9 +364,15 @@
  /**
   * @brief Emit a _Pragma that will disable warnings about the use of deprecated entities.
   */
@@ -82,9 +101,9 @@ index 6a1e45275b..797f278250 100644
 +#define mlib_disable_deprecation_warnings()
 +#else
 +// Not using GCC < 4.6
- #define mlib_disable_deprecation_warnings()                \
-    mlib_gnu_warning_disable ("-Wdeprecated-declarations"); \
-    mlib_msvc_warning (disable : 4996)
+ #define mlib_disable_deprecation_warnings()               \
+    mlib_gnu_warning_disable("-Wdeprecated-declarations"); \
+    mlib_msvc_warning(disable : 4996)
 +#endif
  
  /**

--- a/etc/purls.txt
+++ b/etc/purls.txt
@@ -8,7 +8,7 @@
 # `copyright` property. This information can be manually added.
 
 # libbson is obtained via `cmake/FetchMongoC.cmake`.
-pkg:github/mongodb/mongo-c-driver@v2.1.0?#src/libbson
+pkg:github/mongodb/mongo-c-driver@v2.3.0?#src/libbson
 
 # IntelDFP is obtained via `cmake/IntelDFP.cmake`
 pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz

--- a/src/mc-fle2-find-range-payload-v2.c
+++ b/src/mc-fle2-find-range-payload-v2.c
@@ -67,7 +67,7 @@ bool mc_FLE2FindRangePayloadV2_serialize(const mc_FLE2FindRangePayloadV2_t *payl
         }
         // Append "payload.g" array of EdgeTokenSets.
         bson_t g_bson;
-        if (!BSON_APPEND_ARRAY_BEGIN(&payload_bson, "g", &g_bson)) {
+        if (!BSON_APPEND_ARRAY_UNSAFE_BEGIN(&payload_bson, "g", &g_bson)) {
             return false;
         }
 

--- a/src/mc-fle2-find-range-payload.c
+++ b/src/mc-fle2-find-range-payload.c
@@ -68,7 +68,7 @@ bool mc_FLE2FindRangePayload_serialize(const mc_FLE2FindRangePayload_t *payload,
         }
         // Append "payload.g" array of EdgeTokenSets.
         bson_t g_bson;
-        if (!BSON_APPEND_ARRAY_BEGIN(&payload_bson, "g", &g_bson)) {
+        if (!BSON_APPEND_ARRAY_UNSAFE_BEGIN(&payload_bson, "g", &g_bson)) {
             return false;
         }
 

--- a/src/mc-fle2-insert-update-payload-v2.c
+++ b/src/mc-fle2-insert-update-payload-v2.c
@@ -330,7 +330,7 @@ bool mc_FLE2InsertUpdatePayloadV2_serializeForRange(const mc_FLE2InsertUpdatePay
     }
     // Append "g" array of EdgeTokenSets.
     bson_t g_bson;
-    if (!BSON_APPEND_ARRAY_BEGIN(out, "g", &g_bson)) {
+    if (!BSON_APPEND_ARRAY_UNSAFE_BEGIN(out, "g", &g_bson)) {
         return false;
     }
 
@@ -432,7 +432,7 @@ SERIALIZE_TEXT_TOKEN_SET_FOR_TYPE_IMPL(Prefix)
         BSON_ASSERT_PARAM(array_name);                                                                                 \
         BSON_ASSERT_PARAM(array);                                                                                      \
         bson_t arr_bson;                                                                                               \
-        if (!BSON_APPEND_ARRAY_BEGIN(parent, array_name, &arr_bson)) {                                                 \
+        if (!BSON_APPEND_ARRAY_UNSAFE_BEGIN(parent, array_name, &arr_bson)) {                                          \
             return false;                                                                                              \
         }                                                                                                              \
                                                                                                                        \

--- a/src/mc-fle2-insert-update-payload.c
+++ b/src/mc-fle2-insert-update-payload.c
@@ -191,7 +191,7 @@ bool mc_FLE2InsertUpdatePayload_serializeForRange(const mc_FLE2InsertUpdatePaylo
     }
     // Append "g" array of EdgeTokenSets.
     bson_t g_bson;
-    if (!BSON_APPEND_ARRAY_BEGIN(out, "g", &g_bson)) {
+    if (!BSON_APPEND_ARRAY_UNSAFE_BEGIN(out, "g", &g_bson)) {
         return false;
     }
 

--- a/src/mc-fle2-rfds.c
+++ b/src/mc-fle2-rfds.c
@@ -506,11 +506,11 @@ bool mc_FLE2RangeFindDriverSpec_to_placeholders(mc_FLE2RangeFindDriverSpec_t *sp
         }
         */
         bson_t and;
-        TRY(BSON_APPEND_ARRAY_BEGIN(out, "$and", &and));
+        TRY(BSON_APPEND_ARRAY_UNSAFE_BEGIN(out, "$and", &and));
         bson_t elem;
         TRY(BSON_APPEND_DOCUMENT_BEGIN(&and, "0", &elem));
         bson_t operator;
-        TRY(BSON_APPEND_ARRAY_BEGIN(&elem, mc_FLE2RangeOperator_to_string(spec->firstOp), &operator));
+        TRY(BSON_APPEND_ARRAY_UNSAFE_BEGIN(&elem, mc_FLE2RangeOperator_to_string(spec->firstOp), &operator));
         TRY(BSON_APPEND_UTF8(&operator, "0", spec->field));
         TRY(_mongocrypt_buffer_append(&p1, &operator, "1", 1));
         TRY(bson_append_array_end(&elem, &operator));
@@ -518,7 +518,7 @@ bool mc_FLE2RangeFindDriverSpec_to_placeholders(mc_FLE2RangeFindDriverSpec_t *sp
 
         if (spec->nOps == 2) {
             TRY(BSON_APPEND_DOCUMENT_BEGIN(&and, "1", &elem));
-            TRY(BSON_APPEND_ARRAY_BEGIN(&elem, mc_FLE2RangeOperator_to_string(spec->secondOp), &operator));
+            TRY(BSON_APPEND_ARRAY_UNSAFE_BEGIN(&elem, mc_FLE2RangeOperator_to_string(spec->secondOp), &operator));
             TRY(BSON_APPEND_UTF8(&operator, "0", spec->field));
             TRY(_mongocrypt_buffer_append(&p2, &operator, "1", 1));
             TRY(bson_append_array_end(&elem, &operator));
@@ -537,7 +537,7 @@ bool mc_FLE2RangeFindDriverSpec_to_placeholders(mc_FLE2RangeFindDriverSpec_t *sp
         }
         */
         bson_t and;
-        TRY(BSON_APPEND_ARRAY_BEGIN(out, "$and", &and));
+        TRY(BSON_APPEND_ARRAY_UNSAFE_BEGIN(out, "$and", &and));
         bson_t elem;
         TRY(BSON_APPEND_DOCUMENT_BEGIN(&and, "0", &elem));
         bson_t operator;

--- a/src/mc-schema-broker.c
+++ b/src/mc-schema-broker.c
@@ -174,7 +174,7 @@ bool mc_schema_broker_append_listCollections_filter(const mc_schema_broker_t *sb
         TRY_BSON_OR(BSON_APPEND_DOCUMENT_BEGIN(out, "name", &in)) {
             return false;
         }
-        TRY_BSON_OR(BSON_APPEND_ARRAY_BEGIN(&in, "$in", &in_array)) {
+        TRY_BSON_OR(BSON_APPEND_ARRAY_UNSAFE_BEGIN(&in, "$in", &in_array)) {
             return false;
         }
 
@@ -783,7 +783,7 @@ static bool append_encryptedFields(const bson_t *encryptedFields,
             }
 
             bson_t new_array;
-            TRY_BSON_OR(BSON_APPEND_ARRAY_BEGIN(out, "fields", &new_array)) {
+            TRY_BSON_OR(BSON_APPEND_ARRAY_UNSAFE_BEGIN(out, "fields", &new_array)) {
                 goto fail;
             }
 
@@ -987,7 +987,7 @@ static bool insert_encryptionInformation(const mc_schema_broker_t *sb,
             bson_copy_to_excluding_noinit(cmd, &out, "nsInfo", NULL);
             // Append `nsInfo` array.
             bson_t nsInfo_array;
-            if (!BSON_APPEND_ARRAY_BEGIN(&out, "nsInfo", &nsInfo_array)) {
+            if (!BSON_APPEND_ARRAY_UNSAFE_BEGIN(&out, "nsInfo", &nsInfo_array)) {
                 CLIENT_ERR("unable to begin appending 'nsInfo' array");
                 goto fail;
             }

--- a/src/mongocrypt-ctx-datakey.c
+++ b/src/mongocrypt-ctx-datakey.c
@@ -483,7 +483,7 @@ static bool _finalize(mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out) {
         _mongocrypt_key_alt_name_t *alt_name = ctx->opts.key_alt_names;
         int i;
 
-        bson_append_array_begin(&key_doc, "keyAltNames", -1, &child);
+        bson_append_array_unsafe_begin(&key_doc, "keyAltNames", -1, &child);
         for (i = 0; alt_name; i++) {
             char *key = bson_strdup_printf("%d", i);
             bson_append_value(&child, key, -1, &alt_name->value);

--- a/src/mongocrypt-ctx-encrypt.c
+++ b/src/mongocrypt-ctx-encrypt.c
@@ -296,7 +296,7 @@ static bool _create_markings_cmd_bson(mongocrypt_ctx_t *ctx, bson_t *out) {
 
                 // Process the fields array using the shared helper function
                 bson_t new_fields;
-                BSON_APPEND_ARRAY_BEGIN(&new_ef, "fields", &new_fields);
+                BSON_APPEND_ARRAY_UNSAFE_BEGIN(&new_ef, "fields", &new_fields);
 
                 const int translated_keyAltName =
                     mc_translate_fields_keyAltName_to_keyId(&fields_bson, &ctx->kb, &new_fields, ctx->status);
@@ -1101,7 +1101,7 @@ _fle2_strip_encryptionInformation(const char *cmd_name, bson_t *cmd /* in and ou
             bson_copy_to_excluding_noinit(cmd, &stripped, "nsInfo", NULL);
             // Append `nsInfo` array.
             bson_t nsInfo_array;
-            if (!BSON_APPEND_ARRAY_BEGIN(&stripped, "nsInfo", &nsInfo_array)) {
+            if (!BSON_APPEND_ARRAY_UNSAFE_BEGIN(&stripped, "nsInfo", &nsInfo_array)) {
                 CLIENT_ERR("unable to begin appending 'nsInfo' array");
                 goto fail;
             }

--- a/src/mongocrypt-ctx-rewrap-many-datakey.c
+++ b/src/mongocrypt-ctx-rewrap-many-datakey.c
@@ -25,7 +25,7 @@ static bool _finalize(mongocrypt_ctx_t *ctx, mongocrypt_binary_t *out) {
     BSON_ASSERT_PARAM(ctx);
     BSON_ASSERT_PARAM(out);
 
-    BSON_ASSERT(BSON_APPEND_ARRAY_BEGIN(&doc, "v", &array));
+    BSON_ASSERT(BSON_APPEND_ARRAY_UNSAFE_BEGIN(&doc, "v", &array));
     {
         _mongocrypt_ctx_rmd_datakey_t *iter = NULL;
         size_t idx = 0u;

--- a/src/mongocrypt-traverse-util.c
+++ b/src/mongocrypt-traverse-util.c
@@ -102,7 +102,7 @@ static bool _recurse(_recurse_state_t *state) {
             if (state->copy) {
                 const uint32_t key_len = bson_iter_key_len(&state->iter);
                 BSON_ASSERT(key_len <= INT_MAX);
-                bson_append_array_begin(state->copy, bson_iter_key(&state->iter), (int)key_len, &state->child);
+                bson_append_array_unsafe_begin(state->copy, bson_iter_key(&state->iter), (int)key_len, &state->child);
                 child_state.copy = &state->child;
             }
             ret = _recurse(&child_state);

--- a/test/test-mc-fle2-rfds.c
+++ b/test/test-mc-fle2-rfds.c
@@ -133,7 +133,7 @@ addPlaceholders_recursive(bson_iter_t *iter, bson_t *out, _mongocrypt_buffer_t *
         if (BSON_ITER_HOLDS_ARRAY(iter)) {
             bson_t child;
             bson_iter_t iter_child;
-            ASSERT(BSON_APPEND_ARRAY_BEGIN(out, key, &child));
+            ASSERT(BSON_APPEND_ARRAY_UNSAFE_BEGIN(out, key, &child));
             ASSERT(bson_iter_recurse(iter, &iter_child));
             addPlaceholders_recursive(&iter_child, &child, p1, p2);
             ASSERT(bson_append_array_end(out, &child));

--- a/test/test-mongocrypt-key-broker.c
+++ b/test/test-mongocrypt-key-broker.c
@@ -51,7 +51,7 @@ static void _gen_uuid_and_key_and_altname(_mongocrypt_tester_t *tester,
     BSON_ASSERT(_mongocrypt_buffer_append(id, &copied, "_id", 3));
     if (altname) {
         bson_t child;
-        bson_append_array_begin(&copied, "keyAltNames", -1, &child);
+        bson_append_array_unsafe_begin(&copied, "keyAltNames", -1, &child);
         bson_append_utf8(&child, "0", -1, altname, -1);
         bson_append_array_end(&copied, &child);
     }

--- a/test/test-mongocrypt-key-cache.c
+++ b/test/test-mongocrypt-key-cache.c
@@ -80,7 +80,7 @@ gen_key(_mongocrypt_tester_t *tester, bson_t *key_description, bson_t *key_out, 
         bson_t key_alt_name_bson;
         int counter = 0;
 
-        BSON_APPEND_ARRAY_BEGIN(&key, "keyAltNames", &key_alt_name_bson);
+        BSON_APPEND_ARRAY_UNSAFE_BEGIN(&key, "keyAltNames", &key_alt_name_bson);
         for (bson_iter_recurse(&iter, &iter); bson_iter_next(&iter);) {
             char *field;
 

--- a/test/test-mongocrypt-traverse-util.c
+++ b/test/test-mongocrypt-traverse-util.c
@@ -80,7 +80,7 @@ static void _reset_nesting(bson_t *parent, bson_t *bson, _nesting_t nesting, cha
         bson_append_document_begin(parent, name, -1, bson);
     } else if (nesting == NEST_IN_ARRAY) {
         BSON_ASSERT(bson_append_array_end(parent, bson));
-        bson_append_array_begin(parent, name, -1, bson);
+        bson_append_array_unsafe_begin(parent, name, -1, bson);
     }
 }
 
@@ -174,7 +174,7 @@ static bson_t *_assemble_bson(int num_markings,
         bson_append_document_begin(parent, "other", -1, &bson);
     } else if (tester->parent == NEST_IN_ARRAY) {
         parent = bson_new();
-        bson_append_array_begin(parent, "other", -1, &bson);
+        bson_append_array_unsafe_begin(parent, "other", -1, &bson);
     } else {
         bson_init(&bson);
     }


### PR DESCRIPTION
# Summary
Update downloaded libbson from 2.1.0 to 2.3.0.

# Details

ARM64 ASan tasks failed with [compiler errors](https://spruce.corp.mongodb.com/task/libmongocrypt_ubuntu2204_arm64_build_and_test_asan_patch_f78ca9f6e6595fa7dc57cccbf0db08874ef707ae_69e7856825e9e2000738a614_26_04_21_14_10_52/logs?execution=0). Since there are existing ASan tasks on other architectures, these tasks are now removed.

---

Patches of the C driver are updated to account for formatting changes. `libbson-remove-GCC-diagnostic-pragma.patch` is extended to address an observed RHEL 6.2 [failure](https://spruce.corp.mongodb.com/task/libmongocrypt_rhel_62_64_bit_build_and_test_and_upload_patch_f78ca9f6e6595fa7dc57cccbf0db08874ef707ae_69e7856825e9e2000738a614_26_04_21_14_10_52/logs?execution=0):
```
[...]/mongoc-oidc-cache.c:163: error: #pragma GCC diagnostic not allowed inside functions
```

---

CDRIVER-6180 deprecates `bson_append_array_begin`. Calls are migrated to the equivalent `bson_append_array_unsafe_begin` which signals the intent to opt-in to supplying correct array keys "0", "1", etc. It seemed unnecessary to migrate calls to the alternative `bson_append_array_array_builder_begin`. As noted in CDRIVER-6247, `bson_append_array_array_builder_begin` adds an allocation and requires freeing.
