### PR TITLE
[r1.18] MONGOCRYPT-910 validate HTTP sizes

### DIFF
--- a/kms-message/src/hexlify.c
+++ b/kms-message/src/hexlify.c
@@ -20,6 +20,7 @@
 
 #include "kms_message_private.h"
 
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -50,8 +51,8 @@ unhexlify (const char *in, size_t len)
 {
    int i;
    int byte;
-   int total = 0;
-   int multiplier = 1;
+   int64_t total = 0;
+   int64_t multiplier = 1;
 
    for (i = (int) len - 1; i >= 0; i--) {
       char c = *(in + i);
@@ -66,8 +67,11 @@ unhexlify (const char *in, size_t len)
          return -1;
       }
 
-      total += byte * multiplier;
+      total += (int64_t) byte * multiplier;
+      if (total > INT_MAX) {
+         return -1;
+      }
       multiplier *= 16;
    }
-   return total;
+   return (int) total;
 }

--- a/kms-message/src/kms_response_parser.c
+++ b/kms-message/src/kms_response_parser.c
@@ -234,7 +234,7 @@ _parse_line (kms_response_parser_t *parser, int end)
       /* if we have *not* read the Content-Length yet, check. */
       if (parser->content_length == -1 &&
           strcmp (key->str, "Content-Length") == 0) {
-         if (!_parse_int (val->str, &parser->content_length)) {
+         if (!_parse_int (val->str, &parser->content_length) || parser->content_length > KMS_PARSER_MAX_RESPONSE_LEN || parser->content_length < 0) {
             KMS_ERROR (parser, "Could not parse Content-Length header.");
             kms_request_str_destroy (key);
             kms_request_str_destroy (val);
@@ -258,7 +258,7 @@ _parse_line (kms_response_parser_t *parser, int end)
    } else if (parser->state == PARSING_CHUNK_LENGTH) {
       int result = 0;
 
-      if (!_parse_hex_from_view (raw + i, end - i, &result)) {
+      if (!_parse_hex_from_view (raw + i, end - i, &result) || result > KMS_PARSER_MAX_RESPONSE_LEN || result < 0) {
          KMS_ERROR (parser, "Failed to parse hex chunk length.");
          return PARSING_DONE;
       }
@@ -297,6 +297,9 @@ kms_response_parser_feed (kms_response_parser_t *parser,
          /* find the next \r\n. */
          if (curr && strncmp (raw->str + (curr - 1), "\r\n", 2) == 0) {
             parser->state = _parse_line (parser, curr - 1);
+            if (parser->failed) {
+               return false;
+            }
             parser->start = curr + 1;
          }
          curr++;

--- a/test/data/kms-tests.json
+++ b/test/data/kms-tests.json
@@ -293,5 +293,49 @@
       "{\"KeyId\": \"arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0\", \"CiphertextBlob\": \"A\"}"
     ],
     "expect": "Failed to base64 decode"
+  },
+  {
+    "description": "Chunked transfer with INT_MAX chunk size (MONGOCRYPT-910)",
+    "ctx": [
+      "datakey",
+      "decrypt",
+      "azure_oauth_datakey",
+      "azure_oauth_decrypt",
+      "azure_datakey",
+      "azure_decrypt",
+      "gcp_oauth_datakey",
+      "gcp_oauth_decrypt",
+      "gcp_datakey",
+      "gcp_decrypt"
+    ],
+    "http_reply": [
+      "HTTP/1.1 200 OK\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "\r\n",
+      "7fffffff\r\nX"
+    ],
+    "expect": "Failed to parse hex chunk length"
+  },
+  {
+    "description": "Content-Length too large",
+    "ctx": [
+      "datakey",
+      "decrypt",
+      "azure_oauth_datakey",
+      "azure_oauth_decrypt",
+      "azure_datakey",
+      "azure_decrypt",
+      "gcp_oauth_datakey",
+      "gcp_oauth_decrypt",
+      "gcp_datakey",
+      "gcp_decrypt"
+    ],
+    "http_reply": [
+      "HTTP/1.1 200 OK\r\n",
+      "Content-Length: 123123123\r\n",
+      "\r\n",
+      "{}"
+    ],
+    "expect": "Could not parse Content-Length"
   }
 ]


### PR DESCRIPTION
Cherry-pick of https://github.com/mongodb/libmongocrypt/pull/1173 to 1.18 to include in upcoming 1.18 patch release.