### PR TITLE
Apply post-1.18.1 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 <!-- TODO: add entries for next release -->
 
+## 1.18.1
+
+### Fixed
+- Fix QE text explicit encryption handling of `caseSensitive` and `diacriticSensitive` options.
+    - This is a backwards breaking bug fix, but only applies to the experimental QE text algorithm "TextPreview".
+- Fix handling of malformed KMS replies.
+
 ## 1.18.0
 
 ### Added

--- a/etc/download-artifacts.py
+++ b/etc/download-artifacts.py
@@ -2,14 +2,13 @@
 #
 # /// script
 # dependencies = [
-#   "pyyaml",
 #   "requests",
 # ]
 # ///
 
 import argparse
+import subprocess
 import requests
-import yaml
 from pathlib import Path
 from urllib.parse import urlsplit
 
@@ -30,25 +29,23 @@ def download_file(url: str):
 
 def main():
     parser = argparse.ArgumentParser(description="Download release artifacts from an Evergreen version")
-    parser.add_argument("version_id", help="Evergreen version ID. (e.g. https://evergreen.mongodb.com/version/<version_id>)")
+    parser.add_argument("version_id", help="Evergreen version ID. (e.g. https://evergreen.corp.mongodb.com/version/<version_id>)")
     args = parser.parse_args()
 
     version_id = args.version_id
 
-    # Get Evergreen API credentials:
-    path: Path = Path().home() / ".evergreen.yml"
-    with path.open() as file:
-        evg_settings = yaml.load(file, Loader=yaml.FullLoader)
+    oauth_token = subprocess.check_output(["evergreen", "client", "get-oauth-token"], text=True).strip()
 
-    api_server_host = "https://evergreen.mongodb.com/rest/v2"
-    api_key = evg_settings["api_key"]
-    api_user = evg_settings["user"]
-    headers = {'Api-User': api_user, 'Api-Key': api_key}
+    api_server_host = "https://evergreen.corp.mongodb.com/rest/v2"
+    headers = {'Authorization': f'Bearer {oauth_token}'}
 
     resp: requests.Response = requests.get(
         f"{api_server_host}/versions/{version_id}/builds",
         params={"include_task_info": "true"},
         headers=headers)
+    if resp.status_code != 200:
+        print(f"Failed to get builds for version {version_id}: {resp.status_code} {resp.text}")
+        return
     builds = resp.json()
 
     for build in builds:


### PR DESCRIPTION
- Update CHANGELOG.md for 1.18.1
- Update `download-artifacts.py` to use oauth for Evergreen (see "Static Evergreen API Keys Are Being Deprecated" e-mail). Fixes an observed HTTP 401 error when running this script during the release.