### PR TITLE
fix rpm-package-build task

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -208,11 +208,11 @@ BUILD_EXAMPLE_STATE_MACHINE:
     RUN cd /s && /s/example-state-machine
 
 rpm-build:
-    FROM +init --base fedora:38
+    FROM +init --base fedora:45
     GIT CLONE https://src.fedoraproject.org/rpms/libmongocrypt.git /R
     # Install the packages listed by "BuildRequires" and rpm-build:
-    RUN __install $(awk '/^BuildRequires:/ { print $2 }' /R/libmongocrypt.spec) \
-                  rpm-build
+    RUN __install /R/libmongocrypt.spec
+    RUN __install rpm-build
     DO +COPY_SOURCE
     RUN cp -r /s/libmongocrypt/. /R
     RUN awk -f /R/etc/rpm/tweak.awk < /R/libmongocrypt.spec > /R/libmongocrypt.2.spec
@@ -224,7 +224,7 @@ rpm-build:
 
 rpm-install-runtime:
     # Install the runtime RPM
-    FROM +init --base fedora:38
+    FROM +init --base fedora:45
     COPY +rpm-build/RPMS /tmp/libmongocrypt-rpm/
     RUN dnf makecache
     RUN __install $(find /tmp/libmongocrypt-rpm/ -name 'libmongocrypt-1.*.rpm')

--- a/etc/install-package.sh
+++ b/etc/install-package.sh
@@ -21,9 +21,14 @@ if test -f /etc/debian_version ; then
         apt-get -y install -- "$@"
 elif test -f /etc/redhat-release || grep 'ID="amzn"' /etc/os-release >/dev/null 1>&2; then
     if test -f /usr/bin/dnf; then
-        # 'dnf' will "do the right thing"
-        # --allow-erasing: see https://github.com/jeroen/curl/issues/350.
-        dnf install -y --allowerasing -- "$@"
+        if echo "$@" | grep -q '[.]spec'; then
+            # We use the build-dep command to let dnf do the heavy lifting from the spec file
+            dnf build-dep -y --allowerasing "$@"
+        else
+            # 'dnf' will "do the right thing"
+            # --allow-erasing: see https://github.com/jeroen/curl/issues/350.
+            dnf install -y --allowerasing "$@"
+        fi
     elif test -f /usr/bin/yum; then
         yum install -y -- "$@"
         # 'yum' happily ignores missing packages. Use 'rpm -q' to check that


### PR DESCRIPTION
* use Fedora 45 for building RPMs (to get the appropriate C driver version)
* tweak __install script to leverage 'dnf build-dep' command

Evergreen patch build: https://spruce.corp.mongodb.com/version/69ea90094789950007a664a3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC