### PR TITLE
MONGOCRYPT-956 error if "kmip" configured twice

### DIFF
--- a/src/mongocrypt-opts.c
+++ b/src/mongocrypt-opts.c
@@ -984,6 +984,10 @@ bool _mongocrypt_parse_kms_providers(mongocrypt_binary_t *kms_providers_definiti
         } else if (0 == strcmp(field_name, "kmip") && bson_empty(&field_bson)) {
             kms_providers->need_credentials |= MONGOCRYPT_KMS_PROVIDER_KMIP;
         } else if (0 == strcmp(field_name, "kmip")) {
+            if (0 != (kms_providers->configured_providers & MONGOCRYPT_KMS_PROVIDER_KMIP)) {
+                CLIENT_ERR("kmip KMS provider already set");
+                return false;
+            }
             if (!_mongocrypt_opts_kms_provider_kmip_parse(&kms_providers->kmip_mut, field_name, &field_bson, status)) {
                 return false;
             }

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -906,6 +906,16 @@ static void _test_setopt_kms_providers(_mongocrypt_tester_t *tester) {
         ASSERT_FAILS(mongocrypt_setopt_kms_providers(crypt, more), crypt, "already set");
         mongocrypt_destroy(crypt);
     }
+
+    // Errors if followed by call to `mongocrypt_setopt_kms_providers` configuring "kmip".
+    // This is a regression test for: MONGOCRYPT-956
+    {
+        mongocrypt_binary_t *kms_providers = TEST_BSON("{'kmip' : {'endpoint' : 'localhost'}}");
+        mongocrypt_t *crypt = mongocrypt_new();
+        ASSERT_OK(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt);
+        ASSERT_FAILS(mongocrypt_setopt_kms_providers(crypt, kms_providers), crypt, "already set");
+        mongocrypt_destroy(crypt);
+    }
 }
 
 static void test_tmp_bsonf(_mongocrypt_tester_t *tester) {
@@ -1044,7 +1054,7 @@ get_os_version_failed:
 
             continue; // No match found.
         }
-    found_match : {}
+    found_match: {}
 
         TEST_PRINTF("  begin %s\n", tester.test_names[i]);
         tester.test_fns[i](&tester);

--- a/test/test-mongocrypt.c
+++ b/test/test-mongocrypt.c
@@ -1054,7 +1054,7 @@ get_os_version_failed:
 
             continue; // No match found.
         }
-    found_match: {}
+    found_match : {}
 
         TEST_PRINTF("  begin %s\n", tester.test_names[i]);
         tester.test_fns[i](&tester);


### PR DESCRIPTION
# Summary

Error if `mongocrypt_setopt_kms_providers` is called to configure "kmip" twice.

# Details

https://github.com/mongodb/libmongocrypt/pull/725 applied this fix to other KMS providers, but missed "kmip".

This likely has little-to-no impact on drivers. Quoting MONGOCRYPT-956:

> I expect driver bindings are not calling mongocrypt_setopt_kms_providers more than once, since this is only needed to construct the mongocrypt_t handle.