### PR TITLE
MONGOCRYPT-903 Case and diacritic sensitivity not honoured for explicit encryption

### DIFF
--- a/bindings/python/test/data/fle2-text-search/textopts.json
+++ b/bindings/python/test/data/fle2-text-search/textopts.json
@@ -1,6 +1,6 @@
 {
-    "caseSensitive": true,
-    "diacriticSensitive": true,
+    "caseSensitive": false,
+    "diacriticSensitive": false,
     "prefix": {
         "strMaxQueryLength": 10,
         "strMinQueryLength": 2

--- a/src/mc-textopts.c
+++ b/src/mc-textopts.c
@@ -271,6 +271,7 @@ static bool TextOpts_to_FLE2TextSearchInsertSpec(const mc_TextOpts_t *txo,
         CLIENT_ERR(ERROR_PREFIX "Error appending to BSON");
         return false;
     }
+    // "casef" means "case folding". Case sensitive => not folded. Case insensitive => folded.
     if (!bson_append_bool(&child, "casef", -1, !txo->caseSensitive)) {
         CLIENT_ERR(ERROR_PREFIX "Error appending to BSON");
         return false;

--- a/src/mc-textopts.c
+++ b/src/mc-textopts.c
@@ -271,12 +271,12 @@ static bool TextOpts_to_FLE2TextSearchInsertSpec(const mc_TextOpts_t *txo,
         CLIENT_ERR(ERROR_PREFIX "Error appending to BSON");
         return false;
     }
-    if (!bson_append_bool(&child, "casef", -1, txo->caseSensitive)) {
+    if (!bson_append_bool(&child, "casef", -1, !txo->caseSensitive)) {
         CLIENT_ERR(ERROR_PREFIX "Error appending to BSON");
         return false;
     }
 
-    if (!bson_append_bool(&child, "diacf", -1, txo->diacriticSensitive)) {
+    if (!bson_append_bool(&child, "diacf", -1, !txo->diacriticSensitive)) {
         CLIENT_ERR(ERROR_PREFIX "Error appending to BSON");
         return false;
     }

--- a/src/mc-textopts.c
+++ b/src/mc-textopts.c
@@ -277,6 +277,7 @@ static bool TextOpts_to_FLE2TextSearchInsertSpec(const mc_TextOpts_t *txo,
         return false;
     }
 
+    // "diacf" means "diacritic folding". Diacritic sensitive => not folded. Diacritic insensitive => folded.
     if (!bson_append_bool(&child, "diacf", -1, !txo->diacriticSensitive)) {
         CLIENT_ERR(ERROR_PREFIX "Error appending to BSON");
         return false;

--- a/test/test-mc-textopts.c
+++ b/test/test-mc-textopts.c
@@ -247,7 +247,7 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec_for_query(_mongocrypt_t
          .v = RAW_STRING({"v" : "test"}),
          .qt = MONGOCRYPT_QUERY_TYPE_SUBSTRINGPREVIEW,
          .expect = RAW_STRING(
-             {"v" : {"v" : "test", "casef" : true, "diacf" : false, "substr" : {"mlen" : 10, "ub" : 8, "lb" : 3}}})},
+             {"v" : {"v" : "test", "casef" : false, "diacf" : true, "substr" : {"mlen" : 10, "ub" : 8, "lb" : 3}}})},
         {.desc = "Works with prefix",
          .in = RAW_STRING({
              "caseSensitive" : true,
@@ -257,7 +257,7 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec_for_query(_mongocrypt_t
          .v = RAW_STRING({"v" : "test"}),
          .qt = MONGOCRYPT_QUERY_TYPE_PREFIX,
          .expect =
-             RAW_STRING({"v" : {"v" : "test", "casef" : true, "diacf" : false, "prefix" : {"ub" : 8, "lb" : 3}}})},
+             RAW_STRING({"v" : {"v" : "test", "casef" : false, "diacf" : true, "prefix" : {"ub" : 8, "lb" : 3}}})},
         {.desc = "Works with suffix",
          .in = RAW_STRING({
              "caseSensitive" : true,
@@ -267,7 +267,7 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec_for_query(_mongocrypt_t
          .v = RAW_STRING({"v" : "test"}),
          .qt = MONGOCRYPT_QUERY_TYPE_SUFFIX,
          .expect =
-             RAW_STRING({"v" : {"v" : "test", "casef" : true, "diacf" : false, "suffix" : {"ub" : 8, "lb" : 3}}})},
+             RAW_STRING({"v" : {"v" : "test", "casef" : false, "diacf" : true, "suffix" : {"ub" : 8, "lb" : 3}}})},
         {.desc = "Works with prefix + suffix when querying prefix",
          .in = RAW_STRING({
              "caseSensitive" : true,
@@ -278,7 +278,7 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec_for_query(_mongocrypt_t
          .v = RAW_STRING({"v" : "test"}),
          .qt = MONGOCRYPT_QUERY_TYPE_PREFIX,
          .expect =
-             RAW_STRING({"v" : {"v" : "test", "casef" : true, "diacf" : false, "prefix" : {"ub" : 9, "lb" : 4}}})},
+             RAW_STRING({"v" : {"v" : "test", "casef" : false, "diacf" : true, "prefix" : {"ub" : 9, "lb" : 4}}})},
         {.desc = "Works with prefix + suffix when querying suffix",
          .in = RAW_STRING({
              "caseSensitive" : true,
@@ -289,7 +289,7 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec_for_query(_mongocrypt_t
          .v = RAW_STRING({"v" : "test"}),
          .qt = MONGOCRYPT_QUERY_TYPE_SUFFIX,
          .expect =
-             RAW_STRING({"v" : {"v" : "test", "casef" : true, "diacf" : false, "suffix" : {"ub" : 8, "lb" : 3}}})},
+             RAW_STRING({"v" : {"v" : "test", "casef" : false, "diacf" : true, "suffix" : {"ub" : 8, "lb" : 3}}})},
     };
 
     for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {

--- a/test/test-mc-textopts.c
+++ b/test/test-mc-textopts.c
@@ -43,8 +43,8 @@ static void test_mc_TextOpts_parse(_mongocrypt_tester_t *tester) {
     testcase tests[] = {
         {.desc = "Works with minimal options",
          .in = RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : true,
+             "caseSensitive" : true,
+             "diacriticSensitive" : false,
              "prefix" : {"strMinQueryLength" : 1, "strMaxQueryLength" : 2}
          }),
          .expectCaseSensitive = true,
@@ -54,8 +54,8 @@ static void test_mc_TextOpts_parse(_mongocrypt_tester_t *tester) {
          .expectPrefixStrMaxQueryLength = 2},
         {.desc = "Works with substring options",
          .in = RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : true,
+             "caseSensitive" : true,
+             "diacriticSensitive" : false,
              "substring" : {"strMaxLength" : 10, "strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .expectCaseSensitive = true,
@@ -69,8 +69,8 @@ static void test_mc_TextOpts_parse(_mongocrypt_tester_t *tester) {
          .expectError = "One of 'prefix', 'suffix', or 'substring' is required"},
         {.desc = "Errors if substring, prefix, and suffix are all provided",
          .in = RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : true,
+             "caseSensitive" : true,
+             "diacriticSensitive" : false,
              "substring" : {"strMaxLength" : 10, "strMinQueryLength" : 3, "strMaxQueryLength" : 8},
              "prefix" : {"strMinQueryLength" : 2, "strMaxQueryLength" : 10},
              "suffix" : {"strMinQueryLength" : 4, "strMaxQueryLength" : 12}
@@ -78,15 +78,15 @@ static void test_mc_TextOpts_parse(_mongocrypt_tester_t *tester) {
          .expectError = "Cannot specify 'substring' with 'prefix' or 'suffix'"},
         {.desc = "Errors if strMaxLength is present in prefix",
          .in = RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : true,
+             "caseSensitive" : true,
+             "diacriticSensitive" : false,
              "prefix" : {"strMaxLength" : 12, "strMinQueryLength" : 2, "strMaxQueryLength" : 10}
          }),
          .expectError = "'strMaxLength' is not allowed in 'prefix'"},
         {.desc = "Errors if strMaxLength is present in suffix",
          .in = RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : true,
+             "caseSensitive" : true,
+             "diacriticSensitive" : false,
              "suffix" : {"strMaxLength" : 15, "strMinQueryLength" : 4, "strMaxQueryLength" : 12}
          }),
          .expectError = "'strMaxLength' is not allowed in 'suffix'"},
@@ -157,35 +157,35 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec(_mongocrypt_tester_t *t
     testcase tests[] = {
         {.desc = "Works with substring",
          .in = RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : true,
+             "caseSensitive" : true,
+             "diacriticSensitive" : false,
              "substring" : {"strMaxLength" : 10, "strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .v = RAW_STRING({"v" : "test"}),
          .expect = RAW_STRING(
-             {"v" : {"v" : "test", "casef" : false, "diacf" : true, "substr" : {"mlen" : 10, "ub" : 8, "lb" : 3}}})},
+             {"v" : {"v" : "test", "casef" : true, "diacf" : false, "substr" : {"mlen" : 10, "ub" : 8, "lb" : 3}}})},
         {.desc = "Works with prefix",
          .in = RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : true,
+             "caseSensitive" : true,
+             "diacriticSensitive" : false,
              "prefix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .v = RAW_STRING({"v" : "test"}),
          .expect =
-             RAW_STRING({"v" : {"v" : "test", "casef" : false, "diacf" : true, "prefix" : {"ub" : 8, "lb" : 3}}})},
+             RAW_STRING({"v" : {"v" : "test", "casef" : true, "diacf" : false, "prefix" : {"ub" : 8, "lb" : 3}}})},
         {.desc = "Works with suffix",
          .in = RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : true,
+             "caseSensitive" : true,
+             "diacriticSensitive" : false,
              "suffix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .v = RAW_STRING({"v" : "test"}),
          .expect =
-             RAW_STRING({"v" : {"v" : "test", "casef" : false, "diacf" : true, "suffix" : {"ub" : 8, "lb" : 3}}})},
+             RAW_STRING({"v" : {"v" : "test", "casef" : true, "diacf" : false, "suffix" : {"ub" : 8, "lb" : 3}}})},
         {.desc = "Works with prefix + suffix",
          .in = RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : true,
+             "caseSensitive" : true,
+             "diacriticSensitive" : false,
              "prefix" : {"strMinQueryLength" : 4, "strMaxQueryLength" : 9},
              "suffix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
@@ -193,16 +193,16 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec(_mongocrypt_tester_t *t
          .expect = RAW_STRING({
              "v" : {
                  "v" : "test",
-                 "casef" : false,
-                 "diacf" : true,
+                 "casef" : true,
+                 "diacf" : false,
                  "prefix" : {"ub" : 9, "lb" : 4},
                  "suffix" : {"ub" : 8, "lb" : 3}
              }
          })},
         {.desc = "Errors with missing v",
          .in = RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : true,
+             "caseSensitive" : true,
+             "diacriticSensitive" : false,
              "prefix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .v = RAW_STRING({"foo" : "bar"}),
@@ -240,8 +240,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec_for_query(_mongocrypt_t
     testcase tests[] = {
         {.desc = "Works with substring",
          .in = RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : true,
+             "caseSensitive" : true,
+             "diacriticSensitive" : false,
              "substring" : {"strMaxLength" : 10, "strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .v = RAW_STRING({"v" : "test"}),
@@ -250,8 +250,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec_for_query(_mongocrypt_t
              {"v" : {"v" : "test", "casef" : true, "diacf" : false, "substr" : {"mlen" : 10, "ub" : 8, "lb" : 3}}})},
         {.desc = "Works with prefix",
          .in = RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : true,
+             "caseSensitive" : true,
+             "diacriticSensitive" : false,
              "prefix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .v = RAW_STRING({"v" : "test"}),
@@ -260,8 +260,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec_for_query(_mongocrypt_t
              RAW_STRING({"v" : {"v" : "test", "casef" : true, "diacf" : false, "prefix" : {"ub" : 8, "lb" : 3}}})},
         {.desc = "Works with suffix",
          .in = RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : true,
+             "caseSensitive" : true,
+             "diacriticSensitive" : false,
              "suffix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .v = RAW_STRING({"v" : "test"}),
@@ -270,8 +270,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec_for_query(_mongocrypt_t
              RAW_STRING({"v" : {"v" : "test", "casef" : true, "diacf" : false, "suffix" : {"ub" : 8, "lb" : 3}}})},
         {.desc = "Works with prefix + suffix when querying prefix",
          .in = RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : true,
+             "caseSensitive" : true,
+             "diacriticSensitive" : false,
              "prefix" : {"strMinQueryLength" : 4, "strMaxQueryLength" : 9},
              "suffix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
@@ -281,8 +281,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec_for_query(_mongocrypt_t
              RAW_STRING({"v" : {"v" : "test", "casef" : true, "diacf" : false, "prefix" : {"ub" : 9, "lb" : 4}}})},
         {.desc = "Works with prefix + suffix when querying suffix",
          .in = RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : true,
+             "caseSensitive" : true,
+             "diacriticSensitive" : false,
              "prefix" : {"strMinQueryLength" : 4, "strMaxQueryLength" : 9},
              "suffix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),

--- a/test/test-mc-textopts.c
+++ b/test/test-mc-textopts.c
@@ -157,8 +157,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec(_mongocrypt_tester_t *t
     testcase tests[] = {
         {.desc = "Works with substring",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+             "caseSensitive" : false,
+             "diacriticSensitive" : true,
              "substring" : {"strMaxLength" : 10, "strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .v = RAW_STRING({"v" : "test"}),
@@ -166,8 +166,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec(_mongocrypt_tester_t *t
              {"v" : {"v" : "test", "casef" : true, "diacf" : false, "substr" : {"mlen" : 10, "ub" : 8, "lb" : 3}}})},
         {.desc = "Works with prefix",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+             "caseSensitive" : false,
+             "diacriticSensitive" : true,
              "prefix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .v = RAW_STRING({"v" : "test"}),
@@ -175,8 +175,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec(_mongocrypt_tester_t *t
              RAW_STRING({"v" : {"v" : "test", "casef" : true, "diacf" : false, "prefix" : {"ub" : 8, "lb" : 3}}})},
         {.desc = "Works with suffix",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+             "caseSensitive" : false,
+             "diacriticSensitive" : true,
              "suffix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .v = RAW_STRING({"v" : "test"}),
@@ -184,8 +184,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec(_mongocrypt_tester_t *t
              RAW_STRING({"v" : {"v" : "test", "casef" : true, "diacf" : false, "suffix" : {"ub" : 8, "lb" : 3}}})},
         {.desc = "Works with prefix + suffix",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+             "caseSensitive" : false,
+             "diacriticSensitive" : true,
              "prefix" : {"strMinQueryLength" : 4, "strMaxQueryLength" : 9},
              "suffix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
@@ -201,8 +201,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec(_mongocrypt_tester_t *t
          })},
         {.desc = "Errors with missing v",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+             "caseSensitive" : false,
+             "diacriticSensitive" : true,
              "prefix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .v = RAW_STRING({"foo" : "bar"}),

--- a/test/test-mc-textopts.c
+++ b/test/test-mc-textopts.c
@@ -163,7 +163,7 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec(_mongocrypt_tester_t *t
          }),
          .v = RAW_STRING({"v" : "test"}),
          .expect = RAW_STRING(
-             {"v" : {"v" : "test", "casef" : true, "diacf" : false, "substr" : {"mlen" : 10, "ub" : 8, "lb" : 3}}})},
+             {"v" : {"v" : "test", "casef" : false, "diacf" : true, "substr" : {"mlen" : 10, "ub" : 8, "lb" : 3}}})},
         {.desc = "Works with prefix",
          .in = RAW_STRING({
              "caseSensitive" : true,
@@ -172,7 +172,7 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec(_mongocrypt_tester_t *t
          }),
          .v = RAW_STRING({"v" : "test"}),
          .expect =
-             RAW_STRING({"v" : {"v" : "test", "casef" : true, "diacf" : false, "prefix" : {"ub" : 8, "lb" : 3}}})},
+             RAW_STRING({"v" : {"v" : "test", "casef" : false, "diacf" : true, "prefix" : {"ub" : 8, "lb" : 3}}})},
         {.desc = "Works with suffix",
          .in = RAW_STRING({
              "caseSensitive" : true,
@@ -181,7 +181,7 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec(_mongocrypt_tester_t *t
          }),
          .v = RAW_STRING({"v" : "test"}),
          .expect =
-             RAW_STRING({"v" : {"v" : "test", "casef" : true, "diacf" : false, "suffix" : {"ub" : 8, "lb" : 3}}})},
+             RAW_STRING({"v" : {"v" : "test", "casef" : false, "diacf" : true, "suffix" : {"ub" : 8, "lb" : 3}}})},
         {.desc = "Works with prefix + suffix",
          .in = RAW_STRING({
              "caseSensitive" : true,
@@ -193,8 +193,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec(_mongocrypt_tester_t *t
          .expect = RAW_STRING({
              "v" : {
                  "v" : "test",
-                 "casef" : true,
-                 "diacf" : false,
+                 "casef" : false,
+                 "diacf" : true,
                  "prefix" : {"ub" : 9, "lb" : 4},
                  "suffix" : {"ub" : 8, "lb" : 3}
              }

--- a/test/test-mc-textopts.c
+++ b/test/test-mc-textopts.c
@@ -43,8 +43,8 @@ static void test_mc_TextOpts_parse(_mongocrypt_tester_t *tester) {
     testcase tests[] = {
         {.desc = "Works with minimal options",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+            "caseSensitive" : false,
+            "diacriticSensitive" : true,
              "prefix" : {"strMinQueryLength" : 1, "strMaxQueryLength" : 2}
          }),
          .expectCaseSensitive = true,
@@ -54,8 +54,8 @@ static void test_mc_TextOpts_parse(_mongocrypt_tester_t *tester) {
          .expectPrefixStrMaxQueryLength = 2},
         {.desc = "Works with substring options",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+            "caseSensitive" : false,
+            "diacriticSensitive" : true,
              "substring" : {"strMaxLength" : 10, "strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .expectCaseSensitive = true,
@@ -69,8 +69,8 @@ static void test_mc_TextOpts_parse(_mongocrypt_tester_t *tester) {
          .expectError = "One of 'prefix', 'suffix', or 'substring' is required"},
         {.desc = "Errors if substring, prefix, and suffix are all provided",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+            "caseSensitive" : false,
+            "diacriticSensitive" : true,
              "substring" : {"strMaxLength" : 10, "strMinQueryLength" : 3, "strMaxQueryLength" : 8},
              "prefix" : {"strMinQueryLength" : 2, "strMaxQueryLength" : 10},
              "suffix" : {"strMinQueryLength" : 4, "strMaxQueryLength" : 12}
@@ -78,15 +78,15 @@ static void test_mc_TextOpts_parse(_mongocrypt_tester_t *tester) {
          .expectError = "Cannot specify 'substring' with 'prefix' or 'suffix'"},
         {.desc = "Errors if strMaxLength is present in prefix",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+            "caseSensitive" : false,
+            "diacriticSensitive" : true,
              "prefix" : {"strMaxLength" : 12, "strMinQueryLength" : 2, "strMaxQueryLength" : 10}
          }),
          .expectError = "'strMaxLength' is not allowed in 'prefix'"},
         {.desc = "Errors if strMaxLength is present in suffix",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+            "caseSensitive" : false,
+            "diacriticSensitive" : true,
              "suffix" : {"strMaxLength" : 15, "strMinQueryLength" : 4, "strMaxQueryLength" : 12}
          }),
          .expectError = "'strMaxLength' is not allowed in 'suffix'"},
@@ -157,8 +157,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec(_mongocrypt_tester_t *t
     testcase tests[] = {
         {.desc = "Works with substring",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+            "caseSensitive" : false,
+            "diacriticSensitive" : true,
              "substring" : {"strMaxLength" : 10, "strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .v = RAW_STRING({"v" : "test"}),
@@ -166,8 +166,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec(_mongocrypt_tester_t *t
              {"v" : {"v" : "test", "casef" : false, "diacf" : true, "substr" : {"mlen" : 10, "ub" : 8, "lb" : 3}}})},
         {.desc = "Works with prefix",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+            "caseSensitive" : false,
+            "diacriticSensitive" : true,
              "prefix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .v = RAW_STRING({"v" : "test"}),
@@ -175,8 +175,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec(_mongocrypt_tester_t *t
              RAW_STRING({"v" : {"v" : "test", "casef" : false, "diacf" : true, "prefix" : {"ub" : 8, "lb" : 3}}})},
         {.desc = "Works with suffix",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+            "caseSensitive" : false,
+            "diacriticSensitive" : true,
              "suffix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .v = RAW_STRING({"v" : "test"}),
@@ -184,8 +184,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec(_mongocrypt_tester_t *t
              RAW_STRING({"v" : {"v" : "test", "casef" : false, "diacf" : true, "suffix" : {"ub" : 8, "lb" : 3}}})},
         {.desc = "Works with prefix + suffix",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+            "caseSensitive" : false,
+            "diacriticSensitive" : true,
              "prefix" : {"strMinQueryLength" : 4, "strMaxQueryLength" : 9},
              "suffix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
@@ -201,8 +201,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec(_mongocrypt_tester_t *t
          })},
         {.desc = "Errors with missing v",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+            "caseSensitive" : false,
+            "diacriticSensitive" : true,
              "prefix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .v = RAW_STRING({"foo" : "bar"}),
@@ -240,8 +240,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec_for_query(_mongocrypt_t
     testcase tests[] = {
         {.desc = "Works with substring",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+            "caseSensitive" : false,
+            "diacriticSensitive" : true,
              "substring" : {"strMaxLength" : 10, "strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .v = RAW_STRING({"v" : "test"}),
@@ -250,8 +250,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec_for_query(_mongocrypt_t
              {"v" : {"v" : "test", "casef" : true, "diacf" : false, "substr" : {"mlen" : 10, "ub" : 8, "lb" : 3}}})},
         {.desc = "Works with prefix",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+            "caseSensitive" : false,
+            "diacriticSensitive" : true,
              "prefix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .v = RAW_STRING({"v" : "test"}),
@@ -260,8 +260,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec_for_query(_mongocrypt_t
              RAW_STRING({"v" : {"v" : "test", "casef" : true, "diacf" : false, "prefix" : {"ub" : 8, "lb" : 3}}})},
         {.desc = "Works with suffix",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+            "caseSensitive" : false,
+            "diacriticSensitive" : true,
              "suffix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
          .v = RAW_STRING({"v" : "test"}),
@@ -270,8 +270,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec_for_query(_mongocrypt_t
              RAW_STRING({"v" : {"v" : "test", "casef" : true, "diacf" : false, "suffix" : {"ub" : 8, "lb" : 3}}})},
         {.desc = "Works with prefix + suffix when querying prefix",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+            "caseSensitive" : false,
+            "diacriticSensitive" : true,
              "prefix" : {"strMinQueryLength" : 4, "strMaxQueryLength" : 9},
              "suffix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),
@@ -281,8 +281,8 @@ static void test_mc_TextOpts_to_FLE2TextSearchInsertSpec_for_query(_mongocrypt_t
              RAW_STRING({"v" : {"v" : "test", "casef" : true, "diacf" : false, "prefix" : {"ub" : 9, "lb" : 4}}})},
         {.desc = "Works with prefix + suffix when querying suffix",
          .in = RAW_STRING({
-             "caseSensitive" : true,
-             "diacriticSensitive" : false,
+            "caseSensitive" : false,
+            "diacriticSensitive" : true,
              "prefix" : {"strMinQueryLength" : 4, "strMaxQueryLength" : 9},
              "suffix" : {"strMinQueryLength" : 3, "strMaxQueryLength" : 8}
          }),

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -2484,8 +2484,8 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
         tc.user_key_id = &keyABC_id;
         tc.keys_to_feed[0] = keyABC;
         tc.text_opts = TEST_BSON(RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : false,
+            "caseSensitive" : true,
+            "diacriticSensitive" : true,
             "suffix" : {"strMinQueryLength" : 1, "strMaxQueryLength" : 100}
         }));
         tc.expect = TEST_FILE("./test/data/fle2-explicit/find-suffix.json");
@@ -2502,8 +2502,8 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
         tc.user_key_id = &keyABC_id;
         tc.keys_to_feed[0] = keyABC;
         tc.text_opts = TEST_BSON(RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : false,
+            "caseSensitive" : true,
+            "diacriticSensitive" : true,
             "prefix" : {"strMinQueryLength" : 1, "strMaxQueryLength" : 100}
         }));
         tc.expect = TEST_FILE("./test/data/fle2-explicit/find-prefix.json");
@@ -2520,8 +2520,8 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
         tc.user_key_id = &keyABC_id;
         tc.keys_to_feed[0] = keyABC;
         tc.text_opts = TEST_BSON(RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : false,
+            "caseSensitive" : true,
+            "diacriticSensitive" : true,
             "suffix" : {"strMinQueryLength" : 1, "strMaxQueryLength" : 100}
         }));
         tc.expect = TEST_FILE("./test/data/fle2-explicit/find-suffix.json");
@@ -2538,8 +2538,8 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
         tc.user_key_id = &keyABC_id;
         tc.keys_to_feed[0] = keyABC;
         tc.text_opts = TEST_BSON(RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : false,
+            "caseSensitive" : true,
+            "diacriticSensitive" : true,
             "prefix" : {"strMinQueryLength" : 1, "strMaxQueryLength" : 100}
         }));
         tc.expect = TEST_FILE("./test/data/fle2-explicit/find-prefix.json");
@@ -2556,8 +2556,8 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
         tc.user_key_id = &keyABC_id;
         tc.keys_to_feed[0] = keyABC;
         tc.text_opts = TEST_BSON(RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : false,
+            "caseSensitive" : true,
+            "diacriticSensitive" : true,
             "substring" : {"strMaxLength" : 100, "strMinQueryLength" : 1, "strMaxQueryLength" : 100}
         }));
         tc.expect = TEST_FILE("./test/data/fle2-explicit/find-substring.json");
@@ -2576,8 +2576,8 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
         tc.user_key_id = &keyABC_id;
         tc.keys_to_feed[0] = keyABC;
         tc.text_opts = TEST_BSON(RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : false,
+            "caseSensitive" : true,
+            "diacriticSensitive" : true,
             "suffix" : {"strMinQueryLength" : 1, "strMaxQueryLength" : 100}
         }));
         tc.expect = TEST_FILE("./test/data/fle2-explicit/insert-suffix.json");
@@ -2596,8 +2596,8 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
         tc.user_key_id = &keyABC_id;
         tc.keys_to_feed[0] = keyABC;
         tc.text_opts = TEST_BSON(RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : false,
+            "caseSensitive" : true,
+            "diacriticSensitive" : true,
             "prefix" : {"strMinQueryLength" : 1, "strMaxQueryLength" : 100}
         }));
         tc.expect = TEST_FILE("./test/data/fle2-explicit/insert-prefix.json");
@@ -2616,8 +2616,8 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
         tc.user_key_id = &keyABC_id;
         tc.keys_to_feed[0] = keyABC;
         tc.text_opts = TEST_BSON(RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : false,
+            "caseSensitive" : true,
+            "diacriticSensitive" : true,
             "substring" : {"strMaxLength" : 100, "strMinQueryLength" : 1, "strMaxQueryLength" : 100}
         }));
         tc.expect = TEST_FILE("./test/data/fle2-explicit/insert-substring.json");
@@ -2636,8 +2636,8 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
         tc.user_key_id = &keyABC_id;
         tc.keys_to_feed[0] = keyABC;
         tc.text_opts = TEST_BSON(RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : false,
+            "caseSensitive" : true,
+            "diacriticSensitive" : true,
             "prefix" : {"strMinQueryLength" : 1, "strMaxQueryLength" : 100},
             "suffix" : {"strMinQueryLength" : 1, "strMaxQueryLength" : 100}
         }));
@@ -2675,8 +2675,8 @@ static void _test_encrypt_fle2_explicit(_mongocrypt_tester_t *tester) {
         tc.keys_to_feed[0] = keyABC;
         tc.query_type = MONGOCRYPT_QUERY_TYPE_PREFIXPREVIEW_DEPRECATED_STR;
         tc.text_opts = TEST_BSON(RAW_STRING({
-            "caseSensitive" : false,
-            "diacriticSensitive" : false,
+            "caseSensitive" : true,
+            "diacriticSensitive" : true,
             "prefix" : {"strMinQueryLength" : 1, "strMaxQueryLength" : 100},
             "suffix" : {"strMinQueryLength" : 1, "strMaxQueryLength" : 100}
         }));


### PR DESCRIPTION
The initial interpretation of the `casef` and `diacf` server fields was backwards.