### PR TITLE
check system `uv` for `python` subcommand

### DIFF
--- a/.evergreen/install-build-tools.sh
+++ b/.evergreen/install-build-tools.sh
@@ -17,6 +17,15 @@ export_uv_tool_dirs() {
   export PATH UV_TOOL_DIR UV_TOOL_BIN_DIR UV_PYTHON_INSTALL_DIR
 }
 
+# Returns 0 if system uv supports the `uv python` subcommand (added in uv 0.3.0).
+uv_supports_python() {
+  command -v uv &>/dev/null || return 1
+  uv python --help &>/dev/null || {
+    echo "system-provided uv does not support \`uv python\`: $(uv --version 2>&1)" >&2
+    return 1
+  }
+}
+
 install_build_tools() {
   export_uv_tool_dirs || return
 
@@ -29,8 +38,8 @@ install_build_tools() {
     export UV_PYTHON="/opt/mongodbtoolchain/v4/bin/python3"
   fi
 
-  if ! command -v uv &>/dev/null; then
-    echo "missing system-provided uv binary: fallback to uv-installer.sh" >&2
+  if ! uv_supports_python; then
+    echo "missing or unusable system-provided uv binary: fallback to uv-installer.sh" >&2
     : "${EVG_DIR:="$(dirname "${BASH_SOURCE[0]}")"}" || return
     . "${EVG_DIR:?}/init.sh" || return
 

--- a/.evergreen/install-build-tools.sh
+++ b/.evergreen/install-build-tools.sh
@@ -18,6 +18,7 @@ export_uv_tool_dirs() {
 }
 
 # Returns 0 if system uv supports the `uv python` subcommand (added in uv 0.3.0).
+# TODO(MONGOCRYPT-961) drop this workaround once macOS 11 is dropped (which has too-old uv)
 uv_supports_python() {
   command -v uv &>/dev/null || return 1
   uv python --help &>/dev/null || {


### PR DESCRIPTION
This PR checks that the system `uv` supports the `python` sub-command.

Intended to fix tasks on distros with a too-old `uv`. [Example](https://spruce.corp.mongodb.com/task/libmongocrypt_macos_x86_64_build_and_test_and_upload_1cbe6fe06306454cef6a0531c59ccf3f0067800a_26_08_04_18_04_10/logs?execution=0):

```
[2026/08/04 14:08:01.555] error: unrecognized subcommand 'python'
[2026/08/04 14:08:01.555] Usage: uv [OPTIONS] <COMMAND>
```

The `uv python` subcommand was added in `uv` [0.3.0](https://github.com/astral-sh/uv/blob/main/changelogs/0.3.x.md#030). 