### PR TITLE
MONGOCRYPT-901 fix `upload-release` task for Windows

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1202,9 +1202,9 @@ tasks:
           elif [ -f "$srcdir/lib/libmongocrypt.dylib" ]; then
             mkdir libmongocrypt_upload/lib
             mv $srcdir/lib/libmongocrypt.dylib libmongocrypt_upload/lib
-          elif [ -f "$srcdir/bin/libmongocrypt.dll" ]; then
+          elif [ -f "$srcdir/bin/mongocrypt.dll" ]; then
             mkdir libmongocrypt_upload/bin
-            mv $srcdir/bin/libmongocrypt.dll libmongocrypt_upload/bin
+            mv $srcdir/bin/mongocrypt.dll libmongocrypt_upload/bin
           fi
     - command: archive.targz_pack
       params:


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/libmongocrypt/pull/1145. After the 1.18.0 release it was reported [in slack](https://mongodb.slack.com/archives/C0668RJBA0J/p1777912433360559?thread_ts=1777653659.706309&cid=C0668RJBA0J) the Windows tarball from the `upload-release` did not include the `.dll` files.

Fortunately, the `windows-upload-release` task was not-yet removed. The 1.18.0 release was updated with the signed tarball from `windows-upload-release`. This PR fixes the name reference `libmongocrypt.dll` => `mongocrypt.dll` so the `windows-upload-release` task can be later removed to consistently use the `upload-release` task.