### PR TITLE
MONGOCRYPT-924 Improve arithmetic type consistency when computing metadata_len

### DIFF
--- a/src/mc-fle2-payload-iev-v2.c
+++ b/src/mc-fle2-payload-iev-v2.c
@@ -600,9 +600,8 @@ bool mc_FLE2IndexedEncryptedValueV2_parse(mc_FLE2IndexedEncryptedValueV2_t *iev,
         }
     }
 
-    // Maximum edge_count(4294967295) times kMetadataLen(96) fits easily without
-    // overflow.
-    const uint64_t metadata_len = iev->edge_count * kMetadataLen;
+    // Maximum edge_count(4294967295) times kMetadataLen(96) fits easily without overflowing uint64.
+    const uint64_t metadata_len = (uint64_t)iev->edge_count * (uint64_t)kMetadataLen;
 
     /* Read ServerEncryptedValue. */
     const uint64_t min_required_len = kMinServerEncryptedValueLen + metadata_len;


### PR DESCRIPTION
Resolves MONGOCRYPT-924. See ticket for details.

Considered implementing detailed limit checks which mirror the server's [`checkTagLimitsAndStorageNotExceeded()`](https://github.com/mongodb/mongo/blob/r8.3.2/src/mongo/crypto/fle_crypto.cpp#L3591) behavior, but decided against to keep the scope of changes minimal.