### PR TITLE
MONGOCRYPT-916 remove debug hex helper

### DIFF
--- a/src/mongocrypt-buffer-private.h
+++ b/src/mongocrypt-buffer-private.h
@@ -102,8 +102,6 @@ void _mongocrypt_buffer_copy_from_hex(_mongocrypt_buffer_t *buf, const char *hex
 
 int _mongocrypt_buffer_cmp_hex(_mongocrypt_buffer_t *buf, const char *hex);
 
-char *_mongocrypt_buffer_to_hex(_mongocrypt_buffer_t *buf) MONGOCRYPT_WARN_UNUSED_RESULT;
-
 bool _mongocrypt_buffer_concat(_mongocrypt_buffer_t *dst, const _mongocrypt_buffer_t *srcs, uint32_t num_srcs);
 
 struct _mongocrypt_binary_t *_mongocrypt_buffer_as_binary(_mongocrypt_buffer_t *buf);

--- a/src/mongocrypt-buffer.c
+++ b/src/mongocrypt-buffer.c
@@ -451,22 +451,6 @@ int _mongocrypt_buffer_cmp_hex(_mongocrypt_buffer_t *buf, const char *hex) {
     return res;
 }
 
-char *_mongocrypt_buffer_to_hex(_mongocrypt_buffer_t *buf) {
-    BSON_ASSERT_PARAM(buf);
-    /* since buf->len is a uint32_t, even doubling it won't bring it anywhere
-     * near to SIZE_MAX */
-
-    char *hex = bson_malloc0(buf->len * 2 + 1);
-    BSON_ASSERT(hex);
-
-    char *out = hex;
-
-    for (uint32_t i = 0; i < buf->len; i++, out += 2) {
-        BSON_ASSERT(2 == bson_snprintf(out, 3, "%02X", buf->data[i]));
-    }
-    return hex;
-}
-
 bool _mongocrypt_buffer_concat(_mongocrypt_buffer_t *dst, const _mongocrypt_buffer_t *srcs, uint32_t num_srcs) {
     uint32_t total = 0;
     uint32_t offset;

--- a/src/mongocrypt-cache-key.c
+++ b/src/mongocrypt-cache-key.c
@@ -71,23 +71,6 @@ static void *_copy_contents(void *value) {
     return _mongocrypt_cache_key_value_new(key_value->key_doc, &key_value->decrypted_key_material);
 }
 
-static void _dump_attr(void *attr_in) {
-    _mongocrypt_cache_key_attr_t *attr;
-    _mongocrypt_key_alt_name_t *altname;
-    char *hex;
-
-    BSON_ASSERT_PARAM(attr_in);
-
-    attr = (_mongocrypt_cache_key_attr_t *)attr_in;
-    hex = _mongocrypt_buffer_to_hex(&attr->id);
-    printf("_id=%s,", hex);
-    printf("keyAltNames=");
-    for (altname = attr->alt_names; NULL != altname; altname = altname->next) {
-        printf("%s\n", _mongocrypt_key_alt_name_get_string(altname));
-    }
-    bson_free(hex);
-}
-
 _mongocrypt_cache_key_value_t *_mongocrypt_cache_key_value_new(_mongocrypt_key_doc_t *key_doc,
                                                                _mongocrypt_buffer_t *decrypted_key_material) {
     _mongocrypt_cache_key_value_t *key_value;
@@ -126,7 +109,6 @@ void _mongocrypt_cache_key_init(_mongocrypt_cache_t *cache) {
     cache->destroy_attr = _destroy_attr;
     cache->copy_value = _copy_contents;
     cache->destroy_value = _mongocrypt_cache_key_value_destroy;
-    cache->dump_attr = _dump_attr;
     _mongocrypt_mutex_init(&cache->mutex);
     cache->pair = NULL;
     cache->expiration = CACHE_EXPIRATION_MS_DEFAULT;

--- a/src/mongocrypt-cache-private.h
+++ b/src/mongocrypt-cache-private.h
@@ -66,9 +66,6 @@ bool _mongocrypt_cache_add_stolen(_mongocrypt_cache_t *cache, void *attr, void *
 
 void _mongocrypt_cache_cleanup(_mongocrypt_cache_t *cache);
 
-/* A helper debug function to dump the state of the cache. */
-void _mongocrypt_cache_dump(_mongocrypt_cache_t *cache);
-
 /* Tests may override the default expiration */
 void _mongocrypt_cache_set_expiration(_mongocrypt_cache_t *cache, uint64_t milli);
 

--- a/src/mongocrypt-cache.c
+++ b/src/mongocrypt-cache.c
@@ -249,28 +249,6 @@ void _mongocrypt_cache_cleanup(_mongocrypt_cache_t *cache) {
     }
 }
 
-/* Print the contents of the cache (for debugging purposes) */
-void _mongocrypt_cache_dump(_mongocrypt_cache_t *cache) {
-    _mongocrypt_cache_pair_t *pair;
-    int count;
-
-    BSON_ASSERT_PARAM(cache);
-
-    _mongocrypt_mutex_lock(&cache->mutex);
-    count = 0;
-    for (pair = cache->pair; pair != NULL; pair = pair->next) {
-        /* don't check that int64_t fits in int, since this is only diagnostic */
-        printf("entry:%d last_updated:%d\n", count, (int)pair->last_updated);
-        if (cache->dump_attr) {
-            printf("- attr:");
-            cache->dump_attr(pair->attr);
-        }
-        count++;
-    }
-
-    _mongocrypt_mutex_unlock(&cache->mutex);
-}
-
 uint32_t _mongocrypt_cache_num_entries(_mongocrypt_cache_t *cache) {
     _mongocrypt_cache_pair_t *pair;
     uint32_t count;

--- a/test/test-mongocrypt-crypto-hooks.c
+++ b/test/test-mongocrypt-crypto-hooks.c
@@ -53,12 +53,28 @@ static char *call_history;
     } else                                                                                                             \
         (void)0
 
+static char *to_hex(_mongocrypt_buffer_t *buf) {
+    BSON_ASSERT_PARAM(buf);
+
+    BSON_ASSERT(buf->len < (UINT32_MAX - 1) / 2);
+
+    char *hex = bson_malloc0(buf->len * 2 + 1);
+    BSON_ASSERT(hex);
+
+    char *out = hex;
+
+    for (uint32_t i = 0; i < buf->len; i++, out += 2) {
+        BSON_ASSERT(2 == bson_snprintf(out, 3, "%02X", buf->data[i]));
+    }
+    return hex;
+}
+
 static void _append_bin(const char *name, mongocrypt_binary_t *bin) {
     _mongocrypt_buffer_t tmp;
     char *hex;
 
     _mongocrypt_buffer_from_binary(&tmp, bin);
-    hex = _mongocrypt_buffer_to_hex(&tmp);
+    hex = to_hex(&tmp);
     APPEND_CALLHISTORY("%s:%s\n", name, hex);
     bson_free(hex);
     _mongocrypt_buffer_cleanup(&tmp);


### PR DESCRIPTION
This PR addresses finding with ID:8 in the report attached to MONGOCRYPT-913.

`_mongocrypt_buffer_to_hex` was only used for test code, so has been moved to a test-only `to_hex` helper.