### PR TITLE
MONGOCRYPT-971 reject undersized ciphertext before allocating plaintext

### DIFF
--- a/src/mc-fle2-insert-update-payload-v2.c
+++ b/src/mc-fle2-insert-update-payload-v2.c
@@ -523,7 +523,12 @@ const _mongocrypt_buffer_t *mc_FLE2InsertUpdatePayloadV2_decrypt(_mongocrypt_cry
         return NULL;
     }
 
-    _mongocrypt_buffer_resize(&iup->plaintext, fle2v2->get_plaintext_len(ciphertext.len, status));
+    const uint32_t plaintext_len = fle2v2->get_plaintext_len(ciphertext.len, status);
+    if (!mongocrypt_status_ok(status)) {
+        return NULL;
+    }
+
+    _mongocrypt_buffer_resize(&iup->plaintext, plaintext_len);
     uint32_t bytes_written;
 
     if (!fle2v2->do_decrypt(crypto, &iup->userKeyId, user_key, &ciphertext, &iup->plaintext, &bytes_written, status)) {

--- a/src/mc-fle2-insert-update-payload.c
+++ b/src/mc-fle2-insert-update-payload.c
@@ -252,7 +252,12 @@ const _mongocrypt_buffer_t *mc_FLE2InsertUpdatePayload_decrypt(_mongocrypt_crypt
         return NULL;
     }
 
-    _mongocrypt_buffer_resize(&iup->plaintext, fle2aead->get_plaintext_len(ciphertext.len, status));
+    const uint32_t plaintext_len = fle2aead->get_plaintext_len(ciphertext.len, status);
+    if (!mongocrypt_status_ok(status)) {
+        return NULL;
+    }
+
+    _mongocrypt_buffer_resize(&iup->plaintext, plaintext_len);
     uint32_t bytes_written; /* ignored */
 
     if (!fle2aead

--- a/src/mc-fle2-payload-iev.c
+++ b/src/mc-fle2-payload-iev.c
@@ -353,7 +353,11 @@ static bool mc_FLE2IndexedEncryptedValue_decrypt(_mongocrypt_crypto_t *crypto,
     const _mongocrypt_buffer_t *token_buf = mc_ServerDataEncryptionLevel1Token_get(token);
     uint32_t bytes_written;
 
-    _mongocrypt_buffer_resize(&iev->Inner, fle2alg->get_plaintext_len(iev->InnerEncrypted.len, status));
+    const uint32_t inner_len = fle2alg->get_plaintext_len(iev->InnerEncrypted.len, status);
+    if (!mongocrypt_status_ok(status)) {
+        return false;
+    }
+    _mongocrypt_buffer_resize(&iev->Inner, inner_len);
 
     /* Decrypt InnerEncrypted. */
     if (!fle2alg->do_decrypt(crypto,
@@ -445,7 +449,11 @@ bool mc_FLE2IndexedEncryptedValue_add_K_Key(_mongocrypt_crypto_t *crypto,
         return false;
     }
     /* Attempt to decrypt ClientEncryptedValue */
-    _mongocrypt_buffer_resize(&iev->ClientValue, fle2aead->get_plaintext_len(iev->ClientEncryptedValue.len, status));
+    const uint32_t client_value_len = fle2aead->get_plaintext_len(iev->ClientEncryptedValue.len, status);
+    if (!mongocrypt_status_ok(status)) {
+        return false;
+    }
+    _mongocrypt_buffer_resize(&iev->ClientValue, client_value_len);
     uint32_t bytes_written;
     if (!fle2aead->do_decrypt(crypto,
                               &iev->K_KeyId,

--- a/src/mc-fle2-payload-uev-common.c
+++ b/src/mc-fle2-payload-uev-common.c
@@ -93,7 +93,7 @@ const _mongocrypt_buffer_t *_mc_FLE2UnindexedEncryptedValueCommon_decrypt(_mongo
     memcpy(AD.data + 1, key_uuid->data, key_uuid->len);
     AD.data[1 + key_uuid->len] = (uint8_t)original_bson_type;
     const uint32_t plaintext_len = fle2aead->get_plaintext_len(ciphertext->len, status);
-    if (plaintext_len == 0) {
+    if (!mongocrypt_status_ok(status)) {
         _mongocrypt_buffer_cleanup(&AD);
         return NULL;
     }

--- a/src/mongocrypt-crypto.c
+++ b/src/mongocrypt-crypto.c
@@ -443,9 +443,9 @@ static uint32_t _mongocrypt_calculate_plaintext_len(uint32_t inlen,
                                                     _mongocrypt_hmac_type_t hmac,
                                                     mongocrypt_status_t *status) {
     const uint32_t hmaclen = (hmac == HMAC_NONE) ? 0 : MONGOCRYPT_HMAC_LEN;
-    const uint32_t mincipher = (mode == MODE_CTR) ? 0 : MONGOCRYPT_BLOCK_SIZE;
+    const uint32_t mincipher = (mode == MODE_CTR) ? 1 : MONGOCRYPT_BLOCK_SIZE;
     if (inlen < (MONGOCRYPT_IV_LEN + mincipher + hmaclen)) {
-        CLIENT_ERR("input ciphertext too small. Must be at least %" PRIu32 " bytes",
+        CLIENT_ERR("input ciphertext too small. Must be more than %" PRIu32 " bytes",
                    MONGOCRYPT_IV_LEN + mincipher + hmaclen);
         return 0;
     }
@@ -1346,7 +1346,11 @@ bool _mongocrypt_unwrap_key(_mongocrypt_crypto_t *crypto,
 
     // _mongocrypt_wrap_key() uses FLE1 algorithm parameters.
     _mongocrypt_buffer_init(dek);
-    _mongocrypt_buffer_resize(dek, fle1alg->get_plaintext_len(encrypted_dek->len, status));
+    const uint32_t plaintext_len = fle1alg->get_plaintext_len(encrypted_dek->len, status);
+    if (!mongocrypt_status_ok(status)) {
+        return false;
+    }
+    _mongocrypt_buffer_resize(dek, plaintext_len);
 
     if (!fle1alg->do_decrypt(crypto, NULL /* associated data. */, kek, encrypted_dek, dek, &bytes_written, status)) {
         return false;

--- a/src/mongocrypt-ctx-decrypt.c
+++ b/src/mongocrypt-ctx-decrypt.c
@@ -344,7 +344,7 @@ static bool _replace_FLE1Payload_with_plaintext(void *ctx,
 
     const _mongocrypt_value_encryption_algorithm_t *fle1alg = _mcFLE1Algorithm();
     plaintext.len = fle1alg->get_plaintext_len(ciphertext.data.len, status);
-    CHECK_AND_RETURN(plaintext.len != 0);
+    CHECK_AND_RETURN(mongocrypt_status_ok(status));
     plaintext.data = bson_malloc0(plaintext.len);
     BSON_ASSERT(plaintext.data);
 

--- a/test/test-mc-fle2-payload-iup-v2.c
+++ b/test/test-mc-fle2-payload-iup-v2.c
@@ -289,10 +289,74 @@ static void _test_mc_FLE2InsertUpdatePayloadV2_parse_errors(_mongocrypt_tester_t
     }
 }
 
+/* Builds a minimal parseable FLE2InsertUpdatePayloadV2 with a 'v' of `vlen` bytes.
+ * 'v' is a 16 byte user key UUID followed by (vlen - 16) bytes of ciphertext. */
+static void _make_iup_v2_with_value_len(_mongocrypt_buffer_t *out, uint32_t vlen) {
+    BSON_ASSERT(vlen >= UUID_LEN);
+    uint8_t token[32] = {0};
+    uint8_t uuid[UUID_LEN];
+    uint8_t value[128];
+
+    memset(uuid, 0xAB, sizeof(uuid));
+    memset(value, 0x41, sizeof(value));
+    BSON_ASSERT(vlen <= sizeof(value));
+    memcpy(value, uuid, sizeof(uuid));
+
+    bson_t payload;
+    bson_init(&payload);
+    ASSERT(bson_append_binary(&payload, "d", -1, BSON_SUBTYPE_BINARY, token, sizeof(token)));
+    ASSERT(bson_append_binary(&payload, "s", -1, BSON_SUBTYPE_BINARY, token, sizeof(token)));
+    ASSERT(bson_append_binary(&payload, "p", -1, BSON_SUBTYPE_BINARY, token, sizeof(token)));
+    ASSERT(bson_append_binary(&payload, "u", -1, BSON_SUBTYPE_UUID, uuid, sizeof(uuid)));
+    ASSERT(bson_append_int32(&payload, "t", -1, (int32_t)BSON_TYPE_UTF8));
+    ASSERT(bson_append_binary(&payload, "v", -1, BSON_SUBTYPE_BINARY, value, vlen));
+    ASSERT(bson_append_binary(&payload, "e", -1, BSON_SUBTYPE_BINARY, token, sizeof(token)));
+    ASSERT(bson_append_binary(&payload, "l", -1, BSON_SUBTYPE_BINARY, token, sizeof(token)));
+    ASSERT(bson_append_int64(&payload, "k", -1, 0));
+
+    _mongocrypt_buffer_init_size(out, 1 + (uint32_t)payload.len);
+    out->data[0] = (uint8_t)MC_SUBTYPE_FLE2InsertUpdatePayloadV2;
+    memcpy(out->data + 1, bson_get_data(&payload), payload.len);
+    bson_destroy(&payload);
+}
+
+/* A 'v' short enough that the plaintext length would be zero must be rejected
+ * with an error, not crash. */
+static void _test_mc_FLE2InsertUpdatePayloadV2_decrypt_short_ciphertext(_mongocrypt_tester_t *tester) {
+    mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+    _mongocrypt_buffer_t user_key;
+    _mongocrypt_buffer_init_size(&user_key, MONGOCRYPT_KEY_LEN);
+    memset(user_key.data, 0xCD, user_key.len);
+
+    /* FLE2v2AEAD is CBC + HMAC-SHA256: ciphertext must be at least
+     * IV (16) + one block (16) + HMAC (32) bytes. */
+    const uint32_t vlens[] = {UUID_LEN, UUID_LEN + 1, UUID_LEN + 48, UUID_LEN + 63};
+    for (size_t i = 0; i < sizeof(vlens) / sizeof(vlens[0]); i++) {
+        _mongocrypt_buffer_t input;
+        _make_iup_v2_with_value_len(&input, vlens[i]);
+
+        mc_FLE2InsertUpdatePayloadV2_t iup;
+        mc_FLE2InsertUpdatePayloadV2_init(&iup);
+        mongocrypt_status_t *status = mongocrypt_status_new();
+        ASSERT_OK_STATUS(mc_FLE2InsertUpdatePayloadV2_parse(&iup, &input, status), status);
+
+        const _mongocrypt_buffer_t *got = mc_FLE2InsertUpdatePayloadV2_decrypt(crypt->crypto, &iup, &user_key, status);
+        ASSERT_FAILS_STATUS(got != NULL, status, "input ciphertext too small");
+
+        mc_FLE2InsertUpdatePayloadV2_cleanup(&iup);
+        mongocrypt_status_destroy(status);
+        _mongocrypt_buffer_cleanup(&input);
+    }
+
+    _mongocrypt_buffer_cleanup(&user_key);
+    mongocrypt_destroy(crypt);
+}
+
 void _mongocrypt_tester_install_fle2_payload_iup_v2(_mongocrypt_tester_t *tester) {
     INSTALL_TEST(_test_FLE2InsertUpdatePayloadV2_parse);
     INSTALL_TEST(_test_mc_FLE2InsertUpdatePayloadV2_decrypt);
     INSTALL_TEST(_test_mc_FLE2InsertUpdatePayloadV2_includes_crypto_params);
     INSTALL_TEST(_test_mc_FLE2InsertUpdatePayloadV2_parses_crypto_params);
     INSTALL_TEST(_test_mc_FLE2InsertUpdatePayloadV2_parse_errors);
+    INSTALL_TEST(_test_mc_FLE2InsertUpdatePayloadV2_decrypt_short_ciphertext);
 }

--- a/test/test-mc-fle2-payload-iup.c
+++ b/test/test-mc-fle2-payload-iup.c
@@ -182,8 +182,75 @@ static void test_FLE2InsertUpdatePayload_parse_errors(_mongocrypt_tester_t *test
     _mongocrypt_buffer_cleanup(&input_buf);
 }
 
+/* Builds a minimal parseable FLE2InsertUpdatePayload with a 'v' of `vlen` bytes.
+ * 'v' is a 16 byte user key UUID followed by (vlen - 16) bytes of ciphertext. */
+static void _make_iup_with_value_len(_mongocrypt_buffer_t *out, uint32_t vlen) {
+    BSON_ASSERT(vlen >= UUID_LEN);
+    uint8_t token[32] = {0};
+    uint8_t uuid[UUID_LEN];
+    uint8_t value[128];
+
+    memset(uuid, 0xAB, sizeof(uuid));
+    memset(value, 0x41, sizeof(value));
+    BSON_ASSERT(vlen <= sizeof(value));
+    memcpy(value, uuid, sizeof(uuid));
+
+    bson_t payload;
+    bson_init(&payload);
+    ASSERT(bson_append_binary(&payload, "d", -1, BSON_SUBTYPE_BINARY, token, sizeof(token)));
+    ASSERT(bson_append_binary(&payload, "s", -1, BSON_SUBTYPE_BINARY, token, sizeof(token)));
+    ASSERT(bson_append_binary(&payload, "c", -1, BSON_SUBTYPE_BINARY, token, sizeof(token)));
+    ASSERT(bson_append_binary(&payload, "p", -1, BSON_SUBTYPE_BINARY, token, sizeof(token)));
+    ASSERT(bson_append_binary(&payload, "u", -1, BSON_SUBTYPE_UUID, uuid, sizeof(uuid)));
+    ASSERT(bson_append_int32(&payload, "t", -1, (int32_t)BSON_TYPE_UTF8));
+    ASSERT(bson_append_binary(&payload, "v", -1, BSON_SUBTYPE_BINARY, value, vlen));
+    ASSERT(bson_append_binary(&payload, "e", -1, BSON_SUBTYPE_BINARY, token, sizeof(token)));
+
+    _mongocrypt_buffer_init_size(out, 1 + (uint32_t)payload.len);
+    out->data[0] = (uint8_t)MC_SUBTYPE_FLE2InsertUpdatePayload;
+    memcpy(out->data + 1, bson_get_data(&payload), payload.len);
+    bson_destroy(&payload);
+}
+
+/* A 'v' short enough that the plaintext length would be zero must be rejected
+ * with an error, not crash. */
+static void test_FLE2InsertUpdatePayload_decrypt_short_ciphertext(_mongocrypt_tester_t *tester) {
+    if (!_aes_ctr_is_supported_by_os) {
+        TEST_PRINTF("Common Crypto with no CTR support detected. Skipping.");
+        return;
+    }
+
+    mongocrypt_t *crypt = _mongocrypt_tester_mongocrypt(TESTER_MONGOCRYPT_DEFAULT);
+    _mongocrypt_buffer_t user_key;
+    _mongocrypt_buffer_init_size(&user_key, MONGOCRYPT_KEY_LEN);
+    memset(user_key.data, 0xCD, user_key.len);
+
+    /* FLE2AEAD is CTR + HMAC-SHA256: ciphertext must exceed IV (16) + HMAC (32). */
+    const uint32_t vlens[] = {UUID_LEN, UUID_LEN + 1, UUID_LEN + 47, UUID_LEN + 48};
+    for (size_t i = 0; i < sizeof(vlens) / sizeof(vlens[0]); i++) {
+        _mongocrypt_buffer_t input;
+        _make_iup_with_value_len(&input, vlens[i]);
+
+        mc_FLE2InsertUpdatePayload_t iup;
+        mc_FLE2InsertUpdatePayload_init(&iup);
+        mongocrypt_status_t *status = mongocrypt_status_new();
+        ASSERT_OK_STATUS(mc_FLE2InsertUpdatePayload_parse(&iup, &input, status), status);
+
+        const _mongocrypt_buffer_t *got = mc_FLE2InsertUpdatePayload_decrypt(crypt->crypto, &iup, &user_key, status);
+        ASSERT_FAILS_STATUS(got != NULL, status, "input ciphertext too small");
+
+        mc_FLE2InsertUpdatePayload_cleanup(&iup);
+        mongocrypt_status_destroy(status);
+        _mongocrypt_buffer_cleanup(&input);
+    }
+
+    _mongocrypt_buffer_cleanup(&user_key);
+    mongocrypt_destroy(crypt);
+}
+
 void _mongocrypt_tester_install_fle2_payload_iup(_mongocrypt_tester_t *tester) {
     INSTALL_TEST(test_FLE2InsertUpdatePayload_parse);
     INSTALL_TEST(test_FLE2InsertUpdatePayload_decrypt);
     INSTALL_TEST(test_FLE2InsertUpdatePayload_parse_errors);
+    INSTALL_TEST(test_FLE2InsertUpdatePayload_decrypt_short_ciphertext);
 }


### PR DESCRIPTION
A PR for this change was previously approved (see link in MONGOCRYPT-971). The fix was pushed to r1.20. This PR applies the changes to master (this is notably a reverse of our typical merge process).