### PR TITLE
Do not invoke `ctest` when `BUILD_TESTING=OFF`

### DIFF
--- a/.evergreen/build_all.sh
+++ b/.evergreen/build_all.sh
@@ -115,7 +115,7 @@ if [[ "$release_os_arch" == *glibc* ]]; then
     echo "glibc version check passed: $actual_glibc"
 fi
 
-is_true "$BUILD_TESTING" && run_chdir "$BINARY_DIR" ctest
+is_true BUILD_TESTING && run_chdir "$BINARY_DIR" ctest
 
 # MONGOCRYPT-372, ensure macOS universal builds contain both x86_64 and arm64 architectures.
 if test "${CMAKE_OSX_ARCHITECTURES-}" != ''; then
@@ -145,7 +145,7 @@ _cmake_with_env "${cmake_args[@]}" \
     -DCMAKE_INSTALL_PREFIX="$MONGOCRYPT_INSTALL_PREFIX/nocrypto" \
     -B "$BINARY_DIR" -S "$LIBMONGOCRYPT_DIR"
 _cmake_with_env --build "$BINARY_DIR" --target install
-is_true "$BUILD_TESTING" && run_chdir "$BINARY_DIR" ctest
+is_true BUILD_TESTING && run_chdir "$BINARY_DIR" ctest
 
 # Build and install libmongocrypt without statically linking libbson
 _cmake_with_env "${cmake_args[@]}" \
@@ -153,4 +153,4 @@ _cmake_with_env "${cmake_args[@]}" \
     -DCMAKE_INSTALL_PREFIX="$MONGOCRYPT_INSTALL_PREFIX/sharedbson" \
     -B "$BINARY_DIR" -S "$LIBMONGOCRYPT_DIR"
 _cmake_with_env --build "$BINARY_DIR" --target install
-is_true "$BUILD_TESTING" && run_chdir "$BINARY_DIR" ctest
+is_true BUILD_TESTING && run_chdir "$BINARY_DIR" ctest

--- a/.evergreen/build_all.sh
+++ b/.evergreen/build_all.sh
@@ -115,7 +115,7 @@ if [[ "$release_os_arch" == *glibc* ]]; then
     echo "glibc version check passed: $actual_glibc"
 fi
 
-run_chdir "$BINARY_DIR" ctest
+is_true "$BUILD_TESTING" && run_chdir "$BINARY_DIR" ctest
 
 # MONGOCRYPT-372, ensure macOS universal builds contain both x86_64 and arm64 architectures.
 if test "${CMAKE_OSX_ARCHITECTURES-}" != ''; then
@@ -145,7 +145,7 @@ _cmake_with_env "${cmake_args[@]}" \
     -DCMAKE_INSTALL_PREFIX="$MONGOCRYPT_INSTALL_PREFIX/nocrypto" \
     -B "$BINARY_DIR" -S "$LIBMONGOCRYPT_DIR"
 _cmake_with_env --build "$BINARY_DIR" --target install
-run_chdir "$BINARY_DIR" ctest
+is_true "$BUILD_TESTING" && run_chdir "$BINARY_DIR" ctest
 
 # Build and install libmongocrypt without statically linking libbson
 _cmake_with_env "${cmake_args[@]}" \
@@ -153,4 +153,4 @@ _cmake_with_env "${cmake_args[@]}" \
     -DCMAKE_INSTALL_PREFIX="$MONGOCRYPT_INSTALL_PREFIX/sharedbson" \
     -B "$BINARY_DIR" -S "$LIBMONGOCRYPT_DIR"
 _cmake_with_env --build "$BINARY_DIR" --target install
-run_chdir "$BINARY_DIR" ctest
+is_true "$BUILD_TESTING" && run_chdir "$BINARY_DIR" ctest


### PR DESCRIPTION
Resolve the following error when libmongocrypt is built by the C Driver with CMake 4.4.0 and `BUILD_TESTING=OFF`:

```
*********************************
No test configuration file found!
*********************************
Usage
  ctest [options]
```

Per CMake 4.4.0 [release notes](https://cmake.org/cmake/help/latest/release/4.4.html):

> `ctest` now exits with non-zero if invoked with no arguments and no test input file exists.