### PR TITLE
ci(test-python): cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -17,6 +17,9 @@ defaults:
     working-directory: ./bindings/python
     shell: bash -eux {0}
  
+permissions:
+  contents: read
+
 jobs:
 
   static:


### PR DESCRIPTION
The `test-python` workflow runs the Python test suite. No GitHub API writes, so workflow-level `contents: read` is the right cap.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.