### PR TITLE
PYTHON-5987 Opt in to corporate Azure credentials for test-python-integ

### DIFF
--- a/bindings/python/.evergreen/integ-setup.sh
+++ b/bindings/python/.evergreen/integ-setup.sh
@@ -37,6 +37,8 @@ PROJECT_DIRECTORY="$PROJECT_DIRECTORY"
 EOT
 
 # Get the secrets
+# Opt in to corporate Azure credentials (DRIVERS-3392)
+export FLE_AZURE_USE_CORPORATE=YES
 bash $DRIVERS_TOOLS/.evergreen/csfle/setup-secrets.sh
 # Start the csfle servers
 bash $DRIVERS_TOOLS/.evergreen/csfle/start-servers.sh


### PR DESCRIPTION
PYTHON-5987

## Summary
- The `rhel-80-64-bit` `test-python-integ` task started failing on 2026-07-25 because Azure Key Vault now rejects the deprecated tenant used by the default csfle test credentials.
- `drivers-evergreen-tools` added opt-in corporate Azure credentials (DRIVERS-3392), gated behind `FLE_AZURE_USE_CORPORATE=YES` inside `setup-secrets.sh`.
- This sets that variable in `integ-setup.sh` right before `setup-secrets.sh` runs, so the corporate tenant credentials are used.

## Test plan
- [x] Verified with an Evergreen patch build: https://spruce.corp.mongodb.com/version/6a71ae50193674000705e1b5 (passed)