### PR TITLE
MONGOCRYPT-918 add musl arm64 signed release

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2022,9 +2022,12 @@ buildvariants:
   display_name: "Alpine Linux 3.23 arm64 (via Earthly)"
   expansions:
     earthly_env: alpine
+    release_os_arch: linux-arm64-musl_1_2-nocrypto
   tasks:
   - name: build-with-earthly
     run_on: ubuntu2404-arm64-latest-large
+  - name: upload-release
+    depends_on: build-with-earthly
 
 - name: debian11-arm64-earthly
   display_name: "Debian 11 arm64 (via Earthly)"


### PR DESCRIPTION
musl arm64 builds are needed by the C# driver [here](https://github.com/mongodb/mongo-csharp-driver/blob/4959893adecde56b3c3c856e441236b30bccc489/src/MongoDB.Driver.Encryption/MongoDB.Driver.Encryption.csproj#L72) but were not added in [MONGOCRYPT-841](https://jira.mongodb.org/browse/MONGOCRYPT-841).