### PR TITLE
MONGOCRYPT-834 add fuzz_kms to ENABLE_FUZZING cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -609,6 +609,12 @@ if (ENABLE_FUZZING)
    target_link_libraries (fuzz_mongocrypt PRIVATE mongocrypt_static _mongocrypt::libbson_for_static)
    target_compile_options (fuzz_mongocrypt PRIVATE -fsanitize=fuzzer)
    target_link_options (fuzz_mongocrypt PRIVATE -fsanitize=fuzzer)
+
+   add_executable (fuzz_kms EXCLUDE_FROM_ALL test/fuzz_kms.c)
+   target_include_directories (fuzz_kms PRIVATE ./src ./kms-message ./kms-message/src)
+   target_link_libraries (fuzz_kms PRIVATE mongocrypt_static kms_message_static _mongocrypt::libbson_for_static)
+   target_compile_options (fuzz_kms PRIVATE -fsanitize=fuzzer)
+   target_link_options (fuzz_kms PRIVATE -fsanitize=fuzzer)
 endif ()
 
 if (ENABLE_STATIC)

--- a/test/fuzz_kms.c
+++ b/test/fuzz_kms.c
@@ -15,7 +15,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     kms_response_parser_t *parser = NULL;
     parser = kms_response_parser_new();
     if (parser != NULL) {
-        kms_response_parser_feed(parser, data, size);
+        kms_response_parser_feed(parser, (uint8_t *)data, (uint32_t)size);
         kms_response_parser_destroy(parser);
     }
 

--- a/test/fuzz_kms.c
+++ b/test/fuzz_kms.c
@@ -12,6 +12,9 @@
  * kms_request_new functions.
  */
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size > UINT32_MAX) {
+        return 0;
+    }
     kms_response_parser_t *parser = NULL;
     parser = kms_response_parser_new();
     if (parser != NULL) {


### PR DESCRIPTION
Add the old fuzzer to the ENABLE_FUZZING target to simplify the oss-fuzz script