### PR TITLE
MONGOCRYPT-901 fix `upload-release` task for Windows

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1203,9 +1203,9 @@ tasks:
           elif [ -f "$srcdir/lib/libmongocrypt.dylib" ]; then
             mkdir libmongocrypt_upload/lib
             mv $srcdir/lib/libmongocrypt.dylib libmongocrypt_upload/lib
-          elif [ -f "$srcdir/bin/libmongocrypt.dll" ]; then
+          elif [ -f "$srcdir/bin/mongocrypt.dll" ]; then
             mkdir libmongocrypt_upload/bin
-            mv $srcdir/bin/libmongocrypt.dll libmongocrypt_upload/bin
+            mv $srcdir/bin/mongocrypt.dll libmongocrypt_upload/bin
           fi
     - command: archive.targz_pack
       params:


### PR DESCRIPTION
Cherry-pick of 515160392bed7f986a77570cc1ef5a8f42a48513 onto r1.18.