### PR TITLE
MONGOCRYPT-951: Pin cmake to 4.3.4

### DIFF
--- a/.evergreen/install-build-tools.sh
+++ b/.evergreen/install-build-tools.sh
@@ -51,7 +51,7 @@ install_build_tools() {
   fi
 
   if [[ "${rhel7:?}" == "1" ]]; then
-    uv tool install -q cmake || return
+    uv tool install -q "cmake==4.3.4" || return
     ln -sf /opt/mongodbtoolchain/v4/bin/ninja "${UV_TOOL_BIN_DIR:?}/ninja" || return
   elif [[ "${rhel6:?}" == "1" ]]; then
     ln -sf /opt/mongodbtoolchain/v4/bin/cmake "${UV_TOOL_BIN_DIR:?}/cmake" || return
@@ -61,7 +61,7 @@ install_build_tools() {
     # PyPI `cmake` requires a sufficiently recent Python version.
     uv python install --no-bin -q || uv python install -q || return
 
-    uv tool install -q cmake || return
+    uv tool install -q "cmake==4.3.4" || return
 
     if [[ -f /etc/redhat-release && -x /opt/mongodbtoolchain/v4/bin/ninja ]]; then
       # Avoid strange "Could NOT find Threads" CMake configuration error on RHEL when using PyPI CMake, PyPI Ninja, and


### PR DESCRIPTION
MONGOCRYPT-951

Pin to avoid issue in parent task while investigating the following error from the cmake 4.4.0 release:

```
CMake Error: The warning category "error -DCMAKE_CXX_LINK_EXECUTABLE='echo not linking now...'" is not known.
CMake Error at cmake-build/_deps/embedded_mcd-src/src/libmongoc/CMakeLists.txt:425 (TRY_COMPILE):
  Failed to configure test project build system.
Call Stack (most recent call first):
  cmake-build/_deps/embedded_mcd-src/src/libmongoc/CMakeLists.txt:449 (mongoc_get_accept_args)
```