### PR TITLE
Fix `publish-deb-packages-with-earthly` tasks

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -301,12 +301,11 @@ functions:
           # Some venv-activate scripts are not nounset-clean
           set +u
 
-          # Need requests and poster for notary-client.py
+          # Need requests for notary-client.py
           python -m virtualenv venv
           cd venv
           . bin/activate
           ./bin/pip install requests
-          ./bin/pip install poster
           ./bin/pip install pycrypto
           cd ..
           # Get the current version of libmongocrypt.

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -301,7 +301,7 @@ functions:
           # Some venv-activate scripts are not nounset-clean
           set +u
 
-          # Need requests for notary-client.py
+          # Need requests and pycrypto for notary-client.py
           python -m virtualenv venv
           cd venv
           . bin/activate
@@ -2049,7 +2049,8 @@ buildvariants:
     run_on: ubuntu2404-arm64-latest-large
   - name: publish-deb-packages-with-earthly
     # Use a distro suitable for running curator to publish .deb packages.
-    run_on: ubuntu2404-latest-small
+    # Use 22.04 for Python 3.10 to avoid failure installing pycrypto.
+    run_on: ubuntu2204-latest-small
 
 - name: debian13-arm64-earthly
   display_name: "Debian 13 arm64 (via Earthly)"
@@ -2064,7 +2065,8 @@ buildvariants:
     run_on: ubuntu2404-arm64-latest-large
   - name: publish-deb-packages-with-earthly
     # Use a distro suitable for running curator to publish .deb packages.
-    run_on: ubuntu2404-latest-small
+    # Use 22.04 for Python 3.10 to avoid failure installing pycrypto.
+    run_on: ubuntu2204-latest-small
 
 - name: debian12-arm64-earthly
   display_name: "Debian 12 arm64 (via Earthly)"
@@ -2078,7 +2080,8 @@ buildvariants:
     run_on: ubuntu2404-arm64-latest-large
   - name: publish-deb-packages-with-earthly
     # Use a distro suitable for running curator to publish .deb packages.
-    run_on: ubuntu2404-latest-small
+    # Use 22.04 for Python 3.10 to avoid failure installing pycrypto.
+    run_on: ubuntu2204-latest-small
 
 - name: sbom
   display_name: SBOM


### PR DESCRIPTION
# Summary

Fix failing `publish-deb-packages-with-earthly` tasks:
- Remove unnecessary `pip install poster`
- Use Ubuntu 22.04 to for failing "publish packages" tasks.

[Evergreen patch](https://spruce.corp.mongodb.com/version/69e8c9ebe597d50007df9deb) was run with a [temporary change](https://github.com/kevinAlbs/libmongocrypt/commit/932f7672d9fcddd3b6511dedc1e31578b2277c37) to test `pip install` commands of "publish packages".

# Details

This PR is to fix a newly observed failure ([example](https://spruce.corp.mongodb.com/task/libmongocrypt_debian11_arm64_earthly_publish_deb_packages_with_earthly_4eea95e297df316b840aa09f4d39769c680b5066_26_04_21_19_59_05/logs?execution=0)) in package publishing tasks ahead of the upcoming 1.18.0 release.

The last [success](https://spruce.corp.mongodb.com/task/libmongocrypt_debian11_arm64_earthly_publish_deb_packages_with_earthly_9b72f0c5dc04a117491377bd5d5a7e2bd56f67aa_26_04_16_19_53_13/logs?execution=0) logs `Python 2.7`. The new [failure](https://parsley.corp.mongodb.com/evergreen/libmongocrypt_debian11_arm64_earthly_publish_deb_packages_with_earthly_f78ca9f6e6595fa7dc57cccbf0db08874ef707ae_26_04_20_15_09_07/0/task?bookmarks=0,280) logs `CPython3.12.3`.

libmongocrypt Evergreen config [noted](https://github.com/mongodb/libmongocrypt/blob/4eea95e297df316b840aa09f4d39769c680b5066/.evergreen/config.yml#L304C13-L304C58) `poster` was needed for `notary-client.py`. However, `notary-client.py` appears to no longer need `poster` as of https://github.com/10gen/notary-service/commit/ef2a3a8ff5b9afe179fbab115373232900ada57b. So this PR removes the install of `poster`.

Attempting to `pip install pycrypto` also [fails](https://parsley.corp.mongodb.com/evergreen/libmongocrypt_debian11_arm64_earthly_publish_deb_packages_with_earthly_patch_4eea95e297df316b840aa09f4d39769c680b5066_69e8bc972217b100071f7b26_26_04_22_12_18_33/0/task?bookmarks=0,344) with `fatal error: longintrepr.h: No such file or directory`. This appears to be due to a change in Python 3.11 ([reference](https://github.com/JHUISI/charm/issues/307)). To address, the Ubuntu 24.04 distro is downgraded to 22.04 to use Python 3.10. A brief attempt was made to use `uv`, but `uv` appears [unavailable](https://spruce.corp.mongodb.com/task/libmongocrypt_amazon2023_arm64_publish_packages_patch_4eea95e297df316b840aa09f4d39769c680b5066_69e8c67bbff1930007871be4_26_04_22_13_00_45/logs?execution=0) on RHEL 7.0 hosts. This may overlap with MONGOCRYPT-872, so I wanted to make a minimal change to unblock the release.
