### PR TITLE
MONGOCRYPT-432 always initialize `out` and `key_id_out`

### DIFF
--- a/src/mongocrypt-key-broker.c
+++ b/src/mongocrypt-key-broker.c
@@ -1085,6 +1085,9 @@ bool _mongocrypt_key_broker_decrypted_key_by_name(_mongocrypt_key_broker_t *kb,
     BSON_ASSERT_PARAM(out);
     BSON_ASSERT_PARAM(key_id_out);
 
+    _mongocrypt_buffer_init(out);
+    _mongocrypt_buffer_init(key_id_out);
+
     // We may be in KB_REQUESTING and need keys after requesting keys for keyAltName
     if (kb->state != KB_DONE && kb->state != KB_REQUESTING) {
         return _key_broker_fail_w_msg(kb, "attempting retrieve decrypted key material, but in wrong state");

--- a/src/mongocrypt-key-broker.c
+++ b/src/mongocrypt-key-broker.c
@@ -1063,6 +1063,8 @@ bool _mongocrypt_key_broker_decrypted_key_by_id(_mongocrypt_key_broker_t *kb,
     BSON_ASSERT_PARAM(key_id);
     BSON_ASSERT_PARAM(out);
 
+    _mongocrypt_buffer_init(out);
+
     if (kb->state != KB_DONE && kb->state != KB_REQUESTING) {
         return _key_broker_fail_w_msg(kb, "attempting retrieve decrypted key material, but in wrong state");
     }


### PR DESCRIPTION
# Summary
Initialize out-params in `_mongocrypt_key_broker_decrypted_key_by_id` and `_mongocrypt_key_broker_decrypted_key_by_name` on error.

# Details
Addresses Coverity issue with CID 202881.

`_mongocrypt_key_broker_decrypted_key_by_(id|name)` [documents](https://github.com/mongodb/libmongocrypt/blob/c0353cde50aa9745fe59c14a07772ab7aa9e3777/src/mongocrypt-key-broker-private.h#L151) outputs are: "always initialized, even on error". This does not match the implementation. Changes MONGOCRYPT-432 [expect the initialization](https://github.com/mongodb/libmongocrypt/blob/c0353cde50aa9745fe59c14a07772ab7aa9e3777/src/mc-schema-broker.c#L1220-L1221).

IMO this is a low-severity issue, but worth fixing to match internal documentation. Since the only case an early return would occur is if the functions are called on an incorrect state. I expect that would only be triggered by a libmongocrypt bug (not user code).
