### PR TITLE
Run pymongocrypt release task on macOS 14

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -607,7 +607,7 @@ tasks:
     - func: "test python integ"
       vars: { variant_name: "${build_variant}" }
 
-- name: "release-python-macos-1100"
+- name: "release-python-macos-14-arm64"
   tags: ["release_python_tag"]
   # Run task on macOS 14 since macOS 11 is EOL and fails to run release script.
   # The macOS platform is set by MACOSX_DEPLOYMENT_TARGET/_PYTHON_HOST_PLATFORM in scripts/release.sh, so the produced artifacts do not depend on the host macOS version.

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -609,7 +609,9 @@ tasks:
 
 - name: "release-python-macos-1100"
   tags: ["release_python_tag"]
-  run_on: macos-1100
+  # Run task on macOS 14 since macOS 11 is EOL and fails to run release script.
+  # The macOS platform is set by MACOSX_DEPLOYMENT_TARGET/_PYTHON_HOST_PLATFORM in scripts/release.sh, so the produced artifacts do not depend on the host macOS version.
+  run_on: macos-14-arm64
   commands:
     - func: "fetch source"
     - func: "build python release"


### PR DESCRIPTION
To address task failures of `release-python-macos-1100` due to a too-old `rustc`. [Example](https://spruce.corp.mongodb.com/task/libmongocrypt_python_release_release_python_macos_1100_edadab0e1bd2693de6116503891c237bccaa1b56_26_08_17_21_01_07/logs?execution=0):

```
Building wheel for cryptography (pyproject.toml) did not run successfully.
...
error: rustc 1.78.0 is not supported by the following packages:
```

MONGOCRYPT-961 plans to (soon) drop support for macOS 11 regardless. But this may be a short-term improvement to fix failing CI tasks.

Disclaimer: I used Claude to identify and propose the fix.
