### PR TITLE
MONGOCRYPT-946: improve error message when using "textPreview"

### DIFF
--- a/src/mongocrypt-ctx.c
+++ b/src/mongocrypt-ctx.c
@@ -248,6 +248,9 @@ bool mongocrypt_ctx_setopt_algorithm(mongocrypt_ctx_t *ctx, const char *algorith
     } else if (mstr_eq_ignore_case(algo_str, mstrv_lit(MONGOCRYPT_ALGORITHM_STRING_STR))) {
         ctx->opts.index_type.value = MONGOCRYPT_INDEX_TYPE_STRING;
         ctx->opts.index_type.set = true;
+    } else if (mstr_eq_ignore_case(algo_str, mstrv_lit(MONGOCRYPT_ALGORITHM_TEXTPREVIEW_DEPRECATED_STR))) {
+        _mongocrypt_ctx_fail_w_msg(ctx, "Algorithm 'textPreview' is deprecated, please use 'string'");
+        return false;
     } else {
         char *error = bson_strdup_printf("unsupported algorithm string \"%.*s\"",
                                          algo_str.len <= (size_t)INT_MAX ? (int)algo_str.len : INT_MAX,

--- a/test/test-mongocrypt-ctx-encrypt.c
+++ b/test/test-mongocrypt-ctx-encrypt.c
@@ -4485,7 +4485,7 @@ static void _test_textPreview_fails(_mongocrypt_tester_t *tester) {
     mongocrypt_ctx_t *ctx = mongocrypt_ctx_new(crypt);
     ASSERT_FAILS(mongocrypt_ctx_setopt_algorithm(ctx, MONGOCRYPT_ALGORITHM_TEXTPREVIEW_DEPRECATED_STR, -1),
                  ctx,
-                 "unsupported algorithm");
+                 "please use 'string'");
     mongocrypt_ctx_destroy(ctx);
     mongocrypt_destroy(crypt);
 }


### PR DESCRIPTION
# Summary

Follow-up to https://github.com/mongodb/libmongocrypt/pull/1184 to give an actionable error when the removed "textPreview" algorithm is specified.

Before:
```
unsupported algorithm string "textPreview"
```

After:
```
Algorithm 'textPreview' is deprecated, please use 'string'
```

# Background & Motivation

Relatedly, `prefixPreview` and `suffixPreview` query types were restored https://github.com/mongodb/libmongocrypt/pull/1191. The `textPreview` algorithm is deliberately not restored. The rename does not prevent use of `prefixPreview` and `suffixPreview` on pre-9.0 servers.