### PR TITLE
Remove unnecessary virtualenv

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -253,9 +253,9 @@ functions:
         shell: bash
         script: |
           set -o errexit
-          # if [ "${is_patch}" = "true" ]; then
-          #   exit 0
-          # fi
+          if [ "${is_patch}" = "true" ]; then
+            exit 0
+          fi
 
           # set AWS credentials
           rm -rf ~/.aws
@@ -292,10 +292,10 @@ functions:
           set -o errexit
           set -o verbose
 
-          # if [ "${is_patch}" = "true" ]; then
-          #   echo "patch build, skipping packaging publication"
-          #   exit 0
-          # fi
+          if [ "${is_patch}" = "true" ]; then
+            echo "patch build, skipping packaging publication"
+            exit 0
+          fi
 
           # Get the current version of libmongocrypt.
           pkg_version="$(python etc/calc_release_version.py)"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -253,9 +253,9 @@ functions:
         shell: bash
         script: |
           set -o errexit
-          if [ "${is_patch}" = "true" ]; then
-            exit 0
-          fi
+          # if [ "${is_patch}" = "true" ]; then
+          #   exit 0
+          # fi
 
           # set AWS credentials
           rm -rf ~/.aws
@@ -292,10 +292,10 @@ functions:
           set -o errexit
           set -o verbose
 
-          if [ "${is_patch}" = "true" ]; then
-            echo "patch build, skipping packaging publication"
-            exit 0
-          fi
+          # if [ "${is_patch}" = "true" ]; then
+          #   echo "patch build, skipping packaging publication"
+          #   exit 0
+          # fi
 
           # Get the current version of libmongocrypt.
           pkg_version="$(python etc/calc_release_version.py)"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -297,16 +297,6 @@ functions:
             exit 0
           fi
 
-          # Some venv-activate scripts are not nounset-clean
-          set +u
-
-          # Need requests and pycrypto for notary-client.py
-          python -m virtualenv venv
-          cd venv
-          . bin/activate
-          ./bin/pip install requests
-          ./bin/pip install pycrypto
-          cd ..
           # Get the current version of libmongocrypt.
           pkg_version="$(python etc/calc_release_version.py)"
           CURATOR_RELEASE=${curator_release|"e0b5f66fc89ec0acddcd40ea5f447a8300ded2b9"}


### PR DESCRIPTION
Intended to fix `publish-packages` tasks. [Example](https://spruce.corp.mongodb.com/task/libmongocrypt_linux_64_amazon_ami_publish_packages_1cbe6fe06306454cef6a0531c59ccf3f0067800a_26_08_04_18_04_10/logs?execution=0):

```
RetryError: HTTPSConnectionPool(host='artifactory.corp.mongodb.com', port=443): Max retries exceeded
```

Artifactory was recently disabled (see banner in Evergreen). The virtual environment references a `notary-client.py` but I see no references to it. To test that the `publish-packages` still works without the virtual environment, I temporarily enabled `publish-packages` on a patch build and ran [a patch](https://spruce.corp.mongodb.com/version/6a724ab3861fcb0007981377). This updates the [`development` channel](https://github.com/mongodb/libmongocrypt/#package-publication-channels) of the package, but it will soon be updated on the next Evergreen CI run.

Aside: MONGOCRYPT-363 tracks updating to a newer `curator`. That might help to migrate the `publish-packages` tasks from older distros (`rhel7` and `ubuntu2004`).