### PR TITLE
MONGOCRYPT-899 fix `upload-all` copy

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -871,7 +871,6 @@ tasks:
           if [ -n "${tag_upload_location}" ]; then
             # the "fetch source" step detected a release tag on HEAD, so we
             # prepare a local file for upload to a location based on the tag
-            cp -a libmongocrypt-all-${tag_upload_location!|*revision}.tar.gz libmongocrypt-all-${tag_upload_location}.tar.gz
 
             if [[ "$tag_upload_location" = *-* ]]; then
               # Unstable release, like 1.1.0-beta1 or 1.0.1-rc0.

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -75,7 +75,7 @@ Do the following when releasing:
    - Note that in the future (e.g., if we move to a PR-based workflow for releases, or if we simply want to take better advantage of advanced Evergreen features), it is possible to use Evergreen's "Trigger Versions With Git Tags" feature by updating both `config.yml` and the project's settings in Evergreen
 - Ensure the version on Evergreen with the tagged commit is scheduled. This may require clicking "Force Repotracker Run" in [project settings](https://spruce.corp.mongodb.com/project/libmongocrypt-release/settings/general). The following tasks must pass to complete the release:
    - `upload-all`
-   - `windows-upload-release`
+   - All `upload-release` tasks.
    - All `publish-packages` tasks.
       - If the `publish-packages` tasks fail with an error like `[curator] 2024/01/02 13:56:17 [p=emergency]: problem submitting repobuilder job: 404 (Not Found)`, this suggests the published path does not yet exist. Barque (the Linux package publishing service) has protection to avoid unintentional publishes. File a DEVPROD ticket ([example](https://jira.mongodb.org/browse/DEVPROD-15320)) and assign to the team called Release Infrastructure to request the path be created. Then re-run the failing `publish-packages` task. Ask in the slack channel `#ask-devprod-release-tools` for further help with `Barque` or `curator`.
 - Create the release from the GitHub releases page from the new tag.

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -67,7 +67,6 @@ Do the following when releasing:
 - Ensure `etc/purls.txt` is up-to-date.
 - Update `etc/third_party_vulnerabilities.md` with any updates to new or known vulnerabilities for third party dependencies that must be reported.
 - If this is a new non-patch release (e.g. `x.y.0`):
-   - Update the Linux distribution package installation instructions in [README.md](../README.md) to refer to the new version `x.y`.
    - Update the [libmongocrypt-release](https://spruce.mongodb.com/project/libmongocrypt-release/settings/general) Evergreen project (requires auth) to set `Branch Name` to `rx.y`.
 - Commit the changes on the `rx.y` branch with a message like "Release x.y.z".
 - Tag the commit with `git tag -a <tag>`.

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -73,7 +73,7 @@ Do the following when releasing:
    - Push both the branch ref and tag ref in the same command: `git push origin master 1.8.0-alpha0` or `git push origin r1.8 1.8.4`
    - Pushing the branch ref and the tag ref in the same command eliminates the possibility of a race condition in Evergreen (for building resources based on the presence of a release tag)
    - Note that in the future (e.g., if we move to a PR-based workflow for releases, or if we simply want to take better advantage of advanced Evergreen features), it is possible to use Evergreen's "Trigger Versions With Git Tags" feature by updating both `config.yml` and the project's settings in Evergreen
-- Ensure the version on Evergreen with the tagged commit is scheduled. The following tasks must pass to complete the release:
+- Ensure the version on Evergreen with the tagged commit is scheduled. This may require clicking "Force Repotracker Run" in [project settings](https://spruce.corp.mongodb.com/project/libmongocrypt-release/settings/general). The following tasks must pass to complete the release:
    - `upload-all`
    - `windows-upload-release`
    - All `publish-packages` tasks.


### PR DESCRIPTION
The `upload-all` task on the 1.18.0 release [failed](https://spruce.corp.mongodb.com/task/libmongocrypt_release_publish_upload_all_0dfa86a00f207395600be7059afadd73bdfc69b3_26_05_01_14_03_13/logs?execution=1):

```
cp: 'libmongocrypt-all-1.18.0.tar.gz' and 'libmongocrypt-all-1.18.0.tar.gz' are the same file
```

Due to this copy:
```bash
if [ -n "${tag_upload_location}" ]; then
   # ...
   cp -a libmongocrypt-all-${tag_upload_location!|*revision}.tar.gz libmongocrypt-all-${tag_upload_location}.tar.gz
```

`${tag_upload_location!|*revision}` and `${tag_upload_location}` evaluate the same. But since the copy is guarded by a check for a non-empty `${tag_upload_location}`, the copy is unnecessary.

I do not plan to immediately release 1.18.1 with this fix. libmongocrypt-all.tar.gz is planned for removal in MONGOCRYPT-894. No drivers appear to get binaries directly from this tarball. But I erred towards making this small fix in case there is a need for a 1.18.1 release.

