### PR TITLE
MONGOCRYPT-942 add static libs to release

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1162,7 +1162,7 @@ tasks:
 
 - name: upload-release
   run_on: ubuntu2404-latest-small
-  patchable: false # Garasign credentials are marked as "Admin only" in Evergreen and are not included in patch builds. To test a patch: temporarily unselect "Admin only".
+  # patchable: false # Garasign credentials are marked as "Admin only" in Evergreen and are not included in patch builds. To test a patch: temporarily unselect "Admin only".
   commands:
     - func: "fetch source"
     - command: s3.get # Download build.

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1162,7 +1162,7 @@ tasks:
 
 - name: upload-release
   run_on: ubuntu2404-latest-small
-  # patchable: false # Garasign credentials are marked as "Admin only" in Evergreen and are not included in patch builds. To test a patch: temporarily unselect "Admin only".
+  patchable: false # Garasign credentials are marked as "Admin only" in Evergreen and are not included in patch builds. To test a patch: temporarily unselect "Admin only".
   commands:
     - func: "fetch source"
     - command: s3.get # Download build.

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1192,19 +1192,32 @@ tasks:
           mkdir libmongocrypt_upload/include
           mv $srcdir/include/mongocrypt libmongocrypt_upload/include
 
-          # Move library
+          # Move library files
           if [ -f "$srcdir/lib64/libmongocrypt.so" ]; then
             mkdir libmongocrypt_upload/lib64
             mv $srcdir/lib64/libmongocrypt.so libmongocrypt_upload/lib64
+            mv $srcdir/lib64/libmongocrypt-static.a libmongocrypt_upload/lib64
+            mv $srcdir/lib64/libbson-static-for-libmongocrypt.a libmongocrypt_upload/lib64
+            mv $srcdir/lib64/libkms_message-static.a libmongocrypt_upload/lib64
           elif [ -f "$srcdir/lib/libmongocrypt.so" ]; then
             mkdir libmongocrypt_upload/lib
             mv $srcdir/lib/libmongocrypt.so libmongocrypt_upload/lib
+            mv $srcdir/lib/libmongocrypt-static.a libmongocrypt_upload/lib
+            mv $srcdir/lib/libbson-static-for-libmongocrypt.a libmongocrypt_upload/lib
+            mv $srcdir/lib/libkms_message-static.a libmongocrypt_upload/lib
           elif [ -f "$srcdir/lib/libmongocrypt.dylib" ]; then
             mkdir libmongocrypt_upload/lib
             mv $srcdir/lib/libmongocrypt.dylib libmongocrypt_upload/lib
+            mv $srcdir/lib/libmongocrypt-static.a libmongocrypt_upload/lib
+            mv $srcdir/lib/libbson-static-for-libmongocrypt.a libmongocrypt_upload/lib
+            mv $srcdir/lib/libkms_message-static.a libmongocrypt_upload/lib
           elif [ -f "$srcdir/bin/mongocrypt.dll" ]; then
             mkdir libmongocrypt_upload/bin
+            mkdir libmongocrypt_upload/lib
             mv $srcdir/bin/mongocrypt.dll libmongocrypt_upload/bin
+            mv $srcdir/lib/mongocrypt-static.lib libmongocrypt_upload/lib
+            mv $srcdir/lib/bson-static-for-libmongocrypt.lib libmongocrypt_upload/lib
+            mv $srcdir/lib/kms_message-static.lib libmongocrypt_upload/lib
           fi
     - command: archive.targz_pack
       params:


### PR DESCRIPTION
# Summary
Add static library files to `upload-release` tasks.

# Background & Motivation

MONGOCRYPT-841 added an `upload-release` task to create a signed tarball to attach to the GitHub release. The tarball only included the shared libraries. But the Node driver statically links libmongocrypt, and [references `.a` and `.lib` files](https://github.com/mongodb-js/mongodb-client-encryption/blob/3a2f2fb69fec4faf28a18553947cf69ceccd3602/binding.gyp#L55-L70). This PR adds the static libraries so the Node driver can migrate to the GitHub releases.

Tested by temporarily removing the `patchable: false` from the `upload-release` task an running an Evergreen patch: https://spruce.corp.mongodb.com/version/6a395b4cd214d30007bdae38
