### PR TITLE
[r1.18] MONGOCRYPT-904 fix KMS error messages

### DIFF
--- a/src/mongocrypt-kms-ctx.c
+++ b/src/mongocrypt-kms-ctx.c
@@ -578,9 +578,7 @@ static bool _ctx_done_aws(mongocrypt_kms_ctx_t *kms, const char *json_field) {
      */
     bson_destroy(&body_bson);
     if (body_len > (size_t)SSIZE_MAX) {
-        CLIENT_ERR("Error parsing JSON in KMS response '%s'. "
-                   "Response body exceeds maximum supported length",
-                   bson_error.message);
+        CLIENT_ERR("Error parsing JSON in KMS response. Response body exceeds maximum supported length");
         bson_init(&body_bson);
         goto fail;
     }
@@ -671,9 +669,7 @@ static bool _ctx_done_oauth(mongocrypt_kms_ctx_t *kms) {
     }
 
     if (body_len > (size_t)SSIZE_MAX) {
-        CLIENT_ERR("Error parsing JSON in KMS response '%s'. "
-                   "Response body exceeds maximum supported length",
-                   bson_error.message);
+        CLIENT_ERR("Error parsing JSON in KMS response. Response body exceeds maximum supported length");
         goto fail;
     }
     bson_body = bson_new_from_json((const uint8_t *)body, (ssize_t)body_len, &bson_error);
@@ -763,9 +759,7 @@ static bool _ctx_done_azure_wrapkey_unwrapkey(mongocrypt_kms_ctx_t *kms) {
     }
 
     if (body_len > (size_t)SSIZE_MAX) {
-        CLIENT_ERR("Error parsing JSON in KMS response '%s'. "
-                   "Response body exceeds maximum supported length",
-                   bson_error.message);
+        CLIENT_ERR("Error parsing JSON in KMS response. Response body exceeds maximum supported length");
         goto fail;
     }
     bson_body = bson_new_from_json((const uint8_t *)body, (ssize_t)body_len, &bson_error);
@@ -875,9 +869,7 @@ static bool _ctx_done_gcp(mongocrypt_kms_ctx_t *kms, const char *json_field) {
      */
     bson_destroy(&body_bson);
     if (body_len > (size_t)SSIZE_MAX) {
-        CLIENT_ERR("Error parsing JSON in KMS response '%s'. "
-                   "Response body exceeds maximum supported length",
-                   bson_error.message);
+        CLIENT_ERR("Error parsing JSON in KMS response. Response body exceeds maximum supported length");
         bson_init(&body_bson);
         goto fail;
     }


### PR DESCRIPTION
Cherry-pick of 515160392bed7f986a77570cc1ef5a8f42a48513 onto r1.18.