### PR TITLE
Apply updates after 1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 ## Unreleased
 
+<!-- TODO: add entries for next release -->
+
+## 1.18.0
+
 ### Added
 - Signed binaries for macOS and Linux are now available on the GitHub release.
     - Linux binaries including `nocrypto` in the name have no dependency on OpenSSL. Drivers using the `nocrypto` variant are expected to set crypto callbacks (e.g. call `mongocrypt_setopt_crypto_hooks`) to do operations requiring crypto to avoid an error.
     - Drivers that package libmongocrypt binaries are encouraged to migrate release scripts to use these binaries.
         - No reduction in platform support is expected. glibc dependencies were checked against existing builds on RHEL 6.2 and Ubuntu 16.04.
+- Support referencing keys by `keyAltName` in `encryptedFieldsMap`.
 
 ### Changed
 

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -75,7 +75,7 @@ Do the following when releasing:
    - Note that in the future (e.g., if we move to a PR-based workflow for releases, or if we simply want to take better advantage of advanced Evergreen features), it is possible to use Evergreen's "Trigger Versions With Git Tags" feature by updating both `config.yml` and the project's settings in Evergreen
 - Ensure the version on Evergreen with the tagged commit is scheduled. This may require clicking "Force Repotracker Run" in [project settings](https://spruce.corp.mongodb.com/project/libmongocrypt-release/settings/general). The following tasks must pass to complete the release:
    - `upload-all`
-   - `windows-upload-release`
+   - All `upload-release` tasks.
    - All `publish-packages` tasks.
       - If the `publish-packages` tasks fail with an error like `[curator] 2024/01/02 13:56:17 [p=emergency]: problem submitting repobuilder job: 404 (Not Found)`, this suggests the published path does not yet exist. Barque (the Linux package publishing service) has protection to avoid unintentional publishes. File a DEVPROD ticket ([example](https://jira.mongodb.org/browse/DEVPROD-15320)) and assign to the team called Release Infrastructure to request the path be created. Then re-run the failing `publish-packages` task. Ask in the slack channel `#ask-devprod-release-tools` for further help with `Barque` or `curator`.
 - Create the release from the GitHub releases page from the new tag.

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -67,7 +67,6 @@ Do the following when releasing:
 - Ensure `etc/purls.txt` is up-to-date.
 - Update `etc/third_party_vulnerabilities.md` with any updates to new or known vulnerabilities for third party dependencies that must be reported.
 - If this is a new non-patch release (e.g. `x.y.0`):
-   - Update the Linux distribution package installation instructions in [README.md](../README.md) to refer to the new version `x.y`.
    - Update the [libmongocrypt-release](https://spruce.mongodb.com/project/libmongocrypt-release/settings/general) Evergreen project (requires auth) to set `Branch Name` to `rx.y`.
 - Commit the changes on the `rx.y` branch with a message like "Release x.y.z".
 - Tag the commit with `git tag -a <tag>`.

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -73,7 +73,7 @@ Do the following when releasing:
    - Push both the branch ref and tag ref in the same command: `git push origin master 1.8.0-alpha0` or `git push origin r1.8 1.8.4`
    - Pushing the branch ref and the tag ref in the same command eliminates the possibility of a race condition in Evergreen (for building resources based on the presence of a release tag)
    - Note that in the future (e.g., if we move to a PR-based workflow for releases, or if we simply want to take better advantage of advanced Evergreen features), it is possible to use Evergreen's "Trigger Versions With Git Tags" feature by updating both `config.yml` and the project's settings in Evergreen
-- Ensure the version on Evergreen with the tagged commit is scheduled. The following tasks must pass to complete the release:
+- Ensure the version on Evergreen with the tagged commit is scheduled. This may require clicking "Force Repotracker Run" in [project settings](https://spruce.corp.mongodb.com/project/libmongocrypt-release/settings/general). The following tasks must pass to complete the release:
    - `upload-all`
    - `windows-upload-release`
    - All `publish-packages` tasks.

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -57,7 +57,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2026-04-21T13:26:40.166707+00:00",
+    "timestamp": "2026-05-01T14:49:06.464175+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -100,7 +100,7 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:b91e0dc0-bc3b-4c77-baa4-db53948ddf84",
+  "serialNumber": "urn:uuid:5c89265b-cc3d-4649-878b-17b482325b56",
   "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",


### PR DESCRIPTION
Apply changes following the 1.18.0 release:

- Update the SBOM serial number and CHANGELOG
- Tweak the release steps:
  - After MONGOCRYPT-840, the release step to update the minor version in README.md is no-longer-applicable.
  - Note "Force Repotracker Run" may be needed to force Evergreen to schedule tasks for the tagged commit.
  - Update tasks to wait for "windows-upload-task" => "upload-release" following MONGOCRYPT-841.