### PR TITLE
MONGOCRYPT-952 update downloaded C driver to 2.3.3

### DIFF
--- a/.evergreen/install-build-tools.sh
+++ b/.evergreen/install-build-tools.sh
@@ -51,7 +51,7 @@ install_build_tools() {
   fi
 
   if [[ "${rhel7:?}" == "1" ]]; then
-    uv tool install -q "cmake==4.3.4" || return
+    uv tool install -q cmake || return
     ln -sf /opt/mongodbtoolchain/v4/bin/ninja "${UV_TOOL_BIN_DIR:?}/ninja" || return
   elif [[ "${rhel6:?}" == "1" ]]; then
     ln -sf /opt/mongodbtoolchain/v4/bin/cmake "${UV_TOOL_BIN_DIR:?}/cmake" || return
@@ -61,7 +61,7 @@ install_build_tools() {
     # PyPI `cmake` requires a sufficiently recent Python version.
     uv python install --no-bin -q || uv python install -q || return
 
-    uv tool install -q "cmake==4.3.4" || return
+    uv tool install -q cmake || return
 
     if [[ -f /etc/redhat-release && -x /opt/mongodbtoolchain/v4/bin/ninja ]]; then
       # Avoid strange "Could NOT find Threads" CMake configuration error on RHEL when using PyPI CMake, PyPI Ninja, and

--- a/.evergreen/prep_c_driver_source.sh
+++ b/.evergreen/prep_c_driver_source.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 # Clone mongo-c-driver and check out to a tagged version.
-MONGO_C_DRIVER_VERSION=2.3.0
+MONGO_C_DRIVER_VERSION=2.3.3
 
 # Force checkout with lf endings since .sh must have lf, not crlf on Windows
 git clone https://github.com/mongodb/mongo-c-driver.git --config core.eol=lf --config core.autocrlf=false --depth=1 --branch $MONGO_C_DRIVER_VERSION

--- a/cmake/FetchMongoC.cmake
+++ b/cmake/FetchMongoC.cmake
@@ -2,7 +2,7 @@ include (FetchContent)
 
 # Set the tag that we will fetch.
 # When updating the version of libbson, also update the version in etc/purls.txt and .evergreen/prep_c_driver_source.sh
-set (MONGOC_FETCH_TAG_FOR_LIBBSON "2.3.0" CACHE STRING "The Git tag of mongo-c-driver that will be fetched to obtain libbson")
+set (MONGOC_FETCH_TAG_FOR_LIBBSON "2.3.3" CACHE STRING "The Git tag of mongo-c-driver that will be fetched to obtain libbson")
 
 # Add an option to disable patching if a patch command is unavailable.
 option (LIBBSON_PATCH_ENABLED "Whether to apply patches to the libbson library" ON)

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -1,16 +1,16 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v2.3.0#src/libbson",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v2.3.3#src/libbson",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/v2.3.0.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/v2.3.3.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/v2.3.0"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/v2.3.3"
         }
       ],
       "group": "mongodb",
@@ -22,9 +22,9 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@v2.3.0#src/libbson",
+      "purl": "pkg:github/mongodb/mongo-c-driver@v2.3.3#src/libbson",
       "type": "library",
-      "version": "v2.3.0"
+      "version": "v2.3.3"
     },
     {
       "bom-ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz",
@@ -53,11 +53,11 @@
       "ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz"
     },
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@v2.3.0#src/libbson"
+      "ref": "pkg:github/mongodb/mongo-c-driver@v2.3.3#src/libbson"
     }
   ],
   "metadata": {
-    "timestamp": "2026-06-30T14:46:13.184636+00:00",
+    "timestamp": "2026-07-14T13:54:31.953906+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -1,16 +1,16 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/mongo-c-driver@v2.3.3#src/libbson",
+      "bom-ref": "pkg:github/mongodb/mongo-c-driver@2.3.3#src/libbson",
       "copyright": "Copyright 2009-present MongoDB, Inc.",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/mongo-c-driver/archive/v2.3.3.tar.gz"
+          "url": "https://github.com/mongodb/mongo-c-driver/archive/2.3.3.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/mongo-c-driver/tree/v2.3.3"
+          "url": "https://github.com/mongodb/mongo-c-driver/tree/2.3.3"
         }
       ],
       "group": "mongodb",
@@ -22,9 +22,9 @@
         }
       ],
       "name": "mongo-c-driver",
-      "purl": "pkg:github/mongodb/mongo-c-driver@v2.3.3#src/libbson",
+      "purl": "pkg:github/mongodb/mongo-c-driver@2.3.3#src/libbson",
       "type": "library",
-      "version": "v2.3.3"
+      "version": "2.3.3"
     },
     {
       "bom-ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz",
@@ -53,11 +53,11 @@
       "ref": "pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz"
     },
     {
-      "ref": "pkg:github/mongodb/mongo-c-driver@v2.3.3#src/libbson"
+      "ref": "pkg:github/mongodb/mongo-c-driver@2.3.3#src/libbson"
     }
   ],
   "metadata": {
-    "timestamp": "2026-07-14T13:54:31.953906+00:00",
+    "timestamp": "2026-07-14T13:56:19.068748+00:00",
     "tools": [
       {
         "externalReferences": [

--- a/etc/purls.txt
+++ b/etc/purls.txt
@@ -8,7 +8,7 @@
 # `copyright` property. This information can be manually added.
 
 # libbson is obtained via `cmake/FetchMongoC.cmake`.
-pkg:github/mongodb/mongo-c-driver@v2.3.0?#src/libbson
+pkg:github/mongodb/mongo-c-driver@v2.3.3?#src/libbson
 
 # IntelDFP is obtained via `cmake/IntelDFP.cmake`
 pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz

--- a/etc/purls.txt
+++ b/etc/purls.txt
@@ -8,7 +8,7 @@
 # `copyright` property. This information can be manually added.
 
 # libbson is obtained via `cmake/FetchMongoC.cmake`.
-pkg:github/mongodb/mongo-c-driver@v2.3.3?#src/libbson
+pkg:github/mongodb/mongo-c-driver@2.3.3?#src/libbson
 
 # IntelDFP is obtained via `cmake/IntelDFP.cmake`
 pkg:generic/IntelRDFPMathLib@20U2?download_url=https://www.netlib.org/misc/intel/IntelRDFPMathLib20U2.tar.gz


### PR DESCRIPTION
Update downloaded C driver to 2.3.3 to fix build on CMake 4.4.0 (CDRIVER-6367).

This reverts MONGOCRYPT-951 since pinning to CMake 4.3.4 is no-longer needed.

As a drive-by fix: the extra "v" prefix in purls.txt is removed since C driver tags do not have a "v" prefix. This was similarly done in https://github.com/mongodb/mongo-cxx-driver/pull/1473.

